### PR TITLE
fix(celery): defer request-context task dispatch via transaction.on_commit (closes #442)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,42 @@ class FooConfig(AppConfig):
       food_item = FoodItem.objects.get(name__iexact=name)
   ```
 
+### Celery Dispatch & Transactions (`transaction.on_commit`)
+
+`settings.base` sets `DATABASES["default"]["ATOMIC_REQUESTS"] = True`, so **every HTTP
+request runs inside one DB transaction** that commits only when the view returns
+successfully. `.delay()` pushes the task to the broker **immediately**, regardless of
+that transaction. If a worker picks the task up before the request commits, any
+`Model.objects.get(pk=…)` for a row created in the same request raises `DoesNotExist`
+(intermittent, load-dependent, hard to reproduce).
+
+- **Default rule**: when dispatching a Celery task from anything reachable by an HTTP
+  request (a controller, a service called by a controller, or a `post_save`/`post_delete`
+  signal handler firing during a request), defer the dispatch:
+  ```python
+  from django.db import transaction
+  transaction.on_commit(lambda: my_task.delay(arg))
+  ```
+  If the transaction rolls back, the dispatch is correctly skipped.
+- **Don't wrap task-to-task chains**: code that only runs *inside* a Celery worker (a
+  `@shared_task` calling another task) is not under `ATOMIC_REQUESTS`; bare `.delay()` is
+  fine there unless the task opens its own `@transaction.atomic` block first.
+- **Loop variables**: never `transaction.on_commit(lambda: task.delay(x))` inside a `for x
+  in …` loop — the callback runs after the loop ends and captures the *last* `x`. Build
+  the values first and dispatch them in a single `on_commit` closure, or bind eagerly with
+  `functools.partial(task.delay, x)`.
+- **Dispatch-then-`raise` (anti-enumeration) paths are the exception**: if a handler
+  intentionally dispatches a task and then raises (rolling the request back) — and the task
+  targets a row that *already existed* before this request — use a bare `.delay()`. An
+  `on_commit` callback registered inside an atomic block that then rolls back is discarded,
+  so the task would never run. See `accounts/service/account.register_user` /
+  `send_verification_email_for_user(..., defer=False)`.
+- **Tests**: pytest-django's default `django_db` rolls the wrapping transaction back, so
+  `on_commit` callbacks never fire (and with `CELERY_TASK_ALWAYS_EAGER` the eager task
+  never runs). A test asserting the dispatch/side effect must either wrap the trigger in
+  the `django_capture_on_commit_callbacks(execute=True)` fixture or be marked
+  `@pytest.mark.django_db(transaction=True)` with a docstring explaining why.
+
 ### Query Optimization
 - **Prefetch relationships**: Use `select_related()` for foreign keys, `prefetch_related()` for reverse/M2M
 - **Avoid N+1 in schemas**: When ModelSchema includes nested relationships, ensure the queryset prefetches them

--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -36,6 +36,12 @@ def _send_activation_email_for_guest(user: RevelUser) -> None:
     guest-to-full-user conversion when the link is clicked.
     """
     token = create_password_reset_token(user)
+    # Bare dispatch (no on_commit): this helper is only invoked on the
+    # duplicate-registration anti-enumeration path, which dispatches the
+    # activation email and then raises HttpError(400), rolling the request
+    # transaction back. The target guest already exists (committed), so there
+    # is no read-after-commit race and the email must be sent despite the
+    # rollback. See register_user.
     tasks.send_account_activation_link.delay(user.email, token)
     logger.info("account_activation_email_sent", user_id=str(user.id), email=user.email)
 
@@ -68,7 +74,7 @@ def register_user(payload: schema.RegisterUserSchema) -> tuple[RevelUser, str]:
             _send_activation_email_for_guest(existing_user)
         elif not existing_user.email_verified:
             logger.info("user_registration_duplicate_unverified", email=payload.email)
-            send_verification_email_for_user(existing_user)
+            send_verification_email_for_user(existing_user, defer=False)
         logger.warning("user_registration_duplicate", email=payload.email)
         raise HttpError(400, str(_("A user with this email already exists.")))
 
@@ -161,11 +167,25 @@ def create_deletion_token(user: RevelUser) -> str:
     return token
 
 
-def send_verification_email_for_user(user: RevelUser) -> tuple[RevelUser, str]:
-    """Send a verification email for a user."""
+def send_verification_email_for_user(user: RevelUser, *, defer: bool = True) -> tuple[RevelUser, str]:
+    """Send a verification email for a user.
+
+    Args:
+        user: The user to email.
+        defer: When True (default), the dispatch is deferred until the
+            surrounding transaction commits, so a freshly-created user row is
+            visible to the worker (avoids a read-after-commit race). Pass
+            ``defer=False`` on the duplicate-registration anti-enumeration path
+            that dispatches and then rolls the request transaction back: there
+            the target user already exists, so the email must be sent
+            regardless of the rollback.
+    """
     logger.info("verification_email_requested", user_id=str(user.id), email=user.email)
     token = create_verification_token(user)
-    tasks.send_verification_email.delay(user.email, token)
+    if defer:
+        transaction.on_commit(lambda: tasks.send_verification_email.delay(user.email, token))
+    else:
+        tasks.send_verification_email.delay(user.email, token)
     return user, token
 
 
@@ -265,7 +285,7 @@ def request_password_reset(email: str) -> str | None:
         logger.info("password_reset_blocked_google_sso", user_id=str(user.id), email=email)
         return None
     token = create_password_reset_token(user)
-    tasks.send_password_reset_link.delay(user.email, token)
+    transaction.on_commit(lambda: tasks.send_password_reset_link.delay(user.email, token))
     logger.info("password_reset_email_sent", user_id=str(user.id), email=email)
     return token
 
@@ -281,7 +301,7 @@ def request_account_deletion(user: RevelUser) -> str:
     """
     logger.info("account_deletion_requested", user_id=str(user.id), email=user.email)
     token = create_deletion_token(user)
-    tasks.send_account_deletion_link.delay(user.email, token)
+    transaction.on_commit(lambda: tasks.send_account_deletion_link.delay(user.email, token))
     return token
 
 
@@ -389,8 +409,8 @@ def request_email_change(user: RevelUser, new_email: str, password: str) -> str:
         raise HttpError(400, str(_("This email is already in use.")))
 
     token = create_email_change_token(user, new_email)
-    tasks.send_email_change_confirmation.delay(new_email, token)
-    tasks.send_email_change_notice.delay(user.email, _mask_email(new_email))
+    transaction.on_commit(lambda: tasks.send_email_change_confirmation.delay(new_email, token))
+    transaction.on_commit(lambda: tasks.send_email_change_notice.delay(user.email, _mask_email(new_email)))
     logger.info("email_change_email_sent", user_id=str(user.id), new_email=new_email)
     return token
 
@@ -449,8 +469,8 @@ def confirm_email_change(token: str) -> RevelUser:
         logger.warning("email_change_confirm_race_loss", user_id=str(user.id), new_email=new_email)
         raise HttpError(400, str(_("This email is already in use.")))
 
-    tasks.send_email_change_completed_old.delay(old_email, new_email)
-    tasks.send_email_change_completed_new.delay(new_email, old_email)
+    transaction.on_commit(lambda: tasks.send_email_change_completed_old.delay(old_email, new_email))
+    transaction.on_commit(lambda: tasks.send_email_change_completed_new.delay(new_email, old_email))
     logger.info(
         "email_change_confirmed",
         user_id=str(user.id),
@@ -497,7 +517,7 @@ def confirm_account_deletion(token: str) -> None:
     logger.info("account_deletion_confirmed", user_id=str(user.id), email=user.email)
     blacklist_token(token)
     # Enqueue the deletion as a background task to handle heavy operations
-    tasks.delete_user_account.delay(str(user.id))
+    transaction.on_commit(lambda: tasks.delete_user_account.delay(str(user.id)))
 
 
 def update_profile(user: RevelUser, payload: schema.ProfileUpdateSchema) -> RevelUser:

--- a/src/accounts/tests/test_account_service.py
+++ b/src/accounts/tests/test_account_service.py
@@ -64,6 +64,10 @@ class TestRegisterUserSchemaEmailNormalization:
         assert user.username == "mixedcase@example.com"
 
 
+# transaction=True: register_user dispatches send_verification_email via transaction.on_commit.
+# In default pytest-django mode the wrapping transaction is rolled back and the callback never
+# fires, breaking the delay_mock assertion.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_verification_email.delay")
 def test_register_user_success(mock_send_email: MagicMock, valid_register_payload: schema.RegisterUserSchema) -> None:
     """Test successful user registration creates a user and sends an email."""
@@ -265,6 +269,9 @@ def test_register_user_existing_unverified_non_guest(
     mock_send_email.assert_called_once()
 
 
+# transaction=True: request_password_reset dispatches send_password_reset_link via transaction.on_commit.
+# Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_password_reset_link.delay")
 def test_request_password_reset_success(mock_send_email: MagicMock, user: RevelUser) -> None:
     """Test requesting a password reset sends an email for an existing user."""
@@ -289,6 +296,9 @@ def test_request_password_reset_for_google_user(mock_send_email: MagicMock, goog
     mock_send_email.assert_not_called()
 
 
+# transaction=True: request_password_reset dispatches send_password_reset_link via transaction.on_commit.
+# Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_password_reset_link.delay")
 def test_request_password_reset_for_guest_user(mock_send_email: MagicMock, guest_user: RevelUser) -> None:
     """Test that guest users can request a password reset (converts them on reset)."""
@@ -341,6 +351,9 @@ def test_reset_password_for_google_user_fails(google_user: RevelUser) -> None:
         account_service.reset_password(token, "any-password")
 
 
+# transaction=True: request_account_deletion dispatches send_account_deletion_link via transaction.on_commit.
+# Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_account_deletion_link.delay")
 def test_request_account_deletion(mock_send_email: MagicMock, user: RevelUser) -> None:
     """Test that requesting account deletion sends the correct email task."""
@@ -349,6 +362,10 @@ def test_request_account_deletion(mock_send_email: MagicMock, user: RevelUser) -
     mock_send_email.assert_called_once_with(user.email, token)
 
 
+# transaction=True: confirm_account_deletion dispatches delete_user_account via transaction.on_commit.
+# Default pytest-django mode rolls back the wrapping transaction so the eager task never runs and
+# the user is never deleted.
+@pytest.mark.django_db(transaction=True)
 def test_confirm_account_deletion_success(user: RevelUser) -> None:
     """Test that a valid deletion token successfully deletes the user."""
     payload = schema.DeleteAccountJWTPayloadSchema(

--- a/src/accounts/tests/test_controllers/test_account_controller.py
+++ b/src/accounts/tests/test_controllers/test_account_controller.py
@@ -69,6 +69,10 @@ def test_verify_email_success(
     assert data["token"]["access"] == "access_token"
 
 
+# transaction=True: resend_verification_email dispatches send_verification_email via
+# transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
+# and the callback never fires, breaking the delay_mock assertion.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_verification_email.delay")
 def test_resend_verification_email_success(
     mock_send_email: MagicMock, client: Client, unverified_user: RevelUser
@@ -113,6 +117,10 @@ def test_resend_verification_email_nonexistent_user(mock_send_email: MagicMock, 
     mock_send_email.assert_not_called()
 
 
+# transaction=True: request_account_deletion dispatches send_account_deletion_link via
+# transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
+# and the callback never fires, breaking the delay_mock assertion.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_account_deletion_link.delay")
 def test_delete_account_request(mock_send_email: MagicMock, auth_client: Client) -> None:
     """Test that requesting account deletion returns 200."""
@@ -136,6 +144,10 @@ def test_delete_account_confirm(mock_confirm_delete: MagicMock, client: Client) 
     mock_confirm_delete.assert_called_once_with("valid.deletion.token")
 
 
+# transaction=True: request_password_reset dispatches send_password_reset_link via
+# transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
+# and the callback never fires, breaking the delay_mock assertion.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_password_reset_link.delay")
 def test_password_reset_request(mock_send_email: MagicMock, client: Client, user: RevelUser) -> None:
     """Test password reset request returns 200, preventing user enumeration."""

--- a/src/accounts/tests/test_controllers/test_profile_picture.py
+++ b/src/accounts/tests/test_controllers/test_profile_picture.py
@@ -5,6 +5,7 @@ This module tests the AccountController endpoints:
 - DELETE /account/me/delete-profile-picture
 """
 
+import typing as t
 from io import BytesIO
 
 import pytest
@@ -226,12 +227,15 @@ class TestUploadProfilePicture:
         auth_client: Client,
         user: RevelUser,
         png_bytes: bytes,
+        django_capture_on_commit_callbacks: t.Any,
     ) -> None:
         """Test that uploading creates a FileUploadAudit record for malware scanning.
 
         The system should create an audit record to track uploaded files and
         schedule a malware scan via the ClamAV integration.
         Note: In tests, Celery runs eagerly so the status will be CLEAN after the scan completes.
+        The upload schedules the scan via ``transaction.on_commit``; the capture
+        fixture executes that callback so the eager scan runs and sets the status.
         """
         # Arrange
         png_file = SimpleUploadedFile(
@@ -243,7 +247,8 @@ class TestUploadProfilePicture:
         initial_audit_count = FileUploadAudit.objects.count()
 
         # Act
-        response = auth_client.post(url, data={"profile_picture": png_file}, format="multipart")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = auth_client.post(url, data={"profile_picture": png_file}, format="multipart")
 
         # Assert
         assert response.status_code == 200

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -48,6 +48,10 @@ class TestEmailChangeRequestSchema:
 
 
 class TestRequestEmailChange:
+    # transaction=True: request_email_change dispatches the confirmation/notice emails via
+    # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled
+    # back and the callbacks never fire, breaking the delay_mock assertions.
+    @pytest.mark.django_db(transaction=True)
     @patch("accounts.tasks.send_email_change_notice.delay")
     @patch("accounts.tasks.send_email_change_confirmation.delay")
     def test_success(
@@ -151,6 +155,10 @@ def _make_change_token(user: RevelUser, new_email: str, *, expired: bool = False
 
 
 class TestConfirmEmailChange:
+    # transaction=True: confirm_email_change dispatches the completed-old/new emails via
+    # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled
+    # back and the callbacks never fire, breaking the delay_mock assertions.
+    @pytest.mark.django_db(transaction=True)
     @patch("accounts.tasks.send_email_change_completed_new.delay")
     @patch("accounts.tasks.send_email_change_completed_old.delay")
     def test_success(
@@ -247,6 +255,10 @@ class TestConfirmEmailChange:
 # ===== Controller tests =====
 
 
+# transaction=True: request_email_change dispatches the confirmation/notice emails via
+# transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
+# and the callbacks never fire, breaking the delay_mock assertions.
+@pytest.mark.django_db(transaction=True)
 @patch("accounts.tasks.send_email_change_notice.delay")
 @patch("accounts.tasks.send_email_change_confirmation.delay")
 def test_email_change_request_endpoint(

--- a/src/common/tests/test_tasks.py
+++ b/src/common/tests/test_tasks.py
@@ -14,8 +14,13 @@ from events.models import AdditionalResource, Organization
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.django_db(transaction=True)
 @mock.patch("common.tasks.pyclamd.ClamdNetworkSocket")
 def test_scan_for_malware(mock_clamd: MagicMock, revel_user_factory: RevelUserFactory) -> None:
+    """Uses ``transaction=True`` because ``safe_save_uploaded_file`` schedules the
+    malware scan via ``transaction.on_commit``; in default pytest-django mode the
+    rolled-back transaction suppresses the callback and the scan never runs.
+    """
     eicar_payload = b"X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
     uploader = revel_user_factory()
     org = Organization.objects.create(name="Test Organization", owner=uploader)

--- a/src/common/tests/test_thumbnails_tasks.py
+++ b/src/common/tests/test_thumbnails_tasks.py
@@ -354,8 +354,15 @@ class TestThumbnailIntegration:
 # =============================================================================
 
 
+@pytest.mark.django_db(transaction=True)
 class TestSafeSaveUploadedFileIntegration:
-    """Integration tests for safe_save_uploaded_file with thumbnail generation."""
+    """Integration tests for safe_save_uploaded_file with thumbnail generation.
+
+    Uses ``transaction=True`` because ``safe_save_uploaded_file`` schedules the
+    thumbnail-generation and orphan-deletion tasks via ``transaction.on_commit``;
+    in default pytest-django mode the rolled-back transaction suppresses the
+    callbacks, so the mocked ``.delay`` would never be called.
+    """
 
     def test_safe_save_schedules_thumbnail_generation(
         self,

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -152,7 +152,7 @@ def create_file_audit_and_scan(
         file_hash=file_hash,
         uploader=uploader_email,
     )
-    tasks.scan_for_malware.delay(app=app, model=model, pk=str(instance_pk), field=field)
+    transaction.on_commit(lambda: tasks.scan_for_malware.delay(app=app, model=model, pk=str(instance_pk), field=field))
 
 
 def _validate_file_field(instance: models.Model, field_name: str, file: File) -> None:  # type: ignore[type-arg]
@@ -235,7 +235,7 @@ def safe_save_uploaded_file(
 
     # Schedule deletion of old thumbnails
     if old_thumbnail_paths:
-        delete_orphaned_thumbnails_task.delay(thumbnail_paths=old_thumbnail_paths)
+        transaction.on_commit(lambda: delete_orphaned_thumbnails_task.delay(thumbnail_paths=old_thumbnail_paths))
 
     setattr(instance, field, file)
 
@@ -266,11 +266,13 @@ def safe_save_uploaded_file(
 
     # Schedule thumbnail generation if configured for this model/field
     if config:
-        generate_thumbnails_task.delay(
-            app=app,
-            model=model,
-            pk=str(instance.pk),
-            field=field,
+        transaction.on_commit(
+            lambda: generate_thumbnails_task.delay(
+                app=app,
+                model=model,
+                pk=str(instance.pk),
+                field=field,
+            )
         )
 
     return instance

--- a/src/events/controllers/event_public/attendance.py
+++ b/src/events/controllers/event_public/attendance.py
@@ -304,6 +304,6 @@ class EventPublicAttendanceController(EventPublicBaseController):
                 Questionnaire.QuestionnaireEvaluationMode.AUTOMATIC,
                 Questionnaire.QuestionnaireEvaluationMode.HYBRID,
             ):
-                evaluate_questionnaire_submission.delay(str(db_submission.pk))
+                transaction.on_commit(lambda: evaluate_questionnaire_submission.delay(str(db_submission.pk)))
 
         return QuestionnaireSubmissionResponseSchema.from_orm(db_submission)

--- a/src/events/service/announcement_service.py
+++ b/src/events/service/announcement_service.py
@@ -386,7 +386,7 @@ def send_announcement(announcement: Announcement) -> int:
 
     # Dispatch all notifications in a batch task
     notification_ids = [str(n.id) for n in created_notifications]
-    dispatch_notifications_batch.delay(notification_ids)
+    transaction.on_commit(lambda: dispatch_notifications_batch.delay(notification_ids))
 
     logger.info(
         "announcement_sent",

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -216,7 +216,7 @@ def handle_guest_rsvp(
     token = create_guest_rsvp_token(user, event.id, answer_str)
 
     # Send confirmation email
-    send_guest_rsvp_confirmation.delay(user.email, token, event.name)
+    transaction.on_commit(lambda: send_guest_rsvp_confirmation.delay(user.email, token, event.name))
 
     return schema.GuestActionResponseSchema(message=str(_("Please check your email to confirm your RSVP")))
 
@@ -303,7 +303,7 @@ def handle_guest_ticket_checkout(
         # Non-online payment: require email confirmation
         # Store ticket info in JWT token for later creation
         token = create_guest_ticket_token(user, event.id, tier.id, tickets, pwyc_amount, discount_code)
-        send_guest_ticket_confirmation.delay(user.email, token, event.name, tier.name)
+        transaction.on_commit(lambda: send_guest_ticket_confirmation.delay(user.email, token, event.name, tier.name))
         return schema.GuestCheckoutResponseSchema(
             message=str(_("Please check your email to confirm your ticket purchase")),
             checkout_url=None,

--- a/src/events/service/user_preferences_service.py
+++ b/src/events/service/user_preferences_service.py
@@ -4,6 +4,7 @@ import typing as t
 from dataclasses import dataclass, field
 from uuid import UUID
 
+from django.db import transaction
 from django.utils import timezone
 from pydantic import BaseModel
 
@@ -136,8 +137,13 @@ def trigger_visibility_flags_for_user(user_id: UUID) -> None:
             ).values_list("event_id", flat=True)
         )
     )
-    for event_id in event_ids:
-        build_attendee_visibility_flags.delay(str(event_id))
+    event_id_strs = [str(event_id) for event_id in event_ids]
+
+    def _dispatch_visibility_flags() -> None:
+        for event_id in event_id_strs:
+            build_attendee_visibility_flags.delay(event_id)
+
+    transaction.on_commit(_dispatch_visibility_flags)
 
 
 def resolve_visibility_fast(

--- a/src/events/service/vies_service.py
+++ b/src/events/service/vies_service.py
@@ -5,6 +5,8 @@ Thin wrappers around the generic billing operations in ``common.service.vies_ser
 
 import typing as t
 
+from django.db import transaction
+
 from common.service.vies_service import VIESValidationResult, validate_and_update_vat_entity
 from common.service.vies_service import clear_vat_fields as _clear_vat_fields
 from common.service.vies_service import set_vat_id as _set_vat_id
@@ -25,7 +27,12 @@ def set_org_vat_id(org: "Organization", vat_id: str) -> None:
     def _queue_retry() -> None:
         from events.tasks import revalidate_single_vat_id_task
 
-        revalidate_single_vat_id_task.delay(str(org.id))
+        # _queue_retry runs right before set_vat_id raises HttpError(503). There
+        # is no inner atomic block, and Django Ninja turns the HttpError into a
+        # 503 *response* (no exception reaches the ATOMIC_REQUESTS wrapper), so
+        # the request transaction commits and on_commit fires — deferring avoids
+        # the retry task racing the commit of the org's freshly-set vat_id.
+        transaction.on_commit(lambda: revalidate_single_vat_id_task.delay(str(org.id)))
 
     _set_vat_id(
         org,

--- a/src/events/tests/test_controllers/test_event_controller/test_questionnaire.py
+++ b/src/events/tests/test_controllers/test_event_controller/test_questionnaire.py
@@ -62,6 +62,7 @@ def test_get_nonexistent_questionnaire_fails(nonmember_client: Client, public_ev
     assert response.status_code == 404
 
 
+@pytest.mark.django_db(transaction=True)
 @patch("events.controllers.event_public.attendance.evaluate_questionnaire_submission.delay")
 def test_submit_questionnaire_success_no_auto_eval(
     mock_evaluate_task: MagicMock,
@@ -69,7 +70,13 @@ def test_submit_questionnaire_success_no_auto_eval(
     public_event: Event,
     event_questionnaire: Questionnaire,
 ) -> None:
-    """Test a successful submission that does not trigger immediate evaluation."""
+    """Test a successful submission that does not trigger immediate evaluation.
+
+    Uses ``transaction=True`` because ``submit_questionnaire`` schedules
+    ``evaluate_questionnaire_submission`` via ``transaction.on_commit``. In
+    default pytest-django mode the wrapping transaction is rolled back and the
+    callback never fires, breaking the ``mock_evaluate_task`` assertion.
+    """
     mcq = event_questionnaire.multiplechoicequestion_questions.first()
     option = mcq.options.first()  # type: ignore[union-attr]
     url = reverse(
@@ -93,6 +100,7 @@ def test_submit_questionnaire_success_no_auto_eval(
     mock_evaluate_task.assert_called_once_with(str(submission.pk))  # type: ignore[union-attr]
 
 
+@pytest.mark.django_db(transaction=True)
 @patch("events.controllers.event_public.attendance.evaluate_questionnaire_submission.delay")
 def test_submit_questionnaire_success_with_auto_eval(
     mock_evaluate_task: MagicMock,
@@ -100,7 +108,13 @@ def test_submit_questionnaire_success_with_auto_eval(
     public_event: Event,
     auto_eval_questionnaire: Questionnaire,
 ) -> None:
-    """Test a successful submission that triggers immediate evaluation."""
+    """Test a successful submission that triggers immediate evaluation.
+
+    Uses ``transaction=True`` because ``submit_questionnaire`` schedules
+    ``evaluate_questionnaire_submission`` via ``transaction.on_commit``. In
+    default pytest-django mode the wrapping transaction is rolled back and the
+    callback never fires, breaking the ``mock_evaluate_task`` assertion.
+    """
     mcq = auto_eval_questionnaire.multiplechoicequestion_questions.first()
     option = mcq.options.first()  # type: ignore[union-attr]
     url = reverse(

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_checkout.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_checkout.py
@@ -17,8 +17,15 @@ from events.models import Event, Ticket, TicketTier
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGuestTicketCheckout:
-    """Test guest ticket checkout endpoint for fixed-price tiers."""
+    """Test guest ticket checkout endpoint for fixed-price tiers.
+
+    Uses ``transaction=True`` because the non-online checkout flow schedules
+    ``send_guest_ticket_confirmation`` via ``transaction.on_commit``. In default
+    pytest-django mode the wrapping transaction is rolled back and the callback
+    never fires, breaking the ``mock_send_email`` assertions.
+    """
 
     @patch("events.tasks.send_guest_ticket_confirmation.delay")
     def test_guest_checkout_free_ticket_sends_confirmation(
@@ -204,8 +211,15 @@ class TestGuestTicketCheckout:
         assert "pwyc" in data["detail"].lower()
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGuestPWYCCheckout:
-    """Test guest PWYC ticket checkout endpoint."""
+    """Test guest PWYC ticket checkout endpoint.
+
+    Uses ``transaction=True`` because the non-online PWYC checkout flow schedules
+    ``send_guest_ticket_confirmation`` via ``transaction.on_commit``. In default
+    pytest-django mode the wrapping transaction is rolled back and the callback
+    never fires, breaking the ``mock_send_email`` assertions.
+    """
 
     @patch("events.tasks.send_guest_ticket_confirmation.delay")
     def test_guest_pwyc_checkout_offline_success(

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_integration.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_integration.py
@@ -6,6 +6,7 @@
 """
 
 import re
+import typing as t
 from unittest.mock import Mock, patch
 
 import pytest
@@ -20,9 +21,17 @@ pytestmark = pytest.mark.django_db
 
 
 class TestGuestFlowIntegration:
-    """Test complete guest user flows from start to finish."""
+    """Test complete guest user flows from start to finish.
 
-    def test_complete_rsvp_flow_end_to_end(self, guest_event: Event) -> None:
+    The guest RSVP / non-online ticket flows schedule the confirmation email via
+    ``transaction.on_commit``. These tests wrap the initiating request in
+    ``django_capture_on_commit_callbacks(execute=True)`` so that callback fires
+    (sending the email) while keeping the default rolled-back transaction — using
+    ``transaction=True`` instead would also commit the ``guest_event`` fixture's
+    event-open notification, polluting ``mail.outbox``.
+    """
+
+    def test_complete_rsvp_flow_end_to_end(self, guest_event: Event, django_capture_on_commit_callbacks: t.Any) -> None:
         """Test complete RSVP flow: initiate -> receive email -> confirm -> verify RSVP."""
         from django.core import mail
 
@@ -34,7 +43,8 @@ class TestGuestFlowIntegration:
             "first_name": "End",
             "last_name": "ToEnd",
         }
-        response = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, data=payload, content_type="application/json")
         assert response.status_code == 200
 
         # Step 2: Verify email was sent and extract token
@@ -55,7 +65,9 @@ class TestGuestFlowIntegration:
         rsvp = EventRSVP.objects.get(user=user, event=guest_event)
         assert rsvp.status == EventRSVP.RsvpStatus.YES
 
-    def test_complete_ticket_flow_end_to_end(self, guest_event_with_tickets: Event, free_tier: TicketTier) -> None:
+    def test_complete_ticket_flow_end_to_end(
+        self, guest_event_with_tickets: Event, free_tier: TicketTier, django_capture_on_commit_callbacks: t.Any
+    ) -> None:
         """Test complete ticket flow: initiate -> receive email -> confirm -> verify ticket."""
         from django.core import mail
 
@@ -71,7 +83,8 @@ class TestGuestFlowIntegration:
             "last_name": "Flow",
             "tickets": [{"guest_name": "Ticket Flow"}],
         }
-        response = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, data=payload, content_type="application/json")
         assert response.status_code == 200
 
         # Step 2: Verify email was sent and extract token
@@ -126,7 +139,9 @@ class TestGuestFlowIntegration:
         user = RevelUser.objects.get(email="stripe@example.com")
         assert user.guest is True
 
-    def test_guest_creates_rsvp_then_converts_to_full_user(self, guest_event: Event) -> None:
+    def test_guest_creates_rsvp_then_converts_to_full_user(
+        self, guest_event: Event, django_capture_on_commit_callbacks: t.Any
+    ) -> None:
         """Test guest creates RSVP, then converts to full user via password reset."""
         from django.core import mail
 
@@ -138,7 +153,8 @@ class TestGuestFlowIntegration:
             "first_name": "Convert",
             "last_name": "User",
         }
-        response = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(url, data=payload, content_type="application/json")
         assert response.status_code == 200
 
         # Extract token and confirm RSVP
@@ -162,11 +178,19 @@ class TestGuestFlowIntegration:
 
 
 class TestGuestDuplicateActions:
-    """Test handling of duplicate guest actions."""
+    """Test handling of duplicate guest actions.
+
+    The guest RSVP / non-online ticket flows schedule the confirmation email via
+    ``transaction.on_commit``. Tests that assert the dispatch wrap the initiating
+    request in ``django_capture_on_commit_callbacks(execute=True)`` so the
+    callback fires under the default rolled-back transaction (avoiding the
+    ``mail.outbox`` pollution that ``transaction=True`` would cause by also
+    committing the ``guest_event`` fixture's event-open notification).
+    """
 
     @patch("events.tasks.send_guest_rsvp_confirmation.delay")
     def test_guest_initiates_rsvp_twice_preserves_original_name(
-        self, mock_send_email: Mock, guest_event: Event
+        self, mock_send_email: Mock, guest_event: Event, django_capture_on_commit_callbacks: t.Any
     ) -> None:
         """Test that initiating RSVP twice does not overwrite the guest user's name."""
         # First RSVP
@@ -177,7 +201,8 @@ class TestGuestDuplicateActions:
             "first_name": "First",
             "last_name": "Name",
         }
-        response1 = client.post(url, data=payload1, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response1 = client.post(url, data=payload1, content_type="application/json")
         assert response1.status_code == 200
 
         # Second RSVP with same email, different name
@@ -186,7 +211,8 @@ class TestGuestDuplicateActions:
             "first_name": "Second",
             "last_name": "Name",
         }
-        response2 = client.post(url, data=payload2, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response2 = client.post(url, data=payload2, content_type="application/json")
         assert response2.status_code == 200
 
         # Assert: User's name was NOT updated (preserves original)
@@ -199,7 +225,11 @@ class TestGuestDuplicateActions:
 
     @patch("events.tasks.send_guest_ticket_confirmation.delay")
     def test_guest_initiates_ticket_purchase_twice(
-        self, mock_send_email: Mock, guest_event_with_tickets: Event, free_tier: TicketTier
+        self,
+        mock_send_email: Mock,
+        guest_event_with_tickets: Event,
+        free_tier: TicketTier,
+        django_capture_on_commit_callbacks: t.Any,
     ) -> None:
         """Test that initiating ticket purchase twice before confirming works."""
         # First attempt
@@ -214,11 +244,13 @@ class TestGuestDuplicateActions:
             "last_name": "Ticket",
             "tickets": [{"guest_name": "Dup Ticket"}],
         }
-        response1 = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response1 = client.post(url, data=payload, content_type="application/json")
         assert response1.status_code == 200
 
         # Second attempt
-        response2 = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response2 = client.post(url, data=payload, content_type="application/json")
         assert response2.status_code == 200
 
         # Assert: Both attempts succeeded (new tokens generated)
@@ -243,7 +275,9 @@ class TestGuestDuplicateActions:
         data = response2.json()
         assert "blacklist" in data["detail"].lower()
 
-    def test_guest_changes_rsvp_answer(self, guest_event: Event, existing_guest_user: RevelUser) -> None:
+    def test_guest_changes_rsvp_answer(
+        self, guest_event: Event, existing_guest_user: RevelUser, django_capture_on_commit_callbacks: t.Any
+    ) -> None:
         """Test that guest can change RSVP answer by initiating new RSVP."""
         from django.core import mail
 
@@ -255,7 +289,8 @@ class TestGuestDuplicateActions:
             "first_name": existing_guest_user.first_name,
             "last_name": existing_guest_user.last_name,
         }
-        response1 = client.post(url, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response1 = client.post(url, data=payload, content_type="application/json")
         assert response1.status_code == 200
 
         # Extract and confirm first token
@@ -273,7 +308,8 @@ class TestGuestDuplicateActions:
         # Second RSVP: MAYBE (different answer)
         mail.outbox.clear()
         url2 = reverse("api:guest_rsvp", kwargs={"event_id": guest_event.pk, "answer": "maybe"})
-        response2 = client.post(url2, data=payload, content_type="application/json")
+        with django_capture_on_commit_callbacks(execute=True):
+            response2 = client.post(url2, data=payload, content_type="application/json")
         assert response2.status_code == 200
 
         # Extract and confirm second token

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_rsvp.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_rsvp.py
@@ -12,8 +12,15 @@ from events.models import Event, EventRSVP
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGuestRSVP:
-    """Test guest RSVP endpoint."""
+    """Test guest RSVP endpoint.
+
+    Uses ``transaction=True`` because the guest RSVP flow schedules
+    ``send_guest_rsvp_confirmation`` via ``transaction.on_commit``. In default
+    pytest-django mode the wrapping transaction is rolled back and the callback
+    never fires, breaking the ``mock_send_email`` assertions.
+    """
 
     @patch("events.tasks.send_guest_rsvp_confirmation.delay")
     def test_guest_rsvp_success(self, mock_send_email: Mock, guest_event: Event) -> None:

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_seating.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_seating.py
@@ -92,8 +92,15 @@ def random_seat_tier(
     return tier
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGuestCheckoutReservedSeating:
-    """Test reserved seating functionality for guest ticket checkout endpoints."""
+    """Test reserved seating functionality for guest ticket checkout endpoints.
+
+    Uses ``transaction=True`` because the non-online checkout flow schedules
+    ``send_guest_ticket_confirmation`` via ``transaction.on_commit``. In default
+    pytest-django mode the wrapping transaction is rolled back and the callback
+    never fires, breaking the ``mock_send_email`` assertions.
+    """
 
     @patch("events.tasks.send_guest_ticket_confirmation.delay")
     def test_guest_checkout_user_choice_seating_success(

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
@@ -20,8 +20,16 @@ from events.service.event_manager import UserIsIneligibleError
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.django_db(transaction=True)
 class TestGuestServiceLayer:
-    """Test guest service layer functions."""
+    """Test guest service layer functions.
+
+    Uses ``transaction=True`` because ``handle_guest_rsvp`` and the non-online
+    branch of ``handle_guest_ticket_checkout`` schedule the confirmation email
+    via ``transaction.on_commit``. In default pytest-django mode the wrapping
+    transaction is rolled back and the callback never fires, breaking the
+    ``mock_send_email`` assertions.
+    """
 
     def test_get_or_create_guest_user_creates_new(self) -> None:
         """Test creating a new guest user."""

--- a/src/events/tests/test_controllers/test_organization_admin/test_vat_controller.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_vat_controller.py
@@ -463,6 +463,7 @@ class TestSetVatId:
 
         assert response.status_code == 400
 
+    @pytest.mark.django_db(transaction=True)
     @patch("events.tasks.revalidate_single_vat_id_task.delay")
     @patch("common.service.vies_service.validate_and_update_vat_entity")
     def test_vies_unavailable_returns_503(
@@ -476,6 +477,12 @@ class TestSetVatId:
 
         The VAT ID should be persisted in the database with vat_id_validated=False
         so it can be retried later. A background revalidation task is queued.
+
+        Uses ``transaction=True`` because ``set_org_vat_id`` schedules
+        ``revalidate_single_vat_id_task`` via ``transaction.on_commit`` when VIES
+        is unavailable. In default pytest-django mode the wrapping transaction is
+        rolled back and the callback never fires, breaking the
+        ``mock_revalidate_task`` assertion.
         """
         mock_validate.side_effect = VIESUnavailableError("VIES is down")
 

--- a/src/notifications/admin.py
+++ b/src/notifications/admin.py
@@ -1,9 +1,11 @@
 """Django admin for notification models."""
 
+import functools
 import typing as t
 
 from django import forms
 from django.contrib import admin, messages
+from django.db import transaction
 from django.http import HttpRequest, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
@@ -206,7 +208,10 @@ class NotificationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
                 ]
                 created = bulk_create_notifications(notifications_data)
                 batch_ids = [str(n.id) for n in created]
-                dispatch_notifications_batch.delay(batch_ids)
+                # functools.partial binds batch_ids eagerly so each deferred dispatch
+                # gets its own batch (a lambda would capture the loop variable and fire
+                # the last batch repeatedly once the request transaction commits).
+                transaction.on_commit(functools.partial(dispatch_notifications_batch.delay, batch_ids))
                 total_created += len(batch_ids)
 
             messages.success(

--- a/src/notifications/service/notification_helpers.py
+++ b/src/notifications/service/notification_helpers.py
@@ -8,6 +8,7 @@ import typing as t
 from uuid import UUID
 
 import structlog
+from django.db import transaction
 
 from accounts.models import RevelUser
 from common.models import SiteSettings
@@ -319,7 +320,7 @@ def notify_series_events_generated(series: EventSeries, events: list[Event]) -> 
 
     created_notifications = bulk_create_notifications(notifications_data)
     notification_ids = [str(n.id) for n in created_notifications]
-    dispatch_notifications_batch.delay(notification_ids)
+    transaction.on_commit(lambda: dispatch_notifications_batch.delay(notification_ids))
 
     logger.info(
         "series_events_generated_notifications_sent",

--- a/src/notifications/service/signal_handlers.py
+++ b/src/notifications/service/signal_handlers.py
@@ -3,6 +3,7 @@
 import typing as t
 
 import structlog
+from django.db import transaction
 from django.dispatch import receiver
 
 from notifications.service.dispatcher import create_notification
@@ -54,7 +55,7 @@ def handle_notification_request(sender: t.Any, **kwargs: t.Any) -> None:
         # Dispatch async
         from notifications.tasks import dispatch_notification
 
-        dispatch_notification.delay(str(notification.id))
+        transaction.on_commit(lambda: dispatch_notification.delay(str(notification.id)))
 
         logger.info(
             "notification_request_handled",

--- a/src/notifications/signals/invitation.py
+++ b/src/notifications/signals/invitation.py
@@ -22,7 +22,7 @@ def handle_invitation_save(
     sender: type[EventInvitation], instance: EventInvitation, created: bool, **kwargs: t.Any
 ) -> None:
     """Send notifications after invitation is created."""
-    build_attendee_visibility_flags.delay(str(instance.event_id))
+    transaction.on_commit(lambda: build_attendee_visibility_flags.delay(str(instance.event_id)))
     if not created:
         return
 

--- a/src/notifications/signals/rsvp.py
+++ b/src/notifications/signals/rsvp.py
@@ -132,7 +132,7 @@ def handle_event_rsvp_save(sender: type[EventRSVP], instance: EventRSVP, created
     Sends notifications to:
     - Organization staff and owners (NOT the user who RSVPed)
     """
-    build_attendee_visibility_flags.delay(str(instance.event_id))
+    transaction.on_commit(lambda: build_attendee_visibility_flags.delay(str(instance.event_id)))
 
     def send_notifications() -> None:
         if created:
@@ -150,7 +150,7 @@ def handle_event_rsvp_delete(sender: type[EventRSVP], instance: EventRSVP, **kwa
     Sends notifications to:
     - Organization staff and owners (the user already knows they cancelled)
     """
-    build_attendee_visibility_flags.delay(str(instance.event_id))
+    transaction.on_commit(lambda: build_attendee_visibility_flags.delay(str(instance.event_id)))
 
     # Send notifications after transaction commits
     def send_notifications() -> None:

--- a/src/notifications/tests/test_system_announcement.py
+++ b/src/notifications/tests/test_system_announcement.py
@@ -233,8 +233,16 @@ def _use_simple_staticfiles(settings: t.Any) -> None:
     }
 
 
+@pytest.mark.django_db(transaction=True)
 class TestSendSystemAnnouncementAdminView:
-    """Tests for the admin Send System Announcement view."""
+    """Tests for the admin Send System Announcement view.
+
+    Uses ``transaction=True`` because the admin view schedules
+    ``dispatch_notifications_batch.delay`` via ``transaction.on_commit``; in
+    default pytest-django mode the rolled-back transaction suppresses the
+    callback, so ``mock_dispatch.delay`` assertions (called/not-called) would
+    never reflect the real commit-time behaviour.
+    """
 
     def test_get_renders_form(self, admin_client: Client) -> None:
         """GET should render the announcement form for a superuser."""

--- a/src/questionnaires/service/file_service.py
+++ b/src/questionnaires/service/file_service.py
@@ -112,11 +112,13 @@ def upload_questionnaire_file(user: RevelUser, file: UploadedFile) -> Questionna
     if detected_mime_type in IMAGE_MIME_TYPES:
         from common.thumbnails.tasks import generate_thumbnails_task
 
-        generate_thumbnails_task.delay(
-            app="questionnaires",
-            model="questionnairefile",
-            pk=str(questionnaire_file.pk),
-            field="file",
+        transaction.on_commit(
+            lambda: generate_thumbnails_task.delay(
+                app="questionnaires",
+                model="questionnairefile",
+                pk=str(questionnaire_file.pk),
+                field="file",
+            )
         )
 
     return questionnaire_file

--- a/src/questionnaires/tests/test_file_controller.py
+++ b/src/questionnaires/tests/test_file_controller.py
@@ -196,6 +196,7 @@ class TestUploadFile:
         # Assert
         assert response.status_code == 401
 
+    @pytest.mark.django_db(transaction=True)
     @mock.patch("common.utils.tasks.scan_for_malware")
     def test_upload_file_triggers_malware_scan(
         self, mock_scan: mock.MagicMock, user_client: Client, user: RevelUser, png_bytes: bytes
@@ -203,6 +204,10 @@ class TestUploadFile:
         """Test that file upload triggers malware scan task.
 
         Verifies that scan_for_malware.delay() is called with correct parameters.
+
+        Uses ``transaction=True`` because the upload path schedules the scan via
+        ``transaction.on_commit``; in default pytest-django mode the rolled-back
+        transaction suppresses the callback, so ``.delay`` would never be called.
         """
         # Arrange
         url = reverse("api:upload_questionnaire_file")

--- a/src/telegram/service.py
+++ b/src/telegram/service.py
@@ -69,9 +69,11 @@ def connect_accounts(user: RevelUser, otp: str) -> None:
         )
 
     # Send confirmation message to Telegram
-    send_message_task.delay(
-        tg_user.telegram_id,
-        message=f"✅ Account linked successfully!\n\nWelcome to Revel, {user.display_name}!",
+    transaction.on_commit(
+        lambda: send_message_task.delay(
+            tg_user.telegram_id,
+            message=f"✅ Account linked successfully!\n\nWelcome to Revel, {user.display_name}!",
+        )
     )
 
 


### PR DESCRIPTION
## Summary

Completes the audit from #442. With `ATOMIC_REQUESTS=True`, every HTTP request runs in one DB transaction that commits only when the view returns. A bare `.delay()` pushes to the broker **immediately**, so a worker can pick the task up and read a row created in the same request *before* it commits → intermittent `DoesNotExist`. The fix is to defer such dispatches with `transaction.on_commit(...)`.

## Audit result

~69 production `.delay()` sites classified by execution context (HTTP-request vs Celery-task vs bot/management). Most were already wrapped (including a named-closure pattern the issue's grep-based suspect list missed) or are legitimately bare task-to-task chains. **25 HTTP-request-context dispatches** were newly wrapped across `accounts`, `common`, `events`, `notifications`, `questionnaires`, and `telegram`.

## Two subtleties worth a look in review

1. **`register_user` anti-enumeration paths** — it's `@transaction.atomic` and dispatches an activation/verification email *then* `raise HttpError(400)`. The inner savepoint rollback **discards** the `on_commit` callback, so a blanket wrap would silently stop those emails **in production**. Kept bare via `send_verification_email_for_user(defer=False)` / `_send_activation_email_for_guest`; the new-user success path keeps `on_commit`.
2. **VIES 503 retry** looks similar but has **no inner `@transaction.atomic`** — Ninja turns `HttpError(503)` into a *response*, so the request commits and `on_commit` correctly fires (and is the right choice: it stops the retry racing the freshly-set `vat_id`).

The distinguishing rule (inner atomic → rollback discards `on_commit`; none → Ninja response → commit) is documented in `CLAUDE.md`.

Other notes:
- `notifications/admin`: `functools.partial` binds `batch_ids` eagerly inside the loop (a lambda would re-dispatch the last batch).
- `user_preferences`: dispatch in a single `on_commit` closure over a materialized id list (loop-variable capture).

## Tests

- Dispatch-asserting tests marked `@pytest.mark.django_db(transaction=True)` per the #441 precedent.
- Tests that read `mail.outbox` use `django_capture_on_commit_callbacks(execute=True)` instead — `transaction=True` would commit the fixture's event-open notification and pollute the outbox.
- `make check` clean; full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background task dispatching (emails, file scans, notifications) by ensuring tasks only execute after their parent database transactions successfully commit, preventing duplicate or orphaned task execution when operations fail or are rolled back.

* **Documentation**
  * Added guidelines on transaction-safe background task dispatching patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->