### PR TITLE
fix(notifications): skip follower notifications for non-public events

### DIFF
--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -319,10 +319,14 @@ def capture_event_old_status(sender: type[Event], instance: Event, **kwargs: t.A
 def _should_notify_followers_for_event(event: Event, created: bool) -> bool:
     """Check if followers should be notified for this event status change.
 
-    Returns True only when an event transitions to OPEN status (either on creation
-    or via update). Prevents duplicate notifications.
+    Returns True only when a PUBLIC event transitions to OPEN status (either on
+    creation or via update). Non-public events are only visible to members, staff,
+    or explicitly invited users — not general followers.
     """
     if event.status != Event.EventStatus.OPEN:
+        return False
+
+    if event.visibility != Event.Visibility.PUBLIC:
         return False
 
     if created:

--- a/src/events/tests/test_signals_follow_visibility.py
+++ b/src/events/tests/test_signals_follow_visibility.py
@@ -1,0 +1,203 @@
+"""Tests for follower notification visibility filtering.
+
+Verifies that non-public events (private, members-only, staff-only) do NOT
+trigger follower notifications, since followers lack access to those events.
+"""
+
+import typing as t
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events.models import Event, EventSeries, Organization
+from events.models.follow import EventSeriesFollow, OrganizationFollow
+from notifications.enums import NotificationType
+
+pytestmark = pytest.mark.django_db
+
+FOLLOWER_NOTIFICATION_TYPES = [
+    NotificationType.NEW_EVENT_FROM_FOLLOWED_ORG,
+    NotificationType.NEW_EVENT_FROM_FOLLOWED_SERIES,
+]
+
+
+class TestFollowerNotificationVisibility:
+    """Tests that follower notifications respect event visibility."""
+
+    @pytest.mark.parametrize(
+        "visibility",
+        [
+            Event.Visibility.PRIVATE,
+            Event.Visibility.MEMBERS_ONLY,
+            Event.Visibility.STAFF_ONLY,
+        ],
+    )
+    def test_no_follower_notification_for_non_public_event(
+        self,
+        organization: Organization,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+        visibility: str,
+    ) -> None:
+        """Test that followers are NOT notified when a non-public event opens.
+
+        Non-public events (private, members-only, staff-only) are only visible to
+        specific users. Followers without explicit access should not receive
+        notifications they cannot act on.
+        """
+        # Arrange
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        OrganizationFollow.objects.create(
+            user=nonmember_user,
+            organization=organization,
+            is_archived=False,
+            notify_new_events=True,
+        )
+
+        event = Event.objects.create(
+            organization=organization,
+            name="Non-Public Event",
+            slug=f"non-public-event-{visibility}",
+            event_type=Event.EventType.PRIVATE,
+            visibility=visibility,
+            max_attendees=100,
+            start=timezone.now(),
+            status=Event.EventStatus.DRAFT,
+        )
+
+        # Act
+        with patch("events.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.status = Event.EventStatus.OPEN
+                event.save(update_fields=["status"])
+
+        # Assert
+        follower_calls = [
+            c for c in mock_send.call_args_list if c.kwargs.get("notification_type") in FOLLOWER_NOTIFICATION_TYPES
+        ]
+        assert len(follower_calls) == 0
+
+    def test_no_follower_notification_for_private_event_created_as_open(
+        self,
+        organization: Organization,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Test that creating a private event directly as OPEN doesn't notify followers."""
+        # Arrange
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        OrganizationFollow.objects.create(
+            user=nonmember_user,
+            organization=organization,
+            is_archived=False,
+            notify_new_events=True,
+        )
+
+        # Act
+        with patch("events.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                Event.objects.create(
+                    organization=organization,
+                    name="Private Open Event",
+                    slug="private-open-event",
+                    event_type=Event.EventType.PRIVATE,
+                    visibility=Event.Visibility.PRIVATE,
+                    max_attendees=100,
+                    start=timezone.now(),
+                    status=Event.EventStatus.OPEN,
+                )
+
+        # Assert
+        follower_calls = [
+            c for c in mock_send.call_args_list if c.kwargs.get("notification_type") in FOLLOWER_NOTIFICATION_TYPES
+        ]
+        assert len(follower_calls) == 0
+
+    def test_no_series_follower_notification_for_private_event(
+        self,
+        organization: Organization,
+        event_series: EventSeries,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Test that series followers are also excluded for non-public events."""
+        # Arrange
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        EventSeriesFollow.objects.create(
+            user=nonmember_user,
+            event_series=event_series,
+            is_archived=False,
+            notify_new_events=True,
+        )
+
+        event = Event.objects.create(
+            organization=organization,
+            event_series=event_series,
+            name="Private Series Event",
+            slug="private-series-event",
+            event_type=Event.EventType.PRIVATE,
+            visibility=Event.Visibility.PRIVATE,
+            max_attendees=100,
+            start=timezone.now(),
+            status=Event.EventStatus.DRAFT,
+        )
+
+        # Act
+        with patch("events.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.status = Event.EventStatus.OPEN
+                event.save(update_fields=["status"])
+
+        # Assert
+        follower_calls = [
+            c for c in mock_send.call_args_list if c.kwargs.get("notification_type") in FOLLOWER_NOTIFICATION_TYPES
+        ]
+        assert len(follower_calls) == 0
+
+    def test_public_event_still_notifies_followers(
+        self,
+        organization: Organization,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Regression guard: public events must still notify followers."""
+        # Arrange
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        OrganizationFollow.objects.create(
+            user=nonmember_user,
+            organization=organization,
+            is_archived=False,
+            notify_new_events=True,
+        )
+
+        event = Event.objects.create(
+            organization=organization,
+            name="Public Event",
+            slug="public-event-visibility-test",
+            event_type=Event.EventType.PUBLIC,
+            visibility=Event.Visibility.PUBLIC,
+            max_attendees=100,
+            start=timezone.now(),
+            status=Event.EventStatus.DRAFT,
+        )
+
+        # Act
+        with patch("events.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.status = Event.EventStatus.OPEN
+                event.save(update_fields=["status"])
+
+        # Assert
+        follower_calls = [
+            c
+            for c in mock_send.call_args_list
+            if c.kwargs.get("notification_type") == NotificationType.NEW_EVENT_FROM_FOLLOWED_ORG
+        ]
+        assert len(follower_calls) == 1
+        assert follower_calls[0].kwargs["user"] == nonmember_user


### PR DESCRIPTION
## Summary
- Followers of an org/series were receiving new-event notifications for private, members-only, and staff-only events, leading to 404s when they clicked the link
- The eligibility service (`get_eligible_users_for_event_notification`) already gates member/participant notifications by visibility, but the follower notification path in `handle_event_opened_notify_followers` bypassed it entirely
- Added a `event.visibility != PUBLIC` early-return in `_should_notify_followers_for_event()` to skip follower notifications for non-public events

## Test plan
- [x] Parametrized test: private, members-only, and staff-only events do NOT trigger follower notifications on DRAFT→OPEN transition
- [x] Private event created directly as OPEN does NOT notify followers
- [x] Series followers also excluded for non-public events
- [x] Regression guard: public events still notify followers as before
- [x] All 18 existing follower signal tests still pass
- [x] `make check` passes (format, lint, mypy, migrations, i18n, file-length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Follower notifications now respect event visibility settings. Only public events will notify followers; private and member-only events no longer trigger notifications.

* **Tests**
  * Added comprehensive test coverage for event visibility filtering in follower notifications, including edge cases and regression tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->