### PR TITLE
Make ticket_tier_id optional for event tokens on ticketed events

### DIFF
--- a/src/events/controllers/event_admin/tokens.py
+++ b/src/events/controllers/event_admin/tokens.py
@@ -2,9 +2,7 @@ from uuid import UUID
 
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
-from django.utils.translation import gettext_lazy as _
 from ninja import Query
-from ninja.errors import HttpError
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 from ninja_extra.searching import Searching, searching
@@ -52,7 +50,7 @@ class EventAdminTokensController(EventAdminBaseController):
         - `name`: Optional display name to help you identify this token (e.g., "Alumni Link", "Early Bird")
         - `max_uses`: Maximum number of times this token can be claimed (0 = unlimited)
         - `expires_at`: When the token becomes invalid (users can't claim after this time)
-        - `ticket_tier_id`: Which ticket tier to assign when users claim (required for ticketed events)
+        - `ticket_tier_id`: Optional ticket tier to assign when users claim
         - `invitation`: Custom invitation metadata like welcome messages, special flags, etc.
 
         **Business Logic:**
@@ -210,7 +208,7 @@ class EventAdminTokensController(EventAdminBaseController):
         - `name`: Display name for organization (e.g., "Instagram Followers", "Alumni Network")
         - `duration`: Minutes until expiration (default: 24*60 = 1 day)
         - `max_uses`: Maximum claims allowed (default: 1, use 0 for unlimited)
-        - `ticket_tier_id`: Ticket tier to auto-assign (required for ticketed events, optional otherwise)
+        - `ticket_tier_id`: Optional ticket tier to auto-assign when users claim this token
         - `invitation`: Optional custom metadata:
           - `custom_message`: Personalized welcome text
           - Additional fields that your EventInvitation model supports
@@ -222,7 +220,6 @@ class EventAdminTokensController(EventAdminBaseController):
         - Token issuer is automatically set to the current authenticated user
         - Expiration is calculated from current time + duration
         - If ticket_tier_id provided, validates it belongs to this event
-        - For ticketed events, ticket_tier_id is REQUIRED
         - Token ID is a secure random 8-character alphanumeric code
         - Created tokens start with 0 uses
 
@@ -249,14 +246,10 @@ class EventAdminTokensController(EventAdminBaseController):
         5. After 100 claims or 7 days, token becomes inactive
 
         **Error Cases:**
-        - 400: ticket_tier_id missing for ticketed event, or tier doesn't belong to this event
+        - 404: event_id not found, user lacks access, or tier doesn't belong to this event
         - 403: User lacks "invite_to_event" permission
-        - 404: event_id not found or user lacks access
         """
         event = self.get_one(event_id)
-        # Validate ticket_tier_id is required for ticketed events
-        if event.requires_ticket and not payload.ticket_tier_id:
-            raise HttpError(400, str(_("ticket_tier_id is required for events that require tickets.")))
         if payload.ticket_tier_id:
             get_object_or_404(models.TicketTier, pk=payload.ticket_tier_id, event=event)
         return event_service.create_event_token(event=event, issuer=self.user(), **payload.model_dump())

--- a/src/events/tests/test_controllers/test_token_endpoints.py
+++ b/src/events/tests/test_controllers/test_token_endpoints.py
@@ -153,10 +153,10 @@ def test_get_organization_token_returns_404_for_invalid_token(client: Client) ->
 # --- Tests for ticket_tier_id validation ---
 
 
-def test_create_event_token_requires_ticket_tier_for_ticketed_events(
+def test_create_event_token_succeeds_without_ticket_tier_for_ticketed_events(
     organization_owner_client: Client, event: Event, vip_tier: TicketTier
 ) -> None:
-    """Test that ticket_tier_id is required when event.requires_ticket is True."""
+    """Test that ticket_tier_id is optional even when event.requires_ticket is True."""
     # Arrange - event fixture has requires_ticket=True by default
     url = reverse("api:create_event_token", kwargs={"event_id": event.pk})
     payload = {"name": "Test Token", "max_uses": 10, "duration": 60}
@@ -165,8 +165,10 @@ def test_create_event_token_requires_ticket_tier_for_ticketed_events(
     response = organization_owner_client.post(url, data=orjson.dumps(payload), content_type="application/json")
 
     # Assert
-    assert response.status_code == 400
-    assert b"ticket_tier_id is required" in response.content
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Test Token"
+    assert data["ticket_tier"] is None
 
 
 def test_create_event_token_succeeds_with_ticket_tier_for_ticketed_events(


### PR DESCRIPTION
## Summary
- Remove backend validation that required `ticket_tier_id` when creating event tokens for ticketed events
- The tier on invitations is not enforced downstream (purchasing gate checks for *any* invitation, not a specific tier), so requiring it was unnecessary friction
- Aligns event token behavior with direct invitations, which already treat `tier_id` as fully optional

Closes #306

## Test plan
- [x] Updated test to verify token creation succeeds without tier for ticketed events
- [ ] Existing test still passes: token creation with tier works as before
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)