### PR TITLE
fix: replace appleboy/scp-action with rsync for docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,11 @@
+# Build MkDocs documentation and deploy to the server via rsync.
+#
+# On pull requests: builds only (validation via --strict).
+# On push to main: builds and deploys to docs.letsrevel.io.
+#
+# Deployment uses plain rsync over SSH instead of appleboy/scp-action,
+# which caused persistent timeouts due to UFW rate-limiting on port 22
+# (the action opens multiple parallel SSH connections that trip LIMIT rules).
 name: Docs
 
 on:
@@ -28,15 +36,19 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - name: Deploy via SCP
+      # Deploy steps only run on push to main (not on PRs)
+      - name: Setup SSH key
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.SERVER_PORT }}
-          timeout: 60s
-          command_timeout: 10m
-          source: site/*
-          target: /home/${{ secrets.SERVER_USER }}/infra/docs/
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p ${{ secrets.SERVER_PORT }} ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy via rsync
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SERVER_PORT }}" \
+            site/ \
+            ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/${{ secrets.SERVER_USER }}/infra/docs/site/


### PR DESCRIPTION
## Summary

- Replaced `appleboy/scp-action` with plain `rsync` over SSH for docs deployment
- The action caused persistent `dial tcp: i/o timeout` errors because it opens multiple parallel SSH connections, which triggers UFW's `LIMIT` rule on port 22
- `rsync` uses a single SSH connection, is pre-installed on `ubuntu-latest`, and has the added benefit of `--delete` to remove stale files

## Test plan

- [ ] Merge and verify the docs workflow deploys successfully on push to main
- [ ] Confirm docs.letsrevel.io serves the updated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)