### PR TITLE
feat(subscriptions): list-payments endpoint + org metadata on MySubscriptionSchema (#404)

### DIFF
--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -196,7 +196,7 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         return (
             models.MembershipPayment.objects.filter(subscription=subscription)
             .select_related("recorded_by")
-            .order_by("-created_at")
+            .order_by("-created_at", "-id")
         )
 
     @route.post(

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -182,6 +182,23 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         subscription = subscription_service.create_subscription(plan, user, initial_payment=initial)
         return 201, subscription
 
+    @route.get(
+        "/subscriptions/{sub_id}/payments",
+        url_name="list_subscription_payments",
+        response=PaginatedResponseSchema[schema.MembershipPaymentSchema],
+        throttle=UserDefaultThrottle(),
+    )
+    @paginate(PageNumberPaginationExtra, page_size=20)
+    def list_subscription_payments(self, slug: str, sub_id: UUID) -> QuerySet[models.MembershipPayment]:
+        """List payments recorded against a subscription, newest first."""
+        organization = self.get_one(slug)
+        subscription = get_object_or_404(models.MembershipSubscription, pk=sub_id, organization=organization)
+        return (
+            models.MembershipPayment.objects.filter(subscription=subscription)
+            .select_related("recorded_by")
+            .order_by("-created_at")
+        )
+
     @route.post(
         "/subscriptions/{sub_id}/payments",
         url_name="record_subscription_payment",

--- a/src/events/schema/mixins.py
+++ b/src/events/schema/mixins.py
@@ -12,7 +12,7 @@ from geo.models import City
 from geo.schema import CitySchema
 
 
-def _get_image_field_url(obj: t.Any, field_name: str) -> str | None:
+def get_image_field_url(obj: t.Any, field_name: str) -> str | None:
     """Get URL from an ImageField, handling empty/null values.
 
     Args:
@@ -42,17 +42,17 @@ class LogoCoverArtThumbnailMixin(Schema):
     @staticmethod
     def resolve_logo_thumbnail_url(obj: t.Any) -> str | None:
         """Resolve logo thumbnail URL."""
-        return _get_image_field_url(obj, "logo_thumbnail")
+        return get_image_field_url(obj, "logo_thumbnail")
 
     @staticmethod
     def resolve_cover_art_thumbnail_url(obj: t.Any) -> str | None:
         """Resolve cover art thumbnail URL."""
-        return _get_image_field_url(obj, "cover_art_thumbnail")
+        return get_image_field_url(obj, "cover_art_thumbnail")
 
     @staticmethod
     def resolve_cover_art_social_url(obj: t.Any) -> str | None:
         """Resolve cover art social preview URL."""
-        return _get_image_field_url(obj, "cover_art_social")
+        return get_image_field_url(obj, "cover_art_social")
 
 
 class CityBaseMixin(Schema):

--- a/src/events/schema/subscription.py
+++ b/src/events/schema/subscription.py
@@ -147,11 +147,32 @@ class MySubscriptionSchema(_BaseSubscriptionSchema):
     """Member-facing view of their own subscription (no PII about other users)."""
 
     plan: PlanSchema
+    organization_name: str
+    organization_slug: str
+    organization_logo_url: str | None = None
 
     @staticmethod
     def resolve_plan(obj: MembershipSubscription) -> MembershipSubscriptionPlan:
         """Return the plan for nested serialization."""
         return obj.plan
+
+    @staticmethod
+    def resolve_organization_name(obj: MembershipSubscription) -> str:
+        """Return the parent organization's name."""
+        return obj.organization.name
+
+    @staticmethod
+    def resolve_organization_slug(obj: MembershipSubscription) -> str:
+        """Return the parent organization's slug."""
+        return obj.organization.slug
+
+    @staticmethod
+    def resolve_organization_logo_url(obj: MembershipSubscription) -> str | None:
+        """Return the parent organization's logo thumbnail URL, if any."""
+        thumb = obj.organization.logo_thumbnail
+        if thumb:
+            return str(thumb.url)
+        return None
 
 
 class SubscriptionSchema(_BaseSubscriptionSchema):

--- a/src/events/schema/subscription.py
+++ b/src/events/schema/subscription.py
@@ -8,6 +8,7 @@ from pydantic import AwareDatetime, Field, model_validator
 
 from events.models import MembershipPayment, MembershipSubscription, MembershipSubscriptionPlan
 
+from .mixins import get_image_field_url
 from .ticket import Currencies
 
 
@@ -169,10 +170,7 @@ class MySubscriptionSchema(_BaseSubscriptionSchema):
     @staticmethod
     def resolve_organization_logo_url(obj: MembershipSubscription) -> str | None:
         """Return the parent organization's logo thumbnail URL, if any."""
-        thumb = obj.organization.logo_thumbnail
-        if thumb:
-            return str(thumb.url)
-        return None
+        return get_image_field_url(obj.organization, "logo_thumbnail")
 
 
 class SubscriptionSchema(_BaseSubscriptionSchema):

--- a/src/events/tests/test_controllers/test_me_subscriptions.py
+++ b/src/events/tests/test_controllers/test_me_subscriptions.py
@@ -69,6 +69,39 @@ class TestListMySubscriptions:
         assert response.status_code == 401
 
 
+class TestMySubscriptionOrgMetadata:
+    def test_response_includes_organization_name_and_slug(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+        organization: Organization,
+    ) -> None:
+        url = reverse("api:get_my_organization_subscription", kwargs={"org_id": organization.id})
+        response = subscriber_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["organization_name"] == organization.name
+        assert data["organization_slug"] == organization.slug
+        # Without an uploaded logo, the URL should be null.
+        assert data["organization_logo_url"] is None
+
+    def test_list_includes_organization_metadata(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+        organization: Organization,
+    ) -> None:
+        url = reverse("api:list_my_membership_subscriptions")
+        response = subscriber_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        item = data["results"][0]
+        assert item["organization_name"] == organization.name
+        assert item["organization_slug"] == organization.slug
+        assert "organization_logo_url" in item
+
+
 class TestGetMyOrgSubscription:
     def test_returns_active_subscription(
         self,

--- a/src/events/tests/test_controllers/test_me_subscriptions.py
+++ b/src/events/tests/test_controllers/test_me_subscriptions.py
@@ -99,7 +99,7 @@ class TestMySubscriptionOrgMetadata:
         item = data["results"][0]
         assert item["organization_name"] == organization.name
         assert item["organization_slug"] == organization.slug
-        assert "organization_logo_url" in item
+        assert item["organization_logo_url"] is None
 
 
 class TestGetMyOrgSubscription:

--- a/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
@@ -365,6 +365,26 @@ class TestListSubscriptionPayments:
         assert data["count"] == 2
         assert [item["id"] for item in data["results"]] == [str(second.id), str(first.id)]
 
+    def test_staff_with_permission_can_list_payments(
+        self,
+        organization_staff_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+        staff_member: OrganizationStaff,
+        organization_owner_user: RevelUser,
+    ) -> None:
+        sub = subscription_service.create_subscription(plan, subscriber)
+        subscription_service.record_payment(
+            sub, amount=Decimal("10.00"), currency="EUR", recorded_by=organization_owner_user
+        )
+        _set_staff_permission(staff_member, manage_subscriptions=True)
+
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_staff_client.get(url)
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+
     def test_staff_without_permission_blocked(
         self,
         organization_staff_client: Client,

--- a/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
@@ -341,6 +341,99 @@ class TestSubscriptionEndpoints:
         assert response.status_code == 403
 
 
+class TestListSubscriptionPayments:
+    def test_owner_lists_payments_newest_first(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+        organization_owner_user: RevelUser,
+    ) -> None:
+        sub = subscription_service.create_subscription(plan, subscriber)
+        first = subscription_service.record_payment(
+            sub, amount=Decimal("10.00"), currency="EUR", recorded_by=organization_owner_user
+        )
+        second = subscription_service.record_payment(
+            sub, amount=Decimal("10.00"), currency="EUR", recorded_by=organization_owner_user
+        )
+
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_owner_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 2
+        assert [item["id"] for item in data["results"]] == [str(second.id), str(first.id)]
+
+    def test_staff_without_permission_blocked(
+        self,
+        organization_staff_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+        staff_member: OrganizationStaff,
+    ) -> None:
+        sub = subscription_service.create_subscription(plan, subscriber)
+        _set_staff_permission(staff_member, manage_subscriptions=False)
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_staff_client.get(url)
+        assert response.status_code == 403
+
+    def test_member_cannot_list_payments(
+        self,
+        member_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        sub = subscription_service.create_subscription(plan, subscriber)
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = member_client.get(url)
+        assert response.status_code == 403
+
+    def test_other_org_subscription_returns_404(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        other_owner = RevelUser.objects.create_user(
+            username="payments_other_owner", email="payments-other@example.com", password="pass"
+        )
+        other_org = Organization.objects.create(name="Other Payments Org", slug="other-payments", owner=other_owner)
+        other_tier = MembershipTier.objects.get(organization=other_org, name="General membership")
+        other_plan = subscription_service.create_plan(
+            other_tier, name="Monthly", price=Decimal("5.00"), currency="EUR", period_unit="month"
+        )
+        other_subscriber = RevelUser.objects.create_user(
+            username="payments_other_sub", email="payments-other-sub@example.com", password="pass"
+        )
+        other_sub = subscription_service.create_subscription(other_plan, other_subscriber)
+
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": other_sub.id})
+        response = organization_owner_client.get(url)
+        assert response.status_code == 404
+
+    def test_pagination_respects_page_size(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+        organization_owner_user: RevelUser,
+    ) -> None:
+        sub = subscription_service.create_subscription(plan, subscriber)
+        for _ in range(3):
+            subscription_service.record_payment(
+                sub, amount=Decimal("1.00"), currency="EUR", recorded_by=organization_owner_user
+            )
+        url = reverse("api:list_subscription_payments", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_owner_client.get(url, {"page_size": 2})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 3
+        assert len(data["results"]) == 2
+
+
 class TestCrossOrgIsolation:
     def test_cannot_act_on_other_org_plan(
         self,


### PR DESCRIPTION
Closes #404.

## Summary

- New `GET /api/organization-admin/{slug}/subscriptions/{sub_id}/payments` returns a paginated `MembershipPaymentSchema` list (page size 20, newest first). Reuses the controller's class-level `manage_subscriptions` permission; tagged `UserDefaultThrottle` since it's read-only.
- `MySubscriptionSchema` now resolves `organization_name`, `organization_slug`, and `organization_logo_url` so the member-facing `/account/memberships` UI can render a usable card without N+1 org lookups. The existing `select_related("organization")` in `MeSubscriptionsController` already covers the access cost.

Both changes are additive and minimally conflicting with the dev/subscriptions mega-PR (#403) — a new `@route.get(...)` next to existing routes and two new resolver fields next to existing ones on `MySubscriptionSchema`.

## Test plan

- [x] `make check` — ruff format/lint, mypy --strict, migrations, i18n, file-length all clean
- [x] `make test` — 4446 passed, 15 skipped (95% coverage)
- New tests cover: perm gating (owner / staff w-perm / staff w/o-perm / member), cross-org 404, pagination respecting `page_size`, and that `MySubscriptionSchema` exposes the new org fields in both the list and the org-scoped retrieve endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added staff API endpoint to list and paginate through payments for a specific subscription.
  * Enhanced member subscription views to display associated organization name, slug, and logo information.

* **Tests**
  * Added comprehensive test coverage for subscription payment listing and organization metadata functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/405)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->