### PR TITLE
fix(thumbnails): skip non-image files in generate_thumbnails backfill

### DIFF
--- a/src/common/management/commands/generate_thumbnails.py
+++ b/src/common/management/commands/generate_thumbnails.py
@@ -180,6 +180,12 @@ class Command(BaseCommand):
         # Filter instances that have a source file (ImageField uses isnull and empty string check)
         queryset = manager.exclude(**{f"{field_name}__isnull": True}).exclude(**{field_name: ""})
 
+        # For mixed-content fields (e.g. QuestionnaireFile.file), skip non-image
+        # files up front so we don't enqueue tasks that can only ever fail with
+        # "cannot identify image file".
+        if config.mime_type_field and config.mime_type_allowlist is not None:
+            queryset = queryset.filter(**{f"{config.mime_type_field}__in": config.mime_type_allowlist})
+
         if not force:
             thumbnail_field_names = get_thumbnail_field_names(config)
             if thumbnail_field_names:

--- a/src/common/thumbnails/config.py
+++ b/src/common/thumbnails/config.py
@@ -6,6 +6,22 @@ thumbnail generation. Configuration is centralized here for easy maintenance.
 
 from dataclasses import dataclass
 
+# MIME types that Pillow can actually rasterize into a thumbnail.
+# Used to skip non-image files (audio/video/documents) that may live in the
+# same model/field as images (e.g. QuestionnaireFile.file). Mirrors the image
+# subset of questionnaires.schema; SVG is intentionally excluded (Pillow can't
+# rasterize it and it carries an XSS risk).
+THUMBNAILABLE_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "image/bmp",
+        "image/tiff",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ThumbnailSpec:
@@ -31,12 +47,21 @@ class ModelThumbnailConfig:
         model_name: Model name in lowercase (e.g., "organization", "reveluser").
         source_field: Name of the source image field (e.g., "logo", "profile_picture").
         specs: Tuple of ThumbnailSpec defining sizes to generate.
+        mime_type_field: Name of a model field holding the file's MIME type. Set
+            only for mixed-content fields (e.g. QuestionnaireFile.file, which can
+            hold audio/video/documents). When set, batch processing skips rows
+            whose MIME type is not in mime_type_allowlist. None for dedicated
+            ImageFields, which are always images.
+        mime_type_allowlist: MIME types eligible for thumbnailing. Required when
+            mime_type_field is set; ignored otherwise.
     """
 
     app_label: str
     model_name: str
     source_field: str
     specs: tuple[ThumbnailSpec, ...]
+    mime_type_field: str | None = None
+    mime_type_allowlist: frozenset[str] | None = None
 
 
 # Centralized configuration for all thumbnail-enabled fields
@@ -51,6 +76,10 @@ THUMBNAIL_CONFIGS: dict[tuple[str, str, str], ModelThumbnailConfig] = {
             ThumbnailSpec("thumbnail", 150, 150),
             ThumbnailSpec("preview", 800, 800),
         ),
+        # QuestionnaireFile.file holds arbitrary uploads (audio/video/docs as
+        # well as images). Only thumbnail the image ones during batch backfill.
+        mime_type_field="mime_type",
+        mime_type_allowlist=THUMBNAILABLE_MIME_TYPES,
     ),
     # RevelUser.profile_picture
     ("accounts", "reveluser", "profile_picture"): ModelThumbnailConfig(


### PR DESCRIPTION
## Problem

Prod's Celery results backend had accumulated **143 FAILURE rows**, all from `common.thumbnails.tasks.generate_thumbnails_task`, every one a:

```
ThumbnailGenerationError: cannot identify image file <… .webm>   (or .mp3)
```

The failures arrive in bursts (all sharing one timestamp), which traces them to the `generate_thumbnails` **management command**, not the upload path.

## Root cause

- The upload path is already correct: `questionnaires/service/file_service.py` only enqueues the thumbnail task when `detected_mime_type in IMAGE_MIME_TYPES`.
- The command's `_build_queryset` selected **every** `QuestionnaireFile` with a file but no thumbnail, **with no MIME filter**. `QuestionnaireFile.file` holds arbitrary uploads (audio/video/documents as well as images), so the backfill fanned out tasks for `.webm`/`.mp3`/etc. that Pillow can never decode.
- It's not self-healing: a non-image never acquires a thumbnail field, so the `not force` filter re-selects it on every run — each invocation re-enqueues the same doomed files and adds another batch of FAILUREs + wasted worker cycles.

## Fix (option 1: filter the queryset)

- Add optional `mime_type_field` / `mime_type_allowlist` to `ModelThumbnailConfig`.
- Set them on the `questionnairefile` config (`mime_type` + thumbnailable image types).
- `_build_queryset` applies the filter when present.

Dedicated `ImageField` configs (RevelUser, Organization, Event, EventSeries) leave the fields `None` and are unaffected. Mirrors the existing upload-path `IMAGE_MIME_TYPES` guard.

## Impact / risk

Low blast radius — config + one queryset filter. No schema/migration changes. Behavior for image fields is unchanged; the command simply stops enqueuing tasks that could only ever fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thumbnail generation to skip non-image files, preventing processing failures when handling mixed-content input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->