### PR TITLE
fix(admin): expose notify_organization_created on SiteSettings admin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.50.0"
+version = "1.50.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/common/admin.py
+++ b/src/common/admin.py
@@ -36,13 +36,14 @@ class SiteSettingsAdmin(ModelAdmin):  # type: ignore[misc]
     list_display = [
         "__str__",
         "notify_user_joined",
+        "notify_organization_created",
         "live_emails",
         "data_retention_days",
         "updated_at",
     ]
     readonly_fields = ["created_at", "updated_at"]
     fieldsets = (
-        ("Notifications", {"fields": ("notify_user_joined", "live_emails")}),
+        ("Notifications", {"fields": ("notify_user_joined", "notify_organization_created", "live_emails")}),
         ("Data Management", {"fields": ("data_retention_days",)}),
         ("URLs & Emails", {"fields": ("frontend_base_url", "internal_catchall_email")}),
         (

--- a/uv.lock
+++ b/uv.lock
@@ -3920,7 +3920,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.50.0"
+version = "1.50.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- `notify_organization_created` exists on the `SiteSettings` model but was not declared in the admin's `fieldsets`, so it could not be toggled from the admin UI.
- Added the field to the `Notifications` fieldset and to `list_display`, alongside the existing `notify_user_joined`.

## Test plan
- [ ] Open `/admin/common/sitesettings/` and confirm `notify_organization_created` is editable in the `Notifications` section and visible in the changelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization creation notifications can now be managed in the admin panel under notification settings, alongside other notification controls.
* **Chores**
  * Release version updated to 1.50.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->