### PR TITLE
fix(notifications): point event-series links to public /events route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.62.2] - 2026-06-09
+
+### Fixed
+- Event-series notification links pointed at the admin route (`/org/{slug}/series/{slug}`) instead of the public page (`/events/{slug}/series/{slug}`), producing dead links in the "series followed" (staff) and "series events generated" (follower) notifications. They now resolve to the correct public series URL.
+
 ## [1.62.1] - 2026-06-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.1"
+version = "1.62.2"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/service/follow_service.py
+++ b/src/events/service/follow_service.py
@@ -286,7 +286,7 @@ def _send_series_follow_notification(user: RevelUser, event_series: EventSeries)
                     "follower_id": str(user.id),
                     "follower_name": user.display_name,
                     "follower_email": user.email,
-                    "frontend_url": f"{frontend_base_url}/org/{organization.slug}/series/{event_series.slug}",
+                    "frontend_url": f"{frontend_base_url}/events/{organization.slug}/series/{event_series.slug}",
                 },
             )
 

--- a/src/notifications/service/notification_helpers.py
+++ b/src/notifications/service/notification_helpers.py
@@ -292,7 +292,7 @@ def notify_series_events_generated(series: EventSeries, events: list[Event]) -> 
     visibility = template.visibility
     organization = series.organization
     frontend_base_url = SiteSettings.get_solo().frontend_base_url
-    series_url = f"{frontend_base_url}/org/{organization.slug}/series/{series.slug}"
+    series_url = f"{frontend_base_url}/events/{organization.slug}/series/{series.slug}"
 
     context: dict[str, t.Any] = {
         "organization_id": str(organization.id),

--- a/src/notifications/tests/test_series_templates.py
+++ b/src/notifications/tests/test_series_templates.py
@@ -40,7 +40,7 @@ def _make_notification(user: RevelUser, *, events_count: int) -> Notification:
         "event_series_id": "series-id",
         "event_series_name": "Weekly Standup",
         "events_count": events_count,
-        "series_url": "https://example.com/org/acme/series/weekly-standup",
+        "series_url": "https://example.com/events/acme/series/weekly-standup",
     }
     return Notification.objects.create(
         user=user,

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.1"
+version = "1.62.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary

A user reported that a notification linked to an event series at `https://letsrevel.io/org/{slug}/series/{slug}`, which 404s. The public frontend serves series pages at `/events/{org_slug}/series/{series_slug}`; the `/org/{slug}/...` prefix is the admin/auth area and has **no** public `series` route.

Two backend URL builders used the wrong prefix:

- `events/service/follow_service.py` — `frontend_url` in the **EVENT_SERIES_FOLLOWED** notification (staff)
- `notifications/service/notification_helpers.py` — `series_url` in the **SERIES_EVENTS_GENERATED** digest (followers)

Both now build `/events/{slug}/series/{slug}`.

## Scope check

Swept every `frontend_base_url` URL builder. Plain org links (`/org/{slug}`) are correct — that public route exists. Series links were the only ones pointing at a non-existent public route.

## Changes

- Fix the two series URLs
- Update a misleading fixture value in `test_series_templates.py` (only checks the URL renders into the body; no construction assertion was wrong)
- Bump patch `1.62.1` → `1.62.2` (via `uv version --bump patch`) + CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification links for event series that were incorrectly routing to admin pages, ensuring followers and staff receive working links to the public event series page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->