### PR TITLE
fix(schemas): restrict currency to supported list on update + discount schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.52.2"
+version = "1.52.3"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/schema/discount_code.py
+++ b/src/events/schema/discount_code.py
@@ -8,6 +8,7 @@ from ninja import ModelSchema, Schema
 from pydantic import AwareDatetime, Field, model_validator
 
 from events.models.discount_code import DiscountCode
+from events.schema.ticket import Currencies
 
 # ---- Admin schemas ----
 
@@ -59,7 +60,7 @@ class _DiscountCodeValidatorMixin:
 
     discount_type: DiscountCode.DiscountType | None
     discount_value: Decimal | None
-    currency: str | None
+    currency: Currencies | None
     valid_from: AwareDatetime | None
     valid_until: AwareDatetime | None
 
@@ -91,7 +92,7 @@ class DiscountCodeCreateSchema(_DiscountCodeValidatorMixin, Schema):
     code: str = Field(..., max_length=64, min_length=1, pattern=r"^[^\W_]+$")
     discount_type: DiscountCode.DiscountType
     discount_value: Decimal = Field(..., ge=0)
-    currency: str | None = Field(None, max_length=3)
+    currency: Currencies | None = None
     valid_from: AwareDatetime | None = None
     valid_until: AwareDatetime | None = None
     max_uses: int | None = Field(None, ge=1)
@@ -108,7 +109,7 @@ class DiscountCodeUpdateSchema(_DiscountCodeValidatorMixin, Schema):
 
     discount_type: DiscountCode.DiscountType | None = None
     discount_value: Decimal | None = Field(None, ge=0)
-    currency: str | None = Field(None, max_length=3)
+    currency: Currencies | None = None
     valid_from: AwareDatetime | None = None
     valid_until: AwareDatetime | None = None
     max_uses: int | None = Field(None, ge=1)

--- a/src/events/schema/ticket.py
+++ b/src/events/schema/ticket.py
@@ -366,7 +366,7 @@ class TicketTierUpdateSchema(TicketTierPriceValidationMixin):
     pwyc_min: Decimal | None = Field(None, ge=1)
     pwyc_max: Decimal | None = Field(None, ge=1)
     vat_rate: Decimal | None = Field(None, ge=0, le=100, description="VAT rate override. Null = use org default.")
-    currency: str | None = Field(None, max_length=3)
+    currency: Currencies | None = None
     sales_start_at: AwareDatetime | None = None
     sales_end_at: AwareDatetime | None = None
     total_quantity: int | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -3920,7 +3920,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.52.2"
+version = "1.52.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- `TicketTierUpdateSchema.currency`, `DiscountCodeCreateSchema.currency`, and `DiscountCodeUpdateSchema.currency` accepted any 3-char string, bypassing the `Currencies` whitelist already enforced on `TicketTierCreateSchema`. This let clients set currencies the platform has no exchange rates for.
- All three now use `Currencies | None` so writes are validated against the same supported set (the ECB/frankfurter list).
- Response schemas intentionally remain `str` — they reflect what's stored, and the whitelist is enforced at the write boundary.
- Patch bump: `1.52.2` → `1.52.3`.

## Test plan
- [ ] `make check` (format, lint, mypy, migration-check, i18n-check, file-length) — passes locally
- [ ] `make test` — existing currency tests use only `EUR`/`USD` (both whitelisted), so no regressions expected
- [ ] Spot-check OpenAPI: `TicketTierUpdateSchema` and the two `DiscountCode*` schemas now expose the enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 1.52.3

* **Bug Fixes**
  * Standardized currency validation across discount codes and ticket tiers for consistent pricing configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/392)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->