### PR TITLE
fix: event duplication fields, frankfurter URL, name whitespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.47.0"
+version = "1.48.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -111,6 +111,10 @@ class RevelUser(ExifStripMixin, StripeConnectMixin, AbstractUser):
         """Override save method to call clean()."""
         if self.phone_number:
             self.phone_number = normalize_phone_number(self.phone_number)
+        for field in ("first_name", "last_name", "preferred_name"):
+            value = getattr(self, field, None)
+            if isinstance(value, str):
+                setattr(self, field, value.strip())
         super().save(*args, **kwargs)
 
     def delete(self, *args: t.Any, **kwargs: t.Any) -> tuple[int, dict[str, int]]:

--- a/src/accounts/schema.py
+++ b/src/accounts/schema.py
@@ -236,10 +236,10 @@ SupportedLanguage = t.Literal["en", "de", "it"]
 class ProfileUpdateSchema(Schema):
     """Schema for updating user profile information."""
 
-    preferred_name: str = Field(..., max_length=255, description="User's preferred name")
-    pronouns: str = Field(..., max_length=100, description="User's pronouns")
-    first_name: str = Field(..., max_length=30, description="User's first name")
-    last_name: str = Field(..., max_length=150, description="User's last name")
+    preferred_name: StrippedString = Field(..., max_length=255, description="User's preferred name")
+    pronouns: StrippedString = Field(..., max_length=100, description="User's pronouns")
+    first_name: StrippedString = Field(..., max_length=30, description="User's first name")
+    last_name: StrippedString = Field(..., max_length=150, description="User's last name")
     language: SupportedLanguage = Field("en", max_length=7, description="User's preferred language (en, de, it)")
     bio: str = Field("", max_length=500, description="User's bio (publicly visible)")
 

--- a/src/accounts/tests/test_models.py
+++ b/src/accounts/tests/test_models.py
@@ -62,3 +62,17 @@ def test_reveluser_get_display_name_no_names() -> None:
     """Test that get_display_name() returns username when no other names are available."""
     user = RevelUser.objects.create_user(username="test_user", password="password")
     assert user.get_display_name() == "test_user"
+
+
+def test_reveluser_save_strips_name_whitespace() -> None:
+    """Test that RevelUser.save() strips whitespace from name fields."""
+    user = RevelUser.objects.create_user(
+        username="test_user",
+        first_name="  John  ",
+        last_name="\tDoe\n",
+        preferred_name=" Johnny  ",
+        password="password",
+    )
+    assert user.first_name == "John"
+    assert user.last_name == "Doe"
+    assert user.preferred_name == "Johnny"

--- a/src/common/service/exchange_rate_service.py
+++ b/src/common/service/exchange_rate_service.py
@@ -1,4 +1,4 @@
-"""Exchange rate service using frankfurter.app (ECB data).
+"""Exchange rate service using frankfurter.dev (ECB data).
 
 Provides daily exchange rates with automatic fetching and DB caching.
 Rates are fetched by a daily Celery task and stored in the ExchangeRate model.
@@ -15,7 +15,7 @@ from common.models import ExchangeRate
 
 logger = structlog.get_logger(__name__)
 
-FRANKFURTER_BASE_URL = "https://api.frankfurter.app"
+FRANKFURTER_BASE_URL = "https://api.frankfurter.dev/v1"
 
 
 def fetch_and_store_rates(base: str | None = None, date: datetime.date | None = None) -> ExchangeRate:

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -429,7 +429,7 @@ def cleanup_expired_file_exports() -> dict[str, int]:
     max_retries=5,
 )
 def fetch_exchange_rates() -> dict[str, t.Any]:
-    """Fetch daily exchange rates from frankfurter.app and store them.
+    """Fetch daily exchange rates from frankfurter.dev and store them.
 
     Runs daily at 04:00 UTC via Celery beat. Rates are used for platform fee
     currency conversion and referral payout calculations.

--- a/src/common/tests/test_exchange_rate_service.py
+++ b/src/common/tests/test_exchange_rate_service.py
@@ -113,7 +113,7 @@ def test_convert_from_non_base(exchange_rate: ExchangeRate) -> None:
 
 @patch("common.service.exchange_rate_service.httpx.get")
 def test_fetch_and_store_rates(mock_get: MagicMock) -> None:
-    """Test fetching rates from frankfurter.app and storing them."""
+    """Test fetching rates from frankfurter.dev and storing them."""
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "amount": 1.0,

--- a/src/events/schema/ticket.py
+++ b/src/events/schema/ticket.py
@@ -17,7 +17,7 @@ from .event import MinimalEventSchema
 from .organization import MembershipTierSchema, MinimalOrganizationMemberSchema
 from .venue import MinimalSeatSchema, VenueSchema, VenueSectorSchema
 
-# Supported currencies — must match frankfurter.app for exchange rate availability
+# Supported currencies — must match frankfurter.dev for exchange rate availability
 Currencies = t.Literal[
     "EUR",  # Euro
     "USD",  # US Dollar

--- a/src/events/service/duplication.py
+++ b/src/events/service/duplication.py
@@ -23,7 +23,7 @@ def duplicate_event(
     Copies:
     - All event fields (with date shifts)
     - Ticket tiers (with date shifts, reset quantity_sold)
-    - Suggested potluck items (is_suggested=True)
+    - Potluck items (without assignments; all become host suggestions)
     - Tags
 
     Links to same:
@@ -32,7 +32,7 @@ def duplicate_event(
 
     Does NOT copy:
     - Tickets, RSVPs, invitations, tokens, waitlist
-    - User-contributed potluck items
+    - Potluck item assignees/creators
 
     Args:
         template_event: Event to copy from
@@ -57,6 +57,7 @@ def duplicate_event(
             organization=template_event.organization,
             event_series=template_event.event_series,
             city=template_event.city,
+            venue=template_event.venue,
             # Overrides
             name=new_name,
             status=Event.EventStatus.DRAFT,
@@ -72,14 +73,20 @@ def duplicate_event(
             invitation_message=template_event.invitation_message,
             event_type=template_event.event_type,
             visibility=template_event.visibility,
+            address_visibility=template_event.address_visibility,
             max_attendees=template_event.max_attendees,
+            max_tickets_per_user=template_event.max_tickets_per_user,
             waitlist_open=template_event.waitlist_open,
             requires_ticket=template_event.requires_ticket,
+            requires_full_profile=template_event.requires_full_profile,
             potluck_open=template_event.potluck_open,
             accept_invitation_requests=template_event.accept_invitation_requests,
+            public_pronoun_distribution=template_event.public_pronoun_distribution,
             can_attend_without_login=template_event.can_attend_without_login,
             address=template_event.address,
             location=template_event.location,
+            location_maps_url=template_event.location_maps_url,
+            location_maps_embed=template_event.location_maps_embed,
             logo=template_event.logo,
             cover_art=template_event.cover_art,
         )
@@ -120,8 +127,8 @@ def _duplicate_ticket_tiers(
 
 
 def _duplicate_potluck_items(template_event: Event, new_event: Event) -> None:
-    """Duplicate suggested potluck items only."""
-    suggested_items = [
+    """Duplicate all potluck items as host suggestions, without assignments."""
+    items = [
         PotluckItem(
             event=new_event,
             name=item.name,
@@ -132,10 +139,10 @@ def _duplicate_potluck_items(template_event: Event, new_event: Event) -> None:
             created_by=None,
             assignee=None,
         )
-        for item in template_event.potluck_items.filter(is_suggested=True)
+        for item in template_event.potluck_items.all()
     ]
-    if suggested_items:
-        PotluckItem.objects.bulk_create(suggested_items)
+    if items:
+        PotluckItem.objects.bulk_create(items)
 
 
 def _link_m2m_relations(template_event: Event, new_event: Event) -> None:

--- a/src/events/tests/test_service/test_event_service.py
+++ b/src/events/tests/test_service/test_event_service.py
@@ -403,8 +403,10 @@ class TestDuplicateEvent:
         assert early_bird_tier.sales_start_at == original_tier.sales_start_at + timedelta(days=30)  # type: ignore[operator]
         assert early_bird_tier.sales_end_at == original_tier.sales_end_at + timedelta(days=30)  # type: ignore[operator]
 
-    def test_duplicate_event_copies_suggested_potluck_items(self, organization: Organization) -> None:
-        """Test that suggested potluck items are copied but user items are not."""
+    def test_duplicate_event_copies_all_potluck_items_without_assignments(
+        self, organization: Organization, public_user: RevelUser
+    ) -> None:
+        """Test that all potluck items are copied as host suggestions without assignments."""
         template = Event.objects.create(
             organization=organization,
             name="Potluck Event",
@@ -413,7 +415,7 @@ class TestDuplicateEvent:
             requires_ticket=False,
         )
 
-        # Create a suggested item (host-created)
+        # Host-created suggested item
         PotluckItem.objects.create(
             event=template,
             name="Chips",
@@ -421,12 +423,14 @@ class TestDuplicateEvent:
             is_suggested=True,
         )
 
-        # Create a user-contributed item
+        # User-contributed item with assignment
         PotluckItem.objects.create(
             event=template,
             name="Homemade Cookies",
             item_type=PotluckItem.ItemTypes.DESSERT,
             is_suggested=False,
+            created_by=public_user,
+            assignee=public_user,
         )
 
         new_event = event_service.duplicate_event(
@@ -435,10 +439,12 @@ class TestDuplicateEvent:
             new_start=template.start + timedelta(days=7),
         )
 
-        new_items = list(new_event.potluck_items.all())
-        assert len(new_items) == 1
-        assert new_items[0].name == "Chips"
-        assert new_items[0].is_suggested is True
+        new_items = list(new_event.potluck_items.order_by("name"))
+        assert [i.name for i in new_items] == ["Chips", "Homemade Cookies"]
+        for item in new_items:
+            assert item.is_suggested is True
+            assert item.created_by is None
+            assert item.assignee is None
 
     def test_duplicate_event_copies_tags(self, public_event: Event) -> None:
         """Test that tags are copied to the new event."""
@@ -599,6 +605,35 @@ class TestDuplicateEvent:
         )
 
         assert new_event.apply_before is None
+
+    def test_duplicate_event_copies_extended_fields(self, organization: Organization) -> None:
+        """Test that address_visibility, requires_full_profile, and other extended fields are copied."""
+        from events.models.mixins import ResourceVisibility
+
+        template = Event.objects.create(
+            organization=organization,
+            name="Extended Event",
+            start=timezone.now(),
+            address_visibility=ResourceVisibility.ATTENDEES_ONLY,
+            requires_full_profile=True,
+            public_pronoun_distribution=True,
+            max_tickets_per_user=5,
+            location_maps_url="https://maps.example.com/place",
+            location_maps_embed="https://www.google.com/maps/embed?pb=example",
+        )
+
+        new_event = event_service.duplicate_event(
+            template_event=template,
+            new_name="Copy",
+            new_start=template.start + timedelta(days=1),
+        )
+
+        assert new_event.address_visibility == ResourceVisibility.ATTENDEES_ONLY
+        assert new_event.requires_full_profile is True
+        assert new_event.public_pronoun_distribution is True
+        assert new_event.max_tickets_per_user == 5
+        assert new_event.location_maps_url == "https://maps.example.com/place"
+        assert new_event.location_maps_embed == "https://www.google.com/maps/embed?pb=example"
 
 
 class TestCreateInvitationRequest:

--- a/uv.lock
+++ b/uv.lock
@@ -3639,7 +3639,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.47.0"
+version = "1.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- Event duplication now copies `address_visibility`, `requires_full_profile`, `public_pronoun_distribution`, `max_tickets_per_user`, `venue`, `location_maps_url`, `location_maps_embed`. All potluck items are duplicated as host suggestions (no assignee/created_by).
- Exchange rate fetcher: update base URL to `https://api.frankfurter.dev/v1` — fixes 301 redirect that was crashing the daily Celery task.
- Strip whitespace from `first_name`, `last_name`, `preferred_name` at model `save()` + use `StrippedString` in `ProfileUpdateSchema`.
- Version bumped 1.47.0 → 1.48.0.

## Test plan
- [x] `make check`
- [ ] `make test`
- [ ] Duplicate an event with a custom `address_visibility`, `requires_full_profile=True`, a venue, and both suggested and user-contributed potluck items; verify all fields and items are on the new draft without assignments.
- [ ] Trigger `fetch_exchange_rates` Celery task; confirm it succeeds against `api.frankfurter.dev/v1`.
- [ ] Update a profile with leading/trailing whitespace in name fields; verify stored values are stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)