### PR TITLE
refactor: thread-safe signal suppression via ContextVar

### DIFF
--- a/src/events/service/duplication.py
+++ b/src/events/service/duplication.py
@@ -1,29 +1,12 @@
 """Event duplication service."""
 
 import typing as t
-from contextlib import contextmanager
 from datetime import datetime
 
 from django.db import transaction
-from django.db.models.signals import post_save
 
 from events.models import Event, PotluckItem, TicketTier
-
-
-@contextmanager
-def _disconnected_event_signal() -> t.Iterator[None]:
-    """Context manager to temporarily disconnect the handle_event_save signal.
-
-    This prevents auto-creation of default ticket tiers during event duplication,
-    where we want to copy the template's tiers explicitly.
-    """
-    from events.signals import handle_event_save
-
-    post_save.disconnect(handle_event_save, sender=Event)
-    try:
-        yield
-    finally:
-        post_save.connect(handle_event_save, sender=Event)
+from events.suppression import suppress_default_tier_creation
 
 
 @transaction.atomic
@@ -67,8 +50,8 @@ def duplicate_event(
     # Calculate new end time (end is required, so template_event.end is always set)
     new_end = template_event.end + delta
 
-    # Disconnect the signal to prevent auto-creation of default ticket tier
-    with _disconnected_event_signal():
+    # Suppress auto-creation of default ticket tier (we copy tiers from template)
+    with suppress_default_tier_creation():
         new_event = Event.objects.create(
             # FK references (keep same)
             organization=template_event.organization,

--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -41,6 +41,11 @@ logger = structlog.get_logger(__name__)
 @receiver(post_save, sender=Event)
 def handle_event_save(sender: type[Event], instance: Event, created: bool, **kwargs: t.Any) -> None:
     """Handle event creation and updates."""
+    from events.suppression import _suppress_default_tier_creation
+
+    if _suppress_default_tier_creation.get():
+        return
+
     # Create default ticket tier if needed
     if instance.requires_ticket and not TicketTier.objects.filter(event=instance).exists():
         TicketTier.objects.create(event=instance, name=DEFAULT_TICKET_TIER_NAME)
@@ -309,6 +314,11 @@ def capture_event_old_status(sender: type[Event], instance: Event, **kwargs: t.A
     This allows us to reliably detect when an event's status changes to OPEN,
     regardless of whether save() is called with or without update_fields.
     """
+    from events.suppression import _suppress_event_notifications
+
+    if _suppress_event_notifications.get():
+        return
+
     if instance.pk:
         try:
             old_instance = Event.objects.only("status").get(pk=instance.pk)
@@ -361,6 +371,11 @@ def handle_event_opened_notify_followers(sender: type[Event], instance: Event, c
     Series followers are prioritized - if a user follows both the org and series,
     they receive the series notification only.
     """
+    from events.suppression import _suppress_event_notifications
+
+    if _suppress_event_notifications.get():
+        return
+
     if not _should_notify_followers_for_event(instance, created):
         return
 

--- a/src/events/suppression.py
+++ b/src/events/suppression.py
@@ -1,0 +1,43 @@
+"""Thread-safe signal suppression for event-related side effects.
+
+Uses `contextvars.ContextVar` instead of `post_save.disconnect()` to ensure
+suppression is scoped to the current execution context (thread/coroutine),
+not applied globally.
+"""
+
+import typing as t
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+__all__ = ["suppress_default_tier_creation", "suppress_event_notifications"]
+
+_suppress_default_tier_creation: ContextVar[bool] = ContextVar("_suppress_default_tier_creation", default=False)
+
+_suppress_event_notifications: ContextVar[bool] = ContextVar("_suppress_event_notifications", default=False)
+
+
+@contextmanager
+def suppress_default_tier_creation() -> t.Iterator[None]:
+    """Suppress auto-creation of default ticket tier for events saved in this context.
+
+    Used by `duplicate_event()` which copies tiers explicitly from the template.
+    """
+    token = _suppress_default_tier_creation.set(True)
+    try:
+        yield
+    finally:
+        _suppress_default_tier_creation.reset(token)
+
+
+@contextmanager
+def suppress_event_notifications() -> t.Iterator[None]:
+    """Suppress EVENT_OPEN and follower notifications for events saved in this context.
+
+    Used during batch materialization of recurring events to avoid notification spam.
+    A single digest notification should be sent after the batch completes.
+    """
+    token = _suppress_event_notifications.set(True)
+    try:
+        yield
+    finally:
+        _suppress_event_notifications.reset(token)

--- a/src/notifications/signals/event.py
+++ b/src/notifications/signals/event.py
@@ -205,6 +205,11 @@ def _detect_field_changes(
 @receiver(pre_save, sender=Event)
 def capture_event_state(sender: type[Event], instance: Event, **kwargs: t.Any) -> None:
     """Capture event state before save to detect changes."""
+    from events.suppression import _suppress_event_notifications
+
+    if _suppress_event_notifications.get():
+        return
+
     if instance.pk:
         try:
             old_instance = Event.objects.get(pk=instance.pk)
@@ -229,6 +234,11 @@ def handle_event_notification(sender: type[Event], instance: Event, created: boo
     - EVENT_CANCELLED: When event status changes to DELETED
     - EVENT_UPDATED: When important fields change
     """
+    from events.suppression import _suppress_event_notifications
+
+    if _suppress_event_notifications.get():
+        return
+
     # Get previous state
     previous_state = _event_previous_state.pop(instance.pk, None) if instance.pk else None
 


### PR DESCRIPTION
## Summary

- Replace thread-unsafe `post_save.disconnect()`/`connect()` in `duplicate_event()` with `ContextVar`-based suppression scoped to the current execution context
- Add `suppress_event_notifications` ContextVar (with guards on both pre_save and post_save handlers) for upcoming recurring event materialization (#118)

## Changes

- **`events/suppression.py`** (new): Two `ContextVar[bool]` instances with context managers — `suppress_default_tier_creation()` and `suppress_event_notifications()`
- **`events/service/duplication.py`**: Removed `_disconnected_event_signal()` (global signal disconnect), replaced with `suppress_default_tier_creation()`
- **`events/signals.py`**: Added ContextVar guards to `handle_event_save`, `capture_event_old_status`, `handle_event_opened_notify_followers`
- **`notifications/signals/event.py`**: Added ContextVar guards to `capture_event_state`, `handle_event_notification`

## Why

The old pattern mutated global signal dispatcher state — any concurrent request that triggered `Event.save()` while signals were disconnected would silently lose its side effects (e.g., default ticket tier creation). `ContextVar` scopes suppression to the calling thread/coroutine.

The `suppress_event_notifications` path is not yet exercised but is wired into signal handlers now so the recurring events PR (#118) only needs to wrap its materialization loop — no cross-cutting signal changes.

## Test plan

- [x] `make check` passes (ruff format, ruff lint, mypy strict, migration check, i18n check)
- [x] `make test` passes (4062 passed, 0 failures, 95% coverage)
- [x] Existing `duplicate_event` tests validate that suppression preserves behavior (duplicated events get template tiers, not default tiers)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Event duplication now properly prevents automatic tier creation and unintended follower notifications during the duplication process.

* **Refactor**
  * Enhanced internal event handling to provide better control over automatic side effects, improving reliability during bulk operations and special workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->