### PR TITLE
fix: resolve depends_on_option_id in question and section creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.21.2"
+version = "1.22.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/management/commands/reset_events.py
+++ b/src/events/management/commands/reset_events.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 
 from accounts.models import RevelUser
 from events.models import Organization
+from questionnaires.models import Questionnaire
 
 
 class Command(BaseCommand):
@@ -77,6 +78,7 @@ class Command(BaseCommand):
 
             # Delete all organizations (cascade will handle related objects)
             Organization.objects.all().delete()
+            Questionnaire.objects.all().delete()
             self.stdout.write(self.style.SUCCESS(f"✓ Deleted {org_count} organizations"))
 
             # Delete all users with @example.com emails

--- a/src/events/schema/questionnaire.py
+++ b/src/events/schema/questionnaire.py
@@ -39,7 +39,7 @@ class OrganizationQuestionnaireInListSchema(BaseOrganizationQuestionnaireSchema)
 
 
 class OrganizationQuestionnaireSchema(BaseOrganizationQuestionnaireSchema):
-    questionnaire: questionnaires_schema.QuestionnaireCreateSchema
+    questionnaire: questionnaires_schema.QuestionnaireResponseSchema
 
 
 class OrganizationQuestionnaireFieldsMixin(Schema):

--- a/src/events/tests/test_controllers/test_questionnaire/test_questions.py
+++ b/src/events/tests/test_controllers/test_questionnaire/test_questions.py
@@ -83,22 +83,24 @@ def test_create_mc_question_permission_denied(organization: Organization, nonmem
 
 
 def test_update_mc_question_success(organization: Organization, organization_owner_client: Client) -> None:
-    """Test that a multiple choice question can be updated."""
+    """Test that a multiple choice question can be updated.
+
+    Note: Options are NOT updated via this endpoint. They must be updated individually
+    via the dedicated option endpoints to prevent accidental data loss.
+    """
     questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
     org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
     question = MultipleChoiceQuestion.objects.create(
         questionnaire=questionnaire, question="Original Question", order=1, allow_multiple_answers=False
     )
+    # Create some options to verify they're not touched by the update
+    MultipleChoiceOption.objects.create(question=question, option="Existing Option", is_correct=True, order=1)
 
     payload = MultipleChoiceQuestionUpdateSchema(
         question="Updated Question",
         is_mandatory=True,
         order=2,
         allow_multiple_answers=True,
-        options=[
-            MultipleChoiceOptionCreateSchema(option="Option A", is_correct=True, order=1),
-            MultipleChoiceOptionCreateSchema(option="Option B", is_correct=False, order=2),
-        ],
     )
 
     url = reverse(
@@ -111,12 +113,16 @@ def test_update_mc_question_success(organization: Organization, organization_own
     assert data["question"] == "Updated Question"
     assert data["is_mandatory"] is True
     assert data["allow_multiple_answers"] is True
-    assert len(data["options"]) == 2
 
     # Verify question was updated
     question.refresh_from_db()
     assert question.question == "Updated Question"
     assert question.allow_multiple_answers is True
+    # Options should remain unchanged
+    assert question.options.count() == 1
+    existing_option = question.options.first()
+    assert existing_option is not None
+    assert existing_option.option == "Existing Option"
 
 
 def test_update_mc_question_not_found(organization: Organization, organization_owner_client: Client) -> None:
@@ -126,7 +132,7 @@ def test_update_mc_question_not_found(organization: Organization, organization_o
     questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
     org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
 
-    payload = MultipleChoiceQuestionUpdateSchema(question="Updated Question", options=[])
+    payload = MultipleChoiceQuestionUpdateSchema(question="Updated Question")
 
     url = reverse(
         "api:update_mc_question", kwargs={"org_questionnaire_id": org_questionnaire.id, "question_id": uuid4()}
@@ -470,3 +476,133 @@ def test_delete_ft_question_permission_denied(organization: Organization, nonmem
     response = nonmember_client.delete(url)
 
     assert response.status_code == 404
+
+
+# --- Create conditional question tests (depends_on_option_id) ---
+
+
+def test_create_mc_question_with_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that a conditional MC question can be created with depends_on_option_id."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create a parent question with options
+    parent_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=questionnaire, question="Do you have experience?", order=1
+    )
+    yes_option = MultipleChoiceOption.objects.create(question=parent_question, option="Yes", is_correct=True, order=1)
+
+    # Create a conditional question that depends on the "Yes" option
+    payload = MultipleChoiceQuestionCreateSchema(
+        question="Please describe your experience",
+        depends_on_option_id=yes_option.id,
+        order=2,
+        options=[
+            MultipleChoiceOptionCreateSchema(option="1-2 years", is_correct=False, order=1),
+            MultipleChoiceOptionCreateSchema(option="3+ years", is_correct=True, order=2),
+        ],
+    )
+
+    url = reverse("api:create_mc_question", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["question"] == "Please describe your experience"
+    assert data["depends_on_option_id"] == str(yes_option.id)
+
+    # Verify in database
+    conditional_question = MultipleChoiceQuestion.objects.get(id=data["id"])
+    assert conditional_question.depends_on_option_id == yes_option.id
+
+
+def test_create_ft_question_with_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that a conditional FT question can be created with depends_on_option_id."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create a parent question with options
+    parent_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=questionnaire, question="Do you want to provide details?", order=1
+    )
+    yes_option = MultipleChoiceOption.objects.create(question=parent_question, option="Yes", is_correct=True, order=1)
+
+    # Create a conditional FT question that depends on the "Yes" option
+    payload = FreeTextQuestionCreateSchema(
+        question="Please provide details",
+        depends_on_option_id=yes_option.id,
+        order=2,
+    )
+
+    url = reverse("api:create_ft_question", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["question"] == "Please provide details"
+    assert data["depends_on_option_id"] == str(yes_option.id)
+
+    # Verify in database
+    conditional_question = FreeTextQuestion.objects.get(id=data["id"])
+    assert conditional_question.depends_on_option_id == yes_option.id
+
+
+def test_create_mc_question_with_invalid_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that creating MC question with option from another questionnaire fails."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create option in a different questionnaire
+    other_questionnaire = Questionnaire.objects.create(name="Other Questionnaire")
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=other_questionnaire, question="Other Question", order=1
+    )
+    other_option = MultipleChoiceOption.objects.create(
+        question=other_question, option="Other Option", is_correct=True, order=1
+    )
+
+    payload = MultipleChoiceQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=other_option.id,
+        options=[MultipleChoiceOptionCreateSchema(option="Yes", is_correct=True)],
+    )
+
+    url = reverse("api:create_mc_question", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    # Should return 400 or 422 due to integrity error
+    assert response.status_code in (400, 422)
+
+
+def test_create_ft_question_with_invalid_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that creating FT question with option from another questionnaire fails."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create option in a different questionnaire
+    other_questionnaire = Questionnaire.objects.create(name="Other Questionnaire")
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=other_questionnaire, question="Other Question", order=1
+    )
+    other_option = MultipleChoiceOption.objects.create(
+        question=other_question, option="Other Option", is_correct=True, order=1
+    )
+
+    payload = FreeTextQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=other_option.id,
+    )
+
+    url = reverse("api:create_ft_question", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    # Should return 400 or 422 due to integrity error
+    assert response.status_code in (400, 422)

--- a/src/events/tests/test_controllers/test_questionnaire/test_sections.py
+++ b/src/events/tests/test_controllers/test_questionnaire/test_sections.py
@@ -5,7 +5,7 @@ from django.test import Client
 from django.urls import reverse
 
 from events.models import Organization, OrganizationQuestionnaire
-from questionnaires.models import Questionnaire, QuestionnaireSection
+from questionnaires.models import MultipleChoiceOption, MultipleChoiceQuestion, Questionnaire, QuestionnaireSection
 from questionnaires.schema import SectionCreateSchema, SectionUpdateSchema
 
 pytestmark = pytest.mark.django_db
@@ -126,3 +126,67 @@ def test_delete_section_permission_denied(organization: Organization, nonmember_
     response = nonmember_client.delete(url)
 
     assert response.status_code == 404
+
+
+# --- Create section with depends_on_option_id tests ---
+
+
+def test_create_section_with_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that a conditional section can be created with depends_on_option_id."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create a parent question with options
+    parent_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=questionnaire, question="Do you have experience?", order=1
+    )
+    yes_option = MultipleChoiceOption.objects.create(question=parent_question, option="Yes", is_correct=True, order=1)
+
+    # Create a conditional section that depends on the "Yes" option
+    payload = SectionCreateSchema(
+        name="Experience Details",
+        depends_on_option_id=yes_option.id,
+        order=1,
+    )
+
+    url = reverse("api:create_section", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Experience Details"
+    assert data["depends_on_option_id"] == str(yes_option.id)
+
+    # Verify in database
+    section = QuestionnaireSection.objects.get(id=data["id"])
+    assert section.depends_on_option_id == yes_option.id
+
+
+def test_create_section_with_invalid_depends_on_option_id(
+    organization: Organization, organization_owner_client: Client
+) -> None:
+    """Test that creating section with option from another questionnaire fails."""
+    questionnaire = Questionnaire.objects.create(name="Test Questionnaire")
+    org_questionnaire = OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    # Create option in a different questionnaire
+    other_questionnaire = Questionnaire.objects.create(name="Other Questionnaire")
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=other_questionnaire, question="Other Question", order=1
+    )
+    other_option = MultipleChoiceOption.objects.create(
+        question=other_question, option="Other Option", is_correct=True, order=1
+    )
+
+    payload = SectionCreateSchema(
+        name="Conditional Section",
+        depends_on_option_id=other_option.id,
+    )
+
+    url = reverse("api:create_section", kwargs={"org_questionnaire_id": org_questionnaire.id})
+    response = organization_owner_client.post(url, data=payload.model_dump_json(), content_type="application/json")
+
+    # Should return 400 or 422 due to integrity error
+    assert response.status_code in (400, 422)

--- a/src/questionnaires/tests/test_service/test_build.py
+++ b/src/questionnaires/tests/test_service/test_build.py
@@ -82,10 +82,19 @@ def test_build_questionnaire_with_sorted_options(questionnaire: Questionnaire) -
 
 
 def test_get_questionnaire_schema(complex_questionnaire: Questionnaire) -> None:
-    """Test that the questionnaire schema can be retrieved."""
+    """Test that the questionnaire schema can be retrieved.
+
+    Top-level question arrays should only contain questions without a section.
+    Questions with a section should only appear in their section's arrays.
+    """
     complex_questionnaire.evaluation_mode = "manual"
+    complex_questionnaire.save(update_fields=["evaluation_mode"])
     schema = get_questionnaire_schema(complex_questionnaire)
     assert schema.name == complex_questionnaire.name
-    assert len(schema.multiplechoicequestion_questions) == 2
-    assert len(schema.freetextquestion_questions) == 2
+    # Only top-level questions (those without a section) should appear here
+    assert len(schema.multiplechoicequestion_questions) == 1
+    assert len(schema.freetextquestion_questions) == 1
+    # Sections should contain their own questions
     assert len(schema.sections) == 2
+    assert len(schema.sections[0].multiplechoicequestion_questions) == 1  # Section 1 has 1 MC question
+    assert len(schema.sections[1].freetextquestion_questions) == 1  # Section 2 has 1 FT question

--- a/src/questionnaires/tests/test_service/test_integrity.py
+++ b/src/questionnaires/tests/test_service/test_integrity.py
@@ -9,6 +9,7 @@ from questionnaires.exceptions import (
     SectionIntegrityError,
 )
 from questionnaires.models import (
+    MultipleChoiceOption,
     MultipleChoiceQuestion,
     Questionnaire,
     QuestionnaireSection,
@@ -18,6 +19,7 @@ from questionnaires.schema import (
     MultipleChoiceOptionCreateSchema,
     MultipleChoiceQuestionCreateSchema,
     MultipleChoiceQuestionUpdateSchema,
+    SectionCreateSchema,
 )
 from questionnaires.service import QuestionnaireService
 
@@ -86,7 +88,6 @@ def test_update_mc_question_with_nonexistent_section_raises_error(
     payload = MultipleChoiceQuestionUpdateSchema(
         question="What is your favorite color?",
         section_id=uuid.uuid4(),
-        options=[],
     )
     with pytest.raises(SectionIntegrityError):
         service.update_mc_question(single_answer_mc_question, payload)
@@ -103,3 +104,150 @@ def test_create_ft_question_with_mismatched_section_id_raises_error(
     )
     with pytest.raises(SectionIntegrityError):
         service.create_ft_question(payload, section=QuestionnaireSection())  # Pass a different section object
+
+
+# Tests for depends_on_option_id resolution
+
+
+def test_create_mc_question_with_depends_on_option_id(
+    questionnaire: Questionnaire, correct_option: MultipleChoiceOption
+) -> None:
+    """Test creating a conditional MC question using depends_on_option_id in payload."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = MultipleChoiceQuestionCreateSchema(
+        question="Follow-up question",
+        depends_on_option_id=correct_option.id,
+        options=[MultipleChoiceOptionCreateSchema(option="Yes", is_correct=True)],
+    )
+    question = service.create_mc_question(payload)
+    assert question.depends_on_option_id == correct_option.id
+    assert question.depends_on_option == correct_option
+
+
+def test_create_ft_question_with_depends_on_option_id(
+    questionnaire: Questionnaire, correct_option: MultipleChoiceOption
+) -> None:
+    """Test creating a conditional FT question using depends_on_option_id in payload."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = FreeTextQuestionCreateSchema(
+        question="Please explain",
+        depends_on_option_id=correct_option.id,
+    )
+    question = service.create_ft_question(payload)
+    assert question.depends_on_option_id == correct_option.id
+    assert question.depends_on_option == correct_option
+
+
+def test_create_mc_question_with_invalid_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire, another_questionnaire: Questionnaire
+) -> None:
+    """Test creating an MC question with depends_on_option_id from another questionnaire."""
+    # Create an option in another questionnaire
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=another_questionnaire, question="Other Question"
+    )
+    other_option = MultipleChoiceOption.objects.create(question=other_question, option="Other Option", is_correct=True)
+
+    service = QuestionnaireService(questionnaire.id)
+    payload = MultipleChoiceQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=other_option.id,
+        options=[MultipleChoiceOptionCreateSchema(option="Yes", is_correct=True)],
+    )
+    with pytest.raises(QuestionIntegrityError):
+        service.create_mc_question(payload)
+
+
+def test_create_ft_question_with_invalid_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire, another_questionnaire: Questionnaire
+) -> None:
+    """Test creating an FT question with depends_on_option_id from another questionnaire."""
+    # Create an option in another questionnaire
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=another_questionnaire, question="Other Question"
+    )
+    other_option = MultipleChoiceOption.objects.create(question=other_question, option="Other Option", is_correct=True)
+
+    service = QuestionnaireService(questionnaire.id)
+    payload = FreeTextQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=other_option.id,
+    )
+    with pytest.raises(QuestionIntegrityError):
+        service.create_ft_question(payload)
+
+
+def test_create_mc_question_with_nonexistent_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire,
+) -> None:
+    """Test creating an MC question with a nonexistent depends_on_option_id."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = MultipleChoiceQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=uuid.uuid4(),  # Non-existent UUID
+        options=[MultipleChoiceOptionCreateSchema(option="Yes", is_correct=True)],
+    )
+    with pytest.raises(QuestionIntegrityError):
+        service.create_mc_question(payload)
+
+
+def test_create_ft_question_with_nonexistent_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire,
+) -> None:
+    """Test creating an FT question with a nonexistent depends_on_option_id."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = FreeTextQuestionCreateSchema(
+        question="Conditional question",
+        depends_on_option_id=uuid.uuid4(),  # Non-existent UUID
+    )
+    with pytest.raises(QuestionIntegrityError):
+        service.create_ft_question(payload)
+
+
+# Tests for create_section depends_on_option_id resolution
+
+
+def test_create_section_with_depends_on_option_id(
+    questionnaire: Questionnaire, correct_option: MultipleChoiceOption
+) -> None:
+    """Test creating a conditional section using depends_on_option_id in payload."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = SectionCreateSchema(
+        name="Conditional Section",
+        depends_on_option_id=correct_option.id,
+    )
+    section = service.create_section(payload)
+    assert section.depends_on_option_id == correct_option.id
+    assert section.depends_on_option == correct_option
+
+
+def test_create_section_with_invalid_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire, another_questionnaire: Questionnaire
+) -> None:
+    """Test creating a section with depends_on_option_id from another questionnaire."""
+    # Create an option in another questionnaire
+    other_question = MultipleChoiceQuestion.objects.create(
+        questionnaire=another_questionnaire, question="Other Question"
+    )
+    other_option = MultipleChoiceOption.objects.create(question=other_question, option="Other Option", is_correct=True)
+
+    service = QuestionnaireService(questionnaire.id)
+    payload = SectionCreateSchema(
+        name="Conditional Section",
+        depends_on_option_id=other_option.id,
+    )
+    with pytest.raises(SectionIntegrityError):
+        service.create_section(payload)
+
+
+def test_create_section_with_nonexistent_depends_on_option_id_raises_error(
+    questionnaire: Questionnaire,
+) -> None:
+    """Test creating a section with a nonexistent depends_on_option_id."""
+    service = QuestionnaireService(questionnaire.id)
+    payload = SectionCreateSchema(
+        name="Conditional Section",
+        depends_on_option_id=uuid.uuid4(),  # Non-existent UUID
+    )
+    with pytest.raises(SectionIntegrityError):
+        service.create_section(payload)

--- a/uv.lock
+++ b/uv.lock
@@ -3274,7 +3274,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.21.2"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- Fix `create_mc_question`, `create_ft_question`, and `create_section` service methods to resolve `depends_on_option_id` from the payload when not passed as a parameter
- Update API response schemas to include `id` field for question and section endpoints
- Add comprehensive tests for depends_on_option_id validation and resolution

## Changes

### Service Layer (`src/questionnaires/service.py`)
- `create_mc_question`: Resolves `depends_on_option_id` from payload, validates option belongs to same questionnaire
- `create_ft_question`: Same fix applied
- `create_section`: Same fix applied

### Controller Response Schemas (`src/events/controllers/questionnaire.py`)
- `create_ft_question` / `update_ft_question`: Use `FreeTextQuestionResponseSchema` instead of `FreeTextQuestionUpdateSchema`
- `create_section` / `update_section`: Use `SectionResponseSchema` instead of `SectionUpdateSchema`

### Tests
- Added service tests in `test_integrity.py` for:
  - Happy path: creating conditional questions/sections with valid `depends_on_option_id`
  - Error case: option from another questionnaire raises integrity error
  - Error case: non-existent option raises integrity error
- Added controller tests for the API endpoints

## Test plan
- [x] All 200 questionnaire tests pass
- [x] mypy strict type checking passes
- [x] ruff linting passes

Closes #1 
Closes #175
Closes #176