### PR TITLE
feat: define sales permissions in admin panel

### DIFF
--- a/docs/architecture/permissions.md
+++ b/docs/architecture/permissions.md
@@ -2,6 +2,13 @@
 
 Revel implements a layered permission system built on three distinct concepts: **organization ownership**, **staff memberships with granular permissions**, and **member memberships with statuses**. Permissions are enforced at the API layer via Django Ninja Extra permission classes that use the `has_object_permission` pattern.
 
+!!! info "Admin panel groups are separate"
+    This page covers **API-layer** permissions only. The Django admin panel
+    (`/admin/`) uses Django's built-in `auth.Group` system, which is independent
+    of `OrganizationStaff.permissions`. See the
+    [Admin groups runbook](../runbooks/admin-groups.md) for the `Sales` group
+    policy and the `sync_sales_group` management command.
+
 ## Permission Hierarchy
 
 ```mermaid

--- a/docs/runbooks/admin-groups.md
+++ b/docs/runbooks/admin-groups.md
@@ -1,0 +1,91 @@
+# Admin groups runbook
+
+This page covers the Django **admin panel** groups (`/admin/`). It is unrelated to
+the API-layer permission system documented in
+[Permissions & Roles](../architecture/permissions.md), which governs `Organization`
+owners, staff, and members.
+
+The two systems are independent:
+
+- API permissions are enforced by `RootPermission` subclasses on Django Ninja
+  endpoints and live in `OrganizationStaff.permissions` JSON.
+- Admin permissions are Django's built-in `auth.Group` + `auth.Permission` system
+  and only affect what an authenticated `is_staff` user sees in `/admin/`.
+
+## The `Sales` group
+
+Sales reps need broad admin access to onboard organizations, manage events,
+issue invitations, and create discount codes — but not to delete data, modify
+users, or change platform configuration.
+
+### Policy at a glance
+
+| Tier | Permissions | Models |
+|---|---|---|
+| **Full** | view + add + change | `Organization`, `Event`, `EventSeries`, `RecurrenceRule`, `Venue`, `TicketTier`, `MembershipTier`, `EventInvitation`, `PendingEventInvitation`, `EventToken`, `OrganizationToken`, `DiscountCode`, `Tag`, `TagAssignment` |
+| **Manage** | view + change | `OrganizationMember`, `OrganizationMembershipRequest`, `EventInvitationRequest`, `EventRSVP`, `EventWaitList`, `Ticket`, `PotluckItem` |
+| **View-only** | view | All financial records (`Payment`, `*Invoice`, `*CreditNote`, referrals, billing profiles), `RevelUser`, `Announcement`, compliance models (`Blacklist`, questionnaires), system config (`SiteSettings`, `Legal`, `EmailLog`), notifications, geo, telegram |
+| **No access** | none | Security/audit (`GlobalBan`, `ImpersonationLog`, `UserDataExport`, file audit), dietary PII, user privacy preferences |
+
+**No `delete_*` permission is granted on any model.** Deletion of financial,
+audit, or user data must go through superuser review.
+
+### Source of truth
+
+The exact tier lists live in
+[`src/common/management/commands/sync_sales_group.py`](https://github.com/letsrevel/revel-backend/blob/main/src/common/management/commands/sync_sales_group.py).
+Edit that file to change the policy — there is no DB-only configuration.
+
+## Sync command
+
+Run on every deploy to reconcile the group's permissions with the policy in
+code:
+
+```bash
+python manage.py sync_sales_group
+```
+
+The command is idempotent. It uses `Group.objects.get_or_create` and
+`group.permissions.set(...)`, so it cleanly picks up adds and removes when the
+tier lists change. Missing models or permissions are logged as warnings and do
+not abort the run.
+
+!!! tip "Where to invoke it"
+    Add this to the deployment script next to `migrate` and `compilemessages`,
+    so the group stays in sync as new models are added or moved between tiers.
+
+## Onboarding a sales rep
+
+1. Create the user (or have them register).
+2. In the admin user form, set:
+    - `is_staff = True` (required for any admin access)
+    - `is_superuser = False` (required — superusers bypass the group)
+    - Add them to the `Sales` group under **Groups**.
+3. Confirm in the sidebar that they only see the apps/models from the policy
+   above.
+
+## Admin-side enforcement details
+
+Two pieces of the policy require code, not just permissions:
+
+### Impersonate link hidden for non-superusers
+
+`RevelUserAdmin.get_list_display` removes the `impersonate_link` column for
+anyone who isn't a superuser
+([`src/accounts/admin/user.py`](https://github.com/letsrevel/revel-backend/blob/main/src/accounts/admin/user.py)).
+The underlying impersonation view is also gated by
+`accounts.service.impersonation.can_impersonate`, which requires
+`is_superuser` — the column hide is purely cosmetic.
+
+### Sensitive `Organization` fields read-only
+
+`OrganizationAdmin.get_readonly_fields` locks these fields for non-superusers
+([`src/events/admin/organization.py`](https://github.com/letsrevel/revel-backend/blob/main/src/events/admin/organization.py)):
+
+- `vat_id_validated`, `vat_id_validated_at` — must come from the VAT
+  validation flow, not a manual flip
+- `platform_fee_percent`, `platform_fee_fixed` — superusers only renegotiate
+- `contact_email_verified` — must come from the verification flow
+
+Stripe Connect lives on `RevelUser` (the org owner's account) and the relevant
+fields are already in `RevelUserAdmin.readonly_fields` for everyone.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - adr/0010-dependency-compliance.md
   - Runbooks:
       - runbooks/dependency-audit.md
+      - runbooks/admin-groups.md
   - Post-Mortems:
       - postmortems/index.md
       - postmortems/0001-guest-user-verification-bypass.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.50.1"
+version = "1.51.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/admin/user.py
+++ b/src/accounts/admin/user.py
@@ -483,6 +483,12 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
 
     organization_participation_display.short_description = "Organization Participation"  # type: ignore[attr-defined]
 
+    def get_list_display(self, request: HttpRequest) -> list[str]:  # type: ignore[override]
+        list_display = list(super().get_list_display(request))
+        if not request.user.is_superuser and "impersonate_link" in list_display:
+            list_display.remove("impersonate_link")
+        return list_display  # type: ignore[return-value]
+
     # Impersonation functionality
     @admin.display(description=_("Impersonate"))
     def impersonate_link(self, obj: RevelUser) -> str:

--- a/src/common/management/commands/sync_sales_group.py
+++ b/src/common/management/commands/sync_sales_group.py
@@ -1,0 +1,124 @@
+"""Create or sync the 'Sales' admin group with its permissions.
+
+The Sales group is intended for sales reps who need broad admin access to
+onboard organizations, manage events/tickets/discounts, and view financial
+records — but not delete data, modify users, or change platform configuration.
+
+Run on each deploy to keep the group's permissions in sync with policy:
+    python manage.py sync_sales_group
+"""
+
+import typing as t
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+GROUP_NAME = "Sales"
+
+# Full work surface: view + add + change (no delete)
+TIER_FULL: tuple[tuple[str, str], ...] = (
+    ("events", "organization"),
+    ("events", "event"),
+    ("events", "eventseries"),
+    ("events", "recurrencerule"),
+    ("events", "venue"),
+    ("events", "tickettier"),
+    ("events", "membershiptier"),
+    ("events", "eventinvitation"),
+    ("events", "pendingeventinvitation"),
+    ("events", "eventtoken"),
+    ("events", "organizationtoken"),
+    ("events", "discountcode"),
+    ("common", "tag"),
+    ("common", "tagassignment"),
+)
+
+# Manage existing records: view + change (no add/delete)
+TIER_MANAGE: tuple[tuple[str, str], ...] = (
+    ("events", "organizationmember"),
+    ("events", "organizationmembershiprequest"),
+    ("events", "eventinvitationrequest"),
+    ("events", "eventrsvp"),
+    ("events", "eventwaitlist"),
+    ("events", "ticket"),
+    ("events", "potluckitem"),
+)
+
+# Read-only surface
+TIER_VIEW: tuple[tuple[str, str], ...] = (
+    ("accounts", "reveluser"),
+    ("accounts", "userbillingprofile"),
+    ("accounts", "referralcode"),
+    ("accounts", "referral"),
+    ("accounts", "referralpayout"),
+    ("accounts", "referralpayoutstatement"),
+    ("events", "payment"),
+    ("events", "attendeeinvoice"),
+    ("events", "attendeeinvoicecreditnote"),
+    ("events", "platformfeeinvoice"),
+    ("events", "platformfeecreditnote"),
+    ("events", "blacklist"),
+    ("events", "whitelistrequest"),
+    ("events", "organizationstaff"),
+    ("events", "organizationquestionnaire"),
+    ("events", "venuesector"),
+    ("events", "venueseat"),
+    ("events", "announcement"),
+    ("common", "legal"),
+    ("common", "sitesettings"),
+    ("common", "emaillog"),
+    ("common", "exchangerate"),
+    ("notifications", "notification"),
+    ("notifications", "notificationdelivery"),
+    ("notifications", "notificationpreference"),
+    ("questionnaires", "questionnaire"),
+    ("questionnaires", "questionnairesubmission"),
+    ("questionnaires", "questionnaireevaluation"),
+    ("questionnaires", "multiplechoicequestion"),
+    ("questionnaires", "multiplechoiceoption"),
+    ("questionnaires", "freetextquestion"),
+    ("questionnaires", "fileuploadquestion"),
+    ("questionnaires", "questionnairesection"),
+    ("questionnaires", "questionnairefile"),
+    ("geo", "city"),
+    ("telegram", "telegramuser"),
+)
+
+
+class Command(BaseCommand):
+    help = "Create or sync the 'Sales' admin group with its permissions."
+
+    def handle(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Apply the permissions."""
+        group, created = Group.objects.get_or_create(name=GROUP_NAME)
+        action = "Created" if created else "Found"
+        self.stdout.write(f"{action} group: {group.name}")
+
+        permissions: list[Permission] = []
+        permissions.extend(self._collect(TIER_FULL, ("view", "add", "change")))
+        permissions.extend(self._collect(TIER_MANAGE, ("view", "change")))
+        permissions.extend(self._collect(TIER_VIEW, ("view",)))
+
+        group.permissions.set(permissions)
+        self.stdout.write(self.style.SUCCESS(f"Synced {group.permissions.count()} permissions on '{group.name}'."))
+
+    def _collect(
+        self,
+        specs: tuple[tuple[str, str], ...],
+        prefixes: tuple[str, ...],
+    ) -> list[Permission]:
+        perms: list[Permission] = []
+        for app_label, model in specs:
+            try:
+                ct = ContentType.objects.get(app_label=app_label, model=model)
+            except ContentType.DoesNotExist:
+                self.stdout.write(self.style.WARNING(f"  ! missing content type: {app_label}.{model}"))
+                continue
+            for prefix in prefixes:
+                codename = f"{prefix}_{model}"
+                try:
+                    perms.append(Permission.objects.get(content_type=ct, codename=codename))
+                except Permission.DoesNotExist:
+                    self.stdout.write(self.style.WARNING(f"  ! missing permission: {app_label}.{codename}"))
+        return perms

--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -28,6 +28,22 @@ from events.admin.base import (
 class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
     """Admin model for Organizations."""
 
+    SUPERUSER_ONLY_FIELDS: t.ClassVar[tuple[str, ...]] = (
+        "vat_id_validated",
+        "vat_id_validated_at",
+        "platform_fee_percent",
+        "platform_fee_fixed",
+        "contact_email_verified",
+    )
+
+    def get_readonly_fields(
+        self, request: HttpRequest, obj: models.Organization | None = None
+    ) -> tuple[str, ...] | list[str]:
+        readonly = tuple(super().get_readonly_fields(request, obj))
+        if not request.user.is_superuser:
+            readonly = readonly + self.SUPERUSER_ONLY_FIELDS
+        return readonly
+
     list_display = [
         "name",
         "slug",

--- a/uv.lock
+++ b/uv.lock
@@ -3920,7 +3920,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.50.1"
+version = "1.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on admin panel authorization and access control
  * New runbook detailing admin group permissions, user onboarding procedures, and deployment workflows

* **Admin Interface Changes**
  * Impersonate user functionality now restricted to superuser administrators
  * Organization configuration fields made read-only for non-superuser administrators

* **Chores**
  * Version bumped to 1.51.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->