### PR TITLE
feat(subscriptions): Phase 2 — Stripe ONLINE subscriptions on Connect (#394)

### DIFF
--- a/src/events/admin/subscription.py
+++ b/src/events/admin/subscription.py
@@ -11,12 +11,23 @@ from events.admin.base import OrganizationLinkMixin, UserLinkMixin
 class MembershipSubscriptionPlanAdmin(ModelAdmin):  # type: ignore[misc]
     """Admin for MembershipSubscriptionPlan."""
 
-    list_display = ["__str__", "tier", "price", "currency", "period_unit", "period_count", "is_active"]
-    list_filter = ["is_active", "period_unit", "currency", "tier__organization__name"]
+    list_display = [
+        "__str__",
+        "tier",
+        "price",
+        "currency",
+        "period_unit",
+        "period_count",
+        "payment_method",
+        "is_active",
+    ]
+    list_filter = ["is_active", "payment_method", "period_unit", "currency", "tier__organization__name"]
     list_select_related = ["tier", "tier__organization"]
-    search_fields = ["name", "tier__name", "tier__organization__name"]
+    search_fields = ["name", "tier__name", "tier__organization__name", "stripe_price_id", "stripe_product_id"]
     autocomplete_fields = ["tier"]
-    readonly_fields = ["created_at", "updated_at"]
+    # Stripe IDs are populated by the service layer on save; keep them readonly
+    # so admins don't accidentally desync the local row from Stripe.
+    readonly_fields = ["stripe_product_id", "stripe_price_id", "created_at", "updated_at"]
 
 
 @admin.register(models.MembershipSubscription)
@@ -39,13 +50,20 @@ class MembershipSubscriptionAdmin(ModelAdmin, UserLinkMixin, OrganizationLinkMix
     ]
     list_filter = ["status", "cancel_at_period_end", "organization__name"]
     list_select_related = ["user", "organization", "plan", "plan__tier"]
-    search_fields = ["user__username", "user__email", "organization__name", "plan__name"]
+    search_fields = [
+        "user__username",
+        "user__email",
+        "organization__name",
+        "plan__name",
+        "stripe_subscription_id",
+    ]
     autocomplete_fields = ["user", "organization", "plan"]
     readonly_fields = [
         "status",
         "current_period_start",
         "current_period_end",
         "cancelled_at",
+        "stripe_subscription_id",
         "created_at",
         "updated_at",
     ]
@@ -69,5 +87,25 @@ class MembershipPaymentAdmin(ModelAdmin):  # type: ignore[misc]
         "subscription__organization__name",
     ]
     autocomplete_fields = ["subscription", "recorded_by"]
-    readonly_fields = ["status", "period_start", "period_end", "created_at", "updated_at"]
+    readonly_fields = [
+        "status",
+        "period_start",
+        "period_end",
+        "stripe_invoice_id",
+        "stripe_payment_intent_id",
+        "created_at",
+        "updated_at",
+    ]
     date_hierarchy = "created_at"
+
+
+@admin.register(models.CustomerProfile)
+class CustomerProfileAdmin(ModelAdmin, UserLinkMixin, OrganizationLinkMixin):  # type: ignore[misc]
+    """Admin for the per-(user, organization) Stripe Customer reference."""
+
+    list_display = ["__str__", "user_link", "organization_link", "stripe_customer_id", "created_at"]
+    list_filter = ["organization__name"]
+    list_select_related = ["user", "organization"]
+    search_fields = ["user__username", "user__email", "organization__name", "stripe_customer_id"]
+    autocomplete_fields = ["user", "organization"]
+    readonly_fields = ["stripe_customer_id", "created_at", "updated_at"]

--- a/src/events/controllers/me_subscriptions.py
+++ b/src/events/controllers/me_subscriptions.py
@@ -1,22 +1,25 @@
-"""Member-facing read endpoints for membership subscriptions."""
+"""Member-facing endpoints for membership subscriptions."""
 
 from uuid import UUID
 
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
+from ninja.errors import HttpError
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 
 from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
-from common.throttling import UserDefaultThrottle
+from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import schema
-from events.models import MembershipSubscription
+from events.models import MembershipSubscription, MembershipSubscriptionPlan, Organization
+from events.service import subscription_service, subscription_stripe_service
 
 
 @api_controller("/me", auth=I18nJWTAuth(), tags=["Me - Subscriptions"], throttle=UserDefaultThrottle())
 class MeSubscriptionsController(UserAwareController):
-    """Read-only access to the current user's own membership subscriptions."""
+    """Member-facing access to the current user's own membership subscriptions."""
 
     @route.get(
         "/membership-subscriptions",
@@ -49,3 +52,61 @@ class MeSubscriptionsController(UserAwareController):
             .order_by("-created_at")
         )
         return get_object_or_404(qs)
+
+    @route.post(
+        "/organizations/{org_id}/subscribe",
+        url_name="subscribe_to_membership_plan",
+        response={201: schema.SubscribeResponseSchema},
+        throttle=WriteThrottle(),
+    )
+    def subscribe(
+        self,
+        org_id: UUID,
+        payload: schema.SubscribeRequestSchema,
+    ) -> tuple[int, schema.SubscribeResponseSchema]:
+        """Start a Stripe-backed subscription on an ONLINE plan.
+
+        Returns the local subscription row plus a Stripe ``client_secret`` the
+        frontend uses to confirm the first invoice's PaymentIntent.
+        """
+        organization = get_object_or_404(Organization, pk=org_id)
+        plan = get_object_or_404(
+            MembershipSubscriptionPlan.objects.select_related("tier", "tier__organization"),
+            pk=payload.plan_id,
+            tier__organization=organization,
+            is_active=True,
+        )
+        if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+            raise HttpError(400, str(_("This plan is not available for self-service subscription.")))
+
+        subscription, client_secret = subscription_stripe_service.start_online_subscription(plan, self.user())
+        return 201, schema.SubscribeResponseSchema(
+            subscription=schema.MySubscriptionSchema.model_validate(subscription, from_attributes=True),
+            client_secret=client_secret,
+        )
+
+    @route.post(
+        "/organizations/{org_id}/subscription/cancel",
+        url_name="cancel_my_membership_subscription",
+        response=schema.MySubscriptionSchema,
+        throttle=WriteThrottle(),
+    )
+    def cancel_subscription(
+        self,
+        org_id: UUID,
+        payload: schema.MemberCancelSubscriptionSchema,
+    ) -> MembershipSubscription:
+        """Cancel the caller's active subscription in an organization.
+
+        For ONLINE plans the cancel is mirrored to Stripe; the webhook then
+        settles local state. ``immediate=False`` (default) schedules the
+        cancellation at the period boundary.
+        """
+        qs = (
+            MembershipSubscription.objects.filter(user=self.user(), organization_id=org_id)
+            .exclude(status__in=MembershipSubscription.TERMINAL_STATUSES)
+            .select_related("plan", "plan__tier", "organization")
+            .order_by("-created_at")
+        )
+        subscription = get_object_or_404(qs)
+        return subscription_service.cancel_subscription(subscription, immediate=payload.immediate)

--- a/src/events/controllers/me_subscriptions.py
+++ b/src/events/controllers/me_subscriptions.py
@@ -4,8 +4,6 @@ from uuid import UUID
 
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
-from django.utils.translation import gettext_lazy as _
-from ninja.errors import HttpError
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 
@@ -76,9 +74,8 @@ class MeSubscriptionsController(UserAwareController):
             tier__organization=organization,
             is_active=True,
         )
-        if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
-            raise HttpError(400, str(_("This plan is not available for self-service subscription.")))
-
+        # ``start_online_subscription`` enforces ``payment_method == ONLINE``
+        # and raises 400 if the plan is offline; no need to repeat the check.
         subscription, client_secret = subscription_stripe_service.start_online_subscription(plan, self.user())
         return 201, schema.SubscribeResponseSchema(
             subscription=schema.MySubscriptionSchema.model_validate(subscription, from_attributes=True),

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -162,6 +162,24 @@ class OrganizationController(UserAwareController):
         return self.get_one(slug)
 
     @route.get(
+        "/{slug}/membership-plans",
+        url_name="list_organization_membership_plans",
+        response=list[schema.PublicPlanSchema],
+    )
+    def list_membership_plans(self, slug: str) -> QuerySet[models.MembershipSubscriptionPlan]:
+        """List active subscription plans available on this organization.
+
+        Public endpoint used by the member-facing checkout. Archived (``is_active=False``)
+        plans are filtered out so they cannot be selected for new subscriptions.
+        """
+        organization = self.get_one(slug)
+        return (
+            models.MembershipSubscriptionPlan.objects.filter(tier__organization=organization, is_active=True)
+            .select_related("tier")
+            .order_by("tier__name", "price")
+        )
+
+    @route.get(
         "/{slug}/resources",
         url_name="list_organization_resources",
         response=PaginatedResponseSchema[schema.AdditionalResourceSchema],

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
+from ninja.errors import HttpError
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 from ninja_extra.searching import Searching, searching
@@ -158,13 +160,28 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         slug: str,
         payload: schema.SubscriptionCreateSchema,
     ) -> tuple[int, models.MembershipSubscription]:
-        """Create a subscription on behalf of a user (OFFLINE flow)."""
+        """Create a subscription on behalf of a user (OFFLINE flow only).
+
+        ONLINE (Stripe) plans must be subscribed to by the member themselves
+        via ``POST /api/me/organizations/{org_id}/subscribe`` so the user can
+        confirm the first payment.
+        """
         organization = self.get_one(slug)
         plan = get_object_or_404(
             models.MembershipSubscriptionPlan.objects.select_related("tier"),
             pk=payload.plan_id,
             tier__organization=organization,
         )
+        if plan.payment_method == models.MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+            raise HttpError(
+                400,
+                str(
+                    _(
+                        "ONLINE plans must be subscribed to by the member directly. "
+                        "Send them to the member-facing subscribe endpoint."
+                    )
+                ),
+            )
         user = get_object_or_404(RevelUser, pk=payload.user_id)
 
         initial: InitialPayment | None = None
@@ -193,13 +210,22 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         sub_id: UUID,
         payload: schema.PaymentRecordSchema,
     ) -> tuple[int, models.MembershipPayment]:
-        """Record a manual payment against a subscription."""
+        """Record a manual payment against an OFFLINE subscription.
+
+        ONLINE (Stripe) payments arrive via the ``invoice.paid`` webhook and
+        must not be hand-recorded — that would create duplicates.
+        """
         organization = self.get_one(slug)
         subscription = get_object_or_404(
             models.MembershipSubscription.objects.select_related("plan"),
             pk=sub_id,
             organization=organization,
         )
+        if subscription.plan.payment_method == models.MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+            raise HttpError(
+                400,
+                str(_("ONLINE subscription payments are recorded automatically via Stripe webhooks.")),
+            )
         payment = subscription_service.record_payment(
             subscription,
             amount=payload.amount,

--- a/src/events/migrations/0071_subscription_stripe_fields.py
+++ b/src/events/migrations/0071_subscription_stripe_fields.py
@@ -1,0 +1,97 @@
+# Generated for Phase 2: Stripe ONLINE subscriptions.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("events", "0070_organization_membership_grace_period_days_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="membershipsubscriptionplan",
+            name="payment_method",
+            field=models.CharField(
+                choices=[("online", "Online (Stripe)"), ("offline", "Offline (staff-managed)")],
+                default="offline",
+                help_text="ONLINE plans are billed via Stripe; OFFLINE plans are tracked manually by staff.",
+                max_length=10,
+            ),
+        ),
+        migrations.AddField(
+            model_name="membershipsubscriptionplan",
+            name="stripe_product_id",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+        migrations.AddField(
+            model_name="membershipsubscriptionplan",
+            name="stripe_price_id",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=255),
+        ),
+        migrations.AddField(
+            model_name="membershipsubscription",
+            name="stripe_subscription_id",
+            field=models.CharField(blank=True, max_length=255, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name="membershippayment",
+            name="stripe_invoice_id",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=255),
+        ),
+        migrations.AddField(
+            model_name="membershippayment",
+            name="stripe_payment_intent_id",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=255),
+        ),
+        migrations.CreateModel(
+            name="CustomerProfile",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, db_index=True)),
+                ("stripe_customer_id", models.CharField(db_index=True, max_length=255)),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="customer_profiles",
+                        to="events.organization",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="customer_profiles",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="customerprofile",
+            constraint=models.UniqueConstraint(
+                fields=("user", "organization"), name="unique_customer_per_user_org"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="customerprofile",
+            constraint=models.UniqueConstraint(
+                fields=("organization", "stripe_customer_id"),
+                name="unique_stripe_customer_per_org",
+            ),
+        ),
+    ]

--- a/src/events/models/__init__.py
+++ b/src/events/models/__init__.py
@@ -39,6 +39,7 @@ from .questionnaire import EventQuestionnaireSubmission, OrganizationQuestionnai
 from .recurrence_rule import RecurrenceRule
 from .rsvp import EventRSVP
 from .subscription import (
+    CustomerProfile,
     MembershipPayment,
     MembershipSubscription,
     MembershipSubscriptionPlan,
@@ -80,6 +81,7 @@ __all__ = [
     # Event Series
     "EventSeries",
     # Subscriptions
+    "CustomerProfile",
     "MembershipPayment",
     "MembershipSubscription",
     "MembershipSubscriptionPlan",

--- a/src/events/models/subscription.py
+++ b/src/events/models/subscription.py
@@ -1,8 +1,8 @@
 """Membership subscription models.
 
-Phase 1 (OFFLINE) of the membership-subscriptions roadmap. Stripe-specific
-fields (``stripe_price_id``, ``stripe_subscription_id``, etc.) are intentionally
-omitted here and will be introduced via an additive migration in Phase 2.
+Phase 1 introduced staff-managed (OFFLINE) subscriptions. Phase 2 adds
+Stripe-backed ONLINE subscriptions via additive fields and a per-(user, org)
+:class:`CustomerProfile`.
 """
 
 import typing as t
@@ -37,6 +37,10 @@ class MembershipSubscriptionPlan(TimeStampedModel):
         MONTH = "month", _("Month")
         YEAR = "year", _("Year")
 
+    class PaymentMethod(models.TextChoices):
+        ONLINE = "online", _("Online (Stripe)")
+        OFFLINE = "offline", _("Offline (staff-managed)")
+
     tier = models.ForeignKey(
         MembershipTier,
         on_delete=models.CASCADE,
@@ -60,6 +64,14 @@ class MembershipSubscriptionPlan(TimeStampedModel):
         validators=[MinValueValidator(1)],
     )
     is_active = models.BooleanField(default=True, db_index=True)
+    payment_method = models.CharField(
+        max_length=10,
+        choices=PaymentMethod.choices,
+        default=PaymentMethod.OFFLINE,
+        help_text=_("ONLINE plans are billed via Stripe; OFFLINE plans are tracked manually by staff."),
+    )
+    stripe_product_id = models.CharField(max_length=255, blank=True, default="")
+    stripe_price_id = models.CharField(max_length=255, blank=True, default="", db_index=True)
 
     class Meta:
         ordering = ["tier__name", "name"]
@@ -118,6 +130,7 @@ class MembershipSubscription(TimeStampedModel):
     current_period_end = models.DateTimeField(null=True, blank=True, db_index=True)
     cancel_at_period_end = models.BooleanField(default=False)
     cancelled_at = models.DateTimeField(null=True, blank=True)
+    stripe_subscription_id = models.CharField(max_length=255, null=True, blank=True, unique=True)
 
     class Meta:
         ordering = ["-created_at"]
@@ -191,6 +204,8 @@ class MembershipPayment(TimeStampedModel):
     )
     notes = models.TextField(blank=True, default="")
     raw_response = models.JSONField(default=dict, blank=True)
+    stripe_invoice_id = models.CharField(max_length=255, blank=True, default="", db_index=True)
+    stripe_payment_intent_id = models.CharField(max_length=255, blank=True, default="", db_index=True)
 
     class Meta:
         ordering = ["-created_at"]
@@ -200,3 +215,37 @@ class MembershipPayment(TimeStampedModel):
 
     def __str__(self) -> str:
         return f"Payment {self.id} for sub {self.subscription_id} ({self.status})"
+
+
+class CustomerProfile(TimeStampedModel):
+    """Per-(user, organization) Stripe Customer reference.
+
+    Stripe Connect uses one Customer namespace per connected account, so a
+    single platform-wide Customer doesn't work — each org's Stripe account
+    needs its own Customer for the user. This model is the join.
+    """
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="customer_profiles",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="customer_profiles",
+    )
+    stripe_customer_id = models.CharField(max_length=255, db_index=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(fields=["user", "organization"], name="unique_customer_per_user_org"),
+            models.UniqueConstraint(
+                fields=["organization", "stripe_customer_id"],
+                name="unique_stripe_customer_per_org",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.user_id} @ {self.organization_id} ({self.stripe_customer_id})"

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -289,13 +289,17 @@ from .recurring_event import (
 # Subscription schemas
 from .subscription import (
     CancelSubscriptionSchema,
+    MemberCancelSubscriptionSchema,
     MySubscriptionSchema,
     PaymentRecordSchema,
     PaymentSchema as MembershipPaymentSchema,
     PlanCreateSchema,
     PlanSchema,
     PlanUpdateSchema,
+    PublicPlanSchema,
     RefundSchema,
+    SubscribeRequestSchema,
+    SubscribeResponseSchema,
     SubscriptionCreateSchema,
     SubscriptionSchema,
 )
@@ -529,13 +533,17 @@ __all__ = [
     "TemplateEditSchema",
     # Subscriptions
     "CancelSubscriptionSchema",
+    "MemberCancelSubscriptionSchema",
     "MembershipPaymentSchema",
     "MySubscriptionSchema",
     "PaymentRecordSchema",
     "PlanCreateSchema",
     "PlanSchema",
     "PlanUpdateSchema",
+    "PublicPlanSchema",
     "RefundSchema",
+    "SubscribeRequestSchema",
+    "SubscribeResponseSchema",
     "SubscriptionCreateSchema",
     "SubscriptionSchema",
     # Announcement

--- a/src/events/schema/subscription.py
+++ b/src/events/schema/subscription.py
@@ -12,10 +12,11 @@ from .ticket import Currencies
 
 
 class PlanSchema(ModelSchema):
-    """Response schema for a subscription plan."""
+    """Response schema for a subscription plan (staff-facing)."""
 
     tier_id: UUID
     period_unit: MembershipSubscriptionPlan.PeriodUnit
+    payment_method: MembershipSubscriptionPlan.PaymentMethod
 
     class Meta:
         model = MembershipSubscriptionPlan
@@ -30,6 +31,29 @@ class PlanSchema(ModelSchema):
         ]
 
 
+class PublicPlanSchema(ModelSchema):
+    """Response schema for a subscription plan (public/member-facing).
+
+    Mirrors :class:`PlanSchema` but only exposes archived plans hidden — the
+    public list filters them — and does not return Stripe internals.
+    """
+
+    tier_id: UUID
+    period_unit: MembershipSubscriptionPlan.PeriodUnit
+    payment_method: MembershipSubscriptionPlan.PaymentMethod
+
+    class Meta:
+        model = MembershipSubscriptionPlan
+        fields = [
+            "id",
+            "name",
+            "description",
+            "price",
+            "currency",
+            "period_count",
+        ]
+
+
 class PlanCreateSchema(Schema):
     """Create payload for a subscription plan (tier inferred from URL)."""
 
@@ -40,10 +64,16 @@ class PlanCreateSchema(Schema):
     period_unit: MembershipSubscriptionPlan.PeriodUnit = MembershipSubscriptionPlan.PeriodUnit.MONTH
     period_count: int = Field(1, ge=1, le=120)
     is_active: bool = True
+    payment_method: MembershipSubscriptionPlan.PaymentMethod = MembershipSubscriptionPlan.PaymentMethod.OFFLINE
 
 
 class PlanUpdateSchema(Schema):
-    """Partial update payload for a subscription plan."""
+    """Partial update payload for a subscription plan.
+
+    ``payment_method`` is intentionally not patchable: switching between
+    OFFLINE and ONLINE mid-lifecycle would require non-trivial Stripe
+    migration. Archive the plan and create a new one instead.
+    """
 
     name: str | None = Field(None, max_length=255)
     description: str | None = None
@@ -176,3 +206,26 @@ class SubscriptionSchema(_BaseSubscriptionSchema):
     def resolve_plan(obj: MembershipSubscription) -> MembershipSubscriptionPlan:
         """Return the plan for nested serialization."""
         return obj.plan
+
+
+class SubscribeRequestSchema(Schema):
+    """Member-initiated subscribe payload."""
+
+    plan_id: UUID
+
+
+class SubscribeResponseSchema(Schema):
+    """Response to a member-initiated subscribe.
+
+    Carries the Stripe PaymentIntent ``client_secret`` so the frontend can
+    confirm the first invoice via Stripe.js.
+    """
+
+    subscription: MySubscriptionSchema
+    client_secret: str
+
+
+class MemberCancelSubscriptionSchema(Schema):
+    """Member-initiated cancel payload."""
+
+    immediate: bool = False

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -383,6 +383,38 @@ class StripeEventHandler:
                 quantity_sold=F("quantity_sold") - 1
             )
 
+    # ---- Membership subscription webhooks (Phase 2) ----
+
+    def handle_customer_subscription_created(self, event: stripe.Event) -> None:
+        """Mirror Stripe Subscription state when Stripe confirms creation."""
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.sync_subscription_from_stripe(dict(event.data.object))
+
+    def handle_customer_subscription_updated(self, event: stripe.Event) -> None:
+        """Mirror status / period / cancel_at_period_end onto the local row."""
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.sync_subscription_from_stripe(dict(event.data.object))
+
+    def handle_customer_subscription_deleted(self, event: stripe.Event) -> None:
+        """Stripe-side cancellation (immediate or end-of-period) — mark terminal."""
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.sync_subscription_from_stripe(dict(event.data.object))
+
+    def handle_invoice_paid(self, event: stripe.Event) -> None:
+        """Record a SUCCEEDED MembershipPayment + revive PENDING/PAST_DUE → ACTIVE."""
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.record_stripe_payment_from_invoice(dict(event.data.object), succeeded=True)
+
+    def handle_invoice_payment_failed(self, event: stripe.Event) -> None:
+        """Record a FAILED MembershipPayment + transition subscription to PAST_DUE."""
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.record_stripe_payment_from_invoice(dict(event.data.object), succeeded=False)
+
     @transaction.atomic
     def handle_payment_intent_canceled(self, event: stripe.Event) -> None:
         """Handle canceled payment intents.

--- a/src/events/service/subscription_service.py
+++ b/src/events/service/subscription_service.py
@@ -41,6 +41,20 @@ class InitialPayment:
 # ---- Plan operations ---------------------------------------------------------
 
 
+def _maybe_sync_plan_to_stripe(plan: MembershipSubscriptionPlan) -> MembershipSubscriptionPlan:
+    """Provision (or refresh) the Stripe Product+Price for an ONLINE plan.
+
+    No-op for OFFLINE plans. Stripe failures bubble up as ``HttpError`` so the
+    controller can return a clean ``502``; the DB transaction rolls back along
+    with the plan write so we don't leave a half-provisioned row.
+    """
+    if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        return plan
+    from events.service import subscription_stripe_service  # lazy: avoid cycle
+
+    return subscription_stripe_service.ensure_stripe_price(plan)
+
+
 @transaction.atomic
 def create_plan(
     tier: MembershipTier,
@@ -52,9 +66,14 @@ def create_plan(
     period_count: int = 1,
     description: str = "",
     is_active: bool = True,
+    payment_method: str = MembershipSubscriptionPlan.PaymentMethod.OFFLINE,
 ) -> MembershipSubscriptionPlan:
-    """Create a subscription plan for a membership tier."""
-    return MembershipSubscriptionPlan.objects.create(
+    """Create a subscription plan for a membership tier.
+
+    For ONLINE plans, also provisions the matching Stripe Product+Price on
+    the organization's Connect account.
+    """
+    plan = MembershipSubscriptionPlan.objects.create(
         tier=tier,
         name=name,
         price=price,
@@ -63,7 +82,9 @@ def create_plan(
         period_count=period_count,
         description=description,
         is_active=is_active,
+        payment_method=payment_method,
     )
+    return _maybe_sync_plan_to_stripe(plan)
 
 
 @transaction.atomic
@@ -73,22 +94,32 @@ def update_plan(
 ) -> MembershipSubscriptionPlan:
     """Update a plan in-place.
 
-    Callers pass only the fields to change; full_clean runs on save.
+    Callers pass only the fields to change; full_clean runs on save. When the
+    plan is ONLINE and any pricing-shape field changes, the Stripe Price is
+    archived and a fresh one created (Stripe Prices are immutable).
     """
     if not fields:
         return plan
     for field, value in fields.items():
         setattr(plan, field, value)
     plan.save(update_fields=[*fields.keys(), "updated_at"])
-    return plan
+    return _maybe_sync_plan_to_stripe(plan)
 
 
 @transaction.atomic
 def archive_plan(plan: MembershipSubscriptionPlan) -> MembershipSubscriptionPlan:
-    """Soft-disable a plan by flipping ``is_active``."""
+    """Soft-disable a plan by flipping ``is_active``.
+
+    For ONLINE plans, also archives the Stripe Price so it can't be used for
+    new subscriptions. Existing subscribers keep paying their old Price.
+    """
     if plan.is_active:
         plan.is_active = False
         plan.save(update_fields=["is_active", "updated_at"])
+    if plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        from events.service import subscription_stripe_service
+
+        subscription_stripe_service.archive_stripe_price(plan)
     return plan
 
 
@@ -150,14 +181,18 @@ def create_subscription(
         raise HttpError(400, str(_("This user already has an active subscription in this organization.")))
 
     # Ensure membership exists at plan.tier (don't overwrite BANNED — guarded above).
-    OrganizationMember.objects.update_or_create(
-        organization=organization,
-        user=user,
-        defaults={
-            "tier": plan.tier,
-            "status": OrganizationMember.MembershipStatus.ACTIVE,
-        },
-    )
+    # ONLINE plans gate ACTIVE membership on the first successful Stripe payment,
+    # so we don't grant tier benefits up front: that work moves into the
+    # ``invoice.paid`` / ``customer.subscription.updated`` webhook handlers.
+    if plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.OFFLINE:
+        OrganizationMember.objects.update_or_create(
+            organization=organization,
+            user=user,
+            defaults={
+                "tier": plan.tier,
+                "status": OrganizationMember.MembershipStatus.ACTIVE,
+            },
+        )
 
     try:
         subscription = MembershipSubscription.objects.create(
@@ -269,10 +304,28 @@ def cancel_subscription(
     ``immediate=True`` jumps straight to CANCELLED. PAUSED subscriptions
     refuse the scheduled path — pause freezes time so the period boundary
     would never be reached; callers must resume first or cancel immediately.
+
+    For Stripe-managed (ONLINE) subscriptions, dispatches to the Stripe
+    service so the cancel is mirrored to Stripe; the webhook then settles
+    local state. Falls back to the OFFLINE path when no Stripe link exists.
     """
-    subscription = MembershipSubscription.objects.select_for_update().get(pk=subscription.pk)
+    # Reload up front so the dispatch check sees committed plan/Stripe data.
+    subscription = (
+        MembershipSubscription.objects.select_for_update()
+        .select_related("plan", "plan__tier", "organization")
+        .get(pk=subscription.pk)
+    )
     if subscription.is_terminal:
         return subscription
+
+    if (
+        subscription.plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.ONLINE
+        and subscription.stripe_subscription_id
+    ):
+        # Lazy import to avoid a service<->stripe-service cycle.
+        from events.service import subscription_stripe_service
+
+        return subscription_stripe_service.cancel_online_subscription(subscription, immediate=immediate)
 
     if immediate:
         subscription.status = MembershipSubscription.SubscriptionStatus.CANCELLED
@@ -294,8 +347,22 @@ def cancel_subscription(
 
 @transaction.atomic
 def pause_subscription(subscription: MembershipSubscription) -> MembershipSubscription:
-    """Pause a non-terminal subscription."""
-    subscription = MembershipSubscription.objects.select_for_update().get(pk=subscription.pk)
+    """Pause a non-terminal subscription.
+
+    ONLINE (Stripe-managed) subscriptions are not pausable in Phase 2 —
+    Stripe ``pause_collection`` arrives in Phase 3.
+    """
+    subscription = MembershipSubscription.objects.select_for_update().select_related("plan").get(pk=subscription.pk)
+    if subscription.plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        raise HttpError(
+            400,
+            str(
+                _(
+                    "Stripe-backed subscriptions cannot be paused yet. "
+                    "Cancel instead, or wait for Phase 3 (Stripe pause_collection)."
+                )
+            ),
+        )
     if subscription.is_terminal:
         raise HttpError(400, str(_("Cannot pause a terminal subscription.")))
     if subscription.status == MembershipSubscription.SubscriptionStatus.PAUSED:

--- a/src/events/service/subscription_stripe_service.py
+++ b/src/events/service/subscription_stripe_service.py
@@ -72,6 +72,9 @@ def ensure_customer_profile(user: RevelUser, organization: Organization) -> Cust
             email=user.email,
             name=user.get_display_name() or None,
             metadata={"revel_user_id": str(user.pk), "revel_org_id": str(organization.pk)},
+            # Deterministic key keeps concurrent first-time subscribes from
+            # creating duplicate Stripe Customers on the same Connect account.
+            idempotency_key=f"cust:{user.pk}:{organization.pk}",
             **_stripe_account_kwargs(organization),
         )
     except stripe.error.StripeError as exc:
@@ -236,8 +239,11 @@ def start_online_subscription(
 
     customer = ensure_customer_profile(user, org)
 
-    with transaction.atomic():
-        subscription = subscription_service.create_subscription(plan, user)
+    # ``create_subscription`` is already ``@transaction.atomic`` — no outer
+    # wrapper needed. The local PENDING row commits before the Stripe call,
+    # which is intentional: holding a DB transaction open across a slow
+    # external API call would lock the row for the entire request.
+    subscription = subscription_service.create_subscription(plan, user)
 
     create_kwargs: dict[str, t.Any] = {
         "customer": customer.stripe_customer_id,
@@ -251,6 +257,10 @@ def start_online_subscription(
             "revel_org_id": str(org.pk),
             "revel_plan_id": str(plan.pk),
         },
+        # Deterministic key tied to the local row makes Stripe-side retries
+        # idempotent: a network hiccup that times out the create call won't
+        # accidentally provision two subscriptions on the next attempt.
+        "idempotency_key": f"sub:{subscription.pk}",
     }
     if org.platform_fee_percent and org.stripe_account_id and org.stripe_account_id != settings.STRIPE_ACCOUNT:
         create_kwargs["application_fee_percent"] = float(org.platform_fee_percent)
@@ -269,17 +279,29 @@ def start_online_subscription(
         )
         raise HttpError(502, str(_("Payment processing failed. Please try again later."))) from exc
 
-    subscription.stripe_subscription_id = t.cast(str, stripe_sub.id)
-    subscription.save(update_fields=["stripe_subscription_id", "updated_at"])
-
     client_secret = _extract_client_secret(stripe_sub)
     if not client_secret:
+        # Stripe accepted the create call but didn't return an expandable
+        # PaymentIntent. The user can't confirm payment, so cancel the Stripe
+        # sub (best-effort) and drop the local row so they aren't blocked by
+        # the partial-unique index when they retry.
         logger.warning(
             "subscription_stripe_missing_client_secret",
             stripe_subscription_id=stripe_sub.id,
             subscription_id=str(subscription.pk),
         )
+        try:
+            stripe.Subscription.cancel(stripe_sub.id, **_stripe_account_kwargs(org))  # type: ignore[attr-defined]
+        except stripe.error.StripeError:
+            logger.exception(
+                "subscription_stripe_cleanup_cancel_failed",
+                stripe_subscription_id=stripe_sub.id,
+            )
+        subscription.delete()
         raise HttpError(502, str(_("Payment processing failed. Please try again later.")))
+
+    subscription.stripe_subscription_id = t.cast(str, stripe_sub.id)
+    subscription.save(update_fields=["stripe_subscription_id", "updated_at"])
     return subscription, client_secret
 
 
@@ -472,8 +494,14 @@ def record_stripe_payment_from_invoice(
         return None
 
     currency_code = t.cast(str, invoice.get("currency") or subscription.plan.currency).upper()
-    amount_paid = int(invoice.get("amount_paid") or invoice.get("amount_due") or 0)
-    amount = from_stripe_amount(amount_paid, currency_code) if amount_paid else Decimal("0")
+    # FAILED payments collected nothing — store ``amount=0``. The attempted
+    # amount is preserved in ``raw_response``. SUCCEEDED payments use
+    # ``amount_paid`` (what actually changed hands).
+    if succeeded:
+        amount_minor = int(invoice.get("amount_paid") or 0)
+    else:
+        amount_minor = 0
+    amount = from_stripe_amount(amount_minor, currency_code) if amount_minor else Decimal("0")
 
     period = invoice.get("lines", {}).get("data", [{}])[0].get("period") or {}
     period_start = _epoch_to_dt(period.get("start")) or timezone.now()

--- a/src/events/service/subscription_stripe_service.py
+++ b/src/events/service/subscription_stripe_service.py
@@ -1,0 +1,538 @@
+"""Stripe integration for membership subscriptions (Phase 2).
+
+Lives next to ``subscription_service`` (the OFFLINE/staff-managed flow) and
+adds the ONLINE flow on top of Stripe Connect direct charges. The local
+state machine is still authoritative; Stripe events flow back via the
+webhook handlers in :mod:`events.service.stripe_webhooks`.
+"""
+
+import typing as t
+from datetime import datetime
+from datetime import timezone as _utc
+from decimal import Decimal
+
+import stripe
+import structlog
+from django.conf import settings
+from django.db import models, transaction
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from ninja.errors import HttpError
+
+from accounts.models import RevelUser
+from common.utils import get_or_create_with_race_protection
+from events.models import (
+    CustomerProfile,
+    MembershipPayment,
+    MembershipSubscription,
+    MembershipSubscriptionPlan,
+    Organization,
+    OrganizationMember,
+)
+from events.service import subscription_service
+from events.utils.currency import from_stripe_amount, to_stripe_amount
+
+logger = structlog.get_logger(__name__)
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+
+
+# ---- Stripe-account helpers --------------------------------------------------
+
+
+def _stripe_account_kwargs(organization: Organization) -> dict[str, str]:
+    """Return ``stripe_account=...`` kwargs for a Connect API call.
+
+    When the organization happens to share the platform's own Stripe account,
+    omit the kwarg entirely (mirrors :mod:`events.service.stripe_service`).
+    """
+    if organization.stripe_account_id and organization.stripe_account_id != settings.STRIPE_ACCOUNT:
+        return {"stripe_account": organization.stripe_account_id}
+    return {}
+
+
+def _require_stripe_connected(organization: Organization) -> None:
+    """Raise 400 if the organization has not finished Stripe Connect onboarding."""
+    if not organization.is_stripe_connected:
+        raise HttpError(400, str(_("This organization is not configured to accept payments.")))
+
+
+# ---- Customer profile --------------------------------------------------------
+
+
+def ensure_customer_profile(user: RevelUser, organization: Organization) -> CustomerProfile:
+    """Return the per-(user, organization) Stripe Customer, creating it if needed."""
+    _require_stripe_connected(organization)
+    existing = CustomerProfile.objects.filter(user=user, organization=organization).first()
+    if existing:
+        return existing
+
+    try:
+        customer = stripe.Customer.create(
+            email=user.email,
+            name=user.get_display_name() or None,
+            metadata={"revel_user_id": str(user.pk), "revel_org_id": str(organization.pk)},
+            **_stripe_account_kwargs(organization),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "subscription_stripe_customer_create_failed",
+            user_id=str(user.pk),
+            org_id=str(organization.pk),
+            error=str(exc),
+        )
+        raise HttpError(502, str(_("Payment processing failed. Please try again later."))) from exc
+
+    profile, _created = get_or_create_with_race_protection(
+        CustomerProfile,
+        models.Q(user=user, organization=organization),
+        {
+            "user": user,
+            "organization": organization,
+            "stripe_customer_id": t.cast(str, customer.id),
+        },
+    )
+    return profile
+
+
+# ---- Product + Price provisioning -------------------------------------------
+
+
+def _price_inputs_changed(plan: MembershipSubscriptionPlan, price: stripe.Price) -> bool:
+    """True when ``plan``'s pricing inputs no longer match the Stripe Price."""
+    if not price.active:
+        return True
+    if price.unit_amount != to_stripe_amount(plan.price, plan.currency):
+        return True
+    if (price.currency or "").upper() != plan.currency.upper():
+        return True
+    recurring = price.recurring or {}
+    if recurring.get("interval") != plan.period_unit:
+        return True
+    if recurring.get("interval_count") != plan.period_count:
+        return True
+    return False
+
+
+def ensure_stripe_price(plan: MembershipSubscriptionPlan) -> MembershipSubscriptionPlan:
+    """Create or sync the Stripe Product + Price for an ONLINE plan.
+
+    Stripe Prices are immutable on the dimensions we care about (unit amount,
+    currency, recurring interval). When any of those change we archive the
+    existing Price and create a fresh one.
+
+    A no-op for OFFLINE plans.
+    """
+    if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        return plan
+
+    org = plan.tier.organization
+    _require_stripe_connected(org)
+    kwargs = _stripe_account_kwargs(org)
+    update_fields: list[str] = []
+
+    try:
+        if not plan.stripe_product_id:
+            product = stripe.Product.create(
+                name=f"{plan.tier.name} — {plan.name}",
+                description=plan.description or None,
+                metadata={"revel_plan_id": str(plan.pk)},
+                **kwargs,
+            )
+            plan.stripe_product_id = t.cast(str, product.id)
+            update_fields.append("stripe_product_id")
+
+        needs_new_price = not plan.stripe_price_id
+        if not needs_new_price:
+            existing_price = stripe.Price.retrieve(plan.stripe_price_id, **kwargs)
+            if _price_inputs_changed(plan, existing_price):
+                if existing_price.active:
+                    stripe.Price.modify(plan.stripe_price_id, active=False, **kwargs)
+                needs_new_price = True
+
+        if needs_new_price:
+            new_price = stripe.Price.create(
+                product=plan.stripe_product_id,
+                unit_amount=to_stripe_amount(plan.price, plan.currency),
+                currency=plan.currency.lower(),
+                recurring={"interval": plan.period_unit, "interval_count": plan.period_count},
+                metadata={"revel_plan_id": str(plan.pk)},
+                **kwargs,
+            )
+            plan.stripe_price_id = t.cast(str, new_price.id)
+            update_fields.append("stripe_price_id")
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "subscription_stripe_price_sync_failed",
+            plan_id=str(plan.pk),
+            error=str(exc),
+        )
+        raise HttpError(502, str(_("Could not sync the plan with Stripe. Please try again later."))) from exc
+
+    if update_fields:
+        plan.save(update_fields=[*update_fields, "updated_at"])
+    return plan
+
+
+def archive_stripe_price(plan: MembershipSubscriptionPlan) -> None:
+    """Deactivate the Stripe Price for an archived ONLINE plan.
+
+    Existing subscribers keep paying their old Price (Stripe links are by
+    subscription, not by the active flag), but the Price can no longer be
+    used for new subscriptions.
+    """
+    if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        return
+    if not plan.stripe_price_id:
+        return
+    org = plan.tier.organization
+    if not org.is_stripe_connected:
+        return
+    try:
+        stripe.Price.modify(plan.stripe_price_id, active=False, **_stripe_account_kwargs(org))
+    except stripe.error.InvalidRequestError as exc:
+        # Price already archived or no longer exists — nothing actionable.
+        logger.warning(
+            "subscription_archive_stripe_price_failed",
+            plan_id=str(plan.pk),
+            stripe_price_id=plan.stripe_price_id,
+            error=str(exc),
+        )
+
+
+# ---- Subscribe / cancel -----------------------------------------------------
+
+
+def start_online_subscription(
+    plan: MembershipSubscriptionPlan,
+    user: RevelUser,
+) -> tuple[MembershipSubscription, str]:
+    """Start an ONLINE subscription via Stripe.
+
+    Creates the local row via :func:`subscription_service.create_subscription`
+    (re-using its BANNED / duplicate-active checks and member sync), then
+    creates a Stripe Subscription with ``payment_behavior=default_incomplete``
+    so the client can confirm the first invoice's PaymentIntent.
+
+    Returns:
+        A ``(subscription, client_secret)`` pair. The caller hands
+        ``client_secret`` to Stripe.js to confirm the first payment.
+    """
+    if plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        raise HttpError(400, str(_("This plan is not configured for online checkout.")))
+    if not plan.is_active:
+        raise HttpError(400, str(_("This plan is archived and no longer accepts new subscriptions.")))
+
+    org = plan.tier.organization
+    _require_stripe_connected(org)
+
+    # Lazily provision Stripe Product+Price if missing (e.g. plan was created
+    # before Phase 2 or the Stripe call previously failed).
+    if not plan.stripe_price_id:
+        ensure_stripe_price(plan)
+        plan.refresh_from_db()
+        if not plan.stripe_price_id:
+            raise HttpError(500, str(_("Could not prepare the plan for checkout.")))
+
+    customer = ensure_customer_profile(user, org)
+
+    with transaction.atomic():
+        subscription = subscription_service.create_subscription(plan, user)
+
+    create_kwargs: dict[str, t.Any] = {
+        "customer": customer.stripe_customer_id,
+        "items": [{"price": plan.stripe_price_id}],
+        "payment_behavior": "default_incomplete",
+        "payment_settings": {"save_default_payment_method": "on_subscription"},
+        "expand": ["latest_invoice.payment_intent"],
+        "metadata": {
+            "revel_subscription_id": str(subscription.pk),
+            "revel_user_id": str(user.pk),
+            "revel_org_id": str(org.pk),
+            "revel_plan_id": str(plan.pk),
+        },
+    }
+    if org.platform_fee_percent and org.stripe_account_id and org.stripe_account_id != settings.STRIPE_ACCOUNT:
+        create_kwargs["application_fee_percent"] = float(org.platform_fee_percent)
+    create_kwargs.update(_stripe_account_kwargs(org))
+
+    try:
+        stripe_sub = stripe.Subscription.create(**create_kwargs)
+    except stripe.error.StripeError as exc:
+        # Roll back the local PENDING row so the user can retry cleanly.
+        subscription.delete()
+        logger.error(
+            "subscription_stripe_create_failed",
+            plan_id=str(plan.pk),
+            user_id=str(user.pk),
+            error=str(exc),
+        )
+        raise HttpError(502, str(_("Payment processing failed. Please try again later."))) from exc
+
+    subscription.stripe_subscription_id = t.cast(str, stripe_sub.id)
+    subscription.save(update_fields=["stripe_subscription_id", "updated_at"])
+
+    client_secret = _extract_client_secret(stripe_sub)
+    if not client_secret:
+        logger.warning(
+            "subscription_stripe_missing_client_secret",
+            stripe_subscription_id=stripe_sub.id,
+            subscription_id=str(subscription.pk),
+        )
+        raise HttpError(502, str(_("Payment processing failed. Please try again later.")))
+    return subscription, client_secret
+
+
+def _extract_client_secret(stripe_sub: stripe.Subscription) -> str | None:
+    """Pull the PaymentIntent client_secret off an expanded Subscription."""
+    invoice = getattr(stripe_sub, "latest_invoice", None)
+    if not invoice:
+        return None
+    payment_intent = (
+        invoice.get("payment_intent") if isinstance(invoice, dict) else getattr(invoice, "payment_intent", None)
+    )
+    if not payment_intent:
+        return None
+    if isinstance(payment_intent, dict):
+        return t.cast(str | None, payment_intent.get("client_secret"))
+    return t.cast(str | None, getattr(payment_intent, "client_secret", None))
+
+
+def cancel_online_subscription(
+    subscription: MembershipSubscription,
+    *,
+    immediate: bool = False,
+) -> MembershipSubscription:
+    """Cancel an ONLINE subscription on Stripe.
+
+    Local state is mirrored via the ``customer.subscription.updated`` /
+    ``customer.subscription.deleted`` webhooks. As a UX nicety we also reflect
+    the scheduled flag locally right away so the API caller sees an immediate
+    response without waiting for the webhook round-trip.
+    """
+    if subscription.plan.payment_method != MembershipSubscriptionPlan.PaymentMethod.ONLINE:
+        raise HttpError(400, str(_("This subscription is not managed by Stripe.")))
+    if not subscription.stripe_subscription_id:
+        raise HttpError(400, str(_("This subscription has no linked Stripe record yet.")))
+    if subscription.is_terminal:
+        return subscription
+
+    org = subscription.organization
+    kwargs = _stripe_account_kwargs(org)
+
+    if immediate:
+        # ``Subscription.cancel`` is the documented runtime API; the type stubs
+        # don't expose it as a classmethod, hence the ignore.
+        stripe.Subscription.cancel(subscription.stripe_subscription_id, **kwargs)  # type: ignore[attr-defined]
+        subscription.status = MembershipSubscription.SubscriptionStatus.CANCELLED
+        subscription.cancelled_at = timezone.now()
+        subscription.cancel_at_period_end = False
+        subscription.save(update_fields=["status", "cancelled_at", "cancel_at_period_end", "updated_at"])
+    else:
+        stripe.Subscription.modify(
+            subscription.stripe_subscription_id,
+            cancel_at_period_end=True,
+            **kwargs,
+        )
+        subscription.cancel_at_period_end = True
+        subscription.save(update_fields=["cancel_at_period_end", "updated_at"])
+    return subscription
+
+
+# ---- Webhook helpers --------------------------------------------------------
+
+
+def _ensure_active_member(subscription: MembershipSubscription) -> None:
+    """Make sure an :class:`OrganizationMember` exists for an ONLINE subscriber.
+
+    Phase 1's signal-driven sync intentionally never *creates* members; that
+    responsibility belongs to :func:`subscription_service.create_subscription`
+    for the OFFLINE flow. For ONLINE plans, the equivalent moment is the
+    first successful invoice / Stripe ``active`` status — both of which land
+    in this module's webhook helpers. We use ``get_or_create`` so that an
+    existing BANNED row stays BANNED (the post-save signal then preserves
+    that state when it fires).
+    """
+    OrganizationMember.objects.get_or_create(
+        organization=subscription.organization,
+        user=subscription.user,
+        defaults={
+            "tier": subscription.plan.tier,
+            "status": OrganizationMember.MembershipStatus.ACTIVE,
+        },
+    )
+
+
+_STRIPE_STATUS_MAP: dict[str, str] = {
+    "incomplete": MembershipSubscription.SubscriptionStatus.PENDING.value,
+    "incomplete_expired": MembershipSubscription.SubscriptionStatus.EXPIRED.value,
+    "trialing": MembershipSubscription.SubscriptionStatus.ACTIVE.value,
+    "active": MembershipSubscription.SubscriptionStatus.ACTIVE.value,
+    "past_due": MembershipSubscription.SubscriptionStatus.PAST_DUE.value,
+    "unpaid": MembershipSubscription.SubscriptionStatus.PAST_DUE.value,
+    "canceled": MembershipSubscription.SubscriptionStatus.CANCELLED.value,
+    "paused": MembershipSubscription.SubscriptionStatus.PAUSED.value,
+}
+
+
+def map_stripe_status(stripe_status: str) -> str | None:
+    """Translate a Stripe ``Subscription.status`` to our local enum value."""
+    return _STRIPE_STATUS_MAP.get(stripe_status)
+
+
+def _epoch_to_dt(epoch: int | None) -> datetime | None:
+    """Convert a Stripe Unix timestamp to a tz-aware datetime."""
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch, tz=_utc.utc)
+
+
+@transaction.atomic
+def sync_subscription_from_stripe(
+    stripe_subscription: dict[str, t.Any],
+) -> MembershipSubscription | None:
+    """Mirror Stripe Subscription state onto our local row.
+
+    Used by ``customer.subscription.{created,updated,deleted}`` handlers.
+    Returns ``None`` if we don't know the subscription locally — Stripe-side
+    rows for unrelated Connect accounts are expected and silently ignored.
+    """
+    stripe_id = stripe_subscription.get("id")
+    if not stripe_id:
+        return None
+    subscription = (
+        MembershipSubscription.objects.select_for_update()
+        .select_related("plan", "plan__tier", "organization", "user")
+        .filter(stripe_subscription_id=stripe_id)
+        .first()
+    )
+    if subscription is None:
+        return None
+
+    update_fields: list[str] = []
+
+    mapped = map_stripe_status(t.cast(str, stripe_subscription.get("status", "")))
+    if mapped and subscription.status != mapped:
+        subscription.status = mapped
+        update_fields.append("status")
+        if mapped == MembershipSubscription.SubscriptionStatus.CANCELLED.value and not subscription.cancelled_at:
+            subscription.cancelled_at = timezone.now()
+            update_fields.append("cancelled_at")
+
+    cap = bool(stripe_subscription.get("cancel_at_period_end", False))
+    if subscription.cancel_at_period_end != cap:
+        subscription.cancel_at_period_end = cap
+        update_fields.append("cancel_at_period_end")
+
+    new_start = _epoch_to_dt(stripe_subscription.get("current_period_start"))
+    if new_start and subscription.current_period_start != new_start:
+        subscription.current_period_start = new_start
+        update_fields.append("current_period_start")
+    new_end = _epoch_to_dt(stripe_subscription.get("current_period_end"))
+    if new_end and subscription.current_period_end != new_end:
+        subscription.current_period_end = new_end
+        update_fields.append("current_period_end")
+
+    if update_fields:
+        subscription.save(update_fields=[*update_fields, "updated_at"])
+    if subscription.status == MembershipSubscription.SubscriptionStatus.ACTIVE.value:
+        _ensure_active_member(subscription)
+    return subscription
+
+
+@transaction.atomic
+def record_stripe_payment_from_invoice(
+    invoice: dict[str, t.Any],
+    *,
+    succeeded: bool,
+) -> MembershipPayment | None:
+    """Create or update a :class:`MembershipPayment` from a Stripe Invoice event.
+
+    Args:
+        invoice: The Stripe ``invoice.*`` event's ``data.object``.
+        succeeded: ``True`` for ``invoice.paid``; ``False`` for
+            ``invoice.payment_failed``.
+
+    Returns:
+        The created/updated :class:`MembershipPayment`, or ``None`` when the
+        invoice belongs to a Stripe Subscription we don't know.
+    """
+    stripe_sub_id = invoice.get("subscription")
+    invoice_id = invoice.get("id")
+    if not stripe_sub_id or not invoice_id:
+        return None
+
+    subscription = (
+        MembershipSubscription.objects.select_for_update()
+        .select_related("plan", "plan__tier", "organization")
+        .filter(stripe_subscription_id=stripe_sub_id)
+        .first()
+    )
+    if subscription is None:
+        return None
+
+    currency_code = t.cast(str, invoice.get("currency") or subscription.plan.currency).upper()
+    amount_paid = int(invoice.get("amount_paid") or invoice.get("amount_due") or 0)
+    amount = from_stripe_amount(amount_paid, currency_code) if amount_paid else Decimal("0")
+
+    period = invoice.get("lines", {}).get("data", [{}])[0].get("period") or {}
+    period_start = _epoch_to_dt(period.get("start")) or timezone.now()
+    period_end = _epoch_to_dt(period.get("end")) or timezone.now()
+
+    payment_intent_id = invoice.get("payment_intent") or ""
+
+    payment, created = MembershipPayment.objects.update_or_create(
+        stripe_invoice_id=invoice_id,
+        defaults={
+            "subscription": subscription,
+            "amount": amount,
+            "currency": currency_code,
+            "status": (
+                MembershipPayment.PaymentStatus.SUCCEEDED if succeeded else MembershipPayment.PaymentStatus.FAILED
+            ),
+            "period_start": period_start,
+            "period_end": period_end,
+            "stripe_payment_intent_id": payment_intent_id,
+            "raw_response": invoice,
+        },
+    )
+
+    if succeeded:
+        # Mirror the period from the invoice line and revive PENDING/PAST_DUE.
+        update_fields: list[str] = []
+        if subscription.current_period_start != period_start:
+            subscription.current_period_start = period_start
+            update_fields.append("current_period_start")
+        if subscription.current_period_end != period_end:
+            subscription.current_period_end = period_end
+            update_fields.append("current_period_end")
+        revivable = {
+            MembershipSubscription.SubscriptionStatus.PENDING.value,
+            MembershipSubscription.SubscriptionStatus.PAST_DUE.value,
+        }
+        if subscription.status in revivable:
+            subscription.status = MembershipSubscription.SubscriptionStatus.ACTIVE
+            update_fields.append("status")
+        if update_fields:
+            subscription.save(update_fields=[*update_fields, "updated_at"])
+        _ensure_active_member(subscription)
+    else:
+        # Mirror PAST_DUE for failed payments. The grace-expiry Celery task
+        # from Phase 1 takes over from here.
+        if subscription.status in {
+            MembershipSubscription.SubscriptionStatus.ACTIVE.value,
+            MembershipSubscription.SubscriptionStatus.PENDING.value,
+        }:
+            subscription.status = MembershipSubscription.SubscriptionStatus.PAST_DUE
+            subscription.save(update_fields=["status", "updated_at"])
+
+    logger.info(
+        "subscription_stripe_payment_recorded",
+        subscription_id=str(subscription.pk),
+        stripe_invoice_id=invoice_id,
+        succeeded=succeeded,
+        amount=str(amount),
+        currency=currency_code,
+        created=created,
+    )
+    return payment

--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -17,6 +17,7 @@ from events.models import (
     EventRSVP,
     GeneralUserPreferences,
     MembershipSubscription,
+    MembershipSubscriptionPlan,
     Organization,
     OrganizationMember,
     OrganizationStaff,
@@ -470,6 +471,15 @@ def sync_member_from_subscription(
     """
     target_status = _SUBSCRIPTION_TO_MEMBER_STATUS.get(instance.status)
     if target_status is None:
+        return
+
+    # ONLINE plans gate ACTIVE membership on the first successful Stripe
+    # payment. PENDING is the "awaiting first invoice" state — leave the
+    # member alone until the webhook flips us to ACTIVE.
+    if (
+        instance.status == MembershipSubscription.SubscriptionStatus.PENDING.value
+        and instance.plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.ONLINE.value
+    ):
         return
 
     # If a newer non-terminal subscription exists, it owns the member state.

--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -459,8 +459,12 @@ def sync_member_from_subscription(
     """Sync ``OrganizationMember.status`` and ``tier`` from the subscription.
 
     Rules:
-    - Never creates an :class:`OrganizationMember` — creation belongs to
-      :func:`events.service.subscription_service.create_subscription`.
+    - Never creates an :class:`OrganizationMember`. Creation lives in
+      :func:`events.service.subscription_service.create_subscription` for the
+      OFFLINE flow, and in
+      :func:`events.service.subscription_stripe_service._ensure_active_member`
+      for the ONLINE flow (gated on Stripe's first paid invoice / ``active``
+      status, so members don't get tier benefits before paying).
     - Leaves ``BANNED`` members untouched.
     - Subscription tier wins: ``member.tier`` is set to ``plan.tier`` whenever
       they differ.
@@ -468,6 +472,9 @@ def sync_member_from_subscription(
       same (user, org) — older terminal rows must not clobber the effective
       subscription when, e.g., admin re-saves a historical entry after the
       user has resubscribed.
+    - For ONLINE plans in PENDING state, returns early so a freshly-created
+      subscription doesn't grant ACTIVE membership before Stripe collects
+      the first invoice.
     """
     target_status = _SUBSCRIPTION_TO_MEMBER_STATUS.get(instance.status)
     if target_status is None:

--- a/src/events/tests/test_controllers/test_me_subscriptions.py
+++ b/src/events/tests/test_controllers/test_me_subscriptions.py
@@ -1,8 +1,10 @@
 """Tests for the member-facing /me subscription endpoints."""
 
 from decimal import Decimal
+from unittest import mock
 
 import pytest
+import stripe
 from django.test.client import Client
 from django.urls import reverse
 from ninja_jwt.tokens import RefreshToken
@@ -17,6 +19,13 @@ from events.models import (
 from events.service import subscription_service
 
 pytestmark = pytest.mark.django_db
+
+
+def _make_stripe_connected(org: Organization) -> None:
+    org.stripe_account_id = "acct_test_org"
+    org.stripe_charges_enabled = True
+    org.stripe_details_submitted = True
+    org.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
 
 
 @pytest.fixture
@@ -99,4 +108,139 @@ class TestGetMyOrgSubscription:
         subscription_service.cancel_subscription(their_subscription, immediate=True)
         url = reverse("api:get_my_organization_subscription", kwargs={"org_id": organization.id})
         response = subscriber_client.get(url)
+        assert response.status_code == 404
+
+
+class TestSubscribeEndpoint:
+    @pytest.fixture
+    def online_plan(self, organization: Organization, tier: MembershipTier) -> MembershipSubscriptionPlan:
+        _make_stripe_connected(organization)
+        return MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Monthly Online",
+            price=Decimal("10.00"),
+            currency="EUR",
+            period_unit="month",
+            payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+            stripe_product_id="prod_test",
+            stripe_price_id="price_test",
+        )
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_subscribe_returns_client_secret(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        mock_customer.return_value = mock.MagicMock(id="cus_x")
+        mock_subscription.return_value = mock.MagicMock(
+            id="sub_x", latest_invoice={"payment_intent": {"client_secret": "pi_secret"}}
+        )
+
+        url = reverse("api:subscribe_to_membership_plan", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"plan_id": str(online_plan.id)}, content_type="application/json")
+
+        assert response.status_code == 201, response.content
+        body = response.json()
+        assert body["client_secret"] == "pi_secret"
+        assert body["subscription"]["plan_id"] == str(online_plan.id)
+        assert MembershipSubscription.objects.filter(user=subscriber_user, organization=organization).exists()
+
+    def test_subscribe_refuses_offline_plan(
+        self,
+        subscriber_client: Client,
+        plan: MembershipSubscriptionPlan,  # OFFLINE fixture
+        organization: Organization,
+    ) -> None:
+        _make_stripe_connected(organization)
+        url = reverse("api:subscribe_to_membership_plan", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"plan_id": str(plan.id)}, content_type="application/json")
+        assert response.status_code == 400
+
+    def test_subscribe_unauthenticated_blocked(
+        self,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        url = reverse("api:subscribe_to_membership_plan", kwargs={"org_id": organization.id})
+        response = Client().post(url, data={"plan_id": str(online_plan.id)}, content_type="application/json")
+        assert response.status_code == 401
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_subscribe_stripe_failure_rolls_back(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        mock_customer.return_value = mock.MagicMock(id="cus_x")
+        mock_subscription.side_effect = stripe.error.CardError("declined", "card", "card_declined")
+        url = reverse("api:subscribe_to_membership_plan", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"plan_id": str(online_plan.id)}, content_type="application/json")
+        assert response.status_code == 502
+        assert not MembershipSubscription.objects.filter(user=subscriber_user, organization=organization).exists()
+
+
+class TestCancelMyMembershipEndpoint:
+    @pytest.fixture
+    def online_plan(self, organization: Organization, tier: MembershipTier) -> MembershipSubscriptionPlan:
+        _make_stripe_connected(organization)
+        return MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Monthly Online",
+            price=Decimal("10.00"),
+            currency="EUR",
+            period_unit="month",
+            payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+            stripe_product_id="prod_test",
+            stripe_price_id="price_test",
+        )
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.modify")
+    def test_cancel_online_routes_to_stripe(
+        self,
+        mock_modify: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        MembershipSubscription.objects.create(
+            user=subscriber_user,
+            plan=online_plan,
+            organization=organization,
+            status=MembershipSubscription.SubscriptionStatus.ACTIVE,
+            stripe_subscription_id="sub_to_cancel",
+        )
+
+        url = reverse("api:cancel_my_membership_subscription", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"immediate": False}, content_type="application/json")
+        assert response.status_code == 200, response.content
+        mock_modify.assert_called_once()
+        assert response.json()["cancel_at_period_end"] is True
+
+    def test_cancel_offline_uses_phase1_path(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+        organization: Organization,
+    ) -> None:
+        url = reverse("api:cancel_my_membership_subscription", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"immediate": False}, content_type="application/json")
+        assert response.status_code == 200, response.content
+        their_subscription.refresh_from_db()
+        assert their_subscription.cancel_at_period_end is True
+
+    def test_cancel_404_when_no_active(self, subscriber_client: Client, organization: Organization) -> None:
+        url = reverse("api:cancel_my_membership_subscription", kwargs={"org_id": organization.id})
+        response = subscriber_client.post(url, data={"immediate": False}, content_type="application/json")
         assert response.status_code == 404

--- a/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
@@ -341,6 +341,79 @@ class TestSubscriptionEndpoints:
         assert response.status_code == 403
 
 
+class TestOnlinePlanGuards:
+    """Phase 2 — staff endpoints refuse ONLINE flows that must go through Stripe."""
+
+    @pytest.fixture
+    def online_plan(self, tier: MembershipTier, organization: Organization) -> MembershipSubscriptionPlan:
+        organization.stripe_account_id = "acct_test_org"
+        organization.stripe_charges_enabled = True
+        organization.stripe_details_submitted = True
+        organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+        return MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Monthly Online",
+            price=Decimal("10.00"),
+            currency="EUR",
+            period_unit="month",
+            payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+            stripe_product_id="prod_test",
+            stripe_price_id="price_test",
+        )
+
+    def test_create_subscription_refuses_online_plan(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        url = reverse("api:create_subscription", kwargs={"slug": organization.slug})
+        payload = {"plan_id": str(online_plan.id), "user_id": str(subscriber.id)}
+        response = organization_owner_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+        assert response.status_code == 400
+
+    def test_record_payment_refuses_online_subscription(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        sub = MembershipSubscription.objects.create(
+            user=subscriber,
+            plan=online_plan,
+            organization=organization,
+            status=MembershipSubscription.SubscriptionStatus.ACTIVE,
+            stripe_subscription_id="sub_stripe",
+        )
+        url = reverse("api:record_subscription_payment", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_owner_client.post(
+            url,
+            data=orjson.dumps({"amount": "10.00", "currency": "EUR"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_pause_refuses_online_subscription(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        sub = MembershipSubscription.objects.create(
+            user=subscriber,
+            plan=online_plan,
+            organization=organization,
+            status=MembershipSubscription.SubscriptionStatus.ACTIVE,
+            stripe_subscription_id="sub_stripe",
+        )
+        url = reverse("api:pause_subscription", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_owner_client.post(url)
+        assert response.status_code == 400
+
+
 class TestCrossOrgIsolation:
     def test_cannot_act_on_other_org_plan(
         self,

--- a/src/events/tests/test_controllers/test_organization_controller.py
+++ b/src/events/tests/test_controllers/test_organization_controller.py
@@ -144,9 +144,15 @@ def test_get_organization_by_privileged_users(
 
 
 class TestListMembershipPlans:
-    """Public listing of an organization's active subscription plans."""
+    """Public listing of an organization's active subscription plans.
+
+    Visibility piggybacks on ``get_one`` so private orgs return 404 for
+    anonymous users (same rule as ``get_organization``).
+    """
 
     def test_lists_active_plans_only(self, client: Client, organization: Organization) -> None:
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save(update_fields=["visibility"])
         tier = MembershipTier.objects.get(organization=organization, name="General membership")
         active = MembershipSubscriptionPlan.objects.create(
             tier=tier,
@@ -172,10 +178,18 @@ class TestListMembershipPlans:
         assert body[0]["id"] == str(active.id)
         assert body[0]["payment_method"] == "offline"
 
-    def test_unauthenticated_works(self, client: Client, organization: Organization) -> None:
+    def test_anonymous_can_list_public_org_plans(self, client: Client, organization: Organization) -> None:
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save(update_fields=["visibility"])
         url = reverse("api:list_organization_membership_plans", kwargs={"slug": organization.slug})
         response = client.get(url)
         assert response.status_code == 200
+
+    def test_anonymous_blocked_on_private_org(self, client: Client, organization: Organization) -> None:
+        # Default visibility is private; the endpoint inherits get_one's visibility rule.
+        url = reverse("api:list_organization_membership_plans", kwargs={"slug": organization.slug})
+        response = client.get(url)
+        assert response.status_code == 404
 
 
 def test_get_organization_not_found(client: Client) -> None:

--- a/src/events/tests/test_controllers/test_organization_controller.py
+++ b/src/events/tests/test_controllers/test_organization_controller.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from decimal import Decimal
 
 import pytest
 from django.test.client import Client
@@ -6,7 +7,14 @@ from django.urls import reverse
 from django.utils import timezone
 
 from accounts.models import RevelUser
-from events.models import Organization, OrganizationMember, OrganizationMembershipRequest, OrganizationToken
+from events.models import (
+    MembershipSubscriptionPlan,
+    MembershipTier,
+    Organization,
+    OrganizationMember,
+    OrganizationMembershipRequest,
+    OrganizationToken,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -133,6 +141,41 @@ def test_get_organization_by_privileged_users(
     response = organization_staff_client.get(url)
     assert response.status_code == 200
     assert response.json()["name"] == organization.name
+
+
+class TestListMembershipPlans:
+    """Public listing of an organization's active subscription plans."""
+
+    def test_lists_active_plans_only(self, client: Client, organization: Organization) -> None:
+        tier = MembershipTier.objects.get(organization=organization, name="General membership")
+        active = MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Monthly",
+            price=Decimal("10.00"),
+            currency="EUR",
+            period_unit="month",
+        )
+        MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Old Annual",
+            price=Decimal("100.00"),
+            currency="EUR",
+            period_unit="year",
+            is_active=False,
+        )
+
+        url = reverse("api:list_organization_membership_plans", kwargs={"slug": organization.slug})
+        response = client.get(url)
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["id"] == str(active.id)
+        assert body[0]["payment_method"] == "offline"
+
+    def test_unauthenticated_works(self, client: Client, organization: Organization) -> None:
+        url = reverse("api:list_organization_membership_plans", kwargs={"slug": organization.slug})
+        response = client.get(url)
+        assert response.status_code == 200
 
 
 def test_get_organization_not_found(client: Client) -> None:

--- a/src/events/tests/test_controllers/test_stripe_webhook.py
+++ b/src/events/tests/test_controllers/test_stripe_webhook.py
@@ -190,3 +190,77 @@ class TestStripeWebhookIntegration:
         assert response.status_code == 400
         response_data = response.json()
         assert "Invalid Stripe signature" in response_data["detail"]
+
+
+class TestSubscriptionWebhookDispatch:
+    """Phase 2 — the ``StripeEventHandler`` routes subscription/invoice events.
+
+    Each handler delegates to the Stripe service; here we patch the service
+    helpers and assert dispatch + payload propagation.
+    """
+
+    def _make_event(self, event_type: str, obj: dict[str, object]) -> Mock:
+        event = Mock(spec=stripe.Event)
+        event.type = event_type
+        event.data = Mock()
+        event.data.object = obj
+        return event
+
+    @patch("events.service.subscription_stripe_service.sync_subscription_from_stripe")
+    def test_customer_subscription_created_dispatch(self, mock_sync: Mock) -> None:
+        from events.service.stripe_webhooks import StripeEventHandler
+
+        event = self._make_event(
+            "customer.subscription.created",
+            {"id": "sub_x", "status": "incomplete"},
+        )
+        StripeEventHandler(event).handle()
+        mock_sync.assert_called_once()
+        passed = mock_sync.call_args.args[0]
+        assert passed["id"] == "sub_x"
+
+    @patch("events.service.subscription_stripe_service.sync_subscription_from_stripe")
+    def test_customer_subscription_updated_dispatch(self, mock_sync: Mock) -> None:
+        from events.service.stripe_webhooks import StripeEventHandler
+
+        event = self._make_event(
+            "customer.subscription.updated",
+            {"id": "sub_x", "status": "active", "cancel_at_period_end": True},
+        )
+        StripeEventHandler(event).handle()
+        mock_sync.assert_called_once()
+
+    @patch("events.service.subscription_stripe_service.sync_subscription_from_stripe")
+    def test_customer_subscription_deleted_dispatch(self, mock_sync: Mock) -> None:
+        from events.service.stripe_webhooks import StripeEventHandler
+
+        event = self._make_event(
+            "customer.subscription.deleted",
+            {"id": "sub_x", "status": "canceled"},
+        )
+        StripeEventHandler(event).handle()
+        mock_sync.assert_called_once()
+
+    @patch("events.service.subscription_stripe_service.record_stripe_payment_from_invoice")
+    def test_invoice_paid_dispatch(self, mock_record: Mock) -> None:
+        from events.service.stripe_webhooks import StripeEventHandler
+
+        event = self._make_event(
+            "invoice.paid",
+            {"id": "in_x", "subscription": "sub_x", "amount_paid": 1000, "currency": "eur"},
+        )
+        StripeEventHandler(event).handle()
+        mock_record.assert_called_once()
+        assert mock_record.call_args.kwargs["succeeded"] is True
+
+    @patch("events.service.subscription_stripe_service.record_stripe_payment_from_invoice")
+    def test_invoice_payment_failed_dispatch(self, mock_record: Mock) -> None:
+        from events.service.stripe_webhooks import StripeEventHandler
+
+        event = self._make_event(
+            "invoice.payment_failed",
+            {"id": "in_x", "subscription": "sub_x", "amount_due": 1000, "currency": "eur"},
+        )
+        StripeEventHandler(event).handle()
+        mock_record.assert_called_once()
+        assert mock_record.call_args.kwargs["succeeded"] is False

--- a/src/events/tests/test_service/test_subscription_stripe_service.py
+++ b/src/events/tests/test_service/test_subscription_stripe_service.py
@@ -1,0 +1,520 @@
+"""Tests for the Stripe-backed membership subscription service (Phase 2)."""
+
+from datetime import timedelta
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+import stripe
+from django.utils import timezone
+from ninja.errors import HttpError
+
+from accounts.models import RevelUser
+from events.models import (
+    CustomerProfile,
+    MembershipPayment,
+    MembershipSubscription,
+    MembershipSubscriptionPlan,
+    MembershipTier,
+    Organization,
+    OrganizationMember,
+)
+from events.service import subscription_service, subscription_stripe_service
+
+pytestmark = pytest.mark.django_db
+
+
+# ---- Fixtures ---------------------------------------------------------------
+
+
+def _make_stripe_connected(org: Organization) -> None:
+    """Flip the Stripe Connect flags on an organization."""
+    org.stripe_account_id = "acct_test_org"
+    org.stripe_charges_enabled = True
+    org.stripe_details_submitted = True
+    org.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+
+
+@pytest.fixture
+def stripe_org(organization: Organization) -> Organization:
+    """A Stripe-connected organization."""
+    _make_stripe_connected(organization)
+    return organization
+
+
+@pytest.fixture
+def tier(stripe_org: Organization) -> MembershipTier:
+    return MembershipTier.objects.get(organization=stripe_org, name="General membership")
+
+
+@pytest.fixture
+def online_plan(tier: MembershipTier) -> MembershipSubscriptionPlan:
+    """An ONLINE plan with pre-populated Stripe IDs (skips ensure_stripe_price)."""
+    return MembershipSubscriptionPlan.objects.create(
+        tier=tier,
+        name="Monthly Online",
+        price=Decimal("10.00"),
+        currency="EUR",
+        period_unit="month",
+        period_count=1,
+        payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+        stripe_product_id="prod_test",
+        stripe_price_id="price_test",
+    )
+
+
+@pytest.fixture
+def offline_plan(tier: MembershipTier) -> MembershipSubscriptionPlan:
+    """A bare OFFLINE plan."""
+    return subscription_service.create_plan(
+        tier,
+        name="Monthly Offline",
+        price=Decimal("10.00"),
+        currency="EUR",
+        period_unit="month",
+    )
+
+
+@pytest.fixture
+def subscriber(django_user_model: type[RevelUser]) -> RevelUser:
+    return django_user_model.objects.create_user(
+        username="online_subscriber", email="online@example.com", password="pass"
+    )
+
+
+# ---- ensure_customer_profile -------------------------------------------------
+
+
+class TestEnsureCustomerProfile:
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_creates_stripe_customer_and_db_row(
+        self,
+        mock_create: mock.Mock,
+        stripe_org: Organization,
+        subscriber: RevelUser,
+    ) -> None:
+        mock_create.return_value = mock.MagicMock(id="cus_new_123")
+
+        profile = subscription_stripe_service.ensure_customer_profile(subscriber, stripe_org)
+
+        assert profile.stripe_customer_id == "cus_new_123"
+        assert profile.user == subscriber
+        assert profile.organization == stripe_org
+        mock_create.assert_called_once()
+        # Call goes against the Connect account.
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["stripe_account"] == "acct_test_org"
+        assert kwargs["email"] == subscriber.email
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_reuses_existing_profile(
+        self,
+        mock_create: mock.Mock,
+        stripe_org: Organization,
+        subscriber: RevelUser,
+    ) -> None:
+        existing = CustomerProfile.objects.create(
+            user=subscriber, organization=stripe_org, stripe_customer_id="cus_existing"
+        )
+
+        profile = subscription_stripe_service.ensure_customer_profile(subscriber, stripe_org)
+
+        assert profile.pk == existing.pk
+        mock_create.assert_not_called()
+
+    def test_refuses_non_connected_org(
+        self,
+        organization: Organization,  # not stripe-connected
+        subscriber: RevelUser,
+    ) -> None:
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.ensure_customer_profile(subscriber, organization)
+        assert exc.value.status_code == 400
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_stripe_failure_raises_502(
+        self,
+        mock_create: mock.Mock,
+        stripe_org: Organization,
+        subscriber: RevelUser,
+    ) -> None:
+        mock_create.side_effect = stripe.error.APIConnectionError("boom")
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.ensure_customer_profile(subscriber, stripe_org)
+        assert exc.value.status_code == 502
+
+
+# ---- ensure_stripe_price -----------------------------------------------------
+
+
+class TestEnsureStripePrice:
+    def test_offline_plan_is_noop(self, offline_plan: MembershipSubscriptionPlan) -> None:
+        with mock.patch("events.service.subscription_stripe_service.stripe.Product.create") as p:
+            result = subscription_stripe_service.ensure_stripe_price(offline_plan)
+            p.assert_not_called()
+        assert result == offline_plan
+        assert offline_plan.stripe_product_id == ""
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Product.create")
+    def test_creates_product_and_price_when_missing(
+        self,
+        mock_product: mock.Mock,
+        mock_price: mock.Mock,
+        tier: MembershipTier,
+    ) -> None:
+        plan = MembershipSubscriptionPlan.objects.create(
+            tier=tier,
+            name="Yearly",
+            price=Decimal("100.00"),
+            currency="EUR",
+            period_unit="year",
+            period_count=1,
+            payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+        )
+        mock_product.return_value = mock.MagicMock(id="prod_new")
+        mock_price.return_value = mock.MagicMock(id="price_new")
+
+        result = subscription_stripe_service.ensure_stripe_price(plan)
+
+        assert result.stripe_product_id == "prod_new"
+        assert result.stripe_price_id == "price_new"
+        mock_product.assert_called_once()
+        mock_price.assert_called_once()
+        assert mock_price.call_args.kwargs["unit_amount"] == 10000  # 100.00 EUR
+        assert mock_price.call_args.kwargs["currency"] == "eur"
+        assert mock_price.call_args.kwargs["recurring"] == {"interval": "year", "interval_count": 1}
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.modify")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.retrieve")
+    def test_archives_and_recreates_price_when_inputs_change(
+        self,
+        mock_retrieve: mock.Mock,
+        mock_create: mock.Mock,
+        mock_modify: mock.Mock,
+        online_plan: MembershipSubscriptionPlan,
+    ) -> None:
+        mock_retrieve.return_value = mock.MagicMock(
+            active=True,
+            unit_amount=500,  # plan is 10.00 → 1000; mismatch
+            currency="eur",
+            recurring={"interval": "month", "interval_count": 1},
+        )
+        mock_create.return_value = mock.MagicMock(id="price_v2")
+
+        result = subscription_stripe_service.ensure_stripe_price(online_plan)
+
+        mock_modify.assert_called_once_with("price_test", active=False, stripe_account="acct_test_org")
+        mock_create.assert_called_once()
+        assert result.stripe_price_id == "price_v2"
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.retrieve")
+    def test_no_op_when_inputs_unchanged(
+        self,
+        mock_retrieve: mock.Mock,
+        mock_create: mock.Mock,
+        online_plan: MembershipSubscriptionPlan,
+    ) -> None:
+        mock_retrieve.return_value = mock.MagicMock(
+            active=True,
+            unit_amount=1000,
+            currency="eur",
+            recurring={"interval": "month", "interval_count": 1},
+        )
+        result = subscription_stripe_service.ensure_stripe_price(online_plan)
+        assert result.stripe_price_id == "price_test"
+        mock_create.assert_not_called()
+
+
+# ---- archive_stripe_price ----------------------------------------------------
+
+
+class TestArchiveStripePrice:
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.modify")
+    def test_deactivates_price_for_online(
+        self, mock_modify: mock.Mock, online_plan: MembershipSubscriptionPlan
+    ) -> None:
+        subscription_stripe_service.archive_stripe_price(online_plan)
+        mock_modify.assert_called_once_with("price_test", active=False, stripe_account="acct_test_org")
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.modify")
+    def test_noop_for_offline(self, mock_modify: mock.Mock, offline_plan: MembershipSubscriptionPlan) -> None:
+        subscription_stripe_service.archive_stripe_price(offline_plan)
+        mock_modify.assert_not_called()
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Price.modify")
+    def test_swallows_invalid_request(self, mock_modify: mock.Mock, online_plan: MembershipSubscriptionPlan) -> None:
+        mock_modify.side_effect = stripe.error.InvalidRequestError("already archived", "id")
+        # Must not raise — design intent is record-only cleanup.
+        subscription_stripe_service.archive_stripe_price(online_plan)
+
+
+# ---- start_online_subscription ----------------------------------------------
+
+
+class TestStartOnlineSubscription:
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_happy_path_returns_client_secret(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription: mock.Mock,
+        stripe_org: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        mock_customer.return_value = mock.MagicMock(id="cus_abc")
+        mock_subscription.return_value = mock.MagicMock(
+            id="sub_xyz",
+            latest_invoice={"payment_intent": {"client_secret": "pi_secret_test"}},
+        )
+
+        subscription, client_secret = subscription_stripe_service.start_online_subscription(online_plan, subscriber)
+
+        assert client_secret == "pi_secret_test"
+        assert subscription.stripe_subscription_id == "sub_xyz"
+        assert subscription.status == MembershipSubscription.SubscriptionStatus.PENDING
+        # ONLINE PENDING must not grant member benefits up front.
+        assert not OrganizationMember.objects.filter(organization=stripe_org, user=subscriber).exists()
+
+    def test_refuses_offline_plan(
+        self,
+        offline_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.start_online_subscription(offline_plan, subscriber)
+        assert exc.value.status_code == 400
+
+    def test_refuses_archived_plan(
+        self,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        online_plan.is_active = False
+        online_plan.save(update_fields=["is_active"])
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.start_online_subscription(online_plan, subscriber)
+        assert exc.value.status_code == 400
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_stripe_failure_rolls_back_local_row(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription: mock.Mock,
+        stripe_org: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        mock_customer.return_value = mock.MagicMock(id="cus_abc")
+        mock_subscription.side_effect = stripe.error.CardError("declined", "card", "card_declined")
+
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.start_online_subscription(online_plan, subscriber)
+
+        assert exc.value.status_code == 502
+        assert not MembershipSubscription.objects.filter(user=subscriber, organization=stripe_org).exists()
+
+
+# ---- cancel_online_subscription ---------------------------------------------
+
+
+class TestCancelOnlineSubscription:
+    @pytest.fixture
+    def online_subscription(
+        self,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> MembershipSubscription:
+        sub = MembershipSubscription.objects.create(
+            user=subscriber,
+            plan=online_plan,
+            organization=online_plan.tier.organization,
+            status=MembershipSubscription.SubscriptionStatus.ACTIVE,
+            stripe_subscription_id="sub_abc",
+            current_period_end=timezone.now() + timedelta(days=30),
+        )
+        return sub
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.modify")
+    def test_schedules_at_period_end(self, mock_modify: mock.Mock, online_subscription: MembershipSubscription) -> None:
+        result = subscription_stripe_service.cancel_online_subscription(online_subscription, immediate=False)
+
+        mock_modify.assert_called_once_with("sub_abc", cancel_at_period_end=True, stripe_account="acct_test_org")
+        assert result.cancel_at_period_end is True
+        # Status stays ACTIVE until the period end webhook arrives.
+        assert result.status == MembershipSubscription.SubscriptionStatus.ACTIVE
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.cancel")
+    def test_immediate_cancellation_marks_terminal(
+        self, mock_cancel: mock.Mock, online_subscription: MembershipSubscription
+    ) -> None:
+        result = subscription_stripe_service.cancel_online_subscription(online_subscription, immediate=True)
+
+        mock_cancel.assert_called_once_with("sub_abc", stripe_account="acct_test_org")
+        assert result.status == MembershipSubscription.SubscriptionStatus.CANCELLED
+        assert result.cancelled_at is not None
+
+
+# ---- sync_subscription_from_stripe ------------------------------------------
+
+
+class TestSyncSubscriptionFromStripe:
+    @pytest.fixture
+    def pending_online_subscription(
+        self,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> MembershipSubscription:
+        return MembershipSubscription.objects.create(
+            user=subscriber,
+            plan=online_plan,
+            organization=online_plan.tier.organization,
+            status=MembershipSubscription.SubscriptionStatus.PENDING,
+            stripe_subscription_id="sub_to_sync",
+        )
+
+    def test_mirrors_active_status_and_periods(
+        self,
+        pending_online_subscription: MembershipSubscription,
+    ) -> None:
+        payload = {
+            "id": "sub_to_sync",
+            "status": "active",
+            "cancel_at_period_end": False,
+            "current_period_start": 1_800_000_000,
+            "current_period_end": 1_800_000_000 + 30 * 86400,
+        }
+        result = subscription_stripe_service.sync_subscription_from_stripe(payload)
+        assert result is not None
+        result.refresh_from_db()
+        assert result.status == MembershipSubscription.SubscriptionStatus.ACTIVE
+        assert result.current_period_start is not None
+        assert result.current_period_end is not None
+        # _ensure_active_member should have created the member at the plan tier.
+        member = OrganizationMember.objects.get(
+            organization=pending_online_subscription.organization, user=pending_online_subscription.user
+        )
+        assert member.status == OrganizationMember.MembershipStatus.ACTIVE
+        assert member.tier_id == pending_online_subscription.plan.tier_id
+
+    def test_unknown_subscription_returns_none(self) -> None:
+        result = subscription_stripe_service.sync_subscription_from_stripe({"id": "sub_unknown", "status": "active"})
+        assert result is None
+
+    def test_cancel_at_period_end_mirrored(self, pending_online_subscription: MembershipSubscription) -> None:
+        payload = {
+            "id": "sub_to_sync",
+            "status": "active",
+            "cancel_at_period_end": True,
+        }
+        result = subscription_stripe_service.sync_subscription_from_stripe(payload)
+        assert result is not None
+        assert result.cancel_at_period_end is True
+
+
+# ---- record_stripe_payment_from_invoice -------------------------------------
+
+
+class TestRecordStripePaymentFromInvoice:
+    @pytest.fixture
+    def pending_online_subscription(
+        self,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> MembershipSubscription:
+        return MembershipSubscription.objects.create(
+            user=subscriber,
+            plan=online_plan,
+            organization=online_plan.tier.organization,
+            status=MembershipSubscription.SubscriptionStatus.PENDING,
+            stripe_subscription_id="sub_invoice",
+        )
+
+    def test_succeeded_creates_payment_and_activates_subscription(
+        self,
+        pending_online_subscription: MembershipSubscription,
+    ) -> None:
+        invoice = {
+            "id": "in_test",
+            "subscription": "sub_invoice",
+            "amount_paid": 1000,
+            "currency": "eur",
+            "payment_intent": "pi_test",
+            "lines": {
+                "data": [
+                    {
+                        "period": {
+                            "start": 1_800_000_000,
+                            "end": 1_800_000_000 + 30 * 86400,
+                        }
+                    }
+                ]
+            },
+        }
+        payment = subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=True)
+
+        assert payment is not None
+        assert payment.status == MembershipPayment.PaymentStatus.SUCCEEDED
+        assert payment.amount == Decimal("10.00")
+        assert payment.stripe_invoice_id == "in_test"
+        assert payment.stripe_payment_intent_id == "pi_test"
+
+        pending_online_subscription.refresh_from_db()
+        assert pending_online_subscription.status == MembershipSubscription.SubscriptionStatus.ACTIVE
+        # Member created via _ensure_active_member.
+        member = OrganizationMember.objects.get(
+            organization=pending_online_subscription.organization,
+            user=pending_online_subscription.user,
+        )
+        assert member.status == OrganizationMember.MembershipStatus.ACTIVE
+
+    def test_failed_payment_records_and_transitions_to_past_due(
+        self,
+        pending_online_subscription: MembershipSubscription,
+    ) -> None:
+        pending_online_subscription.status = MembershipSubscription.SubscriptionStatus.ACTIVE
+        pending_online_subscription.save(update_fields=["status"])
+
+        invoice = {
+            "id": "in_fail",
+            "subscription": "sub_invoice",
+            "amount_paid": 0,
+            "amount_due": 1000,
+            "currency": "eur",
+            "payment_intent": "pi_fail",
+            "lines": {"data": [{"period": {"start": 1_800_000_000, "end": 1_800_000_000 + 86400}}]},
+        }
+
+        payment = subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=False)
+        assert payment is not None
+        assert payment.status == MembershipPayment.PaymentStatus.FAILED
+
+        pending_online_subscription.refresh_from_db()
+        assert pending_online_subscription.status == MembershipSubscription.SubscriptionStatus.PAST_DUE
+
+    def test_duplicate_webhook_is_idempotent(self, pending_online_subscription: MembershipSubscription) -> None:
+        invoice = {
+            "id": "in_dup",
+            "subscription": "sub_invoice",
+            "amount_paid": 1000,
+            "currency": "eur",
+            "payment_intent": "pi_dup",
+            "lines": {"data": [{"period": {"start": 1_800_000_000, "end": 1_800_000_000 + 86400}}]},
+        }
+        subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=True)
+        subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=True)
+
+        assert MembershipPayment.objects.filter(stripe_invoice_id="in_dup").count() == 1
+
+    def test_unknown_subscription_returns_none(self) -> None:
+        invoice = {
+            "id": "in_orphan",
+            "subscription": "sub_nope",
+            "amount_paid": 0,
+            "currency": "eur",
+        }
+        assert subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=False) is None

--- a/src/events/tests/test_service/test_subscription_stripe_service.py
+++ b/src/events/tests/test_service/test_subscription_stripe_service.py
@@ -318,6 +318,56 @@ class TestStartOnlineSubscription:
         assert exc.value.status_code == 502
         assert not MembershipSubscription.objects.filter(user=subscriber, organization=stripe_org).exists()
 
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.cancel")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_missing_client_secret_cancels_stripe_and_deletes_local(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription_create: mock.Mock,
+        mock_subscription_cancel: mock.Mock,
+        stripe_org: Organization,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        """If Stripe returns no ``client_secret``, the user can't confirm — clean up both sides."""
+        mock_customer.return_value = mock.MagicMock(id="cus_abc")
+        # Stripe accepts the create but returns a subscription without an
+        # expandable PaymentIntent (no client_secret).
+        mock_subscription_create.return_value = mock.MagicMock(id="sub_orphan", latest_invoice=None)
+
+        with pytest.raises(HttpError) as exc:
+            subscription_stripe_service.start_online_subscription(online_plan, subscriber)
+
+        assert exc.value.status_code == 502
+        mock_subscription_cancel.assert_called_once_with("sub_orphan", stripe_account="acct_test_org")
+        # Local row must not survive — otherwise the partial-unique index
+        # blocks the user from retrying.
+        assert not MembershipSubscription.objects.filter(user=subscriber, organization=stripe_org).exists()
+
+    @mock.patch("events.service.subscription_stripe_service.stripe.Subscription.create")
+    @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
+    def test_idempotency_keys_are_set(
+        self,
+        mock_customer: mock.Mock,
+        mock_subscription: mock.Mock,
+        online_plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        """Customer + Subscription Stripe calls carry deterministic idempotency keys."""
+        mock_customer.return_value = mock.MagicMock(id="cus_idem")
+        mock_subscription.return_value = mock.MagicMock(
+            id="sub_idem",
+            latest_invoice={"payment_intent": {"client_secret": "pi_secret"}},
+        )
+
+        subscription, _ = subscription_stripe_service.start_online_subscription(online_plan, subscriber)
+
+        customer_key = mock_customer.call_args.kwargs["idempotency_key"]
+        assert customer_key == f"cust:{subscriber.pk}:{online_plan.tier.organization_id}"
+        sub_key = mock_subscription.call_args.kwargs["idempotency_key"]
+        assert sub_key == f"sub:{subscription.pk}"
+
 
 # ---- cancel_online_subscription ---------------------------------------------
 
@@ -492,6 +542,10 @@ class TestRecordStripePaymentFromInvoice:
         payment = subscription_stripe_service.record_stripe_payment_from_invoice(invoice, succeeded=False)
         assert payment is not None
         assert payment.status == MembershipPayment.PaymentStatus.FAILED
+        # FAILED payments collected nothing — ``amount`` reflects that.
+        # ``raw_response`` preserves Stripe's reported ``amount_due``.
+        assert payment.amount == Decimal("0")
+        assert payment.raw_response.get("amount_due") == 1000
 
         pending_online_subscription.refresh_from_db()
         assert pending_online_subscription.status == MembershipSubscription.SubscriptionStatus.PAST_DUE


### PR DESCRIPTION
## Summary

Phase 2 of #229 — adds Stripe-backed ONLINE membership subscriptions on top of the OFFLINE foundation merged in #397. Closes #394 once this PR's parent (`dev/subscriptions`) lands on `main`.

### Design choices locked in during this PR

- **Stripe Product/Price provisioning: auto-create on plan save.** When a plan is `payment_method=ONLINE`, `subscription_service.create_plan` / `update_plan` lazy-dispatch to `subscription_stripe_service.ensure_stripe_price`, which:
  - Creates the Stripe Product if missing.
  - Creates a fresh Stripe Price if missing, or if any of `unit_amount` / `currency` / `recurring.{interval,interval_count}` changed (Stripe Prices are immutable on those dimensions). The existing Price is archived (`active=False`) before the new one is created.
- **Single PR for the full Phase 2 surface** (models + Stripe service + webhooks + member endpoints + tests) since the pieces are interdependent — subscribe is meaningless without webhooks to activate it.

## Changes

### Models + migration (`0071_subscription_stripe_fields`)
- New `CustomerProfile(user, organization, stripe_customer_id)` — unique on `(user, org)` and `(org, stripe_customer_id)`.
- `MembershipSubscriptionPlan`: `payment_method` (online/offline, default offline), `stripe_product_id`, `stripe_price_id`.
- `MembershipSubscription`: `stripe_subscription_id` (nullable, unique).
- `MembershipPayment`: `stripe_invoice_id`, `stripe_payment_intent_id`.

### Service (`events/service/subscription_stripe_service.py`)
- `ensure_customer_profile(user, org)` — get-or-create on Stripe Connect + DB; wraps `StripeError` as `502`.
- `ensure_stripe_price(plan)` — auto-provisioning + archive/recreate dance for pricing changes.
- `archive_stripe_price(plan)` — best-effort `Price.modify(active=False)` for archived ONLINE plans.
- `start_online_subscription(plan, user)` — creates Stripe Subscription with `payment_behavior=default_incomplete`, returns `(subscription, client_secret)`. Rolls back the local PENDING row on Stripe failure.
- `cancel_online_subscription(sub, *, immediate)` — `Subscription.cancel` or `cancel_at_period_end`.
- `sync_subscription_from_stripe(payload)` — mirrors status/period/cancel_at_period_end onto the local row.
- `record_stripe_payment_from_invoice(invoice, *, succeeded)` — idempotent `update_or_create` keyed on `stripe_invoice_id`; revives PENDING/PAST_DUE → ACTIVE on success, transitions ACTIVE/PENDING → PAST_DUE on failure.

### Webhook handlers (`events/service/stripe_webhooks.py`)
- `customer.subscription.{created,updated,deleted}` → `sync_subscription_from_stripe`.
- `invoice.paid` → `record_stripe_payment_from_invoice(succeeded=True)`.
- `invoice.payment_failed` → `record_stripe_payment_from_invoice(succeeded=False)`.

### Member-gating change (security-relevant)
ONLINE subscriptions intentionally do not activate `OrganizationMember` at create time — the user shouldn't get tier benefits before paying. Activation moves into both webhook helpers via a new `_ensure_active_member` (uses `get_or_create`, so a pre-existing BANNED row stays BANNED). The signal also early-returns on `PENDING + ONLINE` so a no-op save can't accidentally activate them.

### API
- **Public**: `GET /api/organizations/{slug}/membership-plans` — active plans only, ordered by tier then price.
- **Member**: `POST /api/me/organizations/{org_id}/subscribe` → `client_secret`; `POST /api/me/organizations/{org_id}/subscription/cancel` (routes ONLINE through Stripe, OFFLINE through the Phase 1 path).

### Staff endpoint guards
- `POST /api/organization-admin/{slug}/subscriptions` refuses ONLINE plans (members must go through the member endpoint).
- `POST .../subscriptions/{id}/payments` refuses ONLINE subscriptions (Stripe webhooks own the payment lifecycle).
- `POST .../subscriptions/{id}/pause` refuses ONLINE (Phase 3 lands `pause_collection`).
- `POST .../subscriptions/{id}/cancel` transparently dispatches to Stripe for ONLINE.

### Tests
- `test_service/test_subscription_stripe_service.py` (new, ~520 lines): customer profile lifecycle, Product/Price create + immutability dance + archive, start_online_subscription happy path + rollback + plan-state refusals, cancel both modes, sync from Stripe (active + cancel_at_period_end + unknown), invoice paid + failed + idempotent duplicates + orphan invoices.
- `test_controllers/test_me_subscriptions.py`: subscribe returns client_secret, refuses OFFLINE plans, rolls back on Stripe failure, requires auth; cancel routes ONLINE through Stripe and OFFLINE through Phase 1; cancel 404s when no active sub.
- `test_controllers/test_organization_admin/test_subscriptions.py`: staff guards for ONLINE on create_subscription / record_payment / pause.
- `test_controllers/test_stripe_webhook.py`: dispatch tests for all five new event types.
- `test_controllers/test_organization_controller.py`: public plan listing filters archived plans.

## Test plan

- [x] `make check` — format, lint, mypy strict, migration-check, i18n-check, file-length
- [ ] `make test` — Phase 1 + Phase 2 tests (no Stripe API calls; all mocked)
- [ ] Manual smoke (staging): create an ONLINE plan, hit `/me/.../subscribe`, confirm `client_secret` works through Stripe Elements, watch the webhooks land

## Out of scope

- Plan changes / upgrades (#395)
- Stripe `pause_collection` (#395)
- Customer Portal (#395)
- Dunning + notifications (#396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)