### PR TITLE
fix(events): add check_in_starts_at/ends_at to EventDetailSchema

### DIFF
--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -109,6 +109,8 @@ class EventDetailSchema(EventBaseSchema):
     address: str | None = None
     location_maps_url: str | None = None
     location_maps_embed: str | None = None
+    check_in_starts_at: AwareDatetime | None = None
+    check_in_ends_at: AwareDatetime | None = None
 
     @staticmethod
     def resolve_address(obj: Event, context: t.Any) -> str | None:


### PR DESCRIPTION
## Summary

- `check_in_starts_at` and `check_in_ends_at` were present on the `Event` model and in `EventEditSchema` but missing from `EventDetailSchema`
- The public `GET /api/events/{event_id}` endpoint uses `EventDetailSchema`, so these fields were never returned
- Frontend form always initialized check-in times as `null` on page load, losing any previously saved values

## Test plan

- [x] Create an event with check-in start/end times set
- [x] Reload the event detail/edit page and verify the check-in fields are pre-populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events now support check-in window timing, allowing specification of when check-in opens and closes for better event planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->