### PR TITLE
feat(admin): top 10 organizations by user traction on dashboard (closes #457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.59.0] - 2026-05-25
+
 ### Added
+- **Polls**: a new `polls/` app wrapping the questionnaire pipeline with poll-specific concerns (audience, lifecycle, anonymity, result visibility). A `Poll` is 1:1 with a `Questionnaire` and votes are stored as `QuestionnaireSubmission` rows
+  - New `/api/polls/` endpoint group: list, detail, results, create, patch, open, close, reopen, delete, vote, withdraw
+  - New `manage_polls` permission (JSONField-backed, no migration)
+  - `polls.close_polls_due` Celery beat task auto-closes due polls every minute (row-locked to serialize close-vs-vote races)
+- **Top Organizations by Traction**: admin-dashboard leaderboard of the 10 organizations that reached the most distinct users in the last 12 months (an RSVP of yes/maybe **or** an active/checked-in/pending ticket counts; a user is counted once per organization), shown as a horizontal bar chart plus a ranked table linking to each organization's admin page
+
+### Changed
+- Several API errors now return more accurate HTTP statuses: cancelling an already-cancelled ticket returns **409** (was 400), missing billing info returns **422** (was 400), and file-validation errors return **422** (was 400)
+- Contact-form notifications delivered over **Telegram** no longer include the message subject or preview (Telegram chats are not end-to-end encrypted); recipients are prompted to open Revel for the full message. Email and in-app notifications are unchanged
+
+### Fixed
+- Celery tasks dispatched while handling an HTTP request are now deferred to `transaction.on_commit`, eliminating intermittent `DoesNotExist` errors when a worker picked up a task before the request's transaction had committed
+- The nightly `expire_subscriptions_past_grace` task no longer crashes with `InvalidCursorName` under PgBouncer transaction pooling; server-side cursors are disabled when running behind PgBouncer
+
+## [1.58.0] - 2026-05-21
+
+### Added
+- **Advanced Waitlist Management**: configurable, batched, time-limited waitlist offers, opt-in per event via `Event.waitlist_time_window`. When capacity opens, a batch of waitlisted users (FIFO or lottery) is offered spots with an expiry deadline, and those spots are reserved during the window so non-waitlist users can't take them
+  - New `Event` fields: `waitlist_time_window`, `waitlist_batch_size`, `waitlist_cutoff_date`, `waitlist_cutoff_window`, `waitlist_lottery_mode`
+  - New `WaitlistOffer` model with a partial-unique constraint on `(event, user)` for pending offers, plus admin offer-management endpoints
 - `EventUserEligibility.reason_code` — stable machine-readable `ReasonCode` enum mirroring the human-readable `reason` string; clients should switch on `reason_code` instead of matching localized prose
-- `WaitlistOfferSchema.user` now serializes as a nested `MinimalRevelUserSchema` (id, name, email, …) instead of a bare UUID, so admin UIs can render organizers' offers without a follow-up lookup
+- `WaitlistOfferSchema.user` serializes as a nested `MinimalRevelUserSchema` (id, name, email, …) instead of a bare UUID, so admin UIs can render organizers' offers without a follow-up lookup
 
 ### Changed
 - Admin manual-create and reactivate waitlist-offer endpoints accept a payload-provided `expires_at` even when `event.waitlist_time_window` is not configured globally. Previously both endpoints unconditionally returned 400 in that case; they now only 400 when neither the event nor the payload defines an expiry. The endpoints still default to `now + event.waitlist_time_window` when the global window is set and the payload omits `expires_at`.
 
 ### Fixed
 - Waitlist processing no longer cascades into auto-reoffering a user whose offer was just revoked. The processor now excludes users with REVOKED offers in addition to PENDING; admin revoke is a soft-skip until the offer is reactivated or a manual offer is issued. EXPIRED users stay eligible (normal batch-timeout lifecycle).
+
+## [1.57.0] - 2026-05-19
+
+### Added
+- **Reserved slug tokens**: `Organization` creation is rejected when the name slugifies to a reserved token — a hardcoded set of platform-critical entries (`admin`, `api`, `www`, `revel`, …) unioned with a DB-managed `ReservedSlugToken` soft list (seeded with abuse patterns like `demo`, `test`, `foo`) editable from the Django admin. Enforced in `create_organization`; messages localized in EN/IT/DE
 
 ## [1.56.0] - 2026-05-18
 

--- a/src/events/models/__init__.py
+++ b/src/events/models/__init__.py
@@ -24,6 +24,7 @@ from .organization import (
     MembershipTier,
     Organization,
     OrganizationContactMessage,
+    OrgTractionRow,
     OrganizationMember,
     OrganizationMembershipRequest,
     OrganizationStaff,
@@ -78,6 +79,7 @@ __all__ = [
     "OrganizationMembershipRequest",
     "OrganizationStaff",
     "OrganizationToken",
+    "OrgTractionRow",
     "PermissionMap",
     "PermissionsSchema",
     # Event Series

--- a/src/events/models/organization.py
+++ b/src/events/models/organization.py
@@ -1,5 +1,7 @@
 import typing as t
 import uuid
+from collections import Counter
+from datetime import datetime
 from uuid import UUID
 
 from django.conf import settings
@@ -31,6 +33,14 @@ ALLOWED_MEMBERSHIP_REQUEST_METHODS = ["telegram", "email", "webform"]  # kept fo
 
 def _validate_membership_request_methods(value: list[str]) -> None:
     pass  # kept for backwards compatibility
+
+
+class OrgTractionRow(t.NamedTuple):
+    """A single ranked row in the 'top organizations by traction' leaderboard."""
+
+    organization_id: UUID
+    name: str
+    distinct_users: int
 
 
 class OrganizationQuerySet(models.QuerySet["Organization"]):
@@ -137,6 +147,76 @@ class OrganizationQuerySet(models.QuerySet["Organization"]):
         is_owner_or_staff = Q(owner=user) | Q(staff_members=user)
         return qs.exclude(Q(visibility=Organization.Visibility.UNLISTED) & ~is_owner_or_staff)
 
+    def top_by_traction(self, since: datetime, limit: int = 10) -> list[OrgTractionRow]:
+        """Rank organizations by the number of distinct users they reached since ``since``.
+
+        Traction is the count of distinct users who, with an RSVP/ticket
+        ``created_at`` on or after ``since``, engaged with any event belonging to
+        the organization, where "engaged" means either:
+
+        - an :class:`EventRSVP` with status ``yes`` or ``maybe``, **or**
+        - a :class:`Ticket` with status ``active``, ``checked_in`` or ``pending``.
+
+        A user is counted **once per organization** even if they both RSVP'd and
+        bought a ticket: the two ``(organization, user)`` pair sets are combined with
+        a DB-side ``UNION`` (not ``UNION ALL``), so identical pairs are deduplicated
+        in PostgreSQL before they reach Python.
+
+        Name resolution is scoped to ``self``, so calling this on a filtered queryset
+        (e.g. ``Organization.objects.for_user(user)``) restricts the leaderboard to
+        the organizations in that queryset.
+
+        Performance: the ``UNION`` is deduplicated in the DB, but the per-organization
+        count is done in Python via :class:`collections.Counter`. The Counter consumes
+        the cursor lazily, so peak app memory is bounded by the number of distinct
+        organizations (small); the cost that scales with engagement volume is the
+        DB→app transfer of the deduplicated pairs, not memory. This is acceptable for
+        a low-frequency admin dashboard. If the transfer ever becomes a bottleneck,
+        swap the body for a single raw-SQL ``GROUP BY`` over the ``UNION`` subquery —
+        the ``(since, limit)`` signature is the seam, so callers, the dashboard helper,
+        the template and the tests stay unchanged.
+
+        Args:
+            since: Inclusive lower bound on the RSVP/ticket ``created_at``.
+            limit: Maximum number of organizations to return.
+
+        Returns:
+            Up to ``limit`` rows, ranked by ``distinct_users`` descending, ties broken
+            alphabetically (case-insensitive) by organization name. Organizations with
+            zero qualifying users are omitted.
+        """
+        from events.models import EventRSVP, Ticket
+
+        rsvp_pairs = EventRSVP.objects.filter(
+            status__in=[EventRSVP.RsvpStatus.YES, EventRSVP.RsvpStatus.MAYBE],
+            created_at__gte=since,
+        ).values_list("event__organization_id", "user_id")
+        ticket_pairs = Ticket.objects.filter(
+            status__in=[
+                Ticket.TicketStatus.ACTIVE,
+                Ticket.TicketStatus.CHECKED_IN,
+                Ticket.TicketStatus.PENDING,
+            ],
+            created_at__gte=since,
+        ).values_list("event__organization_id", "user_id")
+
+        # UNION (the default, not UNION ALL) deduplicates identical (org, user) rows in
+        # the DB, so a user who both RSVP'd and bought a ticket for the same org is
+        # counted once. Counting per org happens here because Django cannot apply a
+        # GROUP BY on top of a .union() queryset.
+        counts: Counter[UUID] = Counter(org_id for org_id, _user_id in rsvp_pairs.union(ticket_pairs))
+        if not counts:
+            return []
+
+        names: dict[UUID, str] = dict(self.filter(id__in=list(counts)).values_list("id", "name"))
+        rows = [
+            OrgTractionRow(organization_id=org_id, name=names[org_id], distinct_users=count)
+            for org_id, count in counts.items()
+            if org_id in names
+        ]
+        rows.sort(key=lambda row: (-row.distinct_users, row.name.casefold()))
+        return rows[:limit]
+
 
 class OrganizationManager(models.Manager["Organization"]):
     def get_queryset(self) -> OrganizationQuerySet:
@@ -164,6 +244,10 @@ class OrganizationManager(models.Manager["Organization"]):
     def full(self) -> OrganizationQuerySet:
         """Returns a queryset prefetching the full organizations."""
         return self.get_queryset().with_city().with_tags()
+
+    def top_by_traction(self, since: datetime, limit: int = 10) -> list[OrgTractionRow]:
+        """Rank organizations by distinct users reached since ``since`` (see queryset method)."""
+        return self.get_queryset().top_by_traction(since=since, limit=limit)
 
 
 class Organization(

--- a/src/events/models/organization.py
+++ b/src/events/models/organization.py
@@ -164,7 +164,11 @@ class OrganizationQuerySet(models.QuerySet["Organization"]):
 
         Name resolution is scoped to ``self``, so calling this on a filtered queryset
         (e.g. ``Organization.objects.for_user(user)``) restricts the leaderboard to
-        the organizations in that queryset.
+        the organizations in that queryset. Note that the engagement scan itself is
+        global: ``self`` only filters the final org set, so the result is correctly
+        scoped even though the RSVP/ticket pair counts are computed across all
+        organizations (this keeps the all-orgs dashboard path free of a redundant
+        ``organization_id__in`` subquery).
 
         Performance: the ``UNION`` is deduplicated in the DB, but the per-organization
         count is done in Python via :class:`collections.Counter`. The Counter consumes

--- a/src/revel/dashboard.py
+++ b/src/revel/dashboard.py
@@ -3,6 +3,7 @@
 import typing as t
 from datetime import date, timedelta
 
+from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count
 from django.http import HttpRequest
@@ -201,6 +202,39 @@ def _get_notification_health(days: int = 7) -> dict[str, t.Any]:
     }
 
 
+def _get_top_organizations_by_traction(months: int = 12, limit: int = 10) -> dict[str, t.Any]:
+    """Get the top organizations by user traction over a trailing window.
+
+    Traction is the number of distinct users an organization reached via event
+    RSVPs (yes/maybe) or tickets (active/checked_in/pending) — see
+    ``OrganizationQuerySet.top_by_traction`` for the exact metric.
+
+    Args:
+        months: Size of the trailing window in months (default: 12).
+        limit: Maximum number of organizations to include (default: 10).
+
+    Returns:
+        Dictionary with ``labels`` and ``data`` for the bar chart and ``rows``
+        (rank, name, distinct_users, change_url) for the ranked table.
+    """
+    since = timezone.now() - relativedelta(months=months)
+    rows = Organization.objects.top_by_traction(since=since, limit=limit)
+
+    return {
+        "labels": [row.name for row in rows],
+        "data": [row.distinct_users for row in rows],
+        "rows": [
+            {
+                "rank": rank,
+                "name": row.name,
+                "distinct_users": row.distinct_users,
+                "change_url": reverse("admin:events_organization_change", args=[row.organization_id]),
+            }
+            for rank, row in enumerate(rows, start=1)
+        ],
+    }
+
+
 _BANNER_SEVERITY_STYLES: dict[SiteSettings.BannerSeverity, dict[str, str]] = {
     SiteSettings.BannerSeverity.DEBUG: {
         "accent": "bg-gray-400",
@@ -294,6 +328,9 @@ def dashboard_callback(request: HttpRequest, context: dict[str, t.Any]) -> dict[
     # Event analytics
     event_analytics = _get_event_analytics()
 
+    # Top organizations by user traction (last 12 months)
+    top_organizations = _get_top_organizations_by_traction(months=12, limit=10)
+
     # Task health
     task_health = _get_task_health(days=7)
 
@@ -342,6 +379,7 @@ def dashboard_callback(request: HttpRequest, context: dict[str, t.Any]) -> dict[
                 "user_growth": user_growth,
                 "pronoun_distribution": pronoun_distribution,
                 "event_analytics": event_analytics,
+                "top_organizations": top_organizations,
                 "task_health": task_health,
                 "notification_health": notification_health,
             }

--- a/src/revel/dashboard.py
+++ b/src/revel/dashboard.py
@@ -1,7 +1,7 @@
 """Dashboard callback for Django Unfold admin interface."""
 
 import typing as t
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
@@ -18,7 +18,85 @@ from notifications.models import NotificationDelivery
 from telegram.models import TelegramUser
 
 
-def _get_pronoun_distribution() -> dict[str, t.Any]:
+class PronounDistribution(t.TypedDict):
+    """Pie-chart data for the pronoun distribution card."""
+
+    labels: list[str]
+    data: list[int]
+    total: int
+
+
+class UserGrowthData(t.TypedDict):
+    """Line-chart data for the user-growth card."""
+
+    labels: list[str]
+    data: list[int]
+
+
+class RecentTaskFailure(t.TypedDict):
+    """A single recent Celery task failure rendered in the task-health card."""
+
+    task_name: str | None
+    date_done: datetime | None
+    task_id: str
+
+
+class TaskHealth(t.TypedDict):
+    """Celery task-health summary."""
+
+    failed_count: int
+    recent_failures: list[RecentTaskFailure]
+    days: int
+
+
+class RecentNotificationFailure(t.TypedDict):
+    """A single recent notification-delivery failure rendered in the notification-health card."""
+
+    notification_type: str
+    channel: str
+    created_at: datetime
+    error_message: str
+
+
+class NotificationHealth(t.TypedDict):
+    """Notification-delivery health summary."""
+
+    failed_count: int
+    channel_breakdown: dict[str, int]
+    recent_failures: list[RecentNotificationFailure]
+    days: int
+
+
+class MaintenanceBanner(t.TypedDict):
+    """Active maintenance-banner data for the dashboard."""
+
+    message: str
+    severity: SiteSettings.BannerSeverity
+    scheduled_at: datetime | None
+    ends_at: datetime | None
+    accent: str
+    label: str
+    icon: str
+
+
+class TopOrganizationRow(t.TypedDict):
+    """A single ranked row in the top-organizations-by-traction table."""
+
+    rank: int
+    name: str
+    distinct_users: int
+    change_url: str
+
+
+class TopOrganizationsPayload(t.TypedDict):
+    """Chart series and ranked table rows for the top-organizations-by-traction card."""
+
+    labels: list[str]
+    data: list[int]
+    rows: list[TopOrganizationRow]
+
+
+def _get_pronoun_distribution() -> PronounDistribution:
     """Calculate pronoun distribution among users.
 
     Returns:
@@ -47,7 +125,7 @@ def _get_pronoun_distribution() -> dict[str, t.Any]:
     }
 
 
-def _get_user_growth_data(days: int = 30) -> dict[str, t.Any]:
+def _get_user_growth_data(days: int = 30) -> UserGrowthData:
     """Calculate user growth statistics over the specified period.
 
     Args:
@@ -128,7 +206,7 @@ def _get_event_analytics() -> dict[str, t.Any]:
     }
 
 
-def _get_task_health(days: int = 7) -> dict[str, t.Any]:
+def _get_task_health(days: int = 7) -> TaskHealth:
     """Get Celery task health statistics.
 
     Args:
@@ -145,7 +223,7 @@ def _get_task_health(days: int = 7) -> dict[str, t.Any]:
     failed_tasks = TaskResult.objects.filter(status="FAILURE", date_done__gte=cutoff_date).order_by("-date_done")
 
     failed_count = failed_tasks.count()
-    recent_failures = [
+    recent_failures: list[RecentTaskFailure] = [
         {
             "task_name": task.task_name,
             "date_done": task.date_done,
@@ -161,7 +239,7 @@ def _get_task_health(days: int = 7) -> dict[str, t.Any]:
     }
 
 
-def _get_notification_health(days: int = 7) -> dict[str, t.Any]:
+def _get_notification_health(days: int = 7) -> NotificationHealth:
     """Get notification delivery health statistics.
 
     Args:
@@ -184,7 +262,7 @@ def _get_notification_health(days: int = 7) -> dict[str, t.Any]:
     channel_breakdown = {stat["channel"]: stat["count"] for stat in channel_stats}
 
     # Recent failures
-    recent_failures = [
+    recent_failures: list[RecentNotificationFailure] = [
         {
             "notification_type": delivery.notification.notification_type,
             "channel": delivery.channel,
@@ -202,7 +280,7 @@ def _get_notification_health(days: int = 7) -> dict[str, t.Any]:
     }
 
 
-def _get_top_organizations_by_traction(months: int = 12, limit: int = 10) -> dict[str, t.Any]:
+def _get_top_organizations_by_traction(months: int = 12, limit: int = 10) -> TopOrganizationsPayload:
     """Get the top organizations by user traction over a trailing window.
 
     Traction is the number of distinct users an organization reached via event
@@ -220,18 +298,20 @@ def _get_top_organizations_by_traction(months: int = 12, limit: int = 10) -> dic
     since = timezone.now() - relativedelta(months=months)
     rows = Organization.objects.top_by_traction(since=since, limit=limit)
 
+    table_rows: list[TopOrganizationRow] = [
+        {
+            "rank": rank,
+            "name": row.name,
+            "distinct_users": row.distinct_users,
+            "change_url": reverse("admin:events_organization_change", args=[row.organization_id]),
+        }
+        for rank, row in enumerate(rows, start=1)
+    ]
+
     return {
         "labels": [row.name for row in rows],
         "data": [row.distinct_users for row in rows],
-        "rows": [
-            {
-                "rank": rank,
-                "name": row.name,
-                "distinct_users": row.distinct_users,
-                "change_url": reverse("admin:events_organization_change", args=[row.organization_id]),
-            }
-            for rank, row in enumerate(rows, start=1)
-        ],
+        "rows": table_rows,
     }
 
 
@@ -264,7 +344,7 @@ _BANNER_SEVERITY_STYLES: dict[SiteSettings.BannerSeverity, dict[str, str]] = {
 }
 
 
-def _get_maintenance_banner(site_settings: SiteSettings) -> dict[str, t.Any] | None:
+def _get_maintenance_banner(site_settings: SiteSettings) -> MaintenanceBanner | None:
     """Return maintenance banner data if a banner is currently active.
 
     A banner is active when maintenance_message is non-empty and
@@ -287,7 +367,9 @@ def _get_maintenance_banner(site_settings: SiteSettings) -> dict[str, t.Any] | N
         "severity": severity,
         "scheduled_at": site_settings.maintenance_scheduled_at,
         "ends_at": site_settings.maintenance_ends_at,
-        **styles,
+        "accent": styles["accent"],
+        "label": styles["label"],
+        "icon": styles["icon"],
     }
 
 

--- a/src/revel/tests/test_dashboard.py
+++ b/src/revel/tests/test_dashboard.py
@@ -1,0 +1,190 @@
+"""Tests for the Unfold admin dashboard, focused on the traction leaderboard.
+
+The "top organizations by traction" metric is computed by
+``OrganizationQuerySet.top_by_traction`` and shaped for the template by
+``revel.dashboard._get_top_organizations_by_traction``. These tests cover the
+metric's edge cases (cross-source dedup, status filtering, the trailing-window
+cutoff, ranking/limit) and the helper's output contract.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from conftest import RevelUserFactory
+from events.models import Event, EventRSVP, Organization, Ticket, TicketTier
+from revel.dashboard import _get_top_organizations_by_traction
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_org(name: str, owner: RevelUser) -> Organization:
+    return Organization.objects.create(name=name, slug=name.lower().replace(" ", "-"), owner=owner)
+
+
+def _make_event(org: Organization) -> Event:
+    return Event.objects.create(
+        organization=org,
+        name=f"{org.name} Event",
+        slug="event",
+        event_type=Event.EventType.PUBLIC,
+        visibility=Event.Visibility.PUBLIC,
+        max_attendees=100,
+        status=Event.EventStatus.OPEN,
+        start=timezone.now(),
+        requires_ticket=True,
+    )
+
+
+def _rsvp(
+    event: Event,
+    user: RevelUser,
+    status: EventRSVP.RsvpStatus,
+    *,
+    created_at: datetime | None = None,
+) -> EventRSVP:
+    rsvp = EventRSVP.objects.create(event=event, user=user, status=status)
+    if created_at is not None:
+        # created_at is auto_now_add; .update() bypasses it to backdate engagement.
+        EventRSVP.objects.filter(pk=rsvp.pk).update(created_at=created_at)
+    return rsvp
+
+
+def _ticket(
+    event: Event,
+    user: RevelUser,
+    status: Ticket.TicketStatus = Ticket.TicketStatus.ACTIVE,
+    *,
+    created_at: datetime | None = None,
+) -> Ticket:
+    # TicketTier has a unique (event, name) constraint, so each tier needs a distinct name.
+    tier = TicketTier.objects.create(event=event, name=f"GA-{uuid.uuid4().hex[:8]}")
+    ticket = Ticket.objects.create(event=event, user=user, tier=tier, status=status, guest_name="Guest")
+    if created_at is not None:
+        Ticket.objects.filter(pk=ticket.pk).update(created_at=created_at)
+    return ticket
+
+
+def test_user_with_rsvp_and_ticket_for_same_org_counts_once(revel_user_factory: RevelUserFactory) -> None:
+    """A user who both RSVPs and buys a ticket for the same org is a single distinct user."""
+    owner = revel_user_factory()
+    org = _make_org("Solo Org", owner)
+    event = _make_event(org)
+    user = revel_user_factory()
+    _rsvp(event, user, EventRSVP.RsvpStatus.YES)
+    _ticket(event, user, Ticket.TicketStatus.ACTIVE)
+
+    rows = Organization.objects.top_by_traction(since=timezone.now() - relativedelta(months=12))
+
+    assert len(rows) == 1
+    assert rows[0].organization_id == org.id
+    assert rows[0].distinct_users == 1
+
+
+def test_status_filtering_counts_only_qualifying_engagement(revel_user_factory: RevelUserFactory) -> None:
+    """no RSVPs and cancelled tickets are excluded; yes/maybe RSVPs and active/pending/checked_in tickets count."""
+    owner = revel_user_factory()
+
+    # An org whose only engagement is non-qualifying must be omitted entirely.
+    excluded = _make_org("Excluded Org", owner)
+    excluded_event = _make_event(excluded)
+    _rsvp(excluded_event, revel_user_factory(), EventRSVP.RsvpStatus.NO)
+    _ticket(excluded_event, revel_user_factory(), Ticket.TicketStatus.CANCELLED)
+
+    # An org with one distinct user per qualifying status.
+    included = _make_org("Included Org", owner)
+    included_event = _make_event(included)
+    _rsvp(included_event, revel_user_factory(), EventRSVP.RsvpStatus.YES)
+    _rsvp(included_event, revel_user_factory(), EventRSVP.RsvpStatus.MAYBE)
+    _ticket(included_event, revel_user_factory(), Ticket.TicketStatus.ACTIVE)
+    _ticket(included_event, revel_user_factory(), Ticket.TicketStatus.PENDING)
+    _ticket(included_event, revel_user_factory(), Ticket.TicketStatus.CHECKED_IN)
+
+    rows = Organization.objects.top_by_traction(since=timezone.now() - relativedelta(months=12))
+
+    by_name = {row.name: row.distinct_users for row in rows}
+    assert "Excluded Org" not in by_name
+    assert by_name == {"Included Org": 5}
+
+
+def test_trailing_window_cutoff_is_inclusive_lower_bound(revel_user_factory: RevelUserFactory) -> None:
+    """Engagement on/after ``since`` counts; engagement before ``since`` is excluded."""
+    since = timezone.now() - relativedelta(months=12)
+    owner = revel_user_factory()
+    org = _make_org("Boundary Org", owner)
+    event = _make_event(org)
+
+    _rsvp(event, revel_user_factory(), EventRSVP.RsvpStatus.YES, created_at=since)  # exactly on the boundary: in
+    _rsvp(event, revel_user_factory(), EventRSVP.RsvpStatus.YES, created_at=since + timedelta(days=1))  # inside: in
+    _rsvp(event, revel_user_factory(), EventRSVP.RsvpStatus.YES, created_at=since - timedelta(days=1))  # outside: out
+
+    rows = Organization.objects.top_by_traction(since=since)
+
+    assert len(rows) == 1
+    assert rows[0].distinct_users == 2
+
+
+def test_ranks_descending_and_limits_to_top_n(revel_user_factory: RevelUserFactory) -> None:
+    """Organizations are ranked by distinct users descending and capped at ``limit``."""
+    owner = revel_user_factory()
+    # Reuse a shared user pool so each org's distinct-user count is exactly the slice size.
+    pool = [revel_user_factory() for _ in range(12)]
+
+    # "Org 01" reaches 12 users, "Org 02" reaches 11, ... "Org 12" reaches 1.
+    for index in range(1, 13):
+        org = _make_org(f"Org {index:02d}", owner)
+        event = _make_event(org)
+        for user in pool[: 13 - index]:
+            _rsvp(event, user, EventRSVP.RsvpStatus.YES)
+
+    rows = Organization.objects.top_by_traction(since=timezone.now() - relativedelta(months=12), limit=10)
+
+    assert [row.distinct_users for row in rows] == list(range(12, 2, -1))
+    assert [row.name for row in rows] == [f"Org {index:02d}" for index in range(1, 11)]
+
+
+def test_ties_broken_alphabetically_by_name(revel_user_factory: RevelUserFactory) -> None:
+    """Organizations tied on distinct users are ordered alphabetically (case-insensitive)."""
+    owner = revel_user_factory()
+    shared = [revel_user_factory() for _ in range(2)]
+
+    # Created in non-alphabetical order; both reach the same two users.
+    for name in ("beta org", "Alpha Org"):
+        event = _make_event(_make_org(name, owner))
+        for user in shared:
+            _rsvp(event, user, EventRSVP.RsvpStatus.YES)
+
+    rows = Organization.objects.top_by_traction(since=timezone.now() - relativedelta(months=12))
+
+    assert [row.name for row in rows] == ["Alpha Org", "beta org"]
+    assert {row.distinct_users for row in rows} == {2}
+
+
+def test_get_top_organizations_by_traction_output_shape(revel_user_factory: RevelUserFactory) -> None:
+    """The dashboard helper returns chart labels/data and ranked table rows with admin links."""
+    owner = revel_user_factory()
+    org = _make_org("Shapely Org", owner)
+    event = _make_event(org)
+    _rsvp(event, revel_user_factory(), EventRSVP.RsvpStatus.YES)
+
+    result = _get_top_organizations_by_traction(months=12, limit=10)
+
+    assert result["labels"] == ["Shapely Org"]
+    assert result["data"] == [1]
+    assert len(result["rows"]) == 1
+    row = result["rows"][0]
+    assert row["rank"] == 1
+    assert row["name"] == "Shapely Org"
+    assert row["distinct_users"] == 1
+    assert str(org.id) in row["change_url"]
+
+
+def test_get_top_organizations_by_traction_empty(revel_user_factory: RevelUserFactory) -> None:
+    """With no qualifying engagement the helper returns empty chart series and no rows."""
+    result = _get_top_organizations_by_traction(months=12, limit=10)
+
+    assert result == {"labels": [], "data": [], "rows": []}

--- a/src/templates/admin/index.html
+++ b/src/templates/admin/index.html
@@ -198,6 +198,43 @@
             </div>
         </div>
 
+        {# Top Organizations by Traction #}
+        <div class="bg-white dark:bg-base-900 border border-base-200 dark:border-base-800 rounded-lg shadow p-6 mb-8">
+            <h2 class="text-lg font-semibold mb-1 text-gray-800 dark:text-gray-200">Top Organizations by Traction</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Distinct users reached in the last 12 months (RSVP yes/maybe or active ticket)
+            </p>
+            {% if dashboard.top_organizations.rows %}
+                <div class="h-80 mb-6">
+                    <canvas id="orgTractionChart"></canvas>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="text-left text-gray-600 dark:text-gray-400 border-b border-base-200 dark:border-base-700">
+                                <th class="py-2 pr-4 font-semibold">#</th>
+                                <th class="py-2 pr-4 font-semibold">Organization</th>
+                                <th class="py-2 font-semibold text-right">Distinct users</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for org in dashboard.top_organizations.rows %}
+                                <tr class="border-b border-base-100 dark:border-base-800">
+                                    <td class="py-2 pr-4 text-gray-500 dark:text-gray-400">{{ org.rank }}</td>
+                                    <td class="py-2 pr-4">
+                                        <a href="{{ org.change_url }}" class="text-primary-600 dark:text-primary-500 hover:underline">{{ org.name }}</a>
+                                    </td>
+                                    <td class="py-2 text-right font-semibold text-gray-900 dark:text-gray-100">{{ org.distinct_users }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-gray-600 dark:text-gray-400">No organization traction data available</p>
+            {% endif %}
+        </div>
+
         {# System Health #}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
             {# Failed Tasks #}
@@ -292,6 +329,7 @@
     {# Safe JSON serialization for chart data #}
     {{ dashboard.user_growth|json_script:"user-growth-data" }}
     {{ dashboard.pronoun_distribution|json_script:"pronoun-distribution-data" }}
+    {{ dashboard.top_organizations|json_script:"org-traction-data" }}
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // User Growth Line Chart
@@ -372,6 +410,39 @@
                                         return `${context.label}: ${context.raw} (${percentage}%)`;
                                     }
                                 }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // Top Organizations by Traction Horizontal Bar Chart
+            const orgTractionCtx = document.getElementById('orgTractionChart');
+            if (orgTractionCtx) {
+                const orgTractionData = JSON.parse(document.getElementById('org-traction-data').textContent);
+                new Chart(orgTractionCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: orgTractionData.labels,
+                        datasets: [{
+                            label: 'Distinct users',
+                            data: orgTractionData.data,
+                            backgroundColor: 'rgba(59, 130, 246, 0.6)',
+                            borderColor: '#3b82f6',
+                            borderWidth: 1
+                        }]
+                    },
+                    options: {
+                        indexAxis: 'y',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: { display: false }
+                        },
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                ticks: { stepSize: 1 }
                             }
                         }
                     }

--- a/src/templates/admin/index.html
+++ b/src/templates/admin/index.html
@@ -202,7 +202,7 @@
         <div class="bg-white dark:bg-base-900 border border-base-200 dark:border-base-800 rounded-lg shadow p-6 mb-8">
             <h2 class="text-lg font-semibold mb-1 text-gray-800 dark:text-gray-200">Top Organizations by Traction</h2>
             <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                Distinct users reached in the last 12 months (RSVP yes/maybe or active ticket)
+                Distinct users reached in the last 12 months (RSVP yes/maybe, or an active, checked-in or pending ticket)
             </p>
             {% if dashboard.top_organizations.rows %}
                 <div class="h-80 mb-6">


### PR DESCRIPTION
## Summary

Adds a **Top Organizations by Traction** leaderboard to the Unfold admin dashboard, ranking the 10 organizations that reached the most distinct users in the last 12 months.

**Traction** = count of **distinct users** who, with an RSVP/ticket `created_at` in the last 12 months, engaged with any of the organization's events — where "engaged" means either an `EventRSVP` with status `yes`/`maybe`, **or** a `Ticket` with status `active`/`checked_in`/`pending`. A user is counted **once per organization**: the RSVP-side and ticket-side `(org, user)` pair sets are `UNION`'d so PostgreSQL deduplicates them before counting. Ranked descending, top 10, ties broken alphabetically (case-insensitive); orgs with zero qualifying users are omitted.

Closes #457.

## Changes

- **`events/models/organization.py`** — `OrganizationQuerySet.top_by_traction(since, limit=10)` + manager delegate, and an `OrgTractionRow` `NamedTuple` (exported from `events.models`). The `UNION` dedupes `(org, user)` pairs in the DB; the per-org count is done with `collections.Counter` (Django can't `GROUP BY` over a `.union()`). Org names are resolved through `self`, so calling it on a filtered queryset scopes the leaderboard. The docstring documents the ORM-vs-raw-SQL scale tradeoff and that `(since, limit)` is the seam for a future swap.
- **`revel/dashboard.py`** — `_get_top_organizations_by_traction(months=12, limit=10)` returning `{labels, data, rows}`, merged into `context["dashboard"]`.
- **`templates/admin/index.html`** — new card with a horizontal Chart.js bar chart (mirroring the `userGrowthChart` `json_script` pattern) plus a ranked table (Rank · Org link to `admin:events_organization_change` · distinct users) and an empty-state fallback.
- **`revel/tests/test_dashboard.py`** *(new)* — cross-source dedup, status filtering, the inclusive 12-month cutoff boundary, ranking/limit, alphabetical tie-break, and the helper's output shape.

## Release & changelog

This PR also **reconciles `CHANGELOG.md`**, which was behind:

- Backfills the **1.57.0** (reserved slug tokens) and **1.58.0** (advanced waitlist management + eligibility `reason_code`) sections — both released but never promoted from `[Unreleased]`.
- Adds the upcoming **1.59.0** section: polls, this traction dashboard, the exception→HTTP-status remap, the Telegram contact-content strip, and the `on_commit` / server-side-cursor reliability fixes.

**No version bump in this PR.** `main` is already at `1.59.0` (the polls PR bumped it) but `1.59.0` was never tagged/released, so the next release reuses it rather than skipping to 1.60.0. After this merges, releasing tags **v1.59.0** = polls + fixes + traction.

## Design note

The metric is computed via the ORM (`UNION` + `Counter`) rather than raw SQL — consistent with the codebase's 100%-ORM business layer. App memory stays bounded by org count; the only cost that scales with engagement volume is the DB→app transfer of deduplicated pairs, acceptable for a low-frequency admin page. If that ever becomes a bottleneck, the body can be swapped for a single raw-SQL `GROUP BY` over the `UNION` subquery without touching callers, the template, or the tests.

## Testing

`make test` — full suite green (4941 passed); the 7 new dashboard tests pass. `make check` clean (ruff, mypy --strict, no missing migrations). No schema migration (`OrgTractionRow` is a `NamedTuple`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Top Organizations by Traction" card to the admin dashboard: a horizontal bar chart and ranked table showing organizations' distinct-user engagement (RSVPs and ticket activity) over the trailing 12 months, with linked organization names and proper tie-breaking and limits.

* **Tests**
  * Added comprehensive tests for deduplication, status filtering, inclusive time-window cutoff, ranking/limits, tie-breaking, and output shape/empty-state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->