### PR TITLE
fix(blacklist): reset stale BANNED membership on unban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decomposed long functions into focused helpers for readability
 - Extracted `is_owner_or_staff` and `has_org_permission` permission helpers
 
+## [1.48.1] - 2026-04-17
+
 ### Fixed
 - Unbanning a user now clears the stale `BANNED` `OrganizationMember` row that the ban created. The membership transitions to `CANCELLED` (not `ACTIVE`, to avoid implicitly re-granting prior membership privileges), so the org and its events become visible again. If another blacklist entry still covers the user in the org, the `BANNED` status is preserved.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decomposed long functions into focused helpers for readability
 - Extracted `is_owner_or_staff` and `has_org_permission` permission helpers
 
+### Fixed
+- Unbanning a user now clears the stale `BANNED` `OrganizationMember` row that the ban created. The membership transitions to `CANCELLED` (not `ACTIVE`, to avoid implicitly re-granting prior membership privileges), so the org and its events become visible again. If another blacklist entry still covers the user in the org, the `BANNED` status is preserved.
+
 ## [1.47.0] - 2026-03-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.48.0"
+version = "1.48.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/service/blacklist_service.py
+++ b/src/events/service/blacklist_service.py
@@ -258,13 +258,35 @@ def add_user_to_blacklist(
     )
 
 
+@transaction.atomic
 def remove_from_blacklist(entry: Blacklist) -> None:
     """Remove an entry from the blacklist.
+
+    If the entry was linked to a user and no other blacklist entries cover
+    that user in the organization, any stale ``BANNED`` membership left over
+    from :func:`apply_blacklist_consequences` is transitioned to ``CANCELLED``
+    so the user regains visibility of the organization. ``CANCELLED`` is used
+    instead of restoring ``ACTIVE`` to avoid implicitly re-granting membership
+    privileges that may have pre-existed the ban.
 
     Args:
         entry: The Blacklist entry to remove
     """
+    user = entry.user
+    organization = entry.organization
     entry.delete()
+
+    if user is None:
+        return
+
+    if check_user_hard_blacklisted(user, organization):
+        return
+
+    OrganizationMember.objects.filter(
+        organization=organization,
+        user=user,
+        status=OrganizationMember.MembershipStatus.BANNED,
+    ).update(status=OrganizationMember.MembershipStatus.CANCELLED)
 
 
 def update_blacklist_entry(

--- a/src/events/service/blacklist_service.py
+++ b/src/events/service/blacklist_service.py
@@ -280,13 +280,25 @@ def remove_from_blacklist(entry: Blacklist) -> None:
         return
 
     if check_user_hard_blacklisted(user, organization):
+        logger.info(
+            "unban_skipped_user_still_hard_blacklisted",
+            organization_id=str(organization.id),
+            user_id=str(user.id),
+        )
         return
 
-    OrganizationMember.objects.filter(
+    updated = OrganizationMember.objects.filter(
         organization=organization,
         user=user,
         status=OrganizationMember.MembershipStatus.BANNED,
     ).update(status=OrganizationMember.MembershipStatus.CANCELLED)
+
+    if updated:
+        logger.info(
+            "unbanned_user_membership_status_reset_to_cancelled",
+            organization_id=str(organization.id),
+            user_id=str(user.id),
+        )
 
 
 def update_blacklist_entry(

--- a/src/events/tests/test_service/test_blacklist_service.py
+++ b/src/events/tests/test_service/test_blacklist_service.py
@@ -15,7 +15,7 @@ import pytest
 from ninja.errors import HttpError
 
 from accounts.models import RevelUser
-from events.models import Blacklist, Organization
+from events.models import Blacklist, Organization, OrganizationMember
 from events.service import blacklist_service
 from telegram.models import TelegramUser
 
@@ -821,3 +821,75 @@ class TestUpdateAndRemove:
         blacklist_service.remove_from_blacklist(entry)
 
         assert not Blacklist.objects.filter(id=entry_id).exists()
+
+    def test_remove_from_blacklist_resets_banned_membership(
+        self,
+        blacklist_admin: RevelUser,
+        target_user: RevelUser,
+    ) -> None:
+        """Unbanning a linked user should transition their BANNED membership to CANCELLED.
+
+        Without this, the user's `for_user()` visibility remains blocked forever by
+        the stale BANNED membership even after the Blacklist row is deleted.
+        """
+        # PUBLIC org so visibility is gated purely on the membership row.
+        public_org = Organization.objects.create(
+            name="Public Unban Org",
+            slug="public-unban-org",
+            owner=blacklist_admin,
+            visibility=Organization.Visibility.PUBLIC,
+        )
+        entry = Blacklist.objects.create(
+            organization=public_org,
+            user=target_user,
+            created_by=blacklist_admin,
+        )
+        membership = OrganizationMember.objects.get(organization=public_org, user=target_user)
+        assert membership.status == OrganizationMember.MembershipStatus.BANNED
+        assert public_org not in Organization.objects.for_user(target_user)
+
+        blacklist_service.remove_from_blacklist(entry)
+
+        membership.refresh_from_db()
+        assert membership.status == OrganizationMember.MembershipStatus.CANCELLED
+        assert public_org in Organization.objects.for_user(target_user)
+
+    def test_remove_from_blacklist_keeps_banned_if_other_entries_exist(
+        self,
+        blacklist_org: Organization,
+        blacklist_admin: RevelUser,
+        target_user: RevelUser,
+    ) -> None:
+        """If another blacklist entry still covers the user, the ban must persist."""
+        linked_entry = Blacklist.objects.create(
+            organization=blacklist_org,
+            user=target_user,
+            created_by=blacklist_admin,
+        )
+        # Second entry matches by email only (bypasses the add_to_blacklist dedup check).
+        Blacklist.objects.create(
+            organization=blacklist_org,
+            email=target_user.email,
+            created_by=blacklist_admin,
+        )
+
+        blacklist_service.remove_from_blacklist(linked_entry)
+
+        membership = OrganizationMember.objects.get(organization=blacklist_org, user=target_user)
+        assert membership.status == OrganizationMember.MembershipStatus.BANNED
+
+    def test_remove_from_blacklist_without_user_is_noop(
+        self,
+        blacklist_org: Organization,
+        blacklist_admin: RevelUser,
+    ) -> None:
+        """Removing an entry without a linked user must not touch any memberships."""
+        entry = Blacklist.objects.create(
+            organization=blacklist_org,
+            email="unknown@example.com",
+            created_by=blacklist_admin,
+        )
+
+        blacklist_service.remove_from_blacklist(entry)
+
+        assert not OrganizationMember.objects.filter(organization=blacklist_org).exists()

--- a/uv.lock
+++ b/uv.lock
@@ -3639,7 +3639,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.48.0"
+version = "1.48.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary

- Unbanning a user no longer leaves them invisibly banned from the organization. When a `Blacklist` row was deleted, the `OrganizationMember(status=BANNED)` that `apply_blacklist_consequences` had created/updated was left in place, and `Organization.for_user()` kept excluding the org (and its events) for that user regardless of blacklist state.
- `remove_from_blacklist` now transitions the stale `BANNED` membership to `CANCELLED` (no implicit re-grant of prior `ACTIVE`/staff privileges). The fix is guarded by `check_user_hard_blacklisted`, so if another blacklist entry still covers the user in that org, the ban persists.
- Bumped to **1.48.1**.

## Root cause

`apply_blacklist_consequences` uses `OrganizationMember.objects.update_or_create(..., defaults={"status": BANNED})`, triggered by a `post_save` signal on `Blacklist`. There was no `post_delete` counterpart, and `remove_from_blacklist` only called `entry.delete()`. `Organization.for_user()` excludes orgs for which the user has a `BANNED` membership, independent of the `Blacklist` row — so the ban effectively persisted forever.

## Design choice

- **`CANCELLED`, not `ACTIVE`**: the ban path doesn't record what the status was pre-ban. Restoring to `ACTIVE` would implicitly re-grant membership (and any prior privileges) to a user who might never have had one. `CANCELLED` is treated as "no membership" by the visibility queryset — safe default.
- **Guard against multiple entries**: `link_blacklist_entries_for_user` can attach additional unlinked `Blacklist` rows to a user via `.update()` (bypassing `add_to_blacklist`'s dedup). Removing one must not unban if others still cover the user.
- **Service-layer fix, not a `post_delete` signal**: explicit and traceable, consistent with the existing `add_to_blacklist` / `apply_blacklist_consequences` surface.

## Test plan

- [x] `test_remove_from_blacklist_resets_banned_membership` — PUBLIC org, linked user: ban → assert invisible via `for_user`, unban → assert `CANCELLED` and visible again.
- [x] `test_remove_from_blacklist_keeps_banned_if_other_entries_exist` — second email-only entry keeps the ban in place after the linked entry is removed.
- [x] `test_remove_from_blacklist_without_user_is_noop` — unlinked entry deletion doesn't create or touch memberships.
- [x] `make check` passed locally
- [x] `make test` passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed unbanning behavior: when users are unbanned from organizations, stale membership records are now cleared and membership status is updated appropriately. Prior privileges are prevented from being implicitly re-granted, unless other blacklist entries remain in effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->