### PR TITLE
security: bump to Django==5.2.14 (fix #390)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiogram>=3.20.0.post0",
     "celery>=5.6.2",
     "cryptography>=46.0.4",
-    "django>=5.2.11,<6.0",
+    "django==5.2.14",
     "django-celery-beat>=2.8.1",
     "django-celery-results>=2.6.0",
     "django-cors-headers>=4.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiogram>=3.20.0.post0",
     "celery>=5.6.2",
     "cryptography>=46.0.4",
-    "django==5.2.14",
+    "django>=5.2.14,<6.0",
     "django-celery-beat>=2.8.1",
     "django-celery-results>=2.6.0",
     "django-cors-headers>=4.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.52.1"
+version = "1.52.2"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -771,16 +771,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.13"
+version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
 ]
 
 [[package]]
@@ -4031,7 +4031,7 @@ requires-dist = [
     { name = "aiogram", specifier = ">=3.20.0.post0" },
     { name = "celery", specifier = ">=5.6.2" },
     { name = "cryptography", specifier = ">=46.0.4" },
-    { name = "django", specifier = ">=5.2.11,<6.0" },
+    { name = "django", specifier = "==5.2.14" },
     { name = "django-celery-beat", specifier = ">=2.8.1" },
     { name = "django-celery-results", specifier = ">=2.6.0" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3920,7 +3920,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.52.1"
+version = "1.52.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
@@ -4031,7 +4031,7 @@ requires-dist = [
     { name = "aiogram", specifier = ">=3.20.0.post0" },
     { name = "celery", specifier = ">=5.6.2" },
     { name = "cryptography", specifier = ">=46.0.4" },
-    { name = "django", specifier = "==5.2.14" },
+    { name = "django", specifier = ">=5.2.14,<6.0" },
     { name = "django-celery-beat", specifier = ">=2.8.1" },
     { name = "django-celery-results", specifier = ">=2.6.0" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Django dependency pinned to version 5.2.14 for improved stability and consistency across deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/391)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->