### PR TITLE
feat(questionnaires): add video/webm to audio MIME types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.31.2"
+version = "1.31.3"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/questionnaires/schema.py
+++ b/src/questionnaires/schema.py
@@ -49,12 +49,15 @@ IMAGE_MIME_TYPES: frozenset[str] = frozenset(
 )
 
 # Common audio MIME types
+# Note: video/webm is included because browser MediaRecorder produces video/webm container
+# even for audio-only recordings (libmagic detects WebM container as video/webm)
 AUDIO_MIME_TYPES: frozenset[str] = frozenset(
     {
         "audio/mpeg",  # .mp3
         "audio/wav",
         "audio/ogg",
         "audio/webm",
+        "video/webm",  # WebM container for browser audio recordings
         "audio/aac",
         "audio/flac",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -3621,7 +3621,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.31.2"
+version = "1.31.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
Browser MediaRecorder produces video/webm container even for audio-only recordings. libmagic detects the WebM container as video/webm regardless of content. Add video/webm to AUDIO_MIME_TYPES to accept browser-recorded audio files.