### PR TITLE
feat(accounts): manual referral CRUD in admin + dep CVE patches (#473)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This document provides guidelines for contributing to the project to ensure a sm
 
 There are several ways you can contribute to the project:
 
-*   **Reporting Bugs:** If you find a bug, please check our [GitHub Issues](https://github.com/biagiodistefano/revel/issues) to see if it has already been reported. If not, please open a new issue.
+*   **Reporting Bugs:** If you find a bug, please check our [GitHub Issues](https://github.com/biagiodistefano/revel/issues) to see if it has already been reported. If not, please open a new issue. **Found a security vulnerability? Do not open a public issue** — see [Reporting Security Vulnerabilities](#reporting-security-vulnerabilities) below.
 *   **Suggesting Enhancements:** If you have an idea for a new feature or an improvement to an existing one, open an issue to start a discussion.
 *   **Writing Code:** If you're ready to contribute code, you can pick an existing issue or propose a new one.
 
@@ -62,6 +62,17 @@ Consistency is key. We follow these standards to maintain a clean and readable c
     *   Use string forward references for type hints where necessary (e.g., `-> 'MyModel'`).
 *   **Docstrings:** Use Google-style docstrings for all public modules, classes, functions, and methods.
 *   **Internationalization (i18n):** All user-facing strings must be wrapped with Django's translation utilities. See [i18n.md](i18n.md) for detailed guidelines on adding translatable strings and supporting new languages.
+
+## Reporting Security Vulnerabilities
+
+Please **do not** report security issues through public GitHub issues or pull
+requests. Instead, use GitHub's private vulnerability reporting via the
+repository's **Security** tab →
+**[Report a vulnerability](https://github.com/letsrevel/revel-backend/security/advisories/new)**.
+
+For our full security posture — CI controls, scheduled audits, the CVE
+suppression policy, and what to include in a report — see
+**[SECURITY.md](SECURITY.md)**.
 
 ## Issue Tracking
 

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,24 @@ licensecheck:
 #       `pip-audit` itself (via `pip-api`) — self-referential audit failure.
 #       We never run `pip install` against attacker-controlled archives.
 #       Revisit when a fixed pip release ships.
+#   CVE-2026-34993 / CVE-2026-47265 (aiohttp): fixed in 3.14.0, but unreachable
+#       — `aiogram` pins `aiohttp<3.14` (still true on the latest aiogram
+#       3.28.2), so the resolver caps us at 3.13.x. aiohttp is transitive only
+#       (via `aiogram` → Telegram Bot API, and `instructor` → LLM APIs), used
+#       purely as an HTTP client; we run no aiohttp server. Both advisories are
+#       client-side: 34993 needs `CookieJar.load()` on an attacker-controlled
+#       file (local vector, we never call it); 47265 leaks per-request `cookies=`
+#       across a cross-origin redirect (we set no per-request cookies and only
+#       call fixed, trusted endpoints). Drop when aiogram relaxes the cap.
+#       Tracked privately: GHSA-326c-3pr9-53pf (34993), GHSA-68j9-fg24-qc3g (47265).
 .PHONY: audit
 audit:
 	@uv export --quiet --locked --format requirements-txt --no-emit-project --no-hashes --group dev -o .audit-reqs.txt
 	@trap 'rm -f .audit-reqs.txt' EXIT; uv run pip-audit --strict --no-deps --disable-pip -r .audit-reqs.txt \
 		--ignore-vuln CVE-2025-69872 \
-		--ignore-vuln CVE-2026-3219
+		--ignore-vuln CVE-2026-3219 \
+		--ignore-vuln CVE-2026-34993 \
+		--ignore-vuln CVE-2026-47265
 
 .PHONY: deps-check
 deps-check: licensecheck audit

--- a/Makefile
+++ b/Makefile
@@ -71,15 +71,7 @@ licensecheck:
 #       (LLM client lib). Attack requires write access to the local cache
 #       directory; if an attacker already has that level of filesystem access
 #       on our backend host, they have much larger problems. Revisit when a
-#       diskcache release ships a fix.
-#   CVE-2026-3219 (pip): no fix published as of pip 26.0.1. pip handles
-#       polyglot tar+ZIP archives as ZIP regardless of filename, which could
-#       install "incorrect" files. Not exploitable here: production runs
-#       `uv sync` against `uv.lock` with hash-verified PyPI artefacts, and
-#       pip is only present in the locked graph as a transitive dep of
-#       `pip-audit` itself (via `pip-api`) — self-referential audit failure.
-#       We never run `pip install` against attacker-controlled archives.
-#       Revisit when a fixed pip release ships.
+#       diskcache release ships a fix. Tracked privately: GHSA-mcv5-9q6c-vg2g.
 #   CVE-2026-34993 / CVE-2026-47265 (aiohttp): fixed in 3.14.0, but unreachable
 #       — `aiogram` pins `aiohttp<3.14` (still true on the latest aiogram
 #       3.28.2), so the resolver caps us at 3.13.x. aiohttp is transitive only
@@ -95,7 +87,6 @@ audit:
 	@uv export --quiet --locked --format requirements-txt --no-emit-project --no-hashes --group dev -o .audit-reqs.txt
 	@trap 'rm -f .audit-reqs.txt' EXIT; uv run pip-audit --strict --no-deps --disable-pip -r .audit-reqs.txt \
 		--ignore-vuln CVE-2025-69872 \
-		--ignore-vuln CVE-2026-3219 \
 		--ignore-vuln CVE-2026-34993 \
 		--ignore-vuln CVE-2026-47265
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,19 @@ This is currently heavily WIP.
 
 ---
 
+## 🔒 Security
+
+We run layered, mostly-automated security controls — SAST (bandit), dependency
+CVE scanning (`pip-audit`) and license checks, strict typing, a 90%
+branch-coverage gate, a nightly dependency audit, and periodic OWASP ZAP scans.
+See **[SECURITY.md](SECURITY.md)** for the full posture.
+
+**Found a vulnerability?** Please report it privately via
+**[Report a vulnerability](https://github.com/letsrevel/revel-backend/security/advisories/new)** —
+do not open a public issue.
+
+---
+
 ## 📜 License
 
 This project is licensed under the MIT license. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,91 @@
+# Security Policy
+
+Revel is an event-management and ticketing platform that handles personal data,
+payments, and access control. We take security seriously and run layered,
+mostly-automated controls in CI and on a schedule. This document describes that
+posture and how to report a vulnerability.
+
+## Reporting a vulnerability
+
+**Please report security issues privately — do not open a public issue or PR.**
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the **Security** tab of this repository →
+   **[Report a vulnerability](https://github.com/letsrevel/revel-backend/security/advisories/new)**.
+2. Describe the issue: affected endpoint/component, impact, and reproduction
+   steps or a proof of concept. Include the commit/version if known.
+3. We'll acknowledge within a few business days, work with you privately on a
+   fix, and credit you in the published advisory unless you prefer otherwise.
+
+This opens a **private draft security advisory** visible only to maintainers —
+the report is never exposed publicly until we publish a coordinated advisory.
+
+Please give us reasonable time to remediate before any public disclosure, and
+avoid privacy violations, data destruction, or service degradation while
+testing.
+
+## What's in CI
+
+Every pull request and push runs through these gates (see `.github/workflows/`):
+
+| Control | Tool | Workflow | Trigger |
+|---|---|---|---|
+| **SAST** (static analysis of Python) | `bandit -ll -ii` | `bandit.yaml` | push/PR touching `src/**/*.py` or deps |
+| **Dependency CVE scan** | `pip-audit --strict` (via `make audit`) | `deps.yaml` | push/PR touching `pyproject.toml`, `uv.lock`, `Makefile` |
+| **License compliance** (blocks copyleft / source-available licenses) | `licensecheck` | `deps.yaml` | same as above |
+| **Strict type checking** | `mypy --strict --extra-checks --warn-unreachable` | `test.yaml` | every push/PR |
+| **Lint & format** | `ruff` | `test.yaml` | every push/PR |
+| **Migration & i18n integrity** | `manage.py makemigrations --check`, i18n compile check | `test.yaml` | every push/PR |
+| **Test suite** | `pytest` with **90% branch-coverage gate** (4 shards) | `test.yaml` | every push/PR |
+
+Type strictness and the coverage gate are part of our security posture: they
+keep the auth, permission, and payment paths from regressing silently.
+
+## Scheduled jobs
+
+- **Nightly dependency audit** (`nightly-audit.yml`, `03:17 UTC`) re-runs
+  `pip-audit` and `licensecheck` against `main`, so newly-disclosed advisories
+  surface within ~24h even without a PR. On failure it opens — or bumps — a
+  tracking issue labelled `security` / `dependencies`.
+- **Periodic DAST** — we run [OWASP ZAP](https://www.zaproxy.org/) passive
+  baseline scans against the public (unauthenticated) frontend pages from the
+  separate `pentesting/` repository. These are safe to run against production
+  and surface header, cookie, and information-disclosure regressions.
+
+## AI-assisted security review
+
+The repository ships an adversarial, agent-based review harness under
+`.claude/` (run by maintainers during development, not in CI):
+
+- **`/vuln-scan`** — fans out region-scoped hunters across the codebase in
+  parallel, then runs an independent verification pass to adjudicate each
+  candidate finding and filter false positives.
+- **`vuln-analyst`** — the hunter agent; an adversarial application-security
+  reviewer specialized in this Django/Django-Ninja, multi-tenant, Celery
+  stack. Can also be invoked standalone for an ad-hoc review of a specific
+  endpoint, service, or app.
+- **`vuln-verifier`** — re-reads each candidate finding independently and
+  returns a verdict with a confidence score before anything is reported.
+
+## Dependency CVE suppression policy
+
+When `pip-audit` flags a CVE we cannot immediately fix, we follow the triage in
+[`docs/runbooks/dependency-audit.md`](docs/runbooks/dependency-audit.md):
+
+- **Bump** whenever a fixed version is reachable within our constraints
+  (preferred).
+- **Suppress** only when the advisory is withdrawn, not exploitable in our
+  context, or has no reachable fix. Each suppression lives in the `audit` target
+  of the `Makefile` with an inline rationale, is **tracked privately as a draft
+  GitHub security advisory**, and is **re-reviewed quarterly**.
+
+Suppressing a CVE never hides it: the rationale and the exit condition (what has
+to change to drop the suppression) are recorded alongside the `--ignore-vuln`
+flag and in the linked advisory.
+
+## Supported versions
+
+Revel is deployed as a continuously-released service; security fixes land on
+`main` and are deployed from there. There is no extended support for older
+tags — please report issues against the current `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.0"
+version = "1.62.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/admin/referral.py
+++ b/src/accounts/admin/referral.py
@@ -53,7 +53,11 @@ class ReferralCodeAdmin(ModelAdmin):  # type: ignore[misc]
 
 @admin.register(Referral)
 class ReferralAdmin(ModelAdmin):  # type: ignore[misc]
-    """Admin for Referral model (system-created only, fully readonly)."""
+    """Admin for Referral model (full CRUD for manual sales-rep attribution).
+
+    ``referrer`` is auto-derived from ``referral_code.user`` in ``Referral.save()``,
+    so the form only exposes ``referral_code``, ``referred_user`` and the share %.
+    """
 
     list_display = ["referrer", "referred_user", "revenue_share_percent", "created_at"]
     list_filter = ["created_at"]
@@ -64,11 +68,9 @@ class ReferralAdmin(ModelAdmin):  # type: ignore[misc]
         "referred_user__email",
         "referral_code__code",
     ]
+    autocomplete_fields = ["referral_code", "referred_user"]
     readonly_fields = [
-        "referral_code",
         "referrer",
-        "referred_user",
-        "revenue_share_percent",
         "created_at",
         "updated_at",
     ]
@@ -97,18 +99,6 @@ class ReferralAdmin(ModelAdmin):  # type: ignore[misc]
             },
         ),
     ]
-
-    def has_add_permission(self, request: t.Any) -> bool:
-        """Referrals are created by the system during registration."""
-        return False
-
-    def has_change_permission(self, request: t.Any, obj: t.Any = None) -> bool:
-        """Referrals are immutable."""
-        return False
-
-    def has_delete_permission(self, request: t.Any, obj: t.Any = None) -> bool:
-        """Referrals must not be deleted to preserve the audit trail."""
-        return False
 
 
 @admin.register(ReferralPayout)

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.0"
+version = "1.62.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },

--- a/uv.lock
+++ b/uv.lock
@@ -771,16 +771,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
 ]
 
 [[package]]
@@ -2981,11 +2981,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -3397,11 +3397,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Two bundled changes:

### 1. Manual referral CRUD in the admin
Sales reps sometimes close a referral win where the referred user never used the referrer's link. This enables full add/edit/delete on the `Referral` admin so attribution can be recorded by hand.

- Drop the `has_add`/`has_change`/`has_delete` permission locks on `ReferralAdmin`
- Make `referral_code`, `referred_user`, and `revenue_share_percent` editable (`referrer` stays readonly — it is auto-derived from `referral_code.user` in `Referral.save()`)
- Add autocomplete for `referral_code` and `referred_user`
- Version bump `1.62.0` → `1.62.1` (via `uv version --bump patch`)

Data integrity is unchanged: the `referred_user` OneToOne blocks double-referrals (clean form error), the no-self-referral check constraint holds at the DB level, and `on_delete=PROTECT` blocks deleting a referral that already has payouts.

### 2. Dependency CVE patches — closes #473
Nightly `pip-audit` (#473) flagged CVEs across four packages. Bumped the three with a reachable fix:

| Package | From | To | Advisories |
|---|---|---|---|
| django | 5.2.14 | 5.2.15 | PYSEC-2026-197..201 (stays on 5.2 LTS) |
| pyjwt | 2.12.1 | 2.13.0 | PYSEC-2026-175,177,178,179 |
| pip | 26.1.1 | 26.1.2 | PYSEC-2026-196 |

aiohttp's fix (3.14.0) is **unreachable**: `aiogram` pins `aiohttp<3.14` (still true on the latest aiogram 3.28.2). aiohttp is transitive and client-only in our tree (aiogram → Telegram API, instructor → LLM APIs); we run no aiohttp server and neither client-side trigger applies. `CVE-2026-34993` and `CVE-2026-47265` are therefore suppressed in the `audit` target with rationale (re-review quarterly), and tracked privately via draft security advisories.

`make audit` now reports **"No known vulnerabilities found"**. Declared deps in `pyproject.toml` are untouched — all bumps are transitive in `uv.lock`.

## Test plan
- [ ] `make test`
- [ ] `make deps-check`
- [ ] Manually create a referral in the admin; confirm `referrer` auto-fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral admin panel now supports full create, read, update, and delete operations for referral management (previously read-only).

* **Chores**
  * Version bumped to 1.62.1.
  * Updated security vulnerability checks for project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->