### PR TITLE
fix(observability): emit tracebacks for all 500s

### DIFF
--- a/src/api/exception_handlers.py
+++ b/src/api/exception_handlers.py
@@ -50,10 +50,21 @@ def handle_general_exception(request: HttpRequest, exc: Exception | t.Type[Excep
         except Exception:  # pragma: no cover
             json_payload = None
 
-    # Log to observability stack with full context
+    # Log to observability stack with full context.
+    # Pass the exception instance to ``exc_info`` (not ``True``) so structlog's
+    # ``format_exc_info`` processor pulls the traceback from ``exc.__traceback__``.
+    # ``exc_info=True`` relies on ``sys.exc_info()`` being populated, which is not
+    # guaranteed by the time Ninja's exception dispatch reaches this handler.
+    # We also emit the formatted traceback as an explicit ``traceback`` field as a
+    # belt-and-braces safety net: if anything downstream drops the ``exception``
+    # key (custom processors, renderers, etc.), the stacktrace is still visible.
+    exc_instance = exc if isinstance(exc, BaseException) else None
+    formatted_tb = "".join(traceback.format_exception(exc_instance)) if exc_instance else None
+
     logger.error(
         "unhandled_exception",
-        exc_info=True,
+        exc_info=exc_instance,
+        traceback=formatted_tb,
         method=request.method,
         path=request.path,
         user=str(request.user) if getattr(request, "user", None) else None,
@@ -63,6 +74,7 @@ def handle_general_exception(request: HttpRequest, exc: Exception | t.Type[Excep
         post_params=obfuscate(request.POST.dict() if request.method == "POST" else {}),
         json_payload=json_payload,
         exception_type=type(exc).__name__,
+        exception_message=str(exc),
     )
 
     # Return response

--- a/src/common/middleware/observability.py
+++ b/src/common/middleware/observability.py
@@ -1,6 +1,7 @@
 """Observability middleware for context enrichment."""
 
 import time
+import traceback
 import typing as t
 import uuid
 
@@ -80,9 +81,25 @@ class StructlogContextMiddleware:
 
         structlog.contextvars.bind_contextvars(**context)
 
-        # Process request
+        # Process request. If anything outside the Ninja API (Django admin,
+        # non-API views, middleware) raises, Django swallows the traceback into
+        # a generic 500 — log it here so we always have a stacktrace tied to
+        # the request_id/trace_id context bound above.
         start_time = time.monotonic()
-        response = self.get_response(request)
+        try:
+            response = self.get_response(request)
+        except Exception as exc:
+            logger.error(
+                "unhandled_exception",
+                exc_info=exc,
+                traceback="".join(traceback.format_exception(exc)),
+                exception_type=type(exc).__name__,
+                exception_message=str(exc),
+                method=request.method,
+                path=request.path,
+            )
+            structlog.contextvars.clear_contextvars()
+            raise
 
         # Add request_id to response headers for client-side correlation
         response["X-Request-ID"] = request_id

--- a/src/revel/settings/observability.py
+++ b/src/revel/settings/observability.py
@@ -111,10 +111,14 @@ STRUCTLOG_PROCESSORS = [
 ]
 
 # Processors for foreign loggers (Django, Celery, etc.)
+# ``format_exc_info`` is required so standard-library ``log.error(..., exc_info=...)``
+# calls (e.g. Django's ``django.request`` logger on unhandled 500s) emit the
+# traceback as a serializable ``exception`` field rather than dropping it.
 FOREIGN_PRE_CHAIN = [
     structlog.contextvars.merge_contextvars,
     structlog.stdlib.add_log_level,
     structlog.processors.TimeStamper(fmt="iso"),
+    structlog.processors.format_exc_info,
     add_app_context,
     scrub_pii,
 ]
@@ -170,6 +174,14 @@ LOGGING = {
         "django": {
             "handlers": DEFAULT_HANDLERS,
             "level": "INFO",
+            "propagate": False,
+        },
+        # Django logs unhandled exceptions in views (incl. admin) to ``django.request``
+        # with ``exc_info``. Without this entry, Django's default config sends them to
+        # ``mail_admins`` only — so 500s outside the Ninja API would never reach Loki.
+        "django.request": {
+            "handlers": DEFAULT_HANDLERS,
+            "level": "WARNING",
             "propagate": False,
         },
         "django.server": {


### PR DESCRIPTION
## Summary

We saw repeated 500s in prod (`DELETE /api/event-admin/{id}` and the Django admin `events/event/{id}/change/`) with no traceback in Loki, making them effectively un-debuggable. Three independent gaps were swallowing the stacktrace:

- **Ninja API handler:** `handle_general_exception` called `logger.error(..., exc_info=True, ...)`. Structlog resolves `True` via `sys.exc_info()`, which isn't guaranteed to be populated by the time Ninja Extra's `on_exception` dispatch reaches the registered handler — so the `exception` field was silently dropped. Now we pass the exception instance directly (so structlog reads `exc.__traceback__`) and emit a separate `traceback` string + `exception_message` as belt-and-braces.
- **Django admin / non-API views:** Django logs view exceptions to `django.request` with `exc_info=...`, but our `LOGGING` config didn't override it, so Django's default kicked in and sent it to `mail_admins` only — nothing reached Loki. Added an explicit `django.request` logger entry pointing at our console handler.
- **Foreign loggers:** `FOREIGN_PRE_CHAIN` (used by Django/Celery stdlib logs going through `ProcessorFormatter`) was missing `structlog.processors.format_exc_info`, so even when stdlib loggers were called with `exc_info=...` the traceback never made it into the JSON payload. Added the processor.

Also wrapped `get_response` in `StructlogContextMiddleware` with a try/except that logs middleware-level exceptions against the bound `request_id`/`trace_id` before re-raising — Django's default handler doesn't see anything raised above the view layer.

## Test plan

- [ ] Deploy and trigger a known 500 (e.g. retry one of the failing `DELETE /api/event-admin/{id}` calls from the report).
- [ ] Confirm an `unhandled_exception` log entry appears in Loki with non-empty `exception` and `traceback` fields, tagged with the same `request_id` as the `request_finished` line.
- [ ] Trigger a 500 from the Django admin (e.g. visit a deliberately broken change page) and confirm `django.request` emits an error with a traceback into Loki.
- [ ] Verify existing tests pass — no behavioral change to responses, only logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)