### PR TITLE
docs(changelog): backfill 1.62.0 and add pending 1.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.62.1] - 2026-06-08
+
+### Added
+- Referral admin now supports full create / edit / delete, so staff can manually record a referral win when the referred user never used the referrer's link. `referrer` stays auto-derived from the referral code; double-referrals and referrals that already have payouts remain protected.
+
+### Security
+- Patched dependency CVEs: Django `5.2.14` → `5.2.15` (stays on the 5.2 LTS line), PyJWT `2.12.1` → `2.13.0`, and pip `26.1.1` → `26.1.2`.
+
+## [1.62.0] - 2026-06-02
+
+### Added
+- **Event Cancellation Reason**: organizers can attach an optional reason when cancelling an event
+  - Accepted on `POST /actions/update-status/{status}` (up to 1000 chars) only when transitioning to `cancelled`; automatically cleared when un-cancelling so a stale reason can't resurface on a later re-cancel
+  - Included in the `EVENT_CANCELLED` notification (in-app / email / Telegram) and returned on event list + detail responses
+  - Readable only by attendees — ticket holders, confirmed `YES` RSVPs, and event staff/owners; merely-invited or anonymous users receive `null`
+
+### Changed
+- German (`de`) translations refreshed — standardized colon gendering and harmonized terminology
+
+### Fixed
+- Event-cancellation notifications were never delivered: a missing `refund_available` context key caused the validator to silently reject every `EVENT_CANCELLED` notification (in-app / email / Telegram). They now send correctly, including refund availability.
+
 ## [1.61.0] - 2026-05-28
 
 ### Added


### PR DESCRIPTION
## Summary

Reconciles `CHANGELOG.md` against shipped tags — it was two versions behind (stopped at 1.61.0 while `v1.62.0` is tagged and `pyproject.toml` is bumped to `1.62.1`).

### `[1.62.0] - 2026-06-02` (backfill — tagged but missing)
- **Added** — Event Cancellation Reason: optional reason on `POST /actions/update-status/{status}` when cancelling, cleared on un-cancel, surfaced in the `EVENT_CANCELLED` notification and event list/detail, readable only by attendees (combines #471 + the #472 gating into the net shipped behavior).
- **Changed** — German translation refresh (#469).
- **Fixed** — `EVENT_CANCELLED` notifications were silently dropped by the validator (missing `refund_available`); now delivered (#472).

### `[1.62.1] - 2026-06-08` (pending release — pyproject already bumped, #474 merged)
- **Added** — manual referral CRUD in the admin.
- **Security** — Django `5.2.14` → `5.2.15`, PyJWT `2.12.1` → `2.13.0`, pip `26.1.1` → `26.1.2` CVE patches (unreachable aiohttp CVEs intentionally suppressed, so omitted).

Dates are tag/commit dates, not edit date. `[Unreleased]` left empty for future work. No `pyproject.toml` or tag changes.

> Note: 1.62.1 is dated **2026-06-08** (bump commit date) since it isn't tagged yet — adjust to the actual tag date if released on a different day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral admin capability for complete create, edit, and delete permissions with protection measures
  * Optional Event Cancellation Reason feature with notification support and attendee visibility rules

* **Bug Fixes**
  * Fixed missing event cancellation notifications

* **Chores**
  * Security dependency updates for Django, PyJWT, and pip

<!-- end of auto-generated comment: release notes by coderabbit.ai -->