### PR TITLE
feat(accounts): self-served email change via JWT-confirmation flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.55.0"
+version = "1.56.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/controllers/account.py
+++ b/src/accounts/controllers/account.py
@@ -220,6 +220,47 @@ class AccountController(UserAwareController):
         return ResponseMessage(message=str(_("Password reset successfully.")))
 
     @route.post(
+        "/email-change-request",
+        tags=["Account"],
+        response=ResponseMessage,
+        url_name="email-change-request",
+        throttle=WriteThrottle(),
+    )
+    def email_change_request(self, payload: schema.EmailChangeRequestSchema) -> ResponseMessage:
+        """Begin a self-served email change.
+
+        Validates the current password, ensures the new address is available, issues a
+        single-use JWT, and emails the confirmation link to the **new** address. A
+        separate informational notice is sent to the current address. Returns a generic
+        success message on duplicate-banned-email targets to avoid signalling ban presence.
+        """
+        account_service.request_email_change(
+            user=self.user(),
+            new_email=payload.new_email,
+            password=payload.password,
+        )
+        return ResponseMessage(message=str(_("A confirmation link has been sent to the new email address.")))
+
+    @route.post(
+        "/email-change-confirm",
+        tags=["Account"],
+        response=schema.EmailChangeResponseSchema,
+        url_name="email-change-confirm",
+        auth=None,
+        throttle=WriteThrottle(),
+    )
+    def email_change_confirm(self, payload: schema.EmailChangeConfirmSchema) -> schema.EmailChangeResponseSchema:
+        """Confirm an email change using the token sent to the new address.
+
+        Swaps email/username, blacklists all existing JWTs for the user (email is an
+        identity primitive), and issues a fresh token pair so the confirming device
+        stays signed in. The confirmation token is single-use.
+        """
+        user = account_service.confirm_email_change(payload.token)
+        token = get_token_pair_for_user(user)
+        return schema.EmailChangeResponseSchema(user=RevelUserSchema.from_orm(user), token=token)
+
+    @route.post(
         "/me/upload-profile-picture",
         response=RevelUserSchema,
         url_name="upload-profile-picture",

--- a/src/accounts/controllers/account.py
+++ b/src/accounts/controllers/account.py
@@ -231,8 +231,16 @@ class AccountController(UserAwareController):
 
         Validates the current password, ensures the new address is available, issues a
         single-use JWT, and emails the confirmation link to the **new** address. A
-        separate informational notice is sent to the current address. Returns a generic
-        success message on duplicate-banned-email targets to avoid signalling ban presence.
+        separate informational notice is sent to the current address. Returns 400 if
+        the new address is already in use; returns the generic success message when the
+        target is globally banned, to avoid signalling ban presence.
+
+        Args:
+            payload: Schema with ``new_email`` (lowercased by the schema validator)
+                and the user's current ``password``.
+
+        Returns:
+            A generic success message indicating that the confirmation link was sent.
         """
         account_service.request_email_change(
             user=self.user(),
@@ -255,6 +263,12 @@ class AccountController(UserAwareController):
         Swaps email/username, blacklists all existing JWTs for the user (email is an
         identity primitive), and issues a fresh token pair so the confirming device
         stays signed in. The confirmation token is single-use.
+
+        Args:
+            payload: Schema containing the single-use email-change token.
+
+        Returns:
+            The updated user and a fresh JWT token pair for the confirming device.
         """
         user = account_service.confirm_email_change(payload.token)
         token = get_token_pair_for_user(user)

--- a/src/accounts/jwt.py
+++ b/src/accounts/jwt.py
@@ -126,6 +126,28 @@ def check_blacklist(jti: str) -> None:
         raise HttpError(401, "Token is blacklisted.")
 
 
+def blacklist_user_tokens(user: t.Any) -> int:
+    """Blacklist all outstanding JWT tokens for a user.
+
+    Used when an event invalidates every active session — e.g. global ban,
+    or an identity-primitive change like email rotation.
+
+    Args:
+        user: The user whose tokens should be blacklisted.
+
+    Returns:
+        Number of tokens blacklisted.
+    """
+    outstanding = OutstandingToken.objects.filter(user=user).exclude(blacklistedtoken__isnull=False)
+    count = 0
+    for token in outstanding:
+        BlacklistedToken.objects.get_or_create(token=token)
+        count += 1
+    if count:
+        logger.info("user_tokens_blacklisted", user_id=str(user.id), count=count)
+    return count
+
+
 @transaction.atomic
 def blacklist(
     token: str,

--- a/src/accounts/schema.py
+++ b/src/accounts/schema.py
@@ -214,6 +214,11 @@ class UnsubscribeJWTPayloadSchema(_BaseEmailJWTPayloadSchema):
     type: t.Literal["unsubscribe"] = "unsubscribe"
 
 
+class EmailChangeJWTPayloadSchema(_BaseEmailJWTPayloadSchema):
+    new_email: EmailStr
+    type: t.Literal["email_change"] = "email_change"
+
+
 class DeleteAccountSchema(Schema):
     password: str
 
@@ -261,6 +266,26 @@ class LanguageUpdateSchema(Schema):
 
 
 class VerifyEmailResponseSchema(Schema):
+    user: RevelUserSchema
+    token: TokenObtainPairOutputSchema
+
+
+class EmailChangeRequestSchema(Schema):
+    new_email: EmailStr
+    password: str
+
+    @field_validator("new_email")
+    @classmethod
+    def lowercase_email(cls, v: str) -> str:
+        """Normalize email to lowercase."""
+        return v.lower()
+
+
+class EmailChangeConfirmSchema(Schema):
+    token: str
+
+
+class EmailChangeResponseSchema(Schema):
     user: RevelUserSchema
     token: TokenObtainPairOutputSchema
 

--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -15,11 +15,12 @@ from ninja.errors import HttpError
 
 from accounts import schema, tasks
 from accounts.jwt import blacklist as blacklist_token
-from accounts.jwt import check_blacklist, create_token
+from accounts.jwt import blacklist_user_tokens, check_blacklist, create_token
 from accounts.models import Referral, ReferralCode, RevelUser
 from accounts.password_validation import validate_password
 from common.testing import (
     TOKEN_TYPE_DELETION,
+    TOKEN_TYPE_EMAIL_CHANGE,
     TOKEN_TYPE_PASSWORD_RESET,
     TOKEN_TYPE_VERIFICATION,
     store_test_token,
@@ -312,6 +313,130 @@ def reset_password(token: str, new_password: str) -> RevelUser:
 
     blacklist_token(token)
     logger.info("password_reset_completed", user_id=str(user.id), email=user.email)
+    return user
+
+
+def create_email_change_token(user: RevelUser, new_email: str) -> str:
+    """Create a single-use email change token bound to the user and the proposed new email.
+
+    Args:
+        user: The user requesting the change.
+        new_email: The proposed new email (must already be lowercased).
+
+    Returns:
+        The signed JWT token.
+    """
+    payload = schema.EmailChangeJWTPayloadSchema(
+        user_id=user.id,
+        email=user.email,
+        new_email=new_email,
+        exp=timezone.now() + settings.VERIFY_TOKEN_LIFETIME,
+    )
+    token = create_token(payload.model_dump(mode="json"), settings.SECRET_KEY, settings.JWT_ALGORITHM)
+    store_test_token(TOKEN_TYPE_EMAIL_CHANGE, token)
+    return token
+
+
+def _mask_email(email: str) -> str:
+    """Return a partially-masked rendering of an email for the notice-to-old-address.
+
+    Examples:
+        ``alice@example.com`` -> ``a****@example.com``
+        ``a@example.com``     -> ``*@example.com``
+    """
+    local, _, domain = email.partition("@")
+    if not domain:
+        return "***"
+    if len(local) <= 1:
+        return f"*@{domain}"
+    return f"{local[0]}{'*' * (len(local) - 1)}@{domain}"
+
+
+def request_email_change(user: RevelUser, new_email: str, password: str) -> str:
+    """Begin an email change flow: validate, issue a token, dispatch emails.
+
+    Args:
+        user: The authenticated user requesting the change.
+        new_email: The lowercased new email address.
+        password: The user's current password (defense-in-depth).
+
+    Returns:
+        The signed email-change token (also dispatched to the new address).
+    """
+    from accounts.service.global_ban_service import is_email_globally_banned
+
+    logger.info("email_change_requested", user_id=str(user.id), new_email=new_email)
+
+    if not user.check_password(password):
+        logger.warning("email_change_bad_password", user_id=str(user.id))
+        raise HttpError(400, str(_("Incorrect password.")))
+
+    if GoogleSSOUser.objects.filter(user=user).exists():
+        logger.info("email_change_blocked_google_sso", user_id=str(user.id))
+        raise HttpError(400, str(_("Google SSO users cannot change their email here.")))
+
+    if new_email == user.email:
+        raise HttpError(400, str(_("The new email is the same as the current one.")))
+
+    if is_email_globally_banned(new_email):
+        # Mirror the verification flow: silently no-op to avoid signalling ban presence.
+        logger.info("email_change_blocked_banned_target", user_id=str(user.id))
+        return ""
+
+    if RevelUser.objects.filter(username__iexact=new_email).exists():
+        raise HttpError(400, str(_("This email is already in use.")))
+
+    token = create_email_change_token(user, new_email)
+    tasks.send_email_change_confirmation.delay(new_email, token)
+    tasks.send_email_change_notice.delay(user.email, _mask_email(new_email))
+    logger.info("email_change_email_sent", user_id=str(user.id), new_email=new_email)
+    return token
+
+
+def confirm_email_change(token: str) -> RevelUser:
+    """Confirm an email change and rotate the user's identity.
+
+    Validates and blacklists the token, swaps ``email``/``username`` to the new
+    address, blacklists every outstanding JWT for the user (treating email as
+    an identity primitive), and dispatches notifications to both addresses.
+
+    Args:
+        token: The email-change JWT.
+
+    Returns:
+        The user with the updated email.
+    """
+    payload = token_to_payload(token, schema.EmailChangeJWTPayloadSchema)
+    check_blacklist(payload.jti)
+    user = get_object_or_404(RevelUser, id=payload.user_id)
+    new_email = payload.new_email.lower()
+
+    # Race-safe uniqueness check at confirm time. Done before any state mutation so
+    # the token remains usable for a retry only if the spec allows; here we choose
+    # the conservative path and blacklist regardless.
+    if RevelUser.objects.filter(username__iexact=new_email).exclude(pk=user.pk).exists():
+        blacklist_token(token)
+        logger.warning("email_change_confirm_email_taken", user_id=str(user.id), new_email=new_email)
+        raise HttpError(400, str(_("This email is already in use.")))
+
+    old_email = user.email
+    with transaction.atomic():
+        blacklist_token(token)
+        user.email = new_email
+        user.username = new_email
+        user.email_verified = True
+        user.save(update_fields=["email", "username", "email_verified"])
+        # Email is an identity primitive — invalidate every active session.
+        blacklist_user_tokens(user)
+
+    tasks.send_email_change_completed_old.delay(old_email, new_email)
+    tasks.send_email_change_completed_new.delay(new_email, old_email)
+    logger.info(
+        "email_change_confirmed",
+        user_id=str(user.id),
+        old_email=old_email,
+        new_email=new_email,
+    )
     return user
 
 

--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -5,7 +5,7 @@ import typing as t
 import jwt
 import structlog
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -367,13 +367,15 @@ def request_email_change(user: RevelUser, new_email: str, password: str) -> str:
 
     logger.info("email_change_requested", user_id=str(user.id), new_email=new_email)
 
-    if not user.check_password(password):
-        logger.warning("email_change_bad_password", user_id=str(user.id))
-        raise HttpError(400, str(_("Incorrect password.")))
-
+    # SSO check must run before the password check — SSO accounts have a sentinel
+    # password and would otherwise be rejected with a misleading "Incorrect password".
     if GoogleSSOUser.objects.filter(user=user).exists():
         logger.info("email_change_blocked_google_sso", user_id=str(user.id))
         raise HttpError(400, str(_("Google SSO users cannot change their email here.")))
+
+    if not user.check_password(password):
+        logger.warning("email_change_bad_password", user_id=str(user.id))
+        raise HttpError(400, str(_("Incorrect password.")))
 
     if new_email == user.email:
         raise HttpError(400, str(_("The new email is the same as the current one.")))
@@ -405,29 +407,47 @@ def confirm_email_change(token: str) -> RevelUser:
 
     Returns:
         The user with the updated email.
+
+    Raises:
+        HttpError: 400 if the new address is already taken (including under a
+            DB-level race), 403 if the address became globally banned between
+            request and confirm.
     """
+    from accounts.service.global_ban_service import BAN_ERROR_MESSAGE, is_email_globally_banned
+
     payload = token_to_payload(token, schema.EmailChangeJWTPayloadSchema)
     check_blacklist(payload.jti)
     user = get_object_or_404(RevelUser, id=payload.user_id)
     new_email = payload.new_email.lower()
 
-    # Race-safe uniqueness check at confirm time. Done before any state mutation so
-    # the token remains usable for a retry only if the spec allows; here we choose
-    # the conservative path and blacklist regardless.
+    # Re-check the global ban at confirm time — a ban added between request and
+    # confirm must block the swap (mirrors verify_email).
+    if is_email_globally_banned(new_email):
+        blacklist_token(token)
+        logger.warning("email_change_confirm_blocked_banned_target", user_id=str(user.id))
+        raise HttpError(403, str(BAN_ERROR_MESSAGE))
+
     if RevelUser.objects.filter(username__iexact=new_email).exclude(pk=user.pk).exists():
         blacklist_token(token)
         logger.warning("email_change_confirm_email_taken", user_id=str(user.id), new_email=new_email)
         raise HttpError(400, str(_("This email is already in use.")))
 
     old_email = user.email
-    with transaction.atomic():
+    try:
+        with transaction.atomic():
+            blacklist_token(token)
+            user.email = new_email
+            user.username = new_email
+            user.email_verified = True
+            user.save(update_fields=["email", "username", "email_verified"])
+            # Email is an identity primitive — invalidate every active session.
+            blacklist_user_tokens(user)
+    except IntegrityError:
+        # Another confirmation took the address between the pre-check and the save.
+        # Blacklist outside the rolled-back transaction so the token cannot be retried.
         blacklist_token(token)
-        user.email = new_email
-        user.username = new_email
-        user.email_verified = True
-        user.save(update_fields=["email", "username", "email_verified"])
-        # Email is an identity primitive — invalidate every active session.
-        blacklist_user_tokens(user)
+        logger.warning("email_change_confirm_race_loss", user_id=str(user.id), new_email=new_email)
+        raise HttpError(400, str(_("This email is already in use.")))
 
     tasks.send_email_change_completed_old.delay(old_email, new_email)
     tasks.send_email_change_completed_new.delay(new_email, old_email)

--- a/src/accounts/service/global_ban_service.py
+++ b/src/accounts/service/global_ban_service.py
@@ -4,8 +4,8 @@ import structlog
 from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
-from ninja_jwt.token_blacklist.models import BlacklistedToken, OutstandingToken
 
+from accounts.jwt import blacklist_user_tokens
 from accounts.models import GlobalBan, RevelUser
 from accounts.utils.email_normalization import (
     extract_domain,
@@ -16,25 +16,6 @@ from accounts.utils.email_normalization import (
 logger = structlog.get_logger(__name__)
 
 BAN_ERROR_MESSAGE: str = _("Registration is not available.")  # type: ignore[assignment]
-
-
-def _blacklist_user_tokens(user: RevelUser) -> int:
-    """Blacklist all outstanding JWT tokens for a user.
-
-    Args:
-        user: The user whose tokens should be blacklisted.
-
-    Returns:
-        Number of tokens blacklisted.
-    """
-    outstanding = OutstandingToken.objects.filter(user=user).exclude(blacklistedtoken__isnull=False)
-    count = 0
-    for token in outstanding:
-        BlacklistedToken.objects.get_or_create(token=token)
-        count += 1
-    if count:
-        logger.info("user_tokens_blacklisted", user_id=str(user.id), count=count)
-    return count
 
 
 def is_email_globally_banned(email: str) -> bool:
@@ -100,7 +81,7 @@ def deactivate_user_for_ban(user: RevelUser, reason: str) -> None:
     user.save(update_fields=["is_active"])
 
     # Blacklist all outstanding JWT tokens so the user is immediately locked out
-    _blacklist_user_tokens(user)
+    blacklist_user_tokens(user)
 
     logger.warning("user_deactivated_for_ban", user_id=str(user.id), email=user.email, reason=reason)
 

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -79,6 +79,65 @@ def send_password_reset_link(email: str, token: str) -> None:
 
 
 @shared_task
+def send_email_change_confirmation(new_email: str, token: str) -> None:
+    """Send the confirmation link to the **new** email address.
+
+    Clicking the link proves the user controls the new mailbox.
+    """
+    logger.info("email_change_confirmation_sending", new_email=new_email)
+    subject = str(render_to_string("accounts/emails/email_change_confirmation_subject.txt"))
+    site_settings = SiteSettings.get_solo()
+    confirmation_link = site_settings.frontend_base_url + f"/account/confirm-email-change?token={token}"
+    context = {"confirmation_link": confirmation_link, "frontend_base_url": site_settings.frontend_base_url}
+    body = render_to_string("accounts/emails/email_change_confirmation_body.txt", context)
+    html_body = render_to_string("accounts/emails/email_change_confirmation_body.html", context)
+    send_email(to=new_email, subject=subject, body=body, html_body=html_body)
+    logger.info("email_change_confirmation_sent", new_email=new_email)
+
+
+@shared_task
+def send_email_change_notice(current_email: str, masked_new_email: str) -> None:
+    """Notify the **current** email address that a change was requested.
+
+    Informational only — there is no cancel link in v1.
+    """
+    logger.info("email_change_notice_sending", current_email=current_email)
+    subject = str(render_to_string("accounts/emails/email_change_notice_subject.txt"))
+    site_settings = SiteSettings.get_solo()
+    context = {"masked_new_email": masked_new_email, "frontend_base_url": site_settings.frontend_base_url}
+    body = render_to_string("accounts/emails/email_change_notice_body.txt", context)
+    html_body = render_to_string("accounts/emails/email_change_notice_body.html", context)
+    send_email(to=current_email, subject=subject, body=body, html_body=html_body)
+    logger.info("email_change_notice_sent", current_email=current_email)
+
+
+@shared_task
+def send_email_change_completed_old(old_email: str, new_email: str) -> None:
+    """Notify the **old** address that the email change has completed."""
+    logger.info("email_change_completed_old_sending", old_email=old_email)
+    subject = str(render_to_string("accounts/emails/email_change_completed_old_subject.txt"))
+    site_settings = SiteSettings.get_solo()
+    context = {"old_email": old_email, "new_email": new_email, "frontend_base_url": site_settings.frontend_base_url}
+    body = render_to_string("accounts/emails/email_change_completed_old_body.txt", context)
+    html_body = render_to_string("accounts/emails/email_change_completed_old_body.html", context)
+    send_email(to=old_email, subject=subject, body=body, html_body=html_body)
+    logger.info("email_change_completed_old_sent", old_email=old_email)
+
+
+@shared_task
+def send_email_change_completed_new(new_email: str, old_email: str) -> None:
+    """Welcome message to the **new** address confirming the change is live."""
+    logger.info("email_change_completed_new_sending", new_email=new_email)
+    subject = str(render_to_string("accounts/emails/email_change_completed_new_subject.txt"))
+    site_settings = SiteSettings.get_solo()
+    context = {"old_email": old_email, "new_email": new_email, "frontend_base_url": site_settings.frontend_base_url}
+    body = render_to_string("accounts/emails/email_change_completed_new_body.txt", context)
+    html_body = render_to_string("accounts/emails/email_change_completed_new_body.html", context)
+    send_email(to=new_email, subject=subject, body=body, html_body=html_body)
+    logger.info("email_change_completed_new_sent", new_email=new_email)
+
+
+@shared_task
 def send_account_deletion_link(email: str, token: str) -> None:
     """Send an account deletion confirmation email."""
     logger.info("account_deletion_email_sending", email=email)

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -83,6 +83,10 @@ def send_email_change_confirmation(new_email: str, token: str) -> None:
     """Send the confirmation link to the **new** email address.
 
     Clicking the link proves the user controls the new mailbox.
+
+    Args:
+        new_email: The new email address requested by the user.
+        token: The single-use email-change JWT to embed in the confirmation link.
     """
     logger.info("email_change_confirmation_sending", new_email=new_email)
     subject = str(render_to_string("accounts/emails/email_change_confirmation_subject.txt"))
@@ -100,6 +104,10 @@ def send_email_change_notice(current_email: str, masked_new_email: str) -> None:
     """Notify the **current** email address that a change was requested.
 
     Informational only — there is no cancel link in v1.
+
+    Args:
+        current_email: The user's current email address.
+        masked_new_email: The new address in masked form (e.g. ``a***@example.com``).
     """
     logger.info("email_change_notice_sending", current_email=current_email)
     subject = str(render_to_string("accounts/emails/email_change_notice_subject.txt"))
@@ -113,7 +121,12 @@ def send_email_change_notice(current_email: str, masked_new_email: str) -> None:
 
 @shared_task
 def send_email_change_completed_old(old_email: str, new_email: str) -> None:
-    """Notify the **old** address that the email change has completed."""
+    """Notify the **old** address that the email change has completed.
+
+    Args:
+        old_email: The address being decommissioned.
+        new_email: The address that is now primary on the account.
+    """
     logger.info("email_change_completed_old_sending", old_email=old_email)
     subject = str(render_to_string("accounts/emails/email_change_completed_old_subject.txt"))
     site_settings = SiteSettings.get_solo()
@@ -126,7 +139,12 @@ def send_email_change_completed_old(old_email: str, new_email: str) -> None:
 
 @shared_task
 def send_email_change_completed_new(new_email: str, old_email: str) -> None:
-    """Welcome message to the **new** address confirming the change is live."""
+    """Welcome message to the **new** address confirming the change is live.
+
+    Args:
+        new_email: The address that is now primary on the account.
+        old_email: The previous address (referenced in the body for clarity).
+    """
     logger.info("email_change_completed_new_sending", new_email=new_email)
     subject = str(render_to_string("accounts/emails/email_change_completed_new_subject.txt"))
     site_settings = SiteSettings.get_solo()

--- a/src/accounts/templates/accounts/emails/email_change_completed_new_body.html
+++ b/src/accounts/templates/accounts/emails/email_change_completed_new_body.html
@@ -1,0 +1,17 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% trans "Your Revel email address has been changed" %}</title>
+</head>
+<body>
+    <h2>{% trans "Your Revel email address has been changed" %}</h2>
+    <p>{% blocktrans %}This address (<strong>{{ new_email }}</strong>) is now the primary email on your Revel account. The previous address (<strong>{{ old_email }}</strong>) has been removed and can no longer be used to sign in.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}For security, every other session has been signed out.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}If you did not authorise this change, contact support immediately.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Thank you,<br>The Revel Team{% endblocktrans %}</p>
+</body>
+</html>

--- a/src/accounts/templates/accounts/emails/email_change_completed_new_body.txt
+++ b/src/accounts/templates/accounts/emails/email_change_completed_new_body.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% trans "Your Revel email address has been changed." %}
+
+{% blocktrans %}This address ({{ new_email }}) is now the primary email on your Revel account. The previous address ({{ old_email }}) has been removed and can no longer be used to sign in.{% endblocktrans %}
+
+{% blocktrans %}For security, every other session has been signed out.{% endblocktrans %}
+
+{% blocktrans %}If you did not authorise this change, contact support immediately.{% endblocktrans %}
+
+{% blocktrans %}Thank you,
+The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/email_change_completed_new_subject.txt
+++ b/src/accounts/templates/accounts/emails/email_change_completed_new_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Your Revel email address has been changed" %}

--- a/src/accounts/templates/accounts/emails/email_change_completed_old_body.html
+++ b/src/accounts/templates/accounts/emails/email_change_completed_old_body.html
@@ -1,0 +1,17 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% trans "Your Revel email address has been changed" %}</title>
+</head>
+<body>
+    <h2>{% trans "Your Revel email address has been changed" %}</h2>
+    <p>{% blocktrans %}This is a confirmation that the email address on your Revel account has been changed from <strong>{{ old_email }}</strong> to <strong>{{ new_email }}</strong>.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}All other sessions have been signed out as a security precaution. From now on, sign in using your new address.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}If you did not authorise this change, contact support immediately.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Thank you,<br>The Revel Team{% endblocktrans %}</p>
+</body>
+</html>

--- a/src/accounts/templates/accounts/emails/email_change_completed_old_body.txt
+++ b/src/accounts/templates/accounts/emails/email_change_completed_old_body.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% trans "Your Revel email address has been changed." %}
+
+{% blocktrans %}This is a confirmation that the email address on your Revel account has been changed from {{ old_email }} to {{ new_email }}.{% endblocktrans %}
+
+{% blocktrans %}All other sessions have been signed out as a security precaution. From now on, sign in using your new address.{% endblocktrans %}
+
+{% blocktrans %}If you did not authorise this change, contact support immediately.{% endblocktrans %}
+
+{% blocktrans %}Thank you,
+The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/email_change_completed_old_subject.txt
+++ b/src/accounts/templates/accounts/emails/email_change_completed_old_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Your Revel email address has been changed" %}

--- a/src/accounts/templates/accounts/emails/email_change_confirmation_body.html
+++ b/src/accounts/templates/accounts/emails/email_change_confirmation_body.html
@@ -1,0 +1,23 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% trans "Confirm your new email address" %}</title>
+</head>
+<body>
+    <h2>{% trans "Confirm your new email address" %}</h2>
+    <p>{% blocktrans %}You (or someone using your account) asked to change the email address on your Revel account to this one. To confirm the change, click the button below:{% endblocktrans %}</p>
+
+    <p>
+        <a href="{{ confirmation_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
+            {% trans "Confirm new email" %}
+        </a>
+    </p>
+
+    <p><strong>{% blocktrans %}Important: after you confirm, you will be signed out of every other device and you will need to sign in again using this new email address.{% endblocktrans %}</strong></p>
+
+    <p>{% blocktrans %}If you weren't expecting this email, you can safely ignore it — nothing will change until the link is clicked.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Thank you,<br>The Revel Team{% endblocktrans %}</p>
+</body>
+</html>

--- a/src/accounts/templates/accounts/emails/email_change_confirmation_body.txt
+++ b/src/accounts/templates/accounts/emails/email_change_confirmation_body.txt
@@ -1,0 +1,12 @@
+{% load i18n %}{% trans "Confirm your new email address." %}
+
+{% blocktrans %}You (or someone using your account) asked to change the email address on your Revel account to this one. To confirm the change, click the link below:{% endblocktrans %}
+
+{{ confirmation_link }}
+
+{% blocktrans %}Important: after you confirm, you will be signed out of every other device and you will need to sign in again using this new email address.{% endblocktrans %}
+
+{% blocktrans %}If you weren't expecting this email, you can safely ignore it — nothing will change until the link is clicked.{% endblocktrans %}
+
+{% blocktrans %}Thank you,
+The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/email_change_confirmation_subject.txt
+++ b/src/accounts/templates/accounts/emails/email_change_confirmation_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Confirm your new email address" %}

--- a/src/accounts/templates/accounts/emails/email_change_notice_body.html
+++ b/src/accounts/templates/accounts/emails/email_change_notice_body.html
@@ -1,0 +1,22 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% trans "An email change was requested on your account" %}</title>
+</head>
+<body>
+    <h2>{% trans "An email change was requested on your account" %}</h2>
+    <p>{% blocktrans %}Someone asked to change the email address on your Revel account to <strong>{{ masked_new_email }}</strong>. The change is not active yet — it will only take effect when the new address is confirmed.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}If this wasn't you, change your password immediately and contact support:{% endblocktrans %}</p>
+    <p>
+        <a href="{{ frontend_base_url }}/account/password-reset" style="display: inline-block; padding: 10px 20px; background-color: #dc3545; color: #ffffff; text-decoration: none; border-radius: 5px;">
+            {% trans "Reset my password" %}
+        </a>
+    </p>
+
+    <p>{% blocktrans %}If it was you, no action is needed — finish the confirmation from the email we just sent to your new address.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Thank you,<br>The Revel Team{% endblocktrans %}</p>
+</body>
+</html>

--- a/src/accounts/templates/accounts/emails/email_change_notice_body.txt
+++ b/src/accounts/templates/accounts/emails/email_change_notice_body.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% trans "An email change was requested on your account." %}
+
+{% blocktrans %}Someone asked to change the email address on your Revel account to {{ masked_new_email }}. The change is not active yet — it will only take effect when the new address is confirmed.{% endblocktrans %}
+
+{% blocktrans %}If this wasn't you, change your password immediately at {{ frontend_base_url }}/account/password-reset and contact support.{% endblocktrans %}
+
+{% blocktrans %}If it was you, no action is needed — finish the confirmation from the email we just sent to your new address.{% endblocktrans %}
+
+{% blocktrans %}Thank you,
+The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/email_change_notice_subject.txt
+++ b/src/accounts/templates/accounts/emails/email_change_notice_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "An email change was requested on your account" %}

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -5,6 +5,7 @@ import datetime
 import typing as t
 from unittest.mock import MagicMock, patch
 
+import jwt as pyjwt
 import orjson
 import pytest
 from django.conf import settings
@@ -19,6 +20,17 @@ from accounts import schema
 from accounts.jwt import create_token
 from accounts.models import GlobalBan, RevelUser
 from accounts.service import account as account_service
+
+
+def _jti(token: str) -> str:
+    """Decode an email-change JWT and return its jti claim."""
+    return t.cast(
+        str,
+        pyjwt.decode(token, settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM], audience=settings.JWT_AUDIENCE)[
+            "jti"
+        ],
+    )
+
 
 pytestmark = pytest.mark.django_db
 
@@ -85,24 +97,22 @@ class TestRequestEmailChange:
         self, mock_send: MagicMock, user: RevelUser, django_user_model: t.Type[RevelUser]
     ) -> None:
         django_user_model.objects.create_user(username="taken@example.com", email="taken@example.com", password="x")
+        # Pass mixed-case input to actually exercise the iexact branch.
         with pytest.raises(HttpError):
             account_service.request_email_change(
-                user=user, new_email="TAKEN@example.com".lower(), password="strong-password-123!"
+                user=user, new_email="TAKEN@Example.com", password="strong-password-123!"
             )
         mock_send.assert_not_called()
 
     @patch("accounts.tasks.send_email_change_confirmation.delay")
     def test_google_sso_user_rejected(self, mock_send: MagicMock, google_user: RevelUser) -> None:
-        # Google SSO users have a sentinel password; their check_password will fail,
-        # but the SSO check happens after password check — so use a fake password the
-        # check_password will reject. To test SSO branch directly, set a real password.
-        google_user.set_password("strong-password-123!")
-        google_user.save(update_fields=["password"])
+        # Real SSO accounts have only the sentinel password — do not override it. The
+        # SSO branch must fire before the password check, otherwise these users get the
+        # misleading "Incorrect password" error.
         with pytest.raises(HttpError) as exc:
-            account_service.request_email_change(
-                user=google_user, new_email="new@example.com", password="strong-password-123!"
-            )
+            account_service.request_email_change(user=google_user, new_email="new@example.com", password="any-password")
         assert exc.value.status_code == 400
+        assert "SSO" in str(exc.value.message)
         mock_send.assert_not_called()
 
     @patch("accounts.tasks.send_email_change_notice.delay")
@@ -192,7 +202,9 @@ class TestConfirmEmailChange:
     def test_blacklisted_token_rejected(self, mock_old: MagicMock, mock_new: MagicMock, user: RevelUser) -> None:
         token = _make_change_token(user, "new@example.com")
         account_service.confirm_email_change(token)
-        # Re-using the same token must fail
+        # The specific JTI is blacklisted.
+        assert BlacklistedToken.objects.filter(token__jti=_jti(token)).exists()
+        # Re-using the same token must fail.
         with pytest.raises(HttpError):
             account_service.confirm_email_change(token)
 
@@ -214,8 +226,22 @@ class TestConfirmEmailChange:
         # User's email is unchanged.
         user.refresh_from_db()
         assert user.email != "raced@example.com"
-        # Token is blacklisted so it cannot be retried later.
-        assert BlacklistedToken.objects.exists()
+        # The specific token's JTI is blacklisted — single-use semantics survive race-loss.
+        assert BlacklistedToken.objects.filter(token__jti=_jti(token)).exists()
+
+    def test_globally_banned_at_confirm_time_rejected(self, user: RevelUser) -> None:
+        """A ban added between request and confirm must block the swap."""
+        token = _make_change_token(user, "ban-me-later@example.com")
+        GlobalBan.objects.create(
+            ban_type=GlobalBan.BanType.EMAIL,
+            value="ban-me-later@example.com",
+            reason="test",
+        )
+        with pytest.raises(HttpError) as exc:
+            account_service.confirm_email_change(token)
+        assert exc.value.status_code == 403
+        user.refresh_from_db()
+        assert user.email != "ban-me-later@example.com"
 
 
 # ===== Controller tests =====
@@ -293,5 +319,9 @@ def test_full_flow_old_refresh_tokens_invalidated(
     for jti in old_outstanding_jtis:
         assert BlacklistedToken.objects.filter(token__jti=jti).exists()
 
-    # The freshly returned refresh token must NOT be blacklisted.
-    assert "refresh" in confirm_resp.json()["token"]
+    # The freshly returned refresh token must NOT be blacklisted — the confirming
+    # device stays signed in.
+    new_refresh = confirm_resp.json()["token"]["refresh"]
+    new_jti = pyjwt.decode(new_refresh, options={"verify_signature": False}, algorithms=[settings.JWT_ALGORITHM])["jti"]
+    assert not BlacklistedToken.objects.filter(token__jti=new_jti).exists()
+    assert new_jti not in old_outstanding_jtis

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -1,0 +1,297 @@
+# src/accounts/tests/test_email_change.py
+"""Tests for the self-served email change flow (issue #421)."""
+
+import datetime
+import typing as t
+from unittest.mock import MagicMock, patch
+
+import orjson
+import pytest
+from django.conf import settings
+from django.test.client import Client
+from django.urls import reverse
+from django.utils import timezone
+from ninja.errors import HttpError
+from ninja_jwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+from ninja_jwt.tokens import RefreshToken
+
+from accounts import schema
+from accounts.jwt import create_token
+from accounts.models import GlobalBan, RevelUser
+from accounts.service import account as account_service
+
+pytestmark = pytest.mark.django_db
+
+
+# ===== Schema =====
+
+
+class TestEmailChangeRequestSchema:
+    def test_uppercase_email_lowercased(self) -> None:
+        payload = schema.EmailChangeRequestSchema(new_email="NEW@EXAMPLE.COM", password="x")
+        assert payload.new_email == "new@example.com"
+
+
+# ===== Service: request_email_change =====
+
+
+class TestRequestEmailChange:
+    @patch("accounts.tasks.send_email_change_notice.delay")
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_success(
+        self,
+        mock_send_conf: MagicMock,
+        mock_send_notice: MagicMock,
+        user: RevelUser,
+    ) -> None:
+        token = account_service.request_email_change(
+            user=user, new_email="new@example.com", password="strong-password-123!"
+        )
+        assert token
+        mock_send_conf.assert_called_once_with("new@example.com", token)
+        mock_send_notice.assert_called_once()
+        notice_args = mock_send_notice.call_args
+        assert notice_args.args[0] == user.email
+        # Masking: a****@example.com style
+        assert notice_args.args[1].endswith("@example.com")
+        assert "*" in notice_args.args[1]
+
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_wrong_password(self, mock_send: MagicMock, user: RevelUser) -> None:
+        with pytest.raises(HttpError) as exc:
+            account_service.request_email_change(user=user, new_email="new@example.com", password="WRONG")
+        assert exc.value.status_code == 400
+        mock_send.assert_not_called()
+
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_same_email(self, mock_send: MagicMock, user: RevelUser) -> None:
+        with pytest.raises(HttpError) as exc:
+            account_service.request_email_change(user=user, new_email=user.email, password="strong-password-123!")
+        assert exc.value.status_code == 400
+        mock_send.assert_not_called()
+
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_duplicate_email(self, mock_send: MagicMock, user: RevelUser, django_user_model: t.Type[RevelUser]) -> None:
+        django_user_model.objects.create_user(username="taken@example.com", email="taken@example.com", password="x")
+        with pytest.raises(HttpError) as exc:
+            account_service.request_email_change(
+                user=user, new_email="taken@example.com", password="strong-password-123!"
+            )
+        assert exc.value.status_code == 400
+        mock_send.assert_not_called()
+
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_duplicate_email_case_insensitive(
+        self, mock_send: MagicMock, user: RevelUser, django_user_model: t.Type[RevelUser]
+    ) -> None:
+        django_user_model.objects.create_user(username="taken@example.com", email="taken@example.com", password="x")
+        with pytest.raises(HttpError):
+            account_service.request_email_change(
+                user=user, new_email="TAKEN@example.com".lower(), password="strong-password-123!"
+            )
+        mock_send.assert_not_called()
+
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_google_sso_user_rejected(self, mock_send: MagicMock, google_user: RevelUser) -> None:
+        # Google SSO users have a sentinel password; their check_password will fail,
+        # but the SSO check happens after password check — so use a fake password the
+        # check_password will reject. To test SSO branch directly, set a real password.
+        google_user.set_password("strong-password-123!")
+        google_user.save(update_fields=["password"])
+        with pytest.raises(HttpError) as exc:
+            account_service.request_email_change(
+                user=google_user, new_email="new@example.com", password="strong-password-123!"
+            )
+        assert exc.value.status_code == 400
+        mock_send.assert_not_called()
+
+    @patch("accounts.tasks.send_email_change_notice.delay")
+    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    def test_globally_banned_target_no_op(
+        self,
+        mock_send_conf: MagicMock,
+        mock_send_notice: MagicMock,
+        user: RevelUser,
+    ) -> None:
+        GlobalBan.objects.create(
+            ban_type=GlobalBan.BanType.EMAIL,
+            normalized_value="banned@example.com",
+            reason="test",
+        )
+        token = account_service.request_email_change(
+            user=user, new_email="banned@example.com", password="strong-password-123!"
+        )
+        assert token == ""
+        mock_send_conf.assert_not_called()
+        mock_send_notice.assert_not_called()
+
+
+# ===== Service: confirm_email_change =====
+
+
+def _make_change_token(user: RevelUser, new_email: str, *, expired: bool = False) -> str:
+    exp = timezone.now() - datetime.timedelta(days=1) if expired else timezone.now() + settings.VERIFY_TOKEN_LIFETIME
+    payload = schema.EmailChangeJWTPayloadSchema(
+        user_id=user.id,
+        email=user.email,
+        new_email=new_email,
+        exp=exp,
+    )
+    return create_token(payload.model_dump(mode="json"), settings.SECRET_KEY, settings.JWT_ALGORITHM)
+
+
+class TestConfirmEmailChange:
+    @patch("accounts.tasks.send_email_change_completed_new.delay")
+    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    def test_success(
+        self,
+        mock_send_old: MagicMock,
+        mock_send_new: MagicMock,
+        user: RevelUser,
+    ) -> None:
+        old_email = user.email
+        token = _make_change_token(user, "new@example.com")
+
+        result = account_service.confirm_email_change(token)
+
+        result.refresh_from_db()
+        assert result.email == "new@example.com"
+        assert result.username == "new@example.com"
+        assert result.email_verified is True
+        mock_send_old.assert_called_once_with(old_email, "new@example.com")
+        mock_send_new.assert_called_once_with("new@example.com", old_email)
+
+    @patch("accounts.tasks.send_email_change_completed_new.delay")
+    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    def test_blacklists_all_user_tokens(
+        self,
+        mock_old: MagicMock,
+        mock_new: MagicMock,
+        user: RevelUser,
+    ) -> None:
+        # Issue a couple of refresh tokens for the user — they should all be blacklisted.
+        RefreshToken.for_user(user)
+        RefreshToken.for_user(user)
+        assert OutstandingToken.objects.filter(user=user).count() == 2
+
+        token = _make_change_token(user, "new@example.com")
+        account_service.confirm_email_change(token)
+
+        outstanding = OutstandingToken.objects.filter(user=user)
+        for ot in outstanding:
+            assert BlacklistedToken.objects.filter(token=ot).exists()
+
+    def test_expired_token(self, user: RevelUser) -> None:
+        token = _make_change_token(user, "new@example.com", expired=True)
+        with pytest.raises(HttpError) as exc:
+            account_service.confirm_email_change(token)
+        assert exc.value.status_code == 400
+
+    @patch("accounts.tasks.send_email_change_completed_new.delay")
+    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    def test_blacklisted_token_rejected(self, mock_old: MagicMock, mock_new: MagicMock, user: RevelUser) -> None:
+        token = _make_change_token(user, "new@example.com")
+        account_service.confirm_email_change(token)
+        # Re-using the same token must fail
+        with pytest.raises(HttpError):
+            account_service.confirm_email_change(token)
+
+    @patch("accounts.tasks.send_email_change_completed_new.delay")
+    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    def test_race_email_taken(
+        self,
+        mock_old: MagicMock,
+        mock_new: MagicMock,
+        user: RevelUser,
+        django_user_model: t.Type[RevelUser],
+    ) -> None:
+        token = _make_change_token(user, "raced@example.com")
+        # Between request and confirm, somebody else takes the address.
+        django_user_model.objects.create_user(username="raced@example.com", email="raced@example.com", password="x")
+        with pytest.raises(HttpError) as exc:
+            account_service.confirm_email_change(token)
+        assert exc.value.status_code == 400
+        # User's email is unchanged.
+        user.refresh_from_db()
+        assert user.email != "raced@example.com"
+        # Token is blacklisted so it cannot be retried later.
+        assert BlacklistedToken.objects.exists()
+
+
+# ===== Controller tests =====
+
+
+@patch("accounts.tasks.send_email_change_notice.delay")
+@patch("accounts.tasks.send_email_change_confirmation.delay")
+def test_email_change_request_endpoint(
+    mock_conf: MagicMock, mock_notice: MagicMock, auth_client: Client, user: RevelUser
+) -> None:
+    url = reverse("api:email-change-request")
+    response = auth_client.post(
+        url,
+        data=orjson.dumps({"new_email": "fresh@example.com", "password": "strong-password-123!"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200, response.content
+    assert "confirmation link" in response.json()["message"].lower()
+    mock_conf.assert_called_once()
+    mock_notice.assert_called_once()
+
+
+def test_email_change_request_requires_auth(client: Client) -> None:
+    url = reverse("api:email-change-request")
+    response = client.post(
+        url,
+        data=orjson.dumps({"new_email": "a@example.com", "password": "x"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+
+
+@patch("accounts.tasks.send_email_change_completed_new.delay")
+@patch("accounts.tasks.send_email_change_completed_old.delay")
+def test_email_change_confirm_endpoint(
+    mock_old: MagicMock,
+    mock_new: MagicMock,
+    client: Client,
+    user: RevelUser,
+) -> None:
+    token = _make_change_token(user, "fresh@example.com")
+    url = reverse("api:email-change-confirm")
+    response = client.post(
+        url,
+        data=orjson.dumps({"token": token}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200, response.content
+    data = response.json()
+    assert data["user"]["email"] == "fresh@example.com"
+    assert "access" in data["token"]
+    assert "refresh" in data["token"]
+
+
+@patch("accounts.tasks.send_email_change_completed_new.delay")
+@patch("accounts.tasks.send_email_change_completed_old.delay")
+def test_full_flow_old_refresh_tokens_invalidated(
+    mock_old: MagicMock,
+    mock_new: MagicMock,
+    client: Client,
+    user: RevelUser,
+) -> None:
+    """End-to-end: after confirmation, the previously-issued refresh tokens are blacklisted."""
+    # Pre-confirmation, issue a refresh token for the user.
+    RefreshToken.for_user(user)
+    old_outstanding_jtis = list(OutstandingToken.objects.filter(user=user).values_list("jti", flat=True))
+    assert len(old_outstanding_jtis) == 1
+
+    token = _make_change_token(user, "newer@example.com")
+    confirm_url = reverse("api:email-change-confirm")
+    confirm_resp = client.post(confirm_url, data=orjson.dumps({"token": token}), content_type="application/json")
+    assert confirm_resp.status_code == 200, confirm_resp.content
+
+    # Every refresh token outstanding before the swap must now be blacklisted.
+    for jti in old_outstanding_jtis:
+        assert BlacklistedToken.objects.filter(token__jti=jti).exists()
+
+    # The freshly returned refresh token must NOT be blacklisted.
+    assert "refresh" in confirm_resp.json()["token"]

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -115,7 +115,7 @@ class TestRequestEmailChange:
     ) -> None:
         GlobalBan.objects.create(
             ban_type=GlobalBan.BanType.EMAIL,
-            normalized_value="banned@example.com",
+            value="banned@example.com",
             reason="test",
         )
         token = account_service.request_email_change(

--- a/src/accounts/tests/test_global_ban.py
+++ b/src/accounts/tests/test_global_ban.py
@@ -11,11 +11,11 @@ from django.utils import timezone
 from ninja.errors import HttpError
 
 from accounts import schema
+from accounts.jwt import blacklist_user_tokens
 from accounts.models import GlobalBan, RevelUser
 from accounts.service import account as account_service
 from accounts.service import auth as auth_service
 from accounts.service.global_ban_service import (
-    _blacklist_user_tokens,
     deactivate_user_for_ban,
     is_email_globally_banned,
     is_telegram_globally_banned,
@@ -289,7 +289,7 @@ class TestDeactivateUserForBan:
 
 
 class TestBlacklistUserTokens:
-    """Tests for _blacklist_user_tokens."""
+    """Tests for blacklist_user_tokens."""
 
     def test_blacklists_tokens(self, target_user: RevelUser) -> None:
         from ninja_jwt.token_blacklist.models import BlacklistedToken, OutstandingToken
@@ -299,7 +299,7 @@ class TestBlacklistUserTokens:
         RefreshToken.for_user(target_user)
         assert OutstandingToken.objects.filter(user=target_user).count() == 2
 
-        count = _blacklist_user_tokens(target_user)
+        count = blacklist_user_tokens(target_user)
 
         assert count == 2
         assert BlacklistedToken.objects.filter(token__user=target_user).count() == 2
@@ -309,16 +309,16 @@ class TestBlacklistUserTokens:
         from ninja_jwt.tokens import RefreshToken
 
         RefreshToken.for_user(target_user)
-        _blacklist_user_tokens(target_user)
+        blacklist_user_tokens(target_user)
         assert BlacklistedToken.objects.filter(token__user=target_user).count() == 1
 
         # Running again should not create duplicates
-        count = _blacklist_user_tokens(target_user)
+        count = blacklist_user_tokens(target_user)
         assert count == 0
         assert BlacklistedToken.objects.filter(token__user=target_user).count() == 1
 
     def test_no_tokens(self, target_user: RevelUser) -> None:
-        count = _blacklist_user_tokens(target_user)
+        count = blacklist_user_tokens(target_user)
         assert count == 0
 
 

--- a/src/common/testing.py
+++ b/src/common/testing.py
@@ -46,6 +46,7 @@ def get_and_clear_test_tokens() -> dict[str, str]:
 TOKEN_TYPE_VERIFICATION = "verification"
 TOKEN_TYPE_PASSWORD_RESET = "password-reset"
 TOKEN_TYPE_DELETION = "deletion"
+TOKEN_TYPE_EMAIL_CHANGE = "email-change"
 
 
 def get_header_name(token_type: str) -> str:
@@ -69,4 +70,5 @@ __all__: t.Sequence[str] = [
     "TOKEN_TYPE_VERIFICATION",
     "TOKEN_TYPE_PASSWORD_RESET",
     "TOKEN_TYPE_DELETION",
+    "TOKEN_TYPE_EMAIL_CHANGE",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.55.0"
+version = "1.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
Closes #421.

## Summary
- Adds `POST /account/email-change-request` (auth, WriteThrottle) and `POST /account/email-change-confirm` (anon, WriteThrottle), mirroring the existing JWT-token email flows (verify-email, password-reset, delete-account).
- Confirmation link is sent to the **new** address (proof of control). The current address receives a separate notice with a masked rendering of the new address.
- On confirm: validate + blacklist the single-use token, swap `email` + `username`, blacklist every outstanding JWT for the user (email is an identity primitive), return a fresh token pair so the confirming device stays signed in. Old and new addresses both receive a completion email.
- Promotes `_blacklist_user_tokens` out of `global_ban_service.py` into `accounts/jwt.py` (`blacklist_user_tokens`) so both call sites share it.

## Key files
- `src/accounts/schema.py` — `EmailChangeRequestSchema`, `EmailChangeConfirmSchema`, `EmailChangeJWTPayloadSchema`, `EmailChangeResponseSchema`
- `src/accounts/service/account.py` — `create_email_change_token`, `request_email_change`, `confirm_email_change`, `_mask_email`
- `src/accounts/tasks.py` — `send_email_change_confirmation`, `send_email_change_notice`, `send_email_change_completed_old`, `send_email_change_completed_new`
- `src/accounts/controllers/account.py` — two new endpoints
- `src/accounts/templates/accounts/emails/email_change_*.{txt,html}` — 12 new templates (4 emails × subject/txt/html)
- `src/common/testing.py` — `TOKEN_TYPE_EMAIL_CHANGE`

## Notes / decisions
- **Duplicate / banned target**: clear 400 on duplicate (user already knows the address); silent no-op on globally-banned target (mirrors verification flow, avoids signalling ban presence).
- **Same-email** and **Google-SSO** both rejected with a clear 400.
- **Race-safe**: uniqueness re-checked at confirm time; on race-loss, token is blacklisted (single-use) so it can't be retried later.
- **Two completed-emails tasks** rather than one fan-out task — isolated failure modes.

## Test plan
- [ ] `make check` (green locally)
- [ ] `make test` covering: wrong password, same email, duplicate email (case-insensitive), Google SSO rejection, globally-banned target no-op, expired token, single-use enforcement, race-safe uniqueness, full-flow blacklist of pre-existing refresh tokens
- [ ] Frontend follow-up: regenerate API client (`pnpm generate:api`) once this merges; add the settings UI with the "you will be signed out of every other device" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Users can now change their email address via self-service, requiring password verification.
- Email changes require confirmation through a secure link sent to the new address.
- All existing sessions are automatically signed out after confirming the new email for security.
- Confirmation and notification emails are sent to both old and new addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->