### PR TITLE
feat(events): series admin GET + cadence-drift detection

### DIFF
--- a/src/events/controllers/organization_admin/recurring_events.py
+++ b/src/events/controllers/organization_admin/recurring_events.py
@@ -9,7 +9,7 @@ from ninja_extra import api_controller, route
 
 from common.authentication import I18nJWTAuth
 from common.schema import ValidationErrorResponse
-from common.throttling import WriteThrottle
+from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import models, schema
 from events.controllers.permissions import OrganizationPermission
 from events.service import recurrence_service
@@ -143,6 +143,42 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         series = self._get_series(slug, series_id)
         until = payload.until if payload else None
         return recurrence_service.generate_series_events(series, until_override=until)
+
+    @route.get(
+        "/event-series/{series_id}",
+        url_name="get_series_detail",
+        response=schema.EventSeriesRecurrenceDetailSchema,
+        permissions=[OrganizationPermission("edit_event_series")],
+        throttle=UserDefaultThrottle(),
+    )
+    def get_series_detail(self, slug: str, series_id: UUID) -> models.EventSeries:
+        """Return the full admin detail for a recurring series.
+
+        This is the read counterpart to the PATCH/POST endpoints that also
+        return ``EventSeriesRecurrenceDetailSchema``: the FE dashboard needs
+        the same shape on page load without having to issue a no-op mutation
+        to read it back.
+        """
+        return self._get_series(slug, series_id)
+
+    @route.get(
+        "/event-series/{series_id}/drift",
+        url_name="get_series_drift",
+        response=schema.EventSeriesDriftSchema,
+        permissions=[OrganizationPermission("edit_event_series")],
+        throttle=UserDefaultThrottle(),
+    )
+    def get_series_drift(self, slug: str, series_id: UUID) -> schema.EventSeriesDriftSchema:
+        """Return occurrences whose start doesn't match the current recurrence rule.
+
+        After a cadence change, already-materialized future occurrences keep
+        their old dates. This endpoint computes — server-side, against the
+        authoritative ``dateutil.rrule`` — which of those occurrences are now
+        off-cadence, so the admin UI can highlight them and surface a bulk
+        "cancel stale dates" action.
+        """
+        series = self._get_series(slug, series_id)
+        return schema.EventSeriesDriftSchema(stale_occurrences=recurrence_service.detect_cadence_drift(series))
 
     @route.post(
         "/event-series/{series_id}/pause",

--- a/src/events/controllers/organization_admin/recurring_events.py
+++ b/src/events/controllers/organization_admin/recurring_events.py
@@ -24,7 +24,7 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
 
     Handles creation of recurring events, template editing with propagation,
     recurrence rule updates, occurrence cancellation, manual generation,
-    and pause/resume.
+    pause/resume, admin detail retrieval, and cadence-drift detection.
     """
 
     def _get_series(self, slug: str, series_id: UUID) -> models.EventSeries:

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -268,6 +268,7 @@ from .recurrence_rule import (
 # Recurring event schemas
 from .recurring_event import (
     CancelOccurrenceSchema,
+    EventSeriesDriftSchema,
     EventSeriesRecurrenceDetailSchema,
     EventSeriesRecurrenceUpdateSchema,
     GenerateSeriesEventsSchema,
@@ -486,6 +487,7 @@ __all__ = [
     "RecurrenceRuleSchema",
     "RecurrenceRuleUpdateSchema",
     "CancelOccurrenceSchema",
+    "EventSeriesDriftSchema",
     "EventSeriesRecurrenceDetailSchema",
     "EventSeriesRecurrenceUpdateSchema",
     "GenerateSeriesEventsSchema",

--- a/src/events/schema/recurring_event.py
+++ b/src/events/schema/recurring_event.py
@@ -139,3 +139,23 @@ class EventSeriesRecurrenceDetailSchema(Schema):
     last_generated_until: AwareDatetime | None = None
     recurrence_rule: RecurrenceRuleSchema | None = None
     template_event: MinimalEventSchema | None = None
+
+
+class EventSeriesDriftSchema(Schema):
+    """Response for the cadence-drift detection endpoint.
+
+    After an organiser changes a series' recurrence rule, already-materialized
+    future occurrences keep their old dates. This schema carries the IDs of
+    those "stale" occurrences so the admin UI can highlight them and offer a
+    bulk-cancel action. Manually-modified occurrences (``is_modified=True``)
+    and already-cancelled events are excluded: the former were deliberately
+    shifted off the cadence, the latter are already in their terminal state.
+    """
+
+    stale_occurrences: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "IDs of future, non-cancelled, non-manually-modified occurrences whose "
+            "start datetime does not match the current recurrence rule."
+        ),
+    )

--- a/src/events/service/recurrence_service.py
+++ b/src/events/service/recurrence_service.py
@@ -2,6 +2,7 @@
 
 import enum
 import typing as t
+import uuid
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
@@ -566,3 +567,65 @@ def _parse_exdates(exdates: list[str]) -> set[datetime]:
     membership comparisons against rrule-generated datetimes match by instant.
     """
     return {isoparse(d).astimezone(dt_timezone.utc) for d in exdates if d}
+
+
+def detect_cadence_drift(series: EventSeries) -> list[uuid.UUID]:
+    """Return IDs of future occurrences whose start doesn't match the current RRULE.
+
+    An occurrence is "drifted" when the series' recurrence rule was changed
+    after the occurrence was materialized, so its start datetime is no longer
+    produced by the current rule. The admin UI uses this to highlight stale
+    rows and offer a bulk-cancel action.
+
+    Inclusion criteria (all required):
+    - ``is_template=False`` — the template event is never an occurrence.
+    - ``start >= now()`` — past occurrences can't be rescheduled and are
+      out of scope for the cadence-change workflow.
+    - ``status != CANCELLED`` — already-cancelled events don't need another
+      bulk-cancel pass.
+    - ``is_modified=False`` — manually-modified occurrences were deliberately
+      shifted off the cadence by an organiser (via the standard event edit
+      endpoint, which sets ``is_modified=True``). Reporting them as "stale
+      due to cadence change" would be misleading and would sweep them into a
+      "cancel all stale dates" bulk action the admin did not intend.
+
+    Comparison is by UTC instant: RRULE-produced datetimes and event ``start``
+    fields are both normalized to UTC before set membership is checked, so a
+    DST shift in a stored timezone doesn't cause a spurious drift classification.
+
+    Exdates are removed from the expected set so that an occurrence sitting on
+    an exdate (e.g. mid-materialization race, or legacy data) is correctly
+    reported as drift rather than masked as "expected".
+
+    If the series has no recurrence rule, nothing can drift — returns an empty
+    list. If there are no qualifying future events, also returns an empty list
+    (we never call ``rule.between`` with a bogus range).
+    """
+    if not series.recurrence_rule:
+        return []
+
+    now = timezone.now()
+    future_events = list(
+        series.events.filter(
+            is_template=False,
+            is_modified=False,
+            start__gte=now,
+        )
+        .exclude(status=Event.EventStatus.CANCELLED)
+        .order_by("start")
+        .values_list("id", "start")
+    )
+    if not future_events:
+        return []
+
+    earliest = future_events[0][1]
+    latest = future_events[-1][1]
+
+    rule = series.recurrence_rule.to_rrule()
+    # ``inc=True`` includes both endpoints if they hit the rule, which is what
+    # we want: the earliest and latest event datetimes are the natural bounds
+    # and must be testable for a match.
+    expected = {dt.astimezone(dt_timezone.utc) for dt in rule.between(earliest, latest, inc=True)}
+    expected -= _parse_exdates(series.exdates)
+
+    return [event_id for event_id, start in future_events if start.astimezone(dt_timezone.utc) not in expected]

--- a/src/events/tests/test_controllers/test_organization_admin/test_recurring_events_read.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_recurring_events_read.py
@@ -1,0 +1,266 @@
+"""Tests for the read-only recurring events endpoints.
+
+Covers:
+- ``GET /organization-admin/{slug}/event-series/{series_id}`` — admin detail.
+- ``GET /organization-admin/{slug}/event-series/{series_id}/drift`` — drift.
+
+Kept in a separate module from the mutation tests (create, lifecycle, template)
+so files stay well under the project's 1000-line limit.
+"""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events.models import Event, EventSeries, Organization, RecurrenceRule
+
+from ._recurring_events_helpers import _make_series_with_rule
+
+pytestmark = pytest.mark.django_db
+
+
+class TestGetSeriesDetail:
+    """Tests for ``GET /organization-admin/{slug}/event-series/{series_id}``.
+
+    The endpoint is the read counterpart to the mutation endpoints that already
+    return ``EventSeriesRecurrenceDetailSchema``. These tests verify it returns
+    the expected shape, enforces the ``edit_event_series`` permission, and 404s
+    cleanly when the series doesn't exist.
+    """
+
+    def test_owner_gets_full_shape(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """The owner receives the full admin-detail payload, not the public shape."""
+        # Arrange
+        series = _make_series_with_rule(organization)
+        url = reverse(
+            "api:get_series_detail",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+
+        # Act
+        response = organization_owner_client.get(url)
+
+        # Assert — fields that exist only on the admin schema must all be present
+        # so a regression silently dropping one of them is caught here.
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(series.id)
+        assert data["name"] == series.name
+        assert data["generation_window_weeks"] == 4
+        assert data["is_active"] is True
+        assert data["auto_publish"] is False
+        assert data["exdates"] == []
+        assert data["recurrence_rule"] is not None
+        assert data["recurrence_rule"]["frequency"] == "daily"
+        assert data["template_event"] is not None
+        assert data["template_event"]["id"] == str(series.template_event_id)
+
+    def test_returns_404_for_nonmember(
+        self,
+        nonmember_client: Client,
+        organization: Organization,
+    ) -> None:
+        """A non-member gets 404 (not 403) — same invisibility contract as the mutations."""
+        # Arrange — build a real series so the assertion covers the authorisation
+        # branch rather than "missing resource returns 404".
+        series = _make_series_with_rule(organization)
+        url = reverse(
+            "api:get_series_detail",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+
+        # Act
+        response = nonmember_client.get(url)
+
+        # Assert
+        assert response.status_code == 404
+
+    def test_returns_404_for_missing_series(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """A random uuid returns 404 rather than leaking any org state."""
+        url = reverse(
+            "api:get_series_detail",
+            kwargs={"slug": organization.slug, "series_id": str(uuid4())},
+        )
+        response = organization_owner_client.get(url)
+        assert response.status_code == 404
+
+    def test_returns_404_for_wrong_org_series(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        organization_owner_user: RevelUser,
+    ) -> None:
+        """A series that belongs to a different organization must not be reachable.
+
+        The controller filters by ``organization=...`` in ``_get_series``; this
+        exercises that filter directly so a regression that drops it (returning
+        the series when the slug/uuid pair belongs to two different orgs) trips
+        this test rather than leaking cross-org data.
+        """
+        # Arrange — build a second org with its own series and point the request
+        # at the first org's slug + the second org's series id.
+        other_org = Organization.objects.create(
+            name="Other",
+            slug="other",
+            owner=organization_owner_user,
+        )
+        other_series = _make_series_with_rule(other_org)
+        url = reverse(
+            "api:get_series_detail",
+            kwargs={"slug": organization.slug, "series_id": str(other_series.id)},
+        )
+
+        # Act
+        response = organization_owner_client.get(url)
+
+        # Assert
+        assert response.status_code == 404
+
+
+class TestGetSeriesDrift:
+    """Tests for ``GET /organization-admin/{slug}/event-series/{series_id}/drift``."""
+
+    @staticmethod
+    def _make_occurrence(
+        *,
+        organization: Organization,
+        series: EventSeries,
+        start: datetime,
+        status: str = Event.EventStatus.DRAFT,
+        is_modified: bool = False,
+    ) -> Event:
+        """Build a materialized (non-template) occurrence at an exact instant.
+
+        Controller-level tests can't freeze time (that would invalidate the
+        JWT), so occurrences must be anchored to wall-clock-relative
+        datetimes. Creating the events directly via the ORM (rather than via
+        ``generate_series_events``) lets us position each occurrence exactly
+        on/off the rule.
+        """
+        return Event.objects.create(
+            organization=organization,
+            event_series=series,
+            name="Occurrence",
+            start=start,
+            end=start + timedelta(hours=2),
+            status=status,
+            visibility=Event.Visibility.PUBLIC,
+            event_type=Event.EventType.PUBLIC,
+            is_template=False,
+            is_modified=is_modified,
+        )
+
+    def test_returns_empty_when_events_match_rule(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """If all future events sit on the rule, the response is an empty list.
+
+        ``_make_series_with_rule`` uses a DAILY rule; placing events at
+        ``dtstart + Nd`` means they line up exactly with the rule's instants.
+        """
+        # Arrange — dtstart in the future so events count as "future" under now().
+        dtstart = timezone.now().replace(microsecond=0) + timedelta(days=1)
+        series = _make_series_with_rule(organization, dtstart=dtstart)
+        assert series.recurrence_rule is not None
+        self._make_occurrence(organization=organization, series=series, start=dtstart + timedelta(days=1))
+        self._make_occurrence(organization=organization, series=series, start=dtstart + timedelta(days=2))
+
+        url = reverse(
+            "api:get_series_drift",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+
+        # Act
+        response = organization_owner_client.get(url)
+
+        # Assert
+        assert response.status_code == 200
+        assert response.json() == {"stale_occurrences": []}
+
+    def test_returns_stale_occurrence_ids(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """Events sitting off the rule appear in ``stale_occurrences``.
+
+        The DAILY rule at ``dtstart 10:00`` produces instants at 10:00 on each
+        day. An event placed at ``dtstart + 1d + 12h`` (i.e. 22:00, half a day
+        off the cadence) is not produced by the rule and must drift.
+        """
+        # Arrange
+        dtstart = (timezone.now() + timedelta(days=1)).replace(hour=10, minute=0, second=0, microsecond=0)
+        series = _make_series_with_rule(organization, dtstart=dtstart)
+        # On-cadence event — must NOT drift.
+        on_cadence = self._make_occurrence(organization=organization, series=series, start=dtstart + timedelta(days=1))
+        # Off-cadence event — same day, 12h later. MUST drift.
+        off_cadence = self._make_occurrence(
+            organization=organization, series=series, start=dtstart + timedelta(days=1, hours=12)
+        )
+
+        url = reverse(
+            "api:get_series_drift",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+
+        # Act
+        response = organization_owner_client.get(url)
+
+        # Assert
+        assert response.status_code == 200
+        stale = response.json()["stale_occurrences"]
+        assert str(off_cadence.id) in stale
+        assert str(on_cadence.id) not in stale
+
+    def test_returns_404_for_nonmember(
+        self,
+        nonmember_client: Client,
+        organization: Organization,
+    ) -> None:
+        """A non-member gets 404 — authorisation runs before drift computation."""
+        series = _make_series_with_rule(organization)
+        url = reverse(
+            "api:get_series_drift",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+        response = nonmember_client.get(url)
+        assert response.status_code == 404
+
+    def test_empty_when_no_recurrence_rule(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """A series with no rule cannot drift — the endpoint returns an empty list
+        without raising. This guards the cheap pre-check in ``detect_cadence_drift``
+        that avoids ``rule.between`` on a null rule.
+        """
+        # Arrange — build the series by hand so we can leave ``recurrence_rule=None``.
+        series = _make_series_with_rule(organization)
+        rule: RecurrenceRule = series.recurrence_rule  # type: ignore[assignment]
+        series.recurrence_rule = None
+        series.save(update_fields=["recurrence_rule"])
+        rule.delete()
+
+        url = reverse(
+            "api:get_series_drift",
+            kwargs={"slug": organization.slug, "series_id": str(series.id)},
+        )
+        response = organization_owner_client.get(url)
+        assert response.status_code == 200
+        assert response.json() == {"stale_occurrences": []}

--- a/src/events/tests/test_service/test_recurrence_service_drift.py
+++ b/src/events/tests/test_service/test_recurrence_service_drift.py
@@ -1,0 +1,258 @@
+"""Tests for ``recurrence_service.detect_cadence_drift``.
+
+These live at the service layer because drift detection has enough branching
+(rule-free series, no-future-events, exdates, modified/cancelled exclusions)
+to warrant isolated unit coverage in addition to the controller-level tests.
+
+Uses ``freeze_time`` so past-dated events and rule cadence changes can be
+described with literal dates without fighting the wall clock.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from django.utils import timezone
+from freezegun import freeze_time
+
+from accounts.models import RevelUser
+from events.models import Event, EventSeries, Organization, RecurrenceRule
+from events.service import recurrence_service
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_occurrence(
+    series: EventSeries,
+    start: datetime,
+    *,
+    status: str = Event.EventStatus.DRAFT,
+    is_modified: bool = False,
+) -> Event:
+    """Create a materialized (non-template) occurrence on ``series`` at ``start``.
+
+    Bypasses ``materialize_occurrence`` / ``duplicate_event`` so tests can plant
+    occurrences at specific instants (on- or off-cadence) without re-running the
+    generation pipeline.
+    """
+    return Event.objects.create(
+        organization=series.organization,
+        event_series=series,
+        name="Occurrence",
+        start=start,
+        end=start + timedelta(hours=2),
+        status=status,
+        visibility=Event.Visibility.PUBLIC,
+        event_type=Event.EventType.PUBLIC,
+        is_template=False,
+        is_modified=is_modified,
+    )
+
+
+class TestDetectCadenceDrift:
+    """Happy-path and exclusion rules for ``detect_cadence_drift``."""
+
+    def test_returns_empty_when_no_recurrence_rule(
+        self,
+        event_series: EventSeries,
+    ) -> None:
+        """A series with no rule cannot drift — short-circuit path."""
+        assert event_series.recurrence_rule is None
+        assert recurrence_service.detect_cadence_drift(event_series) == []
+
+    def test_returns_empty_when_no_future_events(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """No qualifying events means nothing to compare — avoids calling
+        ``rule.between`` with a bogus range.
+        """
+        # active_series' dtstart is 2026-04-06; freeze well after so no events
+        # would qualify even if they existed.
+        with freeze_time("2026-05-01 00:00:00"):
+            assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_returns_empty_when_all_events_match_rule(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Events sitting exactly on the weekly-Monday rule must not drift."""
+        # active_series rule: weekly Mondays at 2026-04-06 10:00.
+        dt1 = timezone.make_aware(datetime(2026, 4, 6, 10, 0))
+        dt2 = timezone.make_aware(datetime(2026, 4, 13, 10, 0))
+        _make_occurrence(active_series, dt1)
+        _make_occurrence(active_series, dt2)
+
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_returns_stale_ids_when_events_drift_from_rule(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Events that aren't produced by the current rule are reported as stale.
+
+        Simulates the cadence-change scenario from the issue: old occurrences
+        scheduled under "weekly Mondays" are still in the DB; the operator has
+        since changed the rule to "weekly Tuesdays". The Monday events no
+        longer match and should be flagged.
+        """
+        # Old-cadence occurrences on Mondays.
+        monday = timezone.make_aware(datetime(2026, 4, 6, 10, 0))
+        next_monday = monday + timedelta(days=7)
+        stale_a = _make_occurrence(active_series, monday)
+        stale_b = _make_occurrence(active_series, next_monday)
+
+        # Mutate the rule to "weekly Tuesdays" to represent the operator's PATCH.
+        assert active_series.recurrence_rule is not None
+        active_series.recurrence_rule.weekdays = [1]  # Tuesday
+        active_series.recurrence_rule.dtstart = monday + timedelta(days=1)
+        active_series.recurrence_rule.save()
+
+        result = recurrence_service.detect_cadence_drift(active_series)
+        assert set(result) == {stale_a.id, stale_b.id}
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_excludes_modified_occurrences(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """``is_modified=True`` events are deliberate overrides — never flagged.
+
+        The admin workflow for drift is "which occurrences are off-cadence
+        because the rule changed?". Manually-shifted occurrences were moved
+        intentionally and would hijack a "cancel all stale dates" bulk action.
+        """
+        # Off-cadence Tuesday event, but marked as manually modified.
+        tuesday = timezone.make_aware(datetime(2026, 4, 7, 10, 0))
+        _make_occurrence(active_series, tuesday, is_modified=True)
+
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_excludes_cancelled_occurrences(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Already-cancelled events are terminal — no point flagging for re-cancel."""
+        tuesday = timezone.make_aware(datetime(2026, 4, 7, 10, 0))
+        _make_occurrence(active_series, tuesday, status=Event.EventStatus.CANCELLED)
+
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-08 00:00:00")
+    def test_excludes_past_events(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Past occurrences can't be rescheduled, so they aren't part of the
+        cadence-change workflow.
+        """
+        # A past (2026-04-07) off-cadence event.
+        past_tuesday = timezone.make_aware(datetime(2026, 4, 7, 10, 0))
+        _make_occurrence(active_series, past_tuesday)
+
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_excludes_template_event(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """The template event is never a real occurrence; it must never show up
+        in the drift list even when its start sits off the current rule.
+        """
+        # Change the rule so the template's start (a Monday) doesn't match.
+        assert active_series.recurrence_rule is not None
+        active_series.recurrence_rule.weekdays = [1]  # Tuesday
+        active_series.recurrence_rule.dtstart = timezone.make_aware(datetime(2026, 4, 7, 10, 0))
+        active_series.recurrence_rule.save()
+
+        # No non-template occurrences → empty.
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_event_on_exdate_is_reported_as_drift(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Exdates are removed from the expected set, so any event still sitting
+        on an exdate's instant is classified as drift.
+
+        This is mostly a defensive shape check — normally an exdate implies the
+        event is also cancelled — but it documents that ``_parse_exdates`` is
+        actually applied to the expected set.
+        """
+        monday = timezone.make_aware(datetime(2026, 4, 13, 10, 0))
+        event = _make_occurrence(active_series, monday)
+        # Cancelling adds to exdates AND flips the event to CANCELLED; we want
+        # an exdate without the cancellation to isolate the exdate-only path.
+        active_series.exdates = [monday.isoformat()]
+        active_series.save(update_fields=["exdates"])
+
+        result = recurrence_service.detect_cadence_drift(active_series)
+        assert event.id in result
+
+    @freeze_time("2026-04-06 00:00:00")
+    def test_rrule_computed_with_utc_normalization(
+        self,
+        active_series: EventSeries,
+    ) -> None:
+        """Events stored in UTC must be comparable against rule instants even
+        when the rule's ``to_rrule()`` yields naive-tz datetimes in the
+        same-instant-different-representation.
+
+        This regression test pins the UTC-normalization behaviour: swap it out
+        for a naive ``==`` and on-cadence events start spuriously drifting.
+        """
+        # On-cadence Monday — must not drift.
+        on_rule = timezone.make_aware(datetime(2026, 4, 13, 10, 0))
+        _make_occurrence(active_series, on_rule)
+
+        assert recurrence_service.detect_cadence_drift(active_series) == []
+
+
+class TestDetectCadenceDriftWithoutFixtures:
+    """Drift cases that don't need the shared ``active_series`` fixture."""
+
+    def test_rule_with_count_exhausted_reports_all_future_as_stale(self) -> None:
+        """If the operator sets ``count`` so tightly that no future occurrences
+        are produced, every qualifying future event is by definition off-cadence.
+        This exercises the ``rule.between`` returning an empty list branch.
+        """
+        owner = RevelUser.objects.create_user(username="drift_owner", email="drift@example.com", password="p")
+        org = Organization.objects.create(name="DriftOrg", slug="drift-org", owner=owner)
+
+        # Daily rule with count=1 and dtstart in the past — no future occurrences
+        # produced by the rule, so any future event is drift.
+        past = timezone.now() - timedelta(days=30)
+        rule = RecurrenceRule.objects.create(
+            frequency=RecurrenceRule.Frequency.DAILY,
+            interval=1,
+            dtstart=past,
+            count=1,
+        )
+        series = EventSeries.objects.create(
+            organization=org,
+            name="Drifty",
+            recurrence_rule=rule,
+        )
+        template = Event.objects.create(
+            organization=org,
+            event_series=series,
+            name="Template",
+            start=past,
+            end=past + timedelta(hours=1),
+            status=Event.EventStatus.DRAFT,
+            visibility=Event.Visibility.PUBLIC,
+            event_type=Event.EventType.PUBLIC,
+            is_template=True,
+        )
+        series.template_event = template
+        series.save(update_fields=["template_event"])
+
+        future = timezone.now() + timedelta(days=1)
+        stale = _make_occurrence(series, future)
+
+        result = recurrence_service.detect_cadence_drift(series)
+        assert result == [stale.id]

--- a/src/events/tests/test_service/test_recurrence_service_drift.py
+++ b/src/events/tests/test_service/test_recurrence_service_drift.py
@@ -198,12 +198,15 @@ class TestDetectCadenceDrift:
         self,
         active_series: EventSeries,
     ) -> None:
-        """Events stored in UTC must be comparable against rule instants even
-        when the rule's ``to_rrule()`` yields naive-tz datetimes in the
-        same-instant-different-representation.
+        """Event starts and ``to_rrule()`` outputs must compare as the same
+        instant even when their tzinfo representations differ.
 
-        This regression test pins the UTC-normalization behaviour: swap it out
-        for a naive ``==`` and on-cadence events start spuriously drifting.
+        Django (``USE_TZ=True``) stores event ``start`` fields as aware
+        datetimes in UTC; ``dateutil.rrule`` returns aware datetimes carrying
+        whatever tzinfo ``dtstart`` had (e.g. ``Europe/Vienna``). Those are
+        the same instant but fail a direct ``==`` because their tzinfo objects
+        differ. This regression test pins the UTC-normalization step: drop
+        ``.astimezone(UTC)`` and on-cadence events start spuriously drifting.
         """
         # On-cadence Monday — must not drift.
         on_rule = timezone.make_aware(datetime(2026, 4, 13, 10, 0))


### PR DESCRIPTION
## Summary

Two small read-only additions to the recurring-events admin surface, closing two related FE blockers.

- **Closes #377** — `GET /organization-admin/{slug}/event-series/{series_id}` returns `EventSeriesRecurrenceDetailSchema` (full admin shape: rule, template, exdates, `last_generated_until`, window, active/auto-publish flags). The FE dashboard needed this on page load; before, the only way to read the admin shape was to hit `PATCH .../recurrence` with an empty body, which was semantically ugly.
- **Closes #376** — `GET /organization-admin/{slug}/event-series/{series_id}/drift` returns `{ stale_occurrences: [event_id, ...] }` — IDs of future occurrences whose start no longer matches the current RRULE (i.e. cadence-change drift). Computed server-side against `dateutil.rrule` so the FE doesn't have to re-implement RFC 5545 matching.

Both endpoints:
- Gated on `OrganizationPermission("edit_event_series")` (same guard as the existing mutations).
- Use `UserDefaultThrottle` (per-endpoint override of the class-level `WriteThrottle`) since they're reads.
- Return 404 for non-members — no cross-org leakage.

## Drift semantics

A materialized event is classified as drift iff **all** of these hold:

- `is_template=False`
- `start >= now()` (past occurrences can't be rescheduled)
- `status != CANCELLED` (terminal already)
- `is_modified=False` (manually-shifted occurrences were deliberately moved off-cadence; sweeping them into a "cancel all stale dates" bulk action would be wrong)
- `start.astimezone(UTC) not in {rrule_occurrences_in_[earliest, latest]_minus_exdates}`

Comparison is by UTC instant — events and rrule outputs are both normalized before set membership.

## Test plan

- [x] `make check` (ruff format/lint, mypy --strict, migrations, i18n, file-length) — clean
- [x] `make test` — 4221 passed, 15 skipped, 95% coverage
- [x] 19 new tests: 8 controller (detail + drift) + 11 service (drift) covering empty/no-rule, cadence change, is_modified/cancelled/past exclusions, exdate drift, template exclusion, count-exhausted rule, 404s, cross-org isolation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization admins can retrieve detailed recurring event series info.
  * New cadence-drift check returns a list of future occurrences that no longer match the current recurrence pattern.

* **Tests**
  * Added controller tests covering admin series detail and drift endpoints, including access rules.
  * Added unit tests for drift detection covering exclusions, exdates, UTC normalization, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->