### PR TITLE
fix(db): disable server-side cursors under PgBouncer; materialize task IDs (#458)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,35 @@ that transaction. If a worker picks the task up before the request commits, any
   the `django_capture_on_commit_callbacks(execute=True)` fixture or be marked
   `@pytest.mark.django_db(transaction=True)` with a docstring explaining why.
 
+### Server-Side Cursors & Connection Pooling (`.iterator()`)
+
+Production runs **PgBouncer in transaction-pooling mode**, so `DATABASES["default"]`
+sets `DISABLE_SERVER_SIDE_CURSORS = True` whenever `USE_PGBOUNCER` is on (Django's
+documented requirement for that mode). Keep this in mind when iterating querysets:
+
+- **Never combine `QuerySet.iterator()` with a per-row `transaction.atomic()` commit
+  inside the loop.** `.iterator()` opens a PostgreSQL **server-side cursor**; transaction
+  pooling recycles the backend connection at every `COMMIT`, orphaning that cursor, so the
+  next `fetchmany()`/`close()` raises `psycopg.errors.InvalidCursorName`. This is
+  load-/data-dependent (only fires when the loop body runs ≥1 commit) and **cannot be
+  reproduced in tests** (plain Postgres, no pooler, and psycopg3's `WITH HOLD` cursor
+  survives commits on a single backend). It bit `expire_subscriptions_past_grace` and
+  `close_polls_due` — see #458 and `docs/postmortems/0002-server-side-cursor-pgbouncer.md`.
+- **Correct pattern for "snapshot a candidate set, then process each under its own lock":**
+  materialize the IDs with `list(...)`, then loop and re-fetch each row with
+  `select_for_update()` in its own `transaction.atomic()`:
+  ```python
+  ids = list(Model.objects.filter(...).values_list("id", flat=True))
+  for pk in ids:
+      with transaction.atomic():
+          obj = Model.objects.select_for_update().get(pk=pk)
+          ...  # re-check preconditions inside the lock, then save
+  ```
+  IDs are tiny, so `.iterator()` buys no real memory savings here anyway.
+- **`.iterator()` is still fine** for read-only streaming with no mid-loop DB commits
+  (e.g. dispatching Celery tasks per row). Note that with `DISABLE_SERVER_SIDE_CURSORS`
+  it degrades to a client-side fetch-all — for genuinely large streams, batch explicitly.
+
 ### Query Optimization
 - **Prefetch relationships**: Use `select_related()` for foreign keys, `prefetch_related()` for reverse/M2M
 - **Avoid N+1 in schemas**: When ModelSchema includes nested relationships, ensure the queryset prefetches them

--- a/docs/postmortems/0002-server-side-cursor-pgbouncer.md
+++ b/docs/postmortems/0002-server-side-cursor-pgbouncer.md
@@ -1,0 +1,77 @@
+# PM-0002: Server-Side Cursors Orphaned Under PgBouncer Transaction Pooling
+
+## Summary
+
+The daily Celery task `events.expire_subscriptions_past_grace` failed in
+production on two consecutive nights with
+`psycopg.errors.InvalidCursorName: cursor "_django_curs_..." does not exist`.
+The task iterated a queryset with `QuerySet.iterator()` (a PostgreSQL
+server-side cursor) while committing a per-row `transaction.atomic()` inside the
+loop. Under PgBouncer transaction pooling, each commit recycles the backend
+connection and orphans the cursor, so the next fetch crashes. A second task with
+the identical pattern, `polls.tasks.close_polls_due`, was latent and would have
+failed the same way once it had a due poll to process.
+
+## Detection
+
+Surfaced by an ad-hoc sweep of failed Celery tasks (`failed-tasks.sh prod`),
+which showed two `FAILURE` rows for the same task at exactly `04:00:00 UTC`
+(its `celery-beat` slot) on 2026-05-24 and 2026-05-25.
+
+## Timeline
+
+- **2026-05-11** — `expire_subscriptions_past_grace` shipped (#393, subscriptions Phase 1).
+- **2026-05-24 04:00 UTC** — first observed failure.
+- **2026-05-25 04:00 UTC** — second failure; investigated.
+- **2026-05-25** — root cause identified, latent twin (`close_polls_due`, #446) found, fix opened (#458).
+
+## Root Cause
+
+`QuerySet.iterator()` opens a server-side cursor. The task ran it in autocommit
+(no wrapping transaction) and then opened and committed a per-row
+`transaction.atomic()` inside the loop. Production runs PgBouncer in
+`POOL_MODE: transaction` (`DB_USE_PGBOUNCER=True`), which returns the backend
+connection to the pool at every `COMMIT`. The named cursor lived on a
+now-recycled backend, so the subsequent `fetchmany()` / `cursor.close()` routed
+to a different backend and raised `InvalidCursorName`.
+
+It evaded dev/CI because there is no pooler there, and a psycopg3 server-side
+cursor opened in autocommit is `WITH HOLD`, so the mid-loop commit does not
+invalidate it on a single backend. It was data-dependent in production too: the
+crash only occurs once the loop body runs (≥1 row to process), which is why it
+looked transient.
+
+## Impact
+
+The subscription-lifecycle task did not complete on affected nights, so the
+`ACTIVE → PAST_DUE/EXPIRED` and `PAST_DUE → EXPIRED` transitions were cut short.
+Net effect: some lapsed members could retain access past their paid period until
+a subsequent successful run. No data was corrupted; rows committed before each
+crash were durable. `close_polls_due` had not yet failed (no due polls under the
+pooler).
+
+## Resolution
+
+1. **Settings (the fix):** `DISABLE_SERVER_SIDE_CURSORS = True` when
+   `USE_PGBOUNCER` is on (`src/revel/settings/base.py`) — Django's documented
+   requirement for transaction pooling, covering every `.iterator()` callsite.
+2. **Source cleanup:** materialized the candidate IDs with `list(...)` instead of
+   `.iterator()` in `expire_subscriptions_past_grace` and `close_polls_due`. The
+   querysets are `values_list("id", flat=True)`, so streaming saved no real
+   memory while the cursor introduced the fatal incompatibility.
+3. **Guidance:** documented the anti-pattern in `revel-backend/CLAUDE.md`.
+
+## Lessons Learned
+
+- Server-side cursors and per-row commits are incompatible under transaction
+  pooling; the safe pattern is "materialize IDs, then re-fetch each under its own
+  lock."
+- A class of bug that cannot reproduce locally (pooler-only) needs a written rule,
+  not just a test. The fix is therefore primarily a settings guardrail.
+- A failing periodic task should be alerted on, not discovered by an ad-hoc sweep.
+
+## References
+
+- Issue: #458
+- Introduced by: #393 (subscriptions), #446 (polls — latent twin)
+- Django docs: [Transaction pooling and server-side cursors](https://docs.djangoproject.com/en/5.2/ref/databases/#transaction-pooling-and-server-side-cursors)

--- a/docs/postmortems/index.md
+++ b/docs/postmortems/index.md
@@ -55,6 +55,7 @@ Links to issues, PRs, and related resources.
 | PM | Title | Date | Severity |
 |---|---|---|---|
 | [PM-0001](0001-guest-user-verification-bypass.md) | Guest User Verification Bypass | 2026-02-19 | High |
+| [PM-0002](0002-server-side-cursor-pgbouncer.md) | Server-Side Cursors Orphaned Under PgBouncer Transaction Pooling | 2026-05-25 | Medium |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
   - Post-Mortems:
       - postmortems/index.md
       - postmortems/0001-guest-user-verification-bypass.md
+      - postmortems/0002-server-side-cursor-pgbouncer.md
 
 plugins:
   - search

--- a/src/events/tasks.py
+++ b/src/events/tasks.py
@@ -823,11 +823,13 @@ def expire_subscriptions_past_grace() -> SubscriptionExpiryCounters:
     counters: SubscriptionExpiryCounters = {"expired_immediate": 0, "past_due": 0, "expired_after_grace": 0}
 
     # 1 + 2: lapsed ACTIVE → EXPIRED (if cancel_at_period_end) else PAST_DUE.
+    # list(), not .iterator(): a server-side cursor can't survive the per-row
+    # commits below under PgBouncer transaction pooling (see #458).
     active_lapsed_ids = MembershipSubscription.objects.filter(
         status=MembershipSubscription.SubscriptionStatus.ACTIVE,
         current_period_end__lt=now,
     ).values_list("id", flat=True)
-    for sub_id in active_lapsed_ids.iterator():
+    for sub_id in list(active_lapsed_ids):
         with transaction.atomic():
             sub = (
                 MembershipSubscription.objects.select_for_update()
@@ -853,12 +855,12 @@ def expire_subscriptions_past_grace() -> SubscriptionExpiryCounters:
                 sub.save(update_fields=["status", "updated_at"])
                 counters["past_due"] += 1
 
-    # 3: PAST_DUE past grace → EXPIRED.
+    # 3: PAST_DUE past grace → EXPIRED (list() not .iterator(), see #458).
     past_due_ids = MembershipSubscription.objects.filter(
         status=MembershipSubscription.SubscriptionStatus.PAST_DUE,
         current_period_end__isnull=False,
     ).values_list("id", flat=True)
-    for sub_id in past_due_ids.iterator():
+    for sub_id in list(past_due_ids):
         with transaction.atomic():
             sub = (
                 MembershipSubscription.objects.select_for_update()

--- a/src/events/tests/test_subscription_tasks.py
+++ b/src/events/tests/test_subscription_tasks.py
@@ -146,40 +146,42 @@ class TestExpireSubscriptions:
         counters = expire_subscriptions_past_grace()
         assert counters == {"expired_immediate": 0, "past_due": 0, "expired_after_grace": 0}
 
-    @pytest.mark.django_db(transaction=True)
     def test_processes_entire_batch_in_one_run(
         self,
         plan: MembershipSubscriptionPlan,
         django_user_model: type[RevelUser],
-        organization: Organization,
     ) -> None:
         """Regression for #458: every candidate row is processed in a single run.
 
-        Runs with real per-row COMMITs (``transaction=True``) over a multi-row
-        batch spanning all three transitions. The original bug streamed a
-        server-side cursor and crashed once a mid-loop commit recycled the
-        pooled backend, leaving later rows untouched. The pooler-specific
-        ``InvalidCursorName`` cannot be reproduced without PgBouncer — the
-        ``DISABLE_SERVER_SIDE_CURSORS`` settings guardrail covers that — so this
-        asserts the behavioural invariant: the whole batch is transitioned.
+        Builds a multi-row batch spanning all three transitions and asserts the
+        whole batch is handled. The original bug streamed a server-side cursor
+        and crashed once a mid-loop commit recycled the pooled backend, leaving
+        later rows untouched. The pooler-specific ``InvalidCursorName`` cannot be
+        reproduced without PgBouncer — the ``DISABLE_SERVER_SIDE_CURSORS``
+        settings guardrail covers that — so this asserts the behavioural
+        invariant: nothing in the batch is skipped.
+
+        Run time is 2026-05-11; the default grace window is 7 days. ``recent_end``
+        is lapsed but still inside grace (stays PAST_DUE), ``old_end`` is lapsed
+        beyond grace (expires) — keeping the two transitions from cascading.
         """
-        period_end = datetime.datetime(2026, 5, 1, 12, 0, tzinfo=datetime.timezone.utc)
+        recent_end = datetime.datetime(2026, 5, 9, 12, 0, tzinfo=datetime.timezone.utc)
+        old_end = datetime.datetime(2026, 5, 1, 12, 0, tzinfo=datetime.timezone.utc)
 
         def _user(n: int) -> RevelUser:
             return django_user_model.objects.create_user(
                 username=f"batch_user_{n}", email=f"batch{n}@example.com", password="pass"
             )
 
-        to_past_due = [_make_active_sub(plan, _user(i), period_end) for i in range(2)]
-        to_expired_immediate = _make_active_sub(plan, _user(2), period_end, cancel_at_period_end=True)
+        to_past_due = [_make_active_sub(plan, _user(i), recent_end) for i in range(2)]
+        to_expired_immediate = _make_active_sub(plan, _user(2), old_end, cancel_at_period_end=True)
         to_expired_grace = []
         for i in range(3, 5):
-            sub = _make_active_sub(plan, _user(i), period_end)
+            sub = _make_active_sub(plan, _user(i), old_end)
             sub.status = MembershipSubscription.SubscriptionStatus.PAST_DUE
             sub.save()
             to_expired_grace.append(sub)
 
-        # 10 days past period_end, beyond the default 7-day grace.
         with freeze_time("2026-05-11 13:00:00"):
             counters = expire_subscriptions_past_grace()
 

--- a/src/events/tests/test_subscription_tasks.py
+++ b/src/events/tests/test_subscription_tasks.py
@@ -145,3 +145,50 @@ class TestExpireSubscriptions:
         _make_active_sub(plan, subscriber, period_end)
         counters = expire_subscriptions_past_grace()
         assert counters == {"expired_immediate": 0, "past_due": 0, "expired_after_grace": 0}
+
+    @pytest.mark.django_db(transaction=True)
+    def test_processes_entire_batch_in_one_run(
+        self,
+        plan: MembershipSubscriptionPlan,
+        django_user_model: type[RevelUser],
+        organization: Organization,
+    ) -> None:
+        """Regression for #458: every candidate row is processed in a single run.
+
+        Runs with real per-row COMMITs (``transaction=True``) over a multi-row
+        batch spanning all three transitions. The original bug streamed a
+        server-side cursor and crashed once a mid-loop commit recycled the
+        pooled backend, leaving later rows untouched. The pooler-specific
+        ``InvalidCursorName`` cannot be reproduced without PgBouncer — the
+        ``DISABLE_SERVER_SIDE_CURSORS`` settings guardrail covers that — so this
+        asserts the behavioural invariant: the whole batch is transitioned.
+        """
+        period_end = datetime.datetime(2026, 5, 1, 12, 0, tzinfo=datetime.timezone.utc)
+
+        def _user(n: int) -> RevelUser:
+            return django_user_model.objects.create_user(
+                username=f"batch_user_{n}", email=f"batch{n}@example.com", password="pass"
+            )
+
+        to_past_due = [_make_active_sub(plan, _user(i), period_end) for i in range(2)]
+        to_expired_immediate = _make_active_sub(plan, _user(2), period_end, cancel_at_period_end=True)
+        to_expired_grace = []
+        for i in range(3, 5):
+            sub = _make_active_sub(plan, _user(i), period_end)
+            sub.status = MembershipSubscription.SubscriptionStatus.PAST_DUE
+            sub.save()
+            to_expired_grace.append(sub)
+
+        # 10 days past period_end, beyond the default 7-day grace.
+        with freeze_time("2026-05-11 13:00:00"):
+            counters = expire_subscriptions_past_grace()
+
+        assert counters == {"expired_immediate": 1, "past_due": 2, "expired_after_grace": 2}
+        for sub in to_past_due:
+            sub.refresh_from_db()
+            assert sub.status == MembershipSubscription.SubscriptionStatus.PAST_DUE
+        to_expired_immediate.refresh_from_db()
+        assert to_expired_immediate.status == MembershipSubscription.SubscriptionStatus.EXPIRED
+        for sub in to_expired_grace:
+            sub.refresh_from_db()
+            assert sub.status == MembershipSubscription.SubscriptionStatus.EXPIRED

--- a/src/polls/tasks.py
+++ b/src/polls/tasks.py
@@ -11,22 +11,20 @@ from polls.models import Poll
 def close_polls_due() -> int:
     """Close any polls whose ``closes_at`` has elapsed.
 
-    Streams candidate IDs via ``.iterator()`` so the task footprint does not
-    grow with the number of due polls. Each transition is wrapped in its own
+    Snapshots the candidate IDs up front, then processes each in its own
     ``transaction.atomic`` so a slow row does not hold a long-running
-    transaction over the whole batch.
+    transaction over the whole batch. The IDs are materialized (not streamed
+    via ``.iterator()``) because a server-side cursor cannot survive the
+    per-row commits under PgBouncer transaction pooling (see #458); the payload
+    is only IDs, so the memory cost is negligible.
 
     Returns:
         The number of polls that were transitioned from OPEN to CLOSED.
     """
     now = timezone.now()
-    due_ids_qs = (
-        Poll.objects.filter(status=Poll.PollStatus.OPEN, closes_at__lte=now)
-        .values_list("id", flat=True)
-        .iterator(chunk_size=100)
-    )
+    due_ids = list(Poll.objects.filter(status=Poll.PollStatus.OPEN, closes_at__lte=now).values_list("id", flat=True))
     closed = 0
-    for poll_id in due_ids_qs:
+    for poll_id in due_ids:
         with transaction.atomic():
             locked = (
                 Poll.objects.select_for_update()

--- a/src/polls/tests/test_tasks.py
+++ b/src/polls/tests/test_tasks.py
@@ -59,3 +59,35 @@ def test_close_polls_due_is_idempotent(organization: Organization, questionnaire
     close_polls_due()
     poll.refresh_from_db()
     assert poll.closed_at == closed_at_first  # not bumped on the second run
+
+
+@pytest.mark.django_db(transaction=True)
+def test_close_polls_due_processes_entire_batch_in_one_run(organization: Organization) -> None:
+    """Regression for #458: every overdue poll is closed in a single run.
+
+    Runs with real per-row COMMITs (``transaction=True``) over a multi-row
+    batch. The original bug (shared with the subscription-expiry task) streamed
+    a server-side cursor and crashed once a mid-loop commit recycled the pooled
+    backend, leaving later rows untouched. The pooler-specific
+    ``InvalidCursorName`` cannot be reproduced without PgBouncer — the
+    ``DISABLE_SERVER_SIDE_CURSORS`` settings guardrail covers that — so this
+    asserts the behavioural invariant: the whole batch is closed.
+    """
+    polls = [
+        Poll.objects.create(
+            organization=organization,
+            questionnaire=Questionnaire.objects.create(name=f"batch-q-{i}"),
+            vote_visibility=ResourceVisibility.PUBLIC,
+            status=Poll.PollStatus.OPEN,
+            opened_at=timezone.now() - timedelta(hours=2),
+            closes_at=timezone.now() - timedelta(hours=1),
+        )
+        for i in range(5)
+    ]
+
+    closed = close_polls_due()
+
+    assert closed == 5
+    for poll in polls:
+        poll.refresh_from_db()
+        assert poll.status == Poll.PollStatus.CLOSED

--- a/src/polls/tests/test_tasks.py
+++ b/src/polls/tests/test_tasks.py
@@ -61,13 +61,12 @@ def test_close_polls_due_is_idempotent(organization: Organization, questionnaire
     assert poll.closed_at == closed_at_first  # not bumped on the second run
 
 
-@pytest.mark.django_db(transaction=True)
 def test_close_polls_due_processes_entire_batch_in_one_run(organization: Organization) -> None:
     """Regression for #458: every overdue poll is closed in a single run.
 
-    Runs with real per-row COMMITs (``transaction=True``) over a multi-row
-    batch. The original bug (shared with the subscription-expiry task) streamed
-    a server-side cursor and crashed once a mid-loop commit recycled the pooled
+    Builds a multi-row batch of overdue polls and asserts they are all closed.
+    The original bug (shared with the subscription-expiry task) streamed a
+    server-side cursor and crashed once a mid-loop commit recycled the pooled
     backend, leaving later rows untouched. The pooler-specific
     ``InvalidCursorName`` cannot be reproduced without PgBouncer — the
     ``DISABLE_SERVER_SIDE_CURSORS`` settings guardrail covers that — so this

--- a/src/revel/settings/base.py
+++ b/src/revel/settings/base.py
@@ -156,6 +156,11 @@ _postgres_db = {
     "HOST": config("DB_HOST", "localhost"),
     "PORT": config("DB_PORT", "5432"),
     "CONN_MAX_AGE": 0 if USE_PGBOUNCER else config("DB_CONN_MAX_AGE", cast=int, default=60),
+    # PgBouncer transaction-pooling mode recycles the backend connection at every
+    # COMMIT, which orphans PostgreSQL server-side cursors (Django's QuerySet.iterator()).
+    # Django's docs require disabling them in this mode; otherwise a FETCH/CLOSE after a
+    # commit raises InvalidCursorName. See docs/postmortems/0002 and #458.
+    "DISABLE_SERVER_SIDE_CURSORS": USE_PGBOUNCER,
     "ATOMIC_REQUESTS": True,
     "OPTIONS": {
         "connect_timeout": 5,

--- a/src/revel/settings/base.py
+++ b/src/revel/settings/base.py
@@ -159,7 +159,7 @@ _postgres_db = {
     # PgBouncer transaction-pooling mode recycles the backend connection at every
     # COMMIT, which orphans PostgreSQL server-side cursors (Django's QuerySet.iterator()).
     # Django's docs require disabling them in this mode; otherwise a FETCH/CLOSE after a
-    # commit raises InvalidCursorName. See docs/postmortems/0002 and #458.
+    # commit raises InvalidCursorName. See docs/postmortems/0002-server-side-cursor-pgbouncer.md and #458.
     "DISABLE_SERVER_SIDE_CURSORS": USE_PGBOUNCER,
     "ATOMIC_REQUESTS": True,
     "OPTIONS": {


### PR DESCRIPTION
Fixes #458.

## Problem

`events.expire_subscriptions_past_grace` failed nightly in production (2026-05-24 & -25, both at its 04:00 UTC beat slot) with `psycopg.errors.InvalidCursorName: cursor "_django_curs_..." does not exist`.

The task streamed a queryset via `QuerySet.iterator()` (a PostgreSQL **server-side cursor**) while committing a per-row `transaction.atomic()` **inside the loop**. Production runs **PgBouncer in `POOL_MODE: transaction`** (`DB_USE_PGBOUNCER=True`), which returns the backend connection to the pool at every `COMMIT` — orphaning the cursor, so the next `fetchmany()`/`close()` lands on a different backend and raises `InvalidCursorName`.

It looked transient because it only fires when the loop body runs (≥1 row to process), and it never reproduces in dev/CI (no pooler; psycopg3's `WITH HOLD` cursor survives commits on a single backend).

`polls.tasks.close_polls_due` (#446) had the **identical pattern** and is scheduled via beat — a latent twin that would have failed the same way once a poll was due.

## Changes

- **`settings/base.py` — the fix:** `DISABLE_SERVER_SIDE_CURSORS = True` when `USE_PGBOUNCER` is on. Django's documented requirement for transaction pooling; covers every `.iterator()` callsite and is impossible to get wrong in future code.
- **`events/tasks.py`, `polls/tasks.py` — cleanup:** materialize candidate IDs with `list(...)` instead of `.iterator()`. The querysets are `values_list("id", flat=True)`, so streaming saved no real memory while the cursor introduced the incompatibility. (Behavior-preserving; not a correctness fix once the flag is set, but removes the misleading "streaming-that-isn't" once cursors are disabled.)
- **Docs:** new post-mortem `docs/postmortems/0002-server-side-cursor-pgbouncer.md` + index entry, and a CLAUDE.md rule against combining server-side cursors with per-row commits.

## Impact

On affected nights the subscription-lifecycle transitions (`ACTIVE → PAST_DUE/EXPIRED`, `PAST_DUE → EXPIRED`) were cut short, so some lapsed members could retain access past their paid period until a later successful run. No data corruption — rows committed before each crash were durable.

## Heads-up: `telegram.send_broadcast_message_task`

`DISABLE_SERVER_SIDE_CURSORS` turns **all** `.iterator()` into client-side fetch-all. The only callsite streaming a non-trivial payload is `telegram/tasks.py:161` (full `TelegramUser` rows). Its footprint is almost certainly fine, but flagging it — convert to explicit batching if the active-user count ever grows large. Left unchanged here to keep this PR scoped.

## Testing

Existing functional tests already exercise both tasks with ≥1 due row (`events/tests/test_subscription_tasks.py`, `polls/tests/test_tasks.py`) and are the regression guard — the change is behavior-preserving. The cursor failure itself is pooler-only and not reproducible under the rollback test transaction, which is exactly why the primary fix is a settings guardrail rather than a test. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production reliability issue that could orphan server-side cursors and cause subscription expirations and poll closures to fail; background tasks now materialize batches to ensure full processing and per-row commits don't break streaming.

* **Documentation**
  * Added a postmortem of the incident and guidance on server-side cursors & connection-pooling (PgBouncer) best practices.

* **Tests**
  * Added regression tests verifying full-batch processing for subscription expiry and poll closure.

* **Chores**
  * Disabled server-side cursors when using PgBouncer by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->