### PR TITLE
fix(notifications): preserve pre-formatted datetime fields in template context

### DIFF
--- a/src/notifications/tests/test_notification_helpers.py
+++ b/src/notifications/tests/test_notification_helpers.py
@@ -200,8 +200,12 @@ class TestGetFormattedContextForTemplate:
         # Since no timezone info preserved, will show UTC
         assert "2026" in result["event_start_formatted"]
 
-    def test_adds_short_format_when_only_full_exists(self) -> None:
-        """Test that short format is added even if full format exists."""
+    def test_skips_formatting_when_only_full_exists(self) -> None:
+        """Test that short format is NOT added when full format exists.
+
+        This prevents timezone inconsistency: if full format uses event timezone (CET)
+        but short format is generated from UTC ISO string, they would show different times.
+        """
         from notifications.utils import get_formatted_context_for_template
 
         context = {
@@ -214,5 +218,5 @@ class TestGetFormattedContextForTemplate:
 
         # Full format preserved
         assert result["event_start_formatted"] == "Friday, February 6, 2026 at 6:00 PM CET"
-        # Short format should be added
-        assert "event_start_short" in result
+        # Short format should NOT be added (would have wrong timezone)
+        assert "event_start_short" not in result

--- a/src/notifications/utils.py
+++ b/src/notifications/utils.py
@@ -209,12 +209,15 @@ def get_formatted_context_for_template(
 
         for field in datetime_fields:
             if field in enriched and enriched[field]:
-                # Only add formatted versions if they don't already exist
-                # (pre-formatted values use event timezone; reformatting would lose that)
-                if f"{field}_formatted" not in enriched:
-                    enriched[f"{field}_formatted"] = format_datetime(enriched[field], format_type="full")
-                if f"{field}_short" not in enriched:
-                    enriched[f"{field}_short"] = format_datetime(enriched[field], format_type="short")
+                # Only add formatted versions if neither formatted nor short versions exist.
+                # Pre-formatted values use event timezone; reformatting from the raw ISO string
+                # (which may be in UTC) could lose the correct event timezone and lead to
+                # inconsistencies between *_formatted and *_short.
+                formatted_key = f"{field}_formatted"
+                short_key = f"{field}_short"
+                if formatted_key not in enriched and short_key not in enriched:
+                    enriched[formatted_key] = format_datetime(enriched[field], format_type="full")
+                    enriched[short_key] = format_datetime(enriched[field], format_type="short")
 
         # Add organization signature if org info is present
         if "organization_name" in enriched and "organization_slug" in enriched:


### PR DESCRIPTION
## Summary
- Fix timezone inconsistency in notification emails where start time showed "UTC" but end time showed "CET"
- `get_formatted_context_for_template()` was overwriting pre-formatted datetime fields by re-formatting from ISO strings (which lose timezone info)
- Now checks if `{field}_formatted` already exists before overwriting

## Root Cause
Signal handlers format dates using the event's city timezone (e.g., CET). The context stores both:
- `event_start`: ISO string in UTC (`2026-02-06T17:00:00+00:00`)
- `event_start_formatted`: Pre-formatted with event timezone ("Friday, February 6, 2026 at 6:00 PM CET")

The `get_formatted_context_for_template()` function found `event_start` and **overwrote** `event_start_formatted` by re-formatting the ISO string with strftime's `%Z`, which outputs "UTC".

The end time was preserved because only `event_end_formatted` was stored (not `event_end` as ISO), so it wasn't overwritten.

## Test plan
- [x] Added unit tests for `get_formatted_context_for_template` to verify pre-formatted fields are preserved
- [x] All existing notification tests pass
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)