### PR TITLE
fix(notifications): register SERIES_EVENTS_GENERATED template (closes #461)

### DIFF
--- a/src/notifications/apps.py
+++ b/src/notifications/apps.py
@@ -24,6 +24,7 @@ class NotificationsConfig(AppConfig):
         import notifications.service.templates.potluck_templates  # noqa: F401
         import notifications.service.templates.questionnaire_templates  # noqa: F401
         import notifications.service.templates.rsvp_templates  # noqa: F401
+        import notifications.service.templates.series_templates  # noqa: F401
         import notifications.service.templates.system_templates  # noqa: F401
         import notifications.service.templates.ticket_templates  # noqa: F401
         import notifications.service.templates.waitlist_templates  # noqa: F401

--- a/src/notifications/service/templates/series_templates.py
+++ b/src/notifications/service/templates/series_templates.py
@@ -1,0 +1,42 @@
+"""Templates for event-series notifications."""
+
+from django.utils.translation import ngettext
+
+from notifications.enums import NotificationType
+from notifications.models import Notification
+from notifications.service.templates.base import NotificationTemplate
+from notifications.service.templates.registry import register_template
+
+
+class SeriesEventsGeneratedTemplate(NotificationTemplate):
+    """Template for SERIES_EVENTS_GENERATED digest (to series audience).
+
+    Sent when recurring events are materialized for an :class:`EventSeries`.
+    The body templates live under ``notifications/{in_app,email,telegram}/
+    series_events_generated.*`` and are rendered by the base class; this class
+    only supplies the in-app title and email subject.
+    """
+
+    def get_in_app_title(self, notification: Notification) -> str:
+        """Get title for in-app display."""
+        series_name = notification.context.get("event_series_name", "a series")
+        count = notification.context.get("events_count", 0)
+        return ngettext(
+            "%(count)d new event scheduled for %(series)s",
+            "%(count)d new events scheduled for %(series)s",
+            count,
+        ) % {"count": count, "series": series_name}
+
+    def get_email_subject(self, notification: Notification) -> str:
+        """Get email subject."""
+        series_name = notification.context.get("event_series_name", "a series")
+        count = notification.context.get("events_count", 0)
+        return ngettext(
+            "New event scheduled for %(series)s",
+            "%(count)d new events scheduled for %(series)s",
+            count,
+        ) % {"count": count, "series": series_name}
+
+
+# Register templates
+register_template(NotificationType.SERIES_EVENTS_GENERATED, SeriesEventsGeneratedTemplate())

--- a/src/notifications/tests/test_series_templates.py
+++ b/src/notifications/tests/test_series_templates.py
@@ -1,0 +1,118 @@
+"""Tests for the SERIES_EVENTS_GENERATED notification template.
+
+Regression coverage for #461: the digest sent when recurring events are
+materialized had Django body templates but no registered ``NotificationTemplate``
+subclass, so email/Telegram delivery raised ``ValueError`` at ``get_template``.
+"""
+
+import typing as t
+
+import pytest
+
+from accounts.models import RevelUser
+from notifications.context_schemas import NOTIFICATION_CONTEXT_SCHEMAS
+from notifications.enums import NotificationType
+from notifications.models import Notification
+from notifications.service.templates.registry import (
+    get_template,
+    is_template_registered,
+)
+from notifications.service.templates.series_templates import SeriesEventsGeneratedTemplate
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def digest_user(django_user_model: type[RevelUser]) -> RevelUser:
+    """A user to receive the series digest."""
+    return django_user_model.objects.create_user(
+        username="digest@example.com",
+        email="digest@example.com",
+        password="password",
+        first_name="Di",
+        last_name="Gest",
+    )
+
+
+def _make_notification(user: RevelUser, *, events_count: int) -> Notification:
+    """Build a SERIES_EVENTS_GENERATED notification with a valid context."""
+    context: dict[str, t.Any] = {
+        "organization_id": "org-id",
+        "organization_name": "Acme Org",
+        "event_series_id": "series-id",
+        "event_series_name": "Weekly Standup",
+        "events_count": events_count,
+        "series_url": "https://example.com/org/acme/series/weekly-standup",
+    }
+    return Notification.objects.create(
+        user=user,
+        notification_type=NotificationType.SERIES_EVENTS_GENERATED,
+        context=context,
+    )
+
+
+class TestSeriesEventsGeneratedTemplate:
+    """The template must produce a title/subject and render every channel."""
+
+    def test_template_is_registered(self) -> None:
+        """The fix for #461: the type must resolve to the template instance."""
+        assert is_template_registered(NotificationType.SERIES_EVENTS_GENERATED)
+        assert isinstance(
+            get_template(NotificationType.SERIES_EVENTS_GENERATED),
+            SeriesEventsGeneratedTemplate,
+        )
+
+    def test_in_app_title_singular(self, digest_user: RevelUser) -> None:
+        """Singular count uses singular phrasing and names the series."""
+        notification = _make_notification(digest_user, events_count=1)
+        title = SeriesEventsGeneratedTemplate().get_in_app_title(notification)
+        assert "1 new event scheduled" in title
+        assert "Weekly Standup" in title
+
+    def test_in_app_title_plural(self, digest_user: RevelUser) -> None:
+        """Plural count uses plural phrasing and the number."""
+        notification = _make_notification(digest_user, events_count=3)
+        title = SeriesEventsGeneratedTemplate().get_in_app_title(notification)
+        assert "3 new events scheduled" in title
+        assert "Weekly Standup" in title
+
+    def test_email_subject_singular(self, digest_user: RevelUser) -> None:
+        """Singular subject names the series."""
+        notification = _make_notification(digest_user, events_count=1)
+        subject = SeriesEventsGeneratedTemplate().get_email_subject(notification)
+        assert "Weekly Standup" in subject
+
+    def test_email_subject_plural(self, digest_user: RevelUser) -> None:
+        """Plural subject includes the count."""
+        notification = _make_notification(digest_user, events_count=5)
+        subject = SeriesEventsGeneratedTemplate().get_email_subject(notification)
+        assert "5 new events" in subject
+        assert "Weekly Standup" in subject
+
+    def test_all_channels_render(self, digest_user: RevelUser) -> None:
+        """Every channel body renders without raising (the delivery path)."""
+        notification = _make_notification(digest_user, events_count=2)
+        template = SeriesEventsGeneratedTemplate()
+
+        in_app_body = template.get_in_app_body(notification)
+        email_text = template.get_email_text_body(notification)
+        email_html = template.get_email_html_body(notification)
+        telegram_body = template.get_telegram_body(notification)
+
+        for body in (in_app_body, email_text, email_html, telegram_body):
+            assert body
+            assert "Weekly Standup" in body
+        # The series URL must survive into the user-facing bodies.
+        assert notification.context["series_url"] in in_app_body
+        assert notification.context["series_url"] in email_text
+
+
+def test_every_context_schema_has_a_registered_template() -> None:
+    """Guardrail (#461): a context schema without a template fails delivery.
+
+    Every ``NotificationType`` that ships a context schema is deliverable, so it
+    must also have a registered template. This would have caught the missing
+    SERIES_EVENTS_GENERATED template at CI time.
+    """
+    missing = sorted(nt.value for nt in NOTIFICATION_CONTEXT_SCHEMAS if not is_template_registered(nt))
+    assert not missing, f"NotificationTypes with a context schema but no registered template: {missing}"

--- a/src/notifications/tests/test_series_templates.py
+++ b/src/notifications/tests/test_series_templates.py
@@ -5,12 +5,10 @@ materialized had Django body templates but no registered ``NotificationTemplate`
 subclass, so email/Telegram delivery raised ``ValueError`` at ``get_template``.
 """
 
-import typing as t
-
 import pytest
 
 from accounts.models import RevelUser
-from notifications.context_schemas import NOTIFICATION_CONTEXT_SCHEMAS
+from notifications.context_schemas import NOTIFICATION_CONTEXT_SCHEMAS, SeriesEventsGeneratedContext
 from notifications.enums import NotificationType
 from notifications.models import Notification
 from notifications.service.templates.registry import (
@@ -36,7 +34,7 @@ def digest_user(django_user_model: type[RevelUser]) -> RevelUser:
 
 def _make_notification(user: RevelUser, *, events_count: int) -> Notification:
     """Build a SERIES_EVENTS_GENERATED notification with a valid context."""
-    context: dict[str, t.Any] = {
+    context: SeriesEventsGeneratedContext = {
         "organization_id": "org-id",
         "organization_name": "Acme Org",
         "event_series_id": "series-id",


### PR DESCRIPTION
## Summary

Fixes #461. The `series_events_generated` digest (sent when recurring events are materialized) crashed on delivery because **no `NotificationTemplate` was registered** for `NotificationType.SERIES_EVENTS_GENERATED`, even though it had an enum value, a context schema, and a producer.

On inspection, all four Django body templates (`in_app` / `email` `.txt`+`.html` / `telegram`) **already existed and were well-formed** — the only missing piece was the Python `NotificationTemplate` subclass and its registration. So `get_template(...)` raised `ValueError`:

- **Email** ❌ hard failure → delivery marked `FAILED`
- **Telegram** ⚠️ degraded generic formatting (fallback)
- **In-app** ✅ unaffected (doesn't use templates)

## Changes

- **`series_templates.py`** (new) — `SeriesEventsGeneratedTemplate` supplying `get_in_app_title` + `get_email_subject` (the base class renders the existing body templates). Uses `ngettext` so the title/subject pluralize consistently with the bodies.
- **`apps.py`** — import the new module in `ready()` so the template registers at startup.
- **`test_series_templates.py`** (new) — title/subject (singular + plural), end-to-end rendering of all four channels (the delivery path that was crashing), plus the **guardrail** the issue suggested: `test_every_context_schema_has_a_registered_template` asserts every `NotificationType` with a registered context schema also has a registered template. Verified `SERIES_EVENTS_GENERATED` was the only gap.

## Notes

- New `series_templates.py` rather than appending to `follow_templates.py` — matches the per-domain template-file layout and the enum's dedicated "Series notifications" section.
- `make check` is green (ruff, mypy --strict, migrations, i18n, file-length).

Introduced in: #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added series-events notification support with proper singular/plural wording for in-app titles and email subjects; content also rendered for email, in-app, and Telegram channels.

* **Tests**
  * Added comprehensive tests for the series-events notification template, including singular/plural checks, multi-channel rendering, and a guardrail ensuring every notification context has a registered template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letsrevel/revel-backend/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->