### PR TITLE
feat(subscriptions): org-wide plans endpoint + tier_name on PlanSchema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.53.0"
+version = "1.54.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -32,6 +32,22 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
     # ---- Plans ----
 
     @route.get(
+        "/plans",
+        url_name="list_organization_plans",
+        response=list[schema.PlanSchema],
+        throttle=UserDefaultThrottle(),
+    )
+    def list_organization_plans(
+        self, slug: str, is_active: bool | None = None
+    ) -> QuerySet[models.MembershipSubscriptionPlan]:
+        """List all subscription plans across every tier in the organization."""
+        organization = self.get_one(slug)
+        qs = models.MembershipSubscriptionPlan.objects.filter(tier__organization=organization).select_related("tier")
+        if is_active is not None:
+            qs = qs.filter(is_active=is_active)
+        return qs
+
+    @route.get(
         "/tiers/{tier_id}/plans",
         url_name="list_subscription_plans",
         response=list[schema.PlanSchema],
@@ -41,7 +57,7 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         """List all subscription plans for a tier."""
         organization = self.get_one(slug)
         tier = get_object_or_404(models.MembershipTier, pk=tier_id, organization=organization)
-        return models.MembershipSubscriptionPlan.objects.filter(tier=tier)
+        return models.MembershipSubscriptionPlan.objects.filter(tier=tier).select_related("tier")
 
     @route.post(
         "/tiers/{tier_id}/plans",

--- a/src/events/schema/subscription.py
+++ b/src/events/schema/subscription.py
@@ -22,6 +22,7 @@ class PlanSchema(ModelSchema):
     """Response schema for a subscription plan."""
 
     tier_id: UUID
+    tier_name: str
     period_unit: MembershipSubscriptionPlan.PeriodUnit
 
     class Meta:
@@ -35,6 +36,11 @@ class PlanSchema(ModelSchema):
             "period_count",
             "is_active",
         ]
+
+    @staticmethod
+    def resolve_tier_name(obj: MembershipSubscriptionPlan) -> str:
+        """Return the parent tier's display name."""
+        return obj.tier.name
 
 
 class PlanCreateSchema(Schema):

--- a/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
@@ -61,17 +61,110 @@ def _set_staff_permission(staff_member: OrganizationStaff, *, manage_subscriptio
 
 class TestListPlans:
     def test_owner_can_list_plans(
-        self, organization_owner_client: Client, organization: Organization, tier: MembershipTier
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        tier: MembershipTier,
+        plan: MembershipSubscriptionPlan,
     ) -> None:
         url = reverse("api:list_subscription_plans", kwargs={"slug": organization.slug, "tier_id": tier.id})
         response = organization_owner_client.get(url)
         assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["tier_id"] == str(tier.id)
+        assert data[0]["tier_name"] == tier.name
 
     def test_member_cannot_list_plans(
         self, member_client: Client, organization: Organization, tier: MembershipTier
     ) -> None:
         url = reverse("api:list_subscription_plans", kwargs={"slug": organization.slug, "tier_id": tier.id})
         response = member_client.get(url)
+        assert response.status_code == 403
+
+
+class TestListOrganizationPlans:
+    def test_owner_lists_plans_across_tiers(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        tier: MembershipTier,
+        plan: MembershipSubscriptionPlan,
+    ) -> None:
+        other_tier = MembershipTier.objects.create(organization=organization, name="VIP membership")
+        other_plan = subscription_service.create_plan(
+            other_tier, name="VIP Monthly", price=Decimal("50.00"), currency="EUR", period_unit="month"
+        )
+
+        url = reverse("api:list_organization_plans", kwargs={"slug": organization.slug})
+        response = organization_owner_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        by_id = {item["id"]: item for item in data}
+        assert by_id[str(plan.id)]["tier_name"] == tier.name
+        assert by_id[str(other_plan.id)]["tier_name"] == other_tier.name
+
+    def test_is_active_filter(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        tier: MembershipTier,
+        plan: MembershipSubscriptionPlan,
+    ) -> None:
+        archived = subscription_service.create_plan(
+            tier, name="Archived", price=Decimal("1.00"), currency="EUR", period_unit="month"
+        )
+        subscription_service.archive_plan(archived)
+
+        url = reverse("api:list_organization_plans", kwargs={"slug": organization.slug})
+
+        active_only = organization_owner_client.get(url, {"is_active": "true"})
+        assert active_only.status_code == 200
+        active_ids = {item["id"] for item in active_only.json()}
+        assert str(plan.id) in active_ids
+        assert str(archived.id) not in active_ids
+
+        inactive_only = organization_owner_client.get(url, {"is_active": "false"})
+        assert inactive_only.status_code == 200
+        inactive_ids = {item["id"] for item in inactive_only.json()}
+        assert inactive_ids == {str(archived.id)}
+
+    def test_excludes_other_organizations(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+    ) -> None:
+        other_owner = RevelUser.objects.create_user(
+            username="org_plans_other", email="org-plans-other@example.com", password="pass"
+        )
+        other_org = Organization.objects.create(name="Other Plans Org", slug="other-plans", owner=other_owner)
+        other_tier = MembershipTier.objects.get(organization=other_org, name="General membership")
+        subscription_service.create_plan(
+            other_tier, name="Other", price=Decimal("9.00"), currency="EUR", period_unit="month"
+        )
+
+        url = reverse("api:list_organization_plans", kwargs={"slug": organization.slug})
+        response = organization_owner_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert {item["id"] for item in data} == {str(plan.id)}
+
+    def test_member_cannot_list_organization_plans(self, member_client: Client, organization: Organization) -> None:
+        url = reverse("api:list_organization_plans", kwargs={"slug": organization.slug})
+        response = member_client.get(url)
+        assert response.status_code == 403
+
+    def test_staff_without_permission_blocked(
+        self,
+        organization_staff_client: Client,
+        organization: Organization,
+        staff_member: OrganizationStaff,
+    ) -> None:
+        _set_staff_permission(staff_member, manage_subscriptions=False)
+        url = reverse("api:list_organization_plans", kwargs={"slug": organization.slug})
+        response = organization_staff_client.get(url)
         assert response.status_code == 403
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3920,7 +3920,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.53.0"
+version = "1.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
Closes #410.

## Summary
- Add `GET /organization-admin/{slug}/plans` with optional `is_active` filter — lets the admin Create-Subscription modal fetch every plan in one request instead of looping per tier (N+1).
- Add `tier_name: str` to `PlanSchema` (resolved via the already-prefetched `tier` relation) so the frontend can drop its client-side `Map<tier_id, name>` join.
- Add `select_related("tier")` to the per-tier `list_plans` queryset so `tier_name` resolution stays single-query.
- Bump version 1.53.0 → 1.54.0.

The tier-scoped `GET /tiers/{tier_id}/plans` endpoint stays — it's still the right shape for the per-tier PlansList panel.

## Test plan
- [ ] `make check` (format, lint, mypy, migrations, file-length) — passes locally
- [ ] `make test` — new `TestListOrganizationPlans` suite covers: cross-tier listing, `is_active=true/false` filter, cross-org isolation, member 403, staff-without-permission 403
- [ ] Existing `test_owner_can_list_plans` now also asserts `tier_name` is present
- [ ] After merge: `pnpm generate:api` in `revel-frontend` to pick up the new endpoint and schema field

🤖 Generated with [Claude Code](https://claude.com/claude-code)