### PR TITLE
fix(events): repair event-cancelled notification + gate cancellation reason to attendees

### DIFF
--- a/src/events/models/event.py
+++ b/src/events/models/event.py
@@ -510,6 +510,38 @@ class Event(
 
         return False
 
+    def can_user_see_cancellation_reason(self, user: RevelUser | AnonymousUser) -> bool:
+        """Whether the user may see this event's cancellation reason.
+
+        The reason is addressed to people who were actually going to attend, so
+        it is limited to ticket holders and confirmed RSVPs — plus the event's
+        own staff/owners and superusers. This mirrors the ATTENDEES_ONLY tier of
+        :meth:`can_user_see_address`; a merely-invited or anonymous user does not
+        qualify.
+
+        Args:
+            user: The user to check access for.
+
+        Returns:
+            True if the user may see the cancellation reason, False otherwise.
+        """
+        from .rsvp import EventRSVP
+        from .ticket import Ticket
+
+        if user.is_superuser or user.is_staff:
+            return True
+        if user.is_anonymous:
+            return False
+        if self.organization.owner_id == user.id:
+            return True
+        # Use .all() to leverage prefetched data when available (from with_organization()).
+        if any(m.id == user.id for m in self.organization.staff_members.all()):
+            return True
+
+        has_ticket = Ticket.objects.filter(user=user, event=self).exclude(status=Ticket.TicketStatus.CANCELLED).exists()
+        has_rsvp = EventRSVP.objects.filter(user=user, event=self, status=EventRSVP.RsvpStatus.YES).exists()
+        return has_ticket or has_rsvp
+
     def attendees(self, viewer: RevelUser) -> models.QuerySet[RevelUser]:
         """Return attendees based on who wants to see them."""
         from .rsvp import EventRSVP

--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -123,13 +123,22 @@ class EventBaseSchema(TaggableSchemaMixin, LogoCoverArtThumbnailMixin):
     cancellation_reason: str | None = None
 
     @staticmethod
-    def resolve_cancellation_reason(obj: "Event") -> str | None:
-        """Surface the organizer's cancellation reason, normalizing empty to None.
+    def resolve_cancellation_reason(obj: "Event", context: t.Any) -> str | None:
+        """Surface the organizer's cancellation reason to attendees only.
 
         The DB stores an empty string by default; the API contract prefers
-        ``null`` so the frontend only renders the reason when one was set.
+        ``null`` so the frontend only renders the reason when one was set. The
+        reason is only disclosed to users who were actually attending (ticket or
+        confirmed RSVP) plus the event's staff/owners — mirroring address
+        visibility. Empty reasons short-circuit before any access query, so the
+        common non-cancelled list case incurs no extra lookups.
         """
-        return obj.cancellation_reason or None
+        if not obj.cancellation_reason:
+            return None
+        user = context["request"].user
+        if obj.can_user_see_cancellation_reason(user):
+            return obj.cancellation_reason
+        return None
 
     @staticmethod
     def resolve_is_bookmarked(obj: "Event", context: t.Any) -> bool:

--- a/src/events/tests/test_controllers/test_event_public/test_cancellation_reason_visibility.py
+++ b/src/events/tests/test_controllers/test_event_public/test_cancellation_reason_visibility.py
@@ -1,25 +1,13 @@
 """Tests that the event detail endpoint only discloses cancellation_reason to attendees."""
 
-import typing as t
-
 import pytest
 from django.test.client import Client
 from django.urls import reverse
-from ninja_jwt.tokens import RefreshToken
 
 from accounts.models import RevelUser
 from events.models import Event, EventRSVP
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def user_client(revel_user_factory: t.Any) -> tuple[Client, RevelUser]:
-    """Authenticated client for a user with no organization relationships."""
-    user = revel_user_factory()
-    refresh = RefreshToken.for_user(user)
-    client = Client(HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}")  # type: ignore[attr-defined]
-    return client, user
 
 
 @pytest.fixture
@@ -31,26 +19,24 @@ def cancelled_public_event(public_event: Event) -> Event:
     return public_event
 
 
-def test_non_attending_user_does_not_see_reason(
-    user_client: tuple[Client, RevelUser], cancelled_public_event: Event
-) -> None:
+def test_non_attending_user_does_not_see_reason(nonmember_client: Client, cancelled_public_event: Event) -> None:
     """A user with no ticket/RSVP gets null even though the reason is set."""
-    client, _ = user_client
     url = reverse("api:get_event", kwargs={"event_id": str(cancelled_public_event.id)})
 
-    response = client.get(url)
+    response = nonmember_client.get(url)
 
     assert response.status_code == 200
     assert response.json()["cancellation_reason"] is None
 
 
-def test_attending_user_sees_reason(user_client: tuple[Client, RevelUser], cancelled_public_event: Event) -> None:
+def test_attending_user_sees_reason(
+    nonmember_client: Client, nonmember_user: RevelUser, cancelled_public_event: Event
+) -> None:
     """A user with a confirmed RSVP sees the cancellation reason."""
-    client, user = user_client
-    EventRSVP.objects.create(user=user, event=cancelled_public_event, status=EventRSVP.RsvpStatus.YES)
+    EventRSVP.objects.create(user=nonmember_user, event=cancelled_public_event, status=EventRSVP.RsvpStatus.YES)
     url = reverse("api:get_event", kwargs={"event_id": str(cancelled_public_event.id)})
 
-    response = client.get(url)
+    response = nonmember_client.get(url)
 
     assert response.status_code == 200
     assert response.json()["cancellation_reason"] == "Venue flooded"

--- a/src/events/tests/test_controllers/test_event_public/test_cancellation_reason_visibility.py
+++ b/src/events/tests/test_controllers/test_event_public/test_cancellation_reason_visibility.py
@@ -1,0 +1,56 @@
+"""Tests that the event detail endpoint only discloses cancellation_reason to attendees."""
+
+import typing as t
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+from ninja_jwt.tokens import RefreshToken
+
+from accounts.models import RevelUser
+from events.models import Event, EventRSVP
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user_client(revel_user_factory: t.Any) -> tuple[Client, RevelUser]:
+    """Authenticated client for a user with no organization relationships."""
+    user = revel_user_factory()
+    refresh = RefreshToken.for_user(user)
+    client = Client(HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}")  # type: ignore[attr-defined]
+    return client, user
+
+
+@pytest.fixture
+def cancelled_public_event(public_event: Event) -> Event:
+    """The shared public event, cancelled with a reason."""
+    public_event.status = Event.EventStatus.CANCELLED
+    public_event.cancellation_reason = "Venue flooded"
+    public_event.save(update_fields=["status", "cancellation_reason"])
+    return public_event
+
+
+def test_non_attending_user_does_not_see_reason(
+    user_client: tuple[Client, RevelUser], cancelled_public_event: Event
+) -> None:
+    """A user with no ticket/RSVP gets null even though the reason is set."""
+    client, _ = user_client
+    url = reverse("api:get_event", kwargs={"event_id": str(cancelled_public_event.id)})
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json()["cancellation_reason"] is None
+
+
+def test_attending_user_sees_reason(user_client: tuple[Client, RevelUser], cancelled_public_event: Event) -> None:
+    """A user with a confirmed RSVP sees the cancellation reason."""
+    client, user = user_client
+    EventRSVP.objects.create(user=user, event=cancelled_public_event, status=EventRSVP.RsvpStatus.YES)
+    url = reverse("api:get_event", kwargs={"event_id": str(cancelled_public_event.id)})
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json()["cancellation_reason"] == "Venue flooded"

--- a/src/events/tests/test_models/test_models.py
+++ b/src/events/tests/test_models/test_models.py
@@ -803,3 +803,94 @@ class TestCanUserSeeAddress:
             event_with_address.address_visibility = visibility
             event_with_address.save()
             assert event_with_address.can_user_see_address(organization_staff_user) is True, f"Failed for {visibility}"
+
+
+# --- Tests for Event.can_user_see_cancellation_reason ---
+
+
+class TestCanUserSeeCancellationReason:
+    """Tests for the Event.can_user_see_cancellation_reason() method."""
+
+    @pytest.fixture
+    def cancelled_event(self, organization: Organization) -> Event:
+        """A cancelled event carrying a reason."""
+        return Event.objects.create(
+            organization=organization,
+            name="Cancelled Event",
+            start=timezone.now(),
+            status=Event.EventStatus.CANCELLED,
+            cancellation_reason="Venue flooded",
+        )
+
+    @pytest.fixture
+    def ticket_tier(self, cancelled_event: Event) -> TicketTier:
+        return TicketTier.objects.create(event=cancelled_event, name="General")
+
+    @pytest.mark.django_db
+    def test_anonymous_cannot_see(self, cancelled_event: Event) -> None:
+        from django.contrib.auth.models import AnonymousUser
+
+        assert cancelled_event.can_user_see_cancellation_reason(AnonymousUser()) is False
+
+    @pytest.mark.django_db
+    def test_unrelated_user_cannot_see(self, cancelled_event: Event, nonmember_user: RevelUser) -> None:
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is False
+
+    @pytest.mark.django_db
+    def test_invited_only_user_cannot_see(
+        self, cancelled_event: Event, nonmember_user: RevelUser, ticket_tier: TicketTier
+    ) -> None:
+        """A merely-invited user (no ticket/RSVP) does NOT qualify — unlike PRIVATE address."""
+        invitation = EventInvitation.objects.create(user=nonmember_user, event=cancelled_event)
+        invitation.tiers.add(ticket_tier)
+
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is False
+
+    @pytest.mark.django_db
+    def test_ticket_holder_can_see(
+        self, cancelled_event: Event, nonmember_user: RevelUser, ticket_tier: TicketTier
+    ) -> None:
+        Ticket.objects.create(guest_name="Guest", user=nonmember_user, event=cancelled_event, tier=ticket_tier)
+
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is True
+
+    @pytest.mark.django_db
+    def test_cancelled_ticket_holder_cannot_see(
+        self, cancelled_event: Event, nonmember_user: RevelUser, ticket_tier: TicketTier
+    ) -> None:
+        Ticket.objects.create(
+            guest_name="Guest",
+            user=nonmember_user,
+            event=cancelled_event,
+            tier=ticket_tier,
+            status=Ticket.TicketStatus.CANCELLED,
+        )
+
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is False
+
+    @pytest.mark.django_db
+    def test_rsvp_yes_can_see(self, cancelled_event: Event, nonmember_user: RevelUser) -> None:
+        EventRSVP.objects.create(user=nonmember_user, event=cancelled_event, status=EventRSVP.RsvpStatus.YES)
+
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is True
+
+    @pytest.mark.django_db
+    def test_rsvp_no_cannot_see(self, cancelled_event: Event, nonmember_user: RevelUser) -> None:
+        EventRSVP.objects.create(user=nonmember_user, event=cancelled_event, status=EventRSVP.RsvpStatus.NO)
+
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is False
+
+    @pytest.mark.django_db
+    def test_owner_can_see(self, cancelled_event: Event, organization_owner_user: RevelUser) -> None:
+        assert cancelled_event.can_user_see_cancellation_reason(organization_owner_user) is True
+
+    @pytest.mark.django_db
+    def test_staff_member_can_see(
+        self, cancelled_event: Event, organization_staff_user: RevelUser, staff_member: OrganizationStaff
+    ) -> None:
+        assert cancelled_event.can_user_see_cancellation_reason(organization_staff_user) is True
+
+    @pytest.mark.django_db
+    def test_superuser_can_see(self, cancelled_event: Event, nonmember_user: RevelUser) -> None:
+        nonmember_user.is_superuser = True
+        assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is True

--- a/src/notifications/signals/event.py
+++ b/src/notifications/signals/event.py
@@ -39,22 +39,25 @@ def _handle_event_cancelled(sender: type[Event], instance: Event) -> None:
         # Format event details in event's timezone
         event_start_formatted = format_event_datetime(instance.start, instance)
 
-        # Prepare refund info if tickets are required
-        refund_info = None
-        if instance.requires_ticket:
-            refund_info = "Refunds will be processed according to the organizer's refund policy."
+        # Prepare refund info if tickets are required. ``refund_available`` is a
+        # required key on EventCancelledContext, so it must always be present.
+        refund_available = instance.requires_ticket
+        refund_info = (
+            "Refunds will be processed according to the organizer's refund policy." if refund_available else None
+        )
 
         for user in eligible_users:
             # Check address visibility per user
             event_location, address_url = _get_event_location_for_user(instance, user)
 
-            context = {
+            context: dict[str, t.Any] = {
                 "event_id": str(instance.id),
                 "event_name": instance.name,
                 "event_start": instance.start.isoformat() if instance.start else "",
                 "event_start_formatted": event_start_formatted,
                 "event_location": event_location,
                 "event_url": f"{frontend_base_url}/events/{instance.id}",
+                "refund_available": refund_available,
             }
 
             # Add optional fields

--- a/src/notifications/tests/test_signals.py
+++ b/src/notifications/tests/test_signals.py
@@ -10,7 +10,7 @@ from django.db import transaction
 from accounts.models import RevelUser
 from events.models import Payment, Ticket, TicketTier
 from notifications.enums import DeliveryChannel, NotificationType
-from notifications.models import NotificationPreference
+from notifications.models import Notification, NotificationPreference
 from telegram.models import TelegramUser
 from telegram.signals import telegram_account_linked, telegram_account_unlinked
 
@@ -310,3 +310,37 @@ class TestEventCancelledNotificationReason:
         contexts = [call.kwargs["context"] for call in send_mock.call_args_list]
         assert contexts, "expected at least one cancellation notification"
         assert all("cancellation_reason" not in c for c in contexts), contexts
+
+    def test_built_context_satisfies_schema_and_creates_notification(
+        self,
+        public_event: t.Any,
+        user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Regression: the cancellation context must satisfy EventCancelledContext.
+
+        ``refund_available`` is a required key on the schema. The signal previously
+        omitted it, so every cancellation notification failed validation inside
+        ``create_notification`` and was silently swallowed by the request handler.
+        This drives the real ``notification_requested`` -> ``create_notification``
+        -> ``validate_notification_context`` path and asserts a row is created.
+        """
+        from notifications.signals import event as event_signals
+
+        public_event.requires_ticket = True
+        public_event.cancellation_reason = "Venue flooded"
+
+        with (
+            patch.object(
+                event_signals, "get_eligible_users_for_event_notification", return_value=self._build_eligible(user)
+            ),
+            patch.object(event_signals, "_get_event_location_for_user", return_value=("Somewhere", None)),
+            # Avoid actually dispatching; we only care that the row validates + persists.
+            patch("notifications.tasks.dispatch_notification.delay"),
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            event_signals._handle_event_cancelled(type(public_event), public_event)
+
+        notifications = Notification.objects.filter(user=user, notification_type=NotificationType.EVENT_CANCELLED)
+        assert notifications.count() == 1, "context failed schema validation and was swallowed"
+        assert notifications.get().context["refund_available"] is True


### PR DESCRIPTION
## Summary

Two related fixes around event cancellation, surfaced by an e2e smoke test of the #470 feature.

### 1. Event-cancellation notifications were silently never delivered 🐛

`EventCancelledContext` declares `refund_available: bool` as **required**, but `_handle_event_cancelled` only ever set `refund_info` — never `refund_available`. So `create_notification` → `validate_notification_context` raised `ValueError: Missing required context keys ... {'refund_available'}`, which `handle_notification_request` catches and swallows by design. Net effect: **no event-cancellation notification (in-app / email / telegram) was ever created.**

This is a latent pre-existing bug (not introduced by #470) — the #470 signal tests mocked `notification_requested.send`, so they never exercised the validator.

**Fix:** populate `refund_available` (= `event.requires_ticket`, consistent with how `refund_info` is gated) + a regression test that drives the real `notification_requested → create_notification → validate_notification_context` path and asserts a `Notification` row is actually persisted.

### 2. `cancellation_reason` is now disclosed only to attendees 🔒

The reason is addressed to people who were going to attend, so it shouldn't be readable by every user who can see the event. Added `Event.can_user_see_cancellation_reason()` mirroring the **ATTENDEES tier** of `can_user_see_address` (ticket holders + confirmed `YES` RSVPs, plus staff/owners and superusers; a merely-invited or anonymous user does **not** qualify), and gated `EventBaseSchema.resolve_cancellation_reason` on it.

Empty reasons short-circuit **before** any access query, so the common non-cancelled list case (this field lives on `EventBaseSchema`, used by list views) incurs zero extra lookups.

## Tests
- `TestEventCancelledNotificationReason::test_built_context_satisfies_schema_and_creates_notification` — real-path regression guard for the crash.
- `TestCanUserSeeCancellationReason` (10 cases) — anonymous / unrelated / invited-only / ticket / cancelled-ticket / RSVP yes / RSVP no / owner / staff / superuser.
- `test_cancellation_reason_visibility.py` — endpoint-level: non-attending authenticated user gets `null`, attending (RSVP yes) sees the reason.

Relevant suite run locally: **89 passed**. `make check` green (ruff, mypy --strict, migrations, i18n, file-length).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted visibility of event cancellation reasons to attendees and event staff only. Non-attendees will no longer see cancellation reasons.
  * Enhanced cancelled event notifications with refund availability information.

* **Tests**
  * Added tests validating cancellation reason visibility permissions and notification context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->