### PR TITLE
refactor(controllers): thin out event_admin/tickets.py (closes #427)

### DIFF
--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -1,11 +1,8 @@
 import typing as t
 from uuid import UUID
 
-from django.db import transaction
-from django.db.models import F, QuerySet
+from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
-from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from ninja import Body, Query
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -17,43 +14,17 @@ from common.schema import ValidationErrorResponse
 from common.throttling import ExportThrottle, UserDefaultThrottle, WriteThrottle
 from events import filters, models, schema
 from events.controllers.permissions import EventPermission
-from events.models.ticket import CancellationSource
+from events.exceptions import (
+    BillingInfoRequiredError,
+    StripeNotConnectedError,
+    TicketAlreadyCancelledError,
+)
 from events.service import ticket_service
-from events.service.waitlist_service import enqueue_waitlist_processing
 
 from .base import EventAdminBaseController
 
 if t.TYPE_CHECKING:
     from common.models import FileExport
-    from events.models import Organization
-
-
-def _check_online_tier_prerequisites(org: "Organization", payment_method: str) -> None:
-    """Validate prerequisites for creating/updating an online-payment ticket tier.
-
-    Raises HttpError 400 if:
-    - Stripe is not connected
-    - Platform fees are non-zero but billing info is incomplete
-    """
-    if payment_method != models.TicketTier.PaymentMethod.ONLINE:
-        return
-
-    if not org.is_stripe_connected:
-        raise HttpError(400, str(_("You must connect to Stripe first.")))
-
-    has_platform_fees = org.platform_fee_percent > 0 or org.platform_fee_fixed > 0
-    missing_billing = not org.vat_country_code or not org.billing_address or not org.billing_name
-    if has_platform_fees and missing_billing:
-        raise HttpError(
-            400,
-            str(
-                _(
-                    "Billing information is required for online ticket sales with platform fees."
-                    " Please set your billing name, country and billing address"
-                    " in your organization's billing settings."
-                )
-            ),
-        )
 
 
 @api_controller(
@@ -94,21 +65,12 @@ class EventAdminTicketsController(EventAdminBaseController):
     def create_ticket_tier(self, event_id: UUID, payload: schema.TicketTierCreateSchema) -> models.TicketTier:
         """Create a new ticket tier for an event."""
         event = self.get_one(event_id)
-        _check_online_tier_prerequisites(event.organization, payload.payment_method)
-
-        # Extract restricted_to_membership_tiers_ids from payload.
-        # mode="json" coerces nested Pydantic models (e.g. refund_policy) and
-        # Decimals to JSON-serializable primitives so the JSONField's default
-        # encoder can persist them via full_clean().
-        payload_dict = payload.model_dump(exclude_unset=True, mode="json")
-        restricted_to_membership_tiers_ids = payload_dict.pop("restricted_to_membership_tiers_ids", None)
-
-        # Create ticket tier with M2M handling in service layer
-        tier = ticket_service.create_ticket_tier(
-            event=event, tier_data=payload_dict, restricted_to_membership_tiers_ids=restricted_to_membership_tiers_ids
-        )
-        # Refetch with venue/sector for response serialization
-        return models.TicketTier.objects.with_venue_and_sector().get(pk=tier.pk)
+        try:
+            return ticket_service.create_ticket_tier(event, payload)
+        except StripeNotConnectedError as exc:
+            raise HttpError(400, str(ticket_service.STRIPE_NOT_CONNECTED_MESSAGE)) from exc
+        except BillingInfoRequiredError as exc:
+            raise HttpError(400, str(ticket_service.BILLING_INFO_REQUIRED_MESSAGE)) from exc
 
     @route.put(
         "/ticket-tier/{tier_id}",
@@ -121,22 +83,13 @@ class EventAdminTicketsController(EventAdminBaseController):
     ) -> models.TicketTier:
         """Update a ticket tier."""
         event = self.get_one(event_id)
-        if payload.payment_method is not None:
-            _check_online_tier_prerequisites(event.organization, payload.payment_method)
-
         tier = get_object_or_404(models.TicketTier, pk=tier_id, event=event)
-
-        # Extract restricted_to_membership_tiers_ids from payload.
-        # mode="json" — see create_ticket_tier above.
-        payload_dict = payload.model_dump(exclude_unset=True, mode="json")
-        restricted_to_membership_tiers_ids = payload_dict.pop("restricted_to_membership_tiers_ids", None)
-
-        # Update ticket tier with M2M handling in service layer
-        updated_tier = ticket_service.update_ticket_tier(
-            tier=tier, tier_data=payload_dict, restricted_to_membership_tiers_ids=restricted_to_membership_tiers_ids
-        )
-        # Refetch with venue/sector for response serialization
-        return models.TicketTier.objects.with_venue_and_sector().get(pk=updated_tier.pk)
+        try:
+            return ticket_service.update_ticket_tier(tier, payload)
+        except StripeNotConnectedError as exc:
+            raise HttpError(400, str(ticket_service.STRIPE_NOT_CONNECTED_MESSAGE)) from exc
+        except BillingInfoRequiredError as exc:
+            raise HttpError(400, str(ticket_service.BILLING_INFO_REQUIRED_MESSAGE)) from exc
 
     @route.delete(
         "/ticket-tier/{tier_id}",
@@ -284,40 +237,14 @@ class EventAdminTicketsController(EventAdminBaseController):
                 models.TicketTier.PaymentMethod.AT_THE_DOOR,
             ],
         )
-
-        if ticket.status == models.Ticket.TicketStatus.CANCELLED:
-            raise HttpError(400, str(_("Ticket already cancelled")))
-
-        with transaction.atomic():
-            models.TicketTier.objects.filter(pk=ticket.tier.pk, quantity_sold__gt=0).update(
-                quantity_sold=F("quantity_sold") - 1
+        try:
+            return ticket_service.mark_offline_ticket_refunded(
+                ticket,
+                cancelled_by=self.user(),
+                reason=payload.cancellation_reason if payload else None,
             )
-            ticket.status = models.Ticket.TicketStatus.CANCELLED
-            ticket.cancelled_at = timezone.now()
-            ticket.cancelled_by = self.user()
-            ticket.cancellation_source = CancellationSource.ORGANIZER
-            ticket.cancellation_reason = (payload.cancellation_reason if payload else None) or ""
-            ticket.save(
-                update_fields=[
-                    "status",
-                    "cancelled_at",
-                    "cancelled_by",
-                    "cancellation_source",
-                    "cancellation_reason",
-                ]
-            )
-
-            if hasattr(ticket, "payment"):
-                ticket.payment.status = models.Payment.PaymentStatus.REFUNDED
-                ticket.payment.refund_amount = ticket.payment.amount
-                ticket.payment.refund_status = models.Payment.RefundStatus.SUCCEEDED
-                ticket.payment.refunded_at = timezone.now()
-                ticket.payment.save(update_fields=["status", "refund_amount", "refund_status", "refunded_at"])
-
-            enqueue_waitlist_processing(ticket.event_id)
-
-        # Re-fetch with full() to include all related objects for UserTicketSchema
-        return models.Ticket.objects.full().get(pk=ticket.pk)
+        except TicketAlreadyCancelledError as exc:
+            raise HttpError(400, str(ticket_service.TICKET_ALREADY_CANCELLED_MESSAGE)) from exc
 
     @route.post(
         "/tickets/{ticket_id}/cancel",
@@ -346,33 +273,14 @@ class EventAdminTicketsController(EventAdminBaseController):
                 models.TicketTier.PaymentMethod.AT_THE_DOOR,
             ],
         )
-
-        if ticket.status == models.Ticket.TicketStatus.CANCELLED:
-            raise HttpError(400, str(_("Ticket already cancelled")))
-
-        with transaction.atomic():
-            models.TicketTier.objects.filter(pk=ticket.tier.pk, quantity_sold__gt=0).update(
-                quantity_sold=F("quantity_sold") - 1
+        try:
+            return ticket_service.cancel_offline_ticket(
+                ticket,
+                cancelled_by=self.user(),
+                reason=payload.cancellation_reason if payload else None,
             )
-            ticket.status = models.Ticket.TicketStatus.CANCELLED
-            ticket.cancelled_at = timezone.now()
-            ticket.cancelled_by = self.user()
-            ticket.cancellation_source = CancellationSource.ORGANIZER
-            ticket.cancellation_reason = (payload.cancellation_reason if payload else None) or ""
-            ticket.save(
-                update_fields=[
-                    "status",
-                    "cancelled_at",
-                    "cancelled_by",
-                    "cancellation_source",
-                    "cancellation_reason",
-                ]
-            )
-
-            enqueue_waitlist_processing(ticket.event_id)
-
-        # Re-fetch with full() to include all related objects for UserTicketSchema
-        return models.Ticket.objects.full().get(pk=ticket.pk)
+        except TicketAlreadyCancelledError as exc:
+            raise HttpError(400, str(ticket_service.TICKET_ALREADY_CANCELLED_MESSAGE)) from exc
 
     @route.post(
         "/tickets/{ticket_id}/check-in",
@@ -409,15 +317,5 @@ class EventAdminTicketsController(EventAdminBaseController):
         download.
         Requires 'manage_event' permission.
         """
-        from common.models import FileExport
-        from events.tasks import generate_attendee_export_task
-
-        self.get_one(event_id)  # permission check
-
-        export = FileExport.objects.create(
-            requested_by=self.user(),
-            export_type=FileExport.ExportType.ATTENDEE_LIST,
-            parameters={"event_id": str(event_id)},
-        )
-        generate_attendee_export_task.delay(str(export.id))
-        return 202, export
+        event = self.get_one(event_id)
+        return 202, ticket_service.start_attendee_export(event, requested_by=self.user())

--- a/src/events/exceptions.py
+++ b/src/events/exceptions.py
@@ -27,3 +27,15 @@ class OrganizationTokenGrantInvariantError(Exception):
 
 class OrganizationTokenMembershipTierRequiredError(Exception):
     """Raised when an organization-token update would leave ``grants_membership=True`` with no ``membership_tier``."""
+
+
+class TicketAlreadyCancelledError(Exception):
+    """Raised when attempting to cancel/refund a ticket that is already in CANCELLED state."""
+
+
+class StripeNotConnectedError(Exception):
+    """Raised when an online-payment tier cannot be created/updated because the org has no Stripe Connect."""
+
+
+class BillingInfoRequiredError(Exception):
+    """Raised when an online-payment tier with platform fees lacks the organization's billing info."""

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -666,12 +666,13 @@ def _cancel_offline_ticket_core(
 
     This mutates ``ticket`` in place (status, cancelled_at, cancelled_by, cancellation_source,
     cancellation_reason). It must be called inside a ``transaction.atomic()`` block by the caller
-    (``cancel_offline_ticket`` / ``mark_offline_ticket_refunded``).
+    (``cancel_offline_ticket`` / ``mark_offline_ticket_refunded``) with the ticket row already
+    locked via ``select_for_update`` to prevent concurrent double-decrement.
 
     The tier decrement uses ``F("quantity_sold") - 1`` guarded by ``quantity_sold__gt=0`` so the
     counter can never drop below zero (race-safe and floor-safe).
     """
-    TicketTier.objects.filter(pk=ticket.tier.pk, quantity_sold__gt=0).update(quantity_sold=F("quantity_sold") - 1)
+    TicketTier.objects.filter(pk=ticket.tier_id, quantity_sold__gt=0).update(quantity_sold=F("quantity_sold") - 1)
 
     ticket.status = Ticket.TicketStatus.CANCELLED
     ticket.cancelled_at = timezone.now()
@@ -700,8 +701,12 @@ def cancel_offline_ticket(
 ) -> Ticket:
     """Cancel an offline/at-the-door ticket and record organizer audit fields.
 
+    The ticket row is re-fetched with ``select_for_update`` inside the atomic block
+    so concurrent cancel/refund requests serialize on the row lock and cannot both
+    pass the status check and double-decrement ``TicketTier.quantity_sold``.
+
     Args:
-        ticket: The ticket to cancel. Must have ``tier`` prefetched via ``select_related``.
+        ticket: The ticket to cancel.
         cancelled_by: The organizer performing the cancellation.
         reason: Optional free-text cancellation reason.
 
@@ -711,12 +716,13 @@ def cancel_offline_ticket(
     Raises:
         TicketAlreadyCancelledError: If the ticket is already CANCELLED.
     """
-    if ticket.status == Ticket.TicketStatus.CANCELLED:
+    locked_ticket = Ticket.objects.select_for_update().select_related("tier").get(pk=ticket.pk)
+    if locked_ticket.status == Ticket.TicketStatus.CANCELLED:
         raise TicketAlreadyCancelledError
 
-    _cancel_offline_ticket_core(ticket, cancelled_by=cancelled_by, reason=reason or "")
+    _cancel_offline_ticket_core(locked_ticket, cancelled_by=cancelled_by, reason=reason or "")
 
-    return Ticket.objects.full().get(pk=ticket.pk)
+    return Ticket.objects.full().get(pk=locked_ticket.pk)
 
 
 @transaction.atomic
@@ -732,9 +738,13 @@ def mark_offline_ticket_refunded(
     Tickets without an associated ``Payment`` are still cancelled — no payment record
     means there is nothing to refund, which is a valid manual flow.
 
+    The ticket and payment rows are re-fetched with ``select_for_update`` inside the
+    atomic block so concurrent cancel/refund requests serialize on the row locks and
+    cannot both pass the status check and double-apply side effects (tier decrement,
+    waitlist enqueue, payment refund).
+
     Args:
-        ticket: The ticket to refund. Must have ``tier`` and ``payment`` prefetched via
-            ``select_related``.
+        ticket: The ticket to refund.
         cancelled_by: The organizer performing the refund.
         reason: Optional free-text cancellation reason.
 
@@ -744,19 +754,21 @@ def mark_offline_ticket_refunded(
     Raises:
         TicketAlreadyCancelledError: If the ticket is already CANCELLED.
     """
-    if ticket.status == Ticket.TicketStatus.CANCELLED:
+    locked_ticket = Ticket.objects.select_for_update().select_related("tier").get(pk=ticket.pk)
+    if locked_ticket.status == Ticket.TicketStatus.CANCELLED:
         raise TicketAlreadyCancelledError
 
-    _cancel_offline_ticket_core(ticket, cancelled_by=cancelled_by, reason=reason or "")
+    _cancel_offline_ticket_core(locked_ticket, cancelled_by=cancelled_by, reason=reason or "")
 
-    if hasattr(ticket, "payment"):
-        ticket.payment.status = Payment.PaymentStatus.REFUNDED
-        ticket.payment.refund_amount = ticket.payment.amount
-        ticket.payment.refund_status = Payment.RefundStatus.SUCCEEDED
-        ticket.payment.refunded_at = timezone.now()
-        ticket.payment.save(update_fields=["status", "refund_amount", "refund_status", "refunded_at"])
+    locked_payment = Payment.objects.select_for_update().filter(ticket=locked_ticket).first()
+    if locked_payment is not None:
+        locked_payment.status = Payment.PaymentStatus.REFUNDED
+        locked_payment.refund_amount = locked_payment.amount
+        locked_payment.refund_status = Payment.RefundStatus.SUCCEEDED
+        locked_payment.refunded_at = timezone.now()
+        locked_payment.save(update_fields=["status", "refund_amount", "refund_status", "refunded_at"])
 
-    return Ticket.objects.full().get(pk=ticket.pk)
+    return Ticket.objects.full().get(pk=locked_ticket.pk)
 
 
 def start_attendee_export(event: Event, requested_by: RevelUser) -> "FileExport":

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -9,18 +9,49 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, F
 from django.shortcuts import get_object_or_404
 from django.utils import formats, timezone
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
 from accounts.models import RevelUser
-from events.models import Event, EventInvitation, EventRSVP, MembershipTier, OrganizationMember, Ticket, TicketTier
+from events.exceptions import (
+    BillingInfoRequiredError,
+    StripeNotConnectedError,
+    TicketAlreadyCancelledError,
+)
+from events.models import (
+    Event,
+    EventInvitation,
+    EventRSVP,
+    MembershipTier,
+    Organization,
+    OrganizationMember,
+    Payment,
+    Ticket,
+    TicketTier,
+)
 from events.models.mixins import VisibilityMixin
+from events.models.ticket import CancellationSource
+from events.service.waitlist_service import enqueue_waitlist_processing
 
 if t.TYPE_CHECKING:
+    from common.models import FileExport
+    from events.schema import TicketTierCreateSchema, TicketTierUpdateSchema
     from events.service.event_manager import EventUserEligibility
+
+
+# Translated messages exposed for HTTP mapping at the controller layer. Keeping
+# them next to the typed exceptions lets the service own the canonical wording
+# while the controller only maps the exception to a status code.
+TICKET_ALREADY_CANCELLED_MESSAGE = _("Ticket already cancelled")
+STRIPE_NOT_CONNECTED_MESSAGE = _("You must connect to Stripe first.")
+BILLING_INFO_REQUIRED_MESSAGE = _(
+    "Billing information is required for online ticket sales with platform fees."
+    " Please set your billing name, country and billing address"
+    " in your organization's billing settings."
+)
 
 
 @dataclass
@@ -468,51 +499,39 @@ def check_in_ticket(
 
 
 @transaction.atomic
-def create_ticket_tier(
-    event: Event, tier_data: dict[str, t.Any], restricted_to_membership_tiers_ids: list[UUID] | None = None
-) -> TicketTier:
-    """Create a ticket tier with membership tier restrictions.
+def create_ticket_tier(event: Event, payload: "TicketTierCreateSchema") -> TicketTier:
+    """Create a ticket tier from a typed payload, validating online prerequisites and M2M restrictions.
 
     Args:
-        event: The event for this ticket tier
-        tier_data: Dictionary of TicketTier model fields
-        restricted_to_membership_tiers_ids: Optional list of MembershipTier IDs to restrict this tier to
+        event: The event for this ticket tier.
+        payload: The validated ``TicketTierCreateSchema`` payload.
 
     Returns:
-        Created TicketTier instance
+        The newly-created tier, re-fetched via ``with_venue_and_sector()`` for serialization.
 
     Raises:
-        Http404: If any membership tier ID doesn't exist or doesn't belong to event's organization
+        StripeNotConnectedError: When the tier is online-payment but the org has no Stripe Connect.
+        BillingInfoRequiredError: When the tier is online-payment with platform fees and the
+            org has incomplete billing info.
+        HttpError 404: If any provided membership tier ID is invalid or belongs to another org.
 
     Note:
-        TimeStampedModel.save() automatically calls full_clean() before saving.
-        After setting M2M relationships, we call full_clean() again to validate them.
+        ``mode="json"`` is used when dumping the payload so nested Pydantic models
+        (e.g. ``refund_policy``) and ``Decimal`` are coerced to JSON-serializable primitives;
+        the JSONField's default encoder relies on this during ``full_clean()``.
     """
+    check_online_tier_prerequisites(event.organization, payload.payment_method)
+
+    payload_dict = payload.model_dump(exclude_unset=True, mode="json")
+    restricted_to_membership_tiers_ids = payload_dict.pop("restricted_to_membership_tiers_ids", None)
+
     # Create the ticket tier (save() will call full_clean() automatically)
-    tier = TicketTier.objects.create(event=event, **tier_data)
+    tier = TicketTier.objects.create(event=event, **payload_dict)
 
-    # Handle membership tier restrictions
     if restricted_to_membership_tiers_ids:
-        # Fetch and validate membership tiers
-        membership_tiers = MembershipTier.objects.filter(
-            id__in=restricted_to_membership_tiers_ids, organization=event.organization
-        )
+        _set_tier_membership_restrictions(tier, restricted_to_membership_tiers_ids, event.organization)
 
-        # Ensure all provided IDs exist and belong to the organization
-        if membership_tiers.count() != len(restricted_to_membership_tiers_ids):
-            # Transaction will rollback automatically due to exception
-            raise HttpError(
-                404,
-                str(_("One or more membership tier IDs are invalid or don't belong to the event's organization.")),
-            )
-
-        # Set the M2M relationship
-        tier.restricted_to_membership_tiers.set(membership_tiers)
-
-        # Validate M2M relationships (TicketTier.clean() checks membership tiers)
-        tier.full_clean()
-
-    return tier
+    return TicketTier.objects.with_venue_and_sector().get(pk=tier.pk)
 
 
 @transaction.atomic
@@ -540,59 +559,226 @@ def reorder_ticket_tiers(event: Event, tier_ids: list[UUID]) -> None:
 
 
 @transaction.atomic
-def update_ticket_tier(
-    tier: TicketTier, tier_data: dict[str, t.Any], restricted_to_membership_tiers_ids: list[UUID] | None = None
-) -> TicketTier:
-    """Update a ticket tier with membership tier restrictions.
+def update_ticket_tier(tier: TicketTier, payload: "TicketTierUpdateSchema") -> TicketTier:
+    """Update a ticket tier from a typed payload, validating online prerequisites and M2M restrictions.
 
     Args:
-        tier: The TicketTier instance to update
-        tier_data: Dictionary of fields to update
-        restricted_to_membership_tiers_ids: Optional list of MembershipTier IDs (replaces existing)
-            - If list provided: replaces all restrictions with new list
-            - If empty list provided: clears all restrictions
-            - If None (not provided): preserves existing restrictions
+        tier: The ``TicketTier`` instance to update.
+        payload: The validated ``TicketTierUpdateSchema`` payload.
 
     Returns:
-        Updated TicketTier instance
+        The updated tier, re-fetched via ``with_venue_and_sector()`` for serialization.
 
     Raises:
-        Http404: If any membership tier ID doesn't exist or doesn't belong to event's organization
+        StripeNotConnectedError: When transitioning to online payment but org has no Stripe Connect.
+        BillingInfoRequiredError: When transitioning to online payment with platform fees and the
+            org has incomplete billing info.
+        HttpError 404: If any provided membership tier ID is invalid or belongs to another org.
 
     Note:
-        TimeStampedModel.save() automatically calls full_clean() before saving.
-        After updating M2M relationships, we call full_clean() again to validate them.
+        ``restricted_to_membership_tiers_ids`` semantics:
+            - non-empty list -> replace all restrictions
+            - empty list     -> clear all restrictions
+            - omitted (None) -> preserve existing restrictions
+
+        ``mode="json"`` see ``create_ticket_tier`` above.
     """
+    payload_dict = payload.model_dump(exclude_unset=True, mode="json")
+    restricted_to_membership_tiers_ids = payload_dict.pop("restricted_to_membership_tiers_ids", None)
+
+    if payload.payment_method is not None:
+        check_online_tier_prerequisites(tier.event.organization, payload.payment_method)
+
     # Update regular fields
-    for field, value in tier_data.items():
+    for field, value in payload_dict.items():
         setattr(tier, field, value)
 
-    if tier_data:
+    if payload_dict:
         # save() will call full_clean() automatically via TimeStampedModel
-        tier.save(update_fields=list(tier_data.keys()))
+        tier.save(update_fields=list(payload_dict.keys()))
 
     # Handle membership tier restrictions update
     if restricted_to_membership_tiers_ids is not None:
         if restricted_to_membership_tiers_ids:
-            # Fetch and validate membership tiers
-            membership_tiers = MembershipTier.objects.filter(
-                id__in=restricted_to_membership_tiers_ids, organization=tier.event.organization
-            )
-
-            # Ensure all provided IDs exist and belong to the organization
-            if membership_tiers.count() != len(restricted_to_membership_tiers_ids):
-                raise HttpError(
-                    404,
-                    str(_("One or more membership tier IDs are invalid or don't belong to the event's organization.")),
-                )
-
-            # Replace the M2M relationship
-            tier.restricted_to_membership_tiers.set(membership_tiers)
+            _set_tier_membership_restrictions(tier, restricted_to_membership_tiers_ids, tier.event.organization)
         else:
             # Empty list means clear all restrictions
             tier.restricted_to_membership_tiers.clear()
+            # Validate M2M relationships (TicketTier.clean() checks membership tiers and purchasable_by logic)
+            tier.full_clean()
 
-        # Validate M2M relationships (TicketTier.clean() checks membership tiers and purchasable_by logic)
-        tier.full_clean()
+    return TicketTier.objects.with_venue_and_sector().get(pk=tier.pk)
 
-    return tier
+
+def _set_tier_membership_restrictions(
+    tier: TicketTier, restricted_to_membership_tiers_ids: list[UUID], organization: "Organization"
+) -> None:
+    """Validate membership tier IDs against the organization, then set them on the tier.
+
+    Raises:
+        HttpError 404: If any ID is unknown or belongs to a different organization.
+    """
+    membership_tiers = MembershipTier.objects.filter(
+        id__in=restricted_to_membership_tiers_ids, organization=organization
+    )
+
+    if membership_tiers.count() != len(restricted_to_membership_tiers_ids):
+        raise HttpError(
+            404,
+            str(_("One or more membership tier IDs are invalid or don't belong to the event's organization.")),
+        )
+
+    tier.restricted_to_membership_tiers.set(membership_tiers)
+    # Validate M2M relationships (TicketTier.clean() checks membership tiers and purchasable_by logic)
+    tier.full_clean()
+
+
+def check_online_tier_prerequisites(org: "Organization", payment_method: TicketTier.PaymentMethod) -> None:
+    """Validate prerequisites for creating/updating an online-payment ticket tier.
+
+    Args:
+        org: The owning organization.
+        payment_method: The tier's payment method.
+
+    Raises:
+        StripeNotConnectedError: If Stripe Connect is not enabled on the organization.
+        BillingInfoRequiredError: If platform fees are non-zero but billing info is incomplete.
+    """
+    if payment_method != TicketTier.PaymentMethod.ONLINE:
+        return
+
+    if not org.is_stripe_connected:
+        raise StripeNotConnectedError
+
+    has_platform_fees = org.platform_fee_percent > 0 or org.platform_fee_fixed > 0
+    missing_billing = not org.vat_country_code or not org.billing_address or not org.billing_name
+    if has_platform_fees and missing_billing:
+        raise BillingInfoRequiredError
+
+
+def _cancel_offline_ticket_core(
+    ticket: Ticket,
+    *,
+    cancelled_by: RevelUser,
+    reason: str,
+) -> None:
+    """Apply the shared cancellation primitive: tier decrement + ticket cancel fields + waitlist enqueue.
+
+    This mutates ``ticket`` in place (status, cancelled_at, cancelled_by, cancellation_source,
+    cancellation_reason). It must be called inside a ``transaction.atomic()`` block by the caller
+    (``cancel_offline_ticket`` / ``mark_offline_ticket_refunded``).
+
+    The tier decrement uses ``F("quantity_sold") - 1`` guarded by ``quantity_sold__gt=0`` so the
+    counter can never drop below zero (race-safe and floor-safe).
+    """
+    TicketTier.objects.filter(pk=ticket.tier.pk, quantity_sold__gt=0).update(quantity_sold=F("quantity_sold") - 1)
+
+    ticket.status = Ticket.TicketStatus.CANCELLED
+    ticket.cancelled_at = timezone.now()
+    ticket.cancelled_by = cancelled_by
+    ticket.cancellation_source = CancellationSource.ORGANIZER
+    ticket.cancellation_reason = reason
+    ticket.save(
+        update_fields=[
+            "status",
+            "cancelled_at",
+            "cancelled_by",
+            "cancellation_source",
+            "cancellation_reason",
+        ]
+    )
+
+    enqueue_waitlist_processing(ticket.event_id)
+
+
+@transaction.atomic
+def cancel_offline_ticket(
+    ticket: Ticket,
+    *,
+    cancelled_by: RevelUser,
+    reason: str | None = None,
+) -> Ticket:
+    """Cancel an offline/at-the-door ticket and record organizer audit fields.
+
+    Args:
+        ticket: The ticket to cancel. Must have ``tier`` prefetched via ``select_related``.
+        cancelled_by: The organizer performing the cancellation.
+        reason: Optional free-text cancellation reason.
+
+    Returns:
+        The re-fetched ticket via ``full()`` for response serialization.
+
+    Raises:
+        TicketAlreadyCancelledError: If the ticket is already CANCELLED.
+    """
+    if ticket.status == Ticket.TicketStatus.CANCELLED:
+        raise TicketAlreadyCancelledError
+
+    _cancel_offline_ticket_core(ticket, cancelled_by=cancelled_by, reason=reason or "")
+
+    return Ticket.objects.full().get(pk=ticket.pk)
+
+
+@transaction.atomic
+def mark_offline_ticket_refunded(
+    ticket: Ticket,
+    *,
+    cancelled_by: RevelUser,
+    reason: str | None = None,
+) -> Ticket:
+    """Mark a manual offline/at-the-door ticket as refunded and cancel it.
+
+    Layers a ``Payment`` refund mutation on top of the shared cancellation primitive.
+    Tickets without an associated ``Payment`` are still cancelled — no payment record
+    means there is nothing to refund, which is a valid manual flow.
+
+    Args:
+        ticket: The ticket to refund. Must have ``tier`` and ``payment`` prefetched via
+            ``select_related``.
+        cancelled_by: The organizer performing the refund.
+        reason: Optional free-text cancellation reason.
+
+    Returns:
+        The re-fetched ticket via ``full()`` for response serialization.
+
+    Raises:
+        TicketAlreadyCancelledError: If the ticket is already CANCELLED.
+    """
+    if ticket.status == Ticket.TicketStatus.CANCELLED:
+        raise TicketAlreadyCancelledError
+
+    _cancel_offline_ticket_core(ticket, cancelled_by=cancelled_by, reason=reason or "")
+
+    if hasattr(ticket, "payment"):
+        ticket.payment.status = Payment.PaymentStatus.REFUNDED
+        ticket.payment.refund_amount = ticket.payment.amount
+        ticket.payment.refund_status = Payment.RefundStatus.SUCCEEDED
+        ticket.payment.refunded_at = timezone.now()
+        ticket.payment.save(update_fields=["status", "refund_amount", "refund_status", "refunded_at"])
+
+    return Ticket.objects.full().get(pk=ticket.pk)
+
+
+def start_attendee_export(event: Event, requested_by: RevelUser) -> "FileExport":
+    """Create a ``FileExport`` record for an attendee-list export and dispatch the export task.
+
+    Args:
+        event: The event whose attendee list should be exported.
+        requested_by: The user requesting the export (recorded on the FileExport).
+
+    Returns:
+        The newly-created ``FileExport`` in PENDING state.
+    """
+    from common.models import FileExport
+    from events.tasks import generate_attendee_export_task
+
+    export = FileExport.objects.create(
+        requested_by=requested_by,
+        export_type=FileExport.ExportType.ATTENDEE_LIST,
+        parameters={"event_id": str(event.id)},
+    )
+    # Defer dispatch until after the surrounding transaction commits so the
+    # worker can SELECT the FileExport row. Consistent with the questionnaire
+    # export pattern.
+    transaction.on_commit(lambda: generate_attendee_export_task.delay(str(export.id)))
+    return export

--- a/src/events/tests/test_controllers/test_export_endpoints.py
+++ b/src/events/tests/test_controllers/test_export_endpoints.py
@@ -309,8 +309,15 @@ class TestExportSubmissionsEndpoint:
 # --- Attendee Export Endpoint Tests ---
 
 
+@pytest.mark.django_db(transaction=True)
 class TestExportAttendeesEndpoint:
-    """Tests for POST /event-admin/{event_id}/export-attendees."""
+    """Tests for POST /event-admin/{event_id}/export-attendees.
+
+    Uses ``transaction=True`` because the underlying service schedules the
+    export task via ``transaction.on_commit``. In default pytest-django mode
+    the wrapping transaction is rolled back and the callback never fires,
+    breaking the ``mock_task.delay`` assertions.
+    """
 
     @patch("events.tasks.generate_attendee_export_task")
     def test_returns_202_for_owner(

--- a/src/events/tests/test_service/test_enqueue_wires.py
+++ b/src/events/tests/test_service/test_enqueue_wires.py
@@ -341,7 +341,7 @@ def test_admin_mark_ticket_refunded_enqueues_waitlist(
         kwargs={"event_id": event.pk, "ticket_id": offline_ticket.pk},
     )
 
-    with mock.patch("events.controllers.event_admin.tickets.enqueue_waitlist_processing") as mocked:
+    with mock.patch("events.service.ticket_service.enqueue_waitlist_processing") as mocked:
         response = owner_jwt_client.post(url, data={}, content_type="application/json")
 
     assert response.status_code == 200
@@ -359,7 +359,7 @@ def test_admin_cancel_ticket_enqueues_waitlist(
         kwargs={"event_id": event.pk, "ticket_id": offline_ticket.pk},
     )
 
-    with mock.patch("events.controllers.event_admin.tickets.enqueue_waitlist_processing") as mocked:
+    with mock.patch("events.service.ticket_service.enqueue_waitlist_processing") as mocked:
         response = owner_jwt_client.post(url, data={}, content_type="application/json")
 
     assert response.status_code == 200

--- a/src/events/tests/test_service/test_ticket_admin_service.py
+++ b/src/events/tests/test_service/test_ticket_admin_service.py
@@ -273,21 +273,22 @@ def test_check_online_tier_prerequisites_passes_when_billing_complete(organizati
 
 
 def test_start_attendee_export_creates_export_row(event: Event, organization_owner_user: RevelUser) -> None:
-    """``start_attendee_export`` creates a FileExport in PENDING with the correct parameters."""
+    """``start_attendee_export`` creates a FileExport in PENDING and dispatches the task on commit."""
+    from django.test import TestCase
+
     from common.models import FileExport
 
-    with patch("events.tasks.generate_attendee_export_task.delay") as delay:
+    with (
+        patch("events.tasks.generate_attendee_export_task.delay") as delay,
+        TestCase.captureOnCommitCallbacks(execute=True),
+    ):
         export = ticket_service.start_attendee_export(event, requested_by=organization_owner_user)
 
     assert export.export_type == FileExport.ExportType.ATTENDEE_LIST
     assert export.status == FileExport.ExportStatus.PENDING
     assert export.parameters == {"event_id": str(event.id)}
     assert export.requested_by_id == organization_owner_user.id
-    # Dispatch is deferred via transaction.on_commit; pytest.mark.django_db wraps each
-    # test in an atomic block that rolls back, so the lambda fires at TestCase teardown.
-    # Asserting on the return shape is enough here; integration coverage lives in the
-    # controller tests.
-    _ = delay
+    delay.assert_called_once_with(str(export.id))
 
 
 def test_start_attendee_export_dispatch_callable_resolves_to_task(

--- a/src/events/tests/test_service/test_ticket_admin_service.py
+++ b/src/events/tests/test_service/test_ticket_admin_service.py
@@ -1,0 +1,315 @@
+"""Unit tests for the ticket admin service functions extracted from event_admin/tickets.py.
+
+Covers:
+- ``cancel_offline_ticket`` / ``mark_offline_ticket_refunded``
+    * Already-CANCELLED ticket raises ``TicketAlreadyCancelledError``
+    * Tier ``quantity_sold`` cannot drop below zero (race-safe floor)
+    * Refund of a ticket without a ``Payment`` row still cancels
+    * Waitlist processing is enqueued on cancel/refund
+- ``check_online_tier_prerequisites`` raises typed exceptions for online flows
+- ``start_attendee_export`` creates the FileExport row and dispatches the task
+"""
+
+import typing as t
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from accounts.models import RevelUser
+from events.exceptions import (
+    BillingInfoRequiredError,
+    StripeNotConnectedError,
+    TicketAlreadyCancelledError,
+)
+from events.models import Event, Organization, Payment, Ticket, TicketTier
+from events.models.ticket import CancellationSource
+from events.service import ticket_service
+
+pytestmark = pytest.mark.django_db
+
+
+# ---- Fixtures local to this test module --------------------------------------
+
+
+@pytest.fixture
+def offline_tier_with_sales(event: Event) -> TicketTier:
+    """Create an offline tier with a positive quantity_sold to exercise the decrement path."""
+    return TicketTier.objects.create(
+        event=event,
+        name="Offline With Sales",
+        price=Decimal("25.00"),
+        payment_method=TicketTier.PaymentMethod.OFFLINE,
+        quantity_sold=3,
+    )
+
+
+@pytest.fixture
+def pending_ticket(public_user: RevelUser, event: Event, offline_tier_with_sales: TicketTier) -> Ticket:
+    """A pending offline ticket usable as cancel/refund target."""
+    return Ticket.objects.create(
+        guest_name="Tester",
+        user=public_user,
+        event=event,
+        tier=offline_tier_with_sales,
+        status=Ticket.TicketStatus.PENDING,
+    )
+
+
+@pytest.fixture
+def cancelled_ticket(public_user: RevelUser, event: Event, offline_tier_with_sales: TicketTier) -> Ticket:
+    """A ticket already in CANCELLED state."""
+    return Ticket.objects.create(
+        guest_name="Cancelled",
+        user=public_user,
+        event=event,
+        tier=offline_tier_with_sales,
+        status=Ticket.TicketStatus.CANCELLED,
+    )
+
+
+# ---- cancel_offline_ticket ---------------------------------------------------
+
+
+def test_cancel_offline_ticket_decrements_tier_and_marks_cancelled(
+    pending_ticket: Ticket,
+    offline_tier_with_sales: TicketTier,
+    organization_owner_user: RevelUser,
+) -> None:
+    """Cancelling decrements ``quantity_sold`` and records audit fields."""
+    starting_sold = offline_tier_with_sales.quantity_sold
+    result = ticket_service.cancel_offline_ticket(
+        pending_ticket, cancelled_by=organization_owner_user, reason="duplicate"
+    )
+
+    assert result.status == Ticket.TicketStatus.CANCELLED
+    pending_ticket.refresh_from_db()
+    assert pending_ticket.status == Ticket.TicketStatus.CANCELLED
+    assert pending_ticket.cancellation_source == CancellationSource.ORGANIZER
+    assert pending_ticket.cancellation_reason == "duplicate"
+    assert pending_ticket.cancelled_by_id == organization_owner_user.id
+    assert pending_ticket.cancelled_at is not None
+
+    offline_tier_with_sales.refresh_from_db()
+    assert offline_tier_with_sales.quantity_sold == starting_sold - 1
+
+
+def test_cancel_offline_ticket_already_cancelled_raises(
+    cancelled_ticket: Ticket, organization_owner_user: RevelUser
+) -> None:
+    """Cancelling an already-cancelled ticket raises the typed exception (controller maps to 400)."""
+    with pytest.raises(TicketAlreadyCancelledError):
+        ticket_service.cancel_offline_ticket(cancelled_ticket, cancelled_by=organization_owner_user)
+
+
+def test_cancel_offline_ticket_floors_quantity_sold_at_zero(
+    pending_ticket: Ticket,
+    offline_tier_with_sales: TicketTier,
+    organization_owner_user: RevelUser,
+) -> None:
+    """``quantity_sold`` can never drop below zero (race-safe floor via gt=0 filter)."""
+    offline_tier_with_sales.quantity_sold = 0
+    offline_tier_with_sales.save(update_fields=["quantity_sold"])
+
+    ticket_service.cancel_offline_ticket(pending_ticket, cancelled_by=organization_owner_user)
+
+    offline_tier_with_sales.refresh_from_db()
+    assert offline_tier_with_sales.quantity_sold == 0
+
+
+def test_cancel_offline_ticket_enqueues_waitlist(pending_ticket: Ticket, organization_owner_user: RevelUser) -> None:
+    """Cancellation enqueues a waitlist processing pass for the event."""
+    with patch("events.service.ticket_service.enqueue_waitlist_processing") as enqueue:
+        ticket_service.cancel_offline_ticket(pending_ticket, cancelled_by=organization_owner_user)
+
+    enqueue.assert_called_once_with(pending_ticket.event_id)
+
+
+def test_cancel_offline_ticket_empty_reason_normalised(
+    pending_ticket: Ticket, organization_owner_user: RevelUser
+) -> None:
+    """``reason=None`` is normalised to an empty string for the audit column."""
+    ticket_service.cancel_offline_ticket(pending_ticket, cancelled_by=organization_owner_user, reason=None)
+
+    pending_ticket.refresh_from_db()
+    assert pending_ticket.cancellation_reason == ""
+
+
+# ---- mark_offline_ticket_refunded --------------------------------------------
+
+
+def test_mark_offline_ticket_refunded_without_payment(
+    pending_ticket: Ticket,
+    offline_tier_with_sales: TicketTier,
+    organization_owner_user: RevelUser,
+) -> None:
+    """A ticket without a Payment row is still cancellable via the refund path."""
+    assert not hasattr(pending_ticket, "payment")
+    starting_sold = offline_tier_with_sales.quantity_sold
+
+    result = ticket_service.mark_offline_ticket_refunded(
+        pending_ticket, cancelled_by=organization_owner_user, reason="no_payment"
+    )
+
+    assert result.status == Ticket.TicketStatus.CANCELLED
+    offline_tier_with_sales.refresh_from_db()
+    assert offline_tier_with_sales.quantity_sold == starting_sold - 1
+
+
+def test_mark_offline_ticket_refunded_with_payment(pending_ticket: Ticket, organization_owner_user: RevelUser) -> None:
+    """When a Payment exists it is marked REFUNDED with refund metadata populated."""
+    payment = Payment.objects.create(
+        ticket=pending_ticket,
+        user=pending_ticket.user,
+        stripe_session_id="session-id",
+        amount=Decimal("25.00"),
+        platform_fee=Decimal("1.00"),
+        currency="EUR",
+        status=Payment.PaymentStatus.SUCCEEDED,
+    )
+
+    # Reload so the payment reverse relation is hydrated on the in-memory ticket.
+    ticket = Ticket.objects.select_related("tier", "payment").get(pk=pending_ticket.pk)
+    ticket_service.mark_offline_ticket_refunded(ticket, cancelled_by=organization_owner_user)
+
+    payment.refresh_from_db()
+    assert payment.status == Payment.PaymentStatus.REFUNDED
+    assert payment.refund_status == Payment.RefundStatus.SUCCEEDED
+    assert payment.refund_amount == payment.amount
+    assert payment.refunded_at is not None
+
+
+def test_mark_offline_ticket_refunded_already_cancelled_raises(
+    cancelled_ticket: Ticket, organization_owner_user: RevelUser
+) -> None:
+    """Already-cancelled tickets are rejected before any side effect runs."""
+    with pytest.raises(TicketAlreadyCancelledError):
+        ticket_service.mark_offline_ticket_refunded(cancelled_ticket, cancelled_by=organization_owner_user)
+
+
+def test_mark_offline_ticket_refunded_enqueues_waitlist(
+    pending_ticket: Ticket, organization_owner_user: RevelUser
+) -> None:
+    """Refund flow also enqueues waitlist processing."""
+    with patch("events.service.ticket_service.enqueue_waitlist_processing") as enqueue:
+        ticket_service.mark_offline_ticket_refunded(pending_ticket, cancelled_by=organization_owner_user)
+
+    enqueue.assert_called_once_with(pending_ticket.event_id)
+
+
+# ---- check_online_tier_prerequisites -----------------------------------------
+
+
+def test_check_online_tier_prerequisites_skips_non_online(organization: Organization) -> None:
+    """Non-online payment methods skip the prerequisite checks entirely."""
+    organization.stripe_account_id = ""
+    organization.stripe_charges_enabled = False
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled"])
+
+    # Should NOT raise even without Stripe Connect.
+    ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.OFFLINE)
+    ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.AT_THE_DOOR)
+    ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.FREE)
+
+
+def test_check_online_tier_prerequisites_raises_without_stripe(organization: Organization) -> None:
+    """Online payment without Stripe Connect raises the typed exception."""
+    organization.stripe_account_id = ""
+    organization.stripe_charges_enabled = False
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled"])
+
+    with pytest.raises(StripeNotConnectedError):
+        ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.ONLINE)
+
+
+def test_check_online_tier_prerequisites_raises_without_billing(organization: Organization) -> None:
+    """Online with platform fees but missing billing info raises BillingInfoRequiredError."""
+    organization.stripe_account_id = "acct_test"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.billing_name = ""
+    organization.billing_address = ""
+    organization.vat_country_code = ""
+    organization.save(
+        update_fields=[
+            "stripe_account_id",
+            "stripe_charges_enabled",
+            "stripe_details_submitted",
+            "billing_name",
+            "billing_address",
+            "vat_country_code",
+        ]
+    )
+    # Sanity: org must have platform fees configured to trigger this path.
+    assert organization.platform_fee_percent > 0 or organization.platform_fee_fixed > 0
+
+    with pytest.raises(BillingInfoRequiredError):
+        ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.ONLINE)
+
+
+def test_check_online_tier_prerequisites_passes_when_billing_complete(organization: Organization) -> None:
+    """Properly-configured online org passes the check silently."""
+    organization.stripe_account_id = "acct_test"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.billing_name = "Acme Ltd"
+    organization.billing_address = "1 Acme St"
+    organization.vat_country_code = "IT"
+    organization.save(
+        update_fields=[
+            "stripe_account_id",
+            "stripe_charges_enabled",
+            "stripe_details_submitted",
+            "billing_name",
+            "billing_address",
+            "vat_country_code",
+        ]
+    )
+
+    ticket_service.check_online_tier_prerequisites(organization, TicketTier.PaymentMethod.ONLINE)
+
+
+# ---- start_attendee_export ---------------------------------------------------
+
+
+def test_start_attendee_export_creates_export_row(event: Event, organization_owner_user: RevelUser) -> None:
+    """``start_attendee_export`` creates a FileExport in PENDING with the correct parameters."""
+    from common.models import FileExport
+
+    with patch("events.tasks.generate_attendee_export_task.delay") as delay:
+        export = ticket_service.start_attendee_export(event, requested_by=organization_owner_user)
+
+    assert export.export_type == FileExport.ExportType.ATTENDEE_LIST
+    assert export.status == FileExport.ExportStatus.PENDING
+    assert export.parameters == {"event_id": str(event.id)}
+    assert export.requested_by_id == organization_owner_user.id
+    # Dispatch is deferred via transaction.on_commit; pytest.mark.django_db wraps each
+    # test in an atomic block that rolls back, so the lambda fires at TestCase teardown.
+    # Asserting on the return shape is enough here; integration coverage lives in the
+    # controller tests.
+    _ = delay
+
+
+def test_start_attendee_export_dispatch_callable_resolves_to_task(
+    event: Event, organization_owner_user: RevelUser
+) -> None:
+    """The on_commit hook ultimately calls the Celery task with the export id (smoke-checked at import)."""
+    from events.tasks import generate_attendee_export_task
+
+    assert callable(getattr(generate_attendee_export_task, "delay", None))
+    export = ticket_service.start_attendee_export(event, requested_by=organization_owner_user)
+    assert export.id is not None
+
+
+# ---- typing sanity -----------------------------------------------------------
+
+
+def test_module_exports_messages() -> None:
+    """Public message constants are exported for the controller's HTTP mapping."""
+    messages: list[t.Any] = [
+        ticket_service.TICKET_ALREADY_CANCELLED_MESSAGE,
+        ticket_service.STRIPE_NOT_CONNECTED_MESSAGE,
+        ticket_service.BILLING_INFO_REQUIRED_MESSAGE,
+    ]
+    for msg in messages:
+        assert str(msg)

--- a/src/events/tests/test_service/test_ticket_tier_cancellation_fields.py
+++ b/src/events/tests/test_service/test_ticket_tier_cancellation_fields.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 
 from events.models import Event, TicketTier
+from events.schema import TicketTierCreateSchema, TicketTierUpdateSchema
 from events.service import ticket_service
 
 pytestmark = pytest.mark.django_db
@@ -13,9 +14,8 @@ pytestmark = pytest.mark.django_db
 
 def test_create_ticket_tier_persists_cancellation_fields(event: Event) -> None:
     """create_ticket_tier should persist allow_user_cancellation, cancellation_deadline_hours, and refund_policy."""
-    tier = ticket_service.create_ticket_tier(
-        event=event,
-        tier_data={
+    payload = TicketTierCreateSchema.model_validate(
+        {
             "name": "VIP",
             "price": Decimal("50"),
             "allow_user_cancellation": True,
@@ -24,9 +24,9 @@ def test_create_ticket_tier_persists_cancellation_fields(event: Event) -> None:
                 "tiers": [{"hours_before_event": 24, "refund_percentage": "50"}],
                 "flat_fee": "0",
             },
-        },
-        restricted_to_membership_tiers_ids=None,
+        }
     )
+    tier = ticket_service.create_ticket_tier(event=event, payload=payload)
     tier.refresh_from_db()
     assert tier.allow_user_cancellation is True
     assert tier.cancellation_deadline_hours == 24
@@ -42,8 +42,7 @@ def test_update_ticket_tier_clears_refund_policy(tier_factory: t.Callable[..., T
             "flat_fee": "0",
         }
     )
-    ticket_service.update_ticket_tier(
-        tier=tier, tier_data={"refund_policy": None}, restricted_to_membership_tiers_ids=None
-    )
+    payload = TicketTierUpdateSchema.model_validate({"refund_policy": None})
+    ticket_service.update_ticket_tier(tier=tier, payload=payload)
     tier.refresh_from_db()
     assert tier.refund_policy is None


### PR DESCRIPTION
## Summary

Move ticket-admin business logic out of `events/controllers/event_admin/tickets.py` and into `events/service/ticket_service.py`, matching the thin-controller pattern landed in #441 (event_questionnaire / event_update / org tokens).

### New service functions

- `cancel_offline_ticket(ticket, *, cancelled_by, reason) -> Ticket`
- `mark_offline_ticket_refunded(ticket, *, cancelled_by, reason) -> Ticket`
- private `_cancel_offline_ticket_core` primitive shared by both — tier `quantity_sold` decrement (guarded by `__gt=0` floor), ticket audit fields, waitlist enqueue. Refund layers the `Payment` mutation on top.
- `check_online_tier_prerequisites(org, payment_method) -> None` — moved from the controller; raises `StripeNotConnectedError` / `BillingInfoRequiredError`.
- `start_attendee_export(event, requested_by) -> FileExport` — owns FileExport row creation and dispatches the Celery task via `transaction.on_commit` (matches the questionnaire export pattern).
- `create_ticket_tier(event, payload: TicketTierCreateSchema)` and `update_ticket_tier(tier, payload: TicketTierUpdateSchema)` now accept the typed Pydantic schema directly and return the prefetched object via `with_venue_and_sector()`. The controller no longer reshapes the payload or refetches.

### New typed exceptions (`events/exceptions.py`)

- `TicketAlreadyCancelledError`
- `StripeNotConnectedError`
- `BillingInfoRequiredError`

### Controller

`tickets.py` shrinks from **423 -> 321** lines. Each method is now permission/lookup -> service call -> return. No `transaction.atomic()`, no direct model mutation, no `F()` manipulation, no `.delay()` in the controller.

## Verification

- `make check` clean (ruff format, ruff check, mypy `--strict --extra-checks --warn-unreachable --warn-unused-ignores`, migration check, i18n check, file-length).
- Per project policy, the pytest suite is **not** run by the assistant — please run `make test` before merging.

## Test plan

- [ ] `make test` passes locally
- [ ] Service-level unit tests in `src/events/tests/test_service/test_ticket_admin_service.py` cover the acceptance-criteria scenarios: already-cancelled ticket raises, tier decrement floor at zero, payment-less refund path, waitlist enqueue assertion, online-prerequisite typed exceptions, attendee export FileExport row.
- [ ] Existing controller tests in `src/events/tests/test_controllers/test_event_admin/test_tickets/` continue to pass (no behavioural change to HTTP responses or status codes — same `400`, same translated `"billing"` / `"Stripe"` / `"already cancelled"` messages).

Closes #427

Notes for reviewer:
- `start_attendee_export` now defers Celery dispatch via `transaction.on_commit` to avoid the race that exists in the old `.delay()`-inline pattern (matches `event_questionnaire_service.start_submissions_export`). HTTP behaviour is unchanged — the 202 still returns immediately with the FileExport row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ticket cancellation and refund flows with stricter checks and clearer error responses for already-cancelled cases.
  * Stronger validation and clearer error messages for online-payment ticket tier creation/update (missing payment connectivity or billing info).

* **New Features**
  * Attendee export requests now start asynchronously and return immediately (background processing).

* **Tests**
  * Added/updated unit tests covering cancellation/refund behavior, online-tier validation, attendee export scheduling, and related wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->