### PR TITLE
feat(scripts): Loki log-reader CLI + skill + /logs command

### DIFF
--- a/.claude/commands/logs.md
+++ b/.claude/commands/logs.md
@@ -1,0 +1,16 @@
+---
+description: Read production logs from Loki (via Grafana) — by service, level, request/trace id, time window
+argument-hint: "[service] [--level error] [--grep TEXT] [--request-id ID] [--since 2h] ... (or a plain-English ask)"
+allowed-tools: Bash(python:*), Bash(.venv/bin/python:*), Read, Grep
+---
+
+Invoke the `loki-logs` skill via the Skill tool, then fetch production logs for the user.
+
+User request (may be raw `loki_logs.py` flags, or plain English): $ARGUMENTS
+
+Guidance:
+- Always use the venv interpreter: `.venv/bin/python scripts/loki_logs.py ...` (the script imports `python-decouple`).
+- If `$ARGUMENTS` already looks like script flags, run `.venv/bin/python scripts/loki_logs.py $ARGUMENTS` (defaulting `--since` to `1h` only if the user gave no window).
+- If it's a plain-English ask ("why did checkout 500 an hour ago", "show celery errors today"), translate it into the right `loki_logs.py` invocation per the skill, run it, and summarise what the logs show — surfacing `trace_id`/`request_id` and offering to drill in.
+- If `$ARGUMENTS` is empty, default to recent errors across the API: `.venv/bin/python scripts/loki_logs.py web --level error --since 1h`.
+- If the script reports `GRAFANA_TOKEN is not set`, stop and tell the user how to set it up (Grafana → Service accounts → Viewer token → add `GRAFANA_TOKEN=<token>` to `.env`). Do not fabricate logs.

--- a/.claude/skills/loki-logs/SKILL.md
+++ b/.claude/skills/loki-logs/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: loki-logs
+description: Use when investigating production behaviour from logs — a 500/error in prod, a failing or stuck Celery task, tracing one request/trace_id/user across services, or confirming a deploy's runtime effect. Pulls real Loki logs from the live stack (web, celery_default, beat, telegram) via Grafana.
+allowed-tools: Bash(python:*), Bash(.venv/bin/python:*), Read, Grep
+---
+
+# Loki Logs
+
+Query the **production** logs from Loki, the live log store. Loki itself is not
+publicly reachable; the script asks Grafana (`grafana.letsrevel.io`) to proxy
+LogQL to its Loki datasource using a service-account token.
+
+## Tool
+
+```bash
+.venv/bin/python scripts/loki_logs.py [SERVICE] [filters] [--since DUR] [-n LIMIT]
+```
+
+`SERVICE` is one of `web`, `celery_default`, `beat`, `telegram` (omit to search all).
+Default window is the **last 1h**, newest first, 100 lines. Run `--help` for the full flag list.
+Use the venv interpreter — the script imports `python-decouple`.
+
+**Auth:** reads `GRAFANA_TOKEN` via decouple (from the project `.env` or the environment).
+If it errors with "GRAFANA_TOKEN is not set", it isn't configured yet — tell the user; do not guess.
+
+## What you can filter on
+
+| Kind | Flags | LogQL |
+|------|-------|-------|
+| Stream labels | `SERVICE`, `--level error` (repeatable), `--env production` | indexed, cheap |
+| Line content | `--grep TEXT`, `--exclude TEXT`, `--regex RE` (all repeatable) | substring / regex |
+| Request metadata | `--trace-id`, `--request-id`, `--user-id`, `--method`, `--path`, `--status-code` | structlog fields |
+| Raw escape hatch | `--query '{service_name="web"} \| status_code="500"'` | any LogQL |
+
+Logs are structlog JSON; the displayed line is the `event` message, with a
+metadata line beneath it (suppress with `--no-meta`, get raw JSON with `--json`).
+
+## Recipes
+
+```bash
+# Errors in the API in the last hour
+.venv/bin/python scripts/loki_logs.py web --level error
+
+# Follow one request end-to-end across every service
+.venv/bin/python scripts/loki_logs.py --request-id <uuid> --since 6h --forward
+
+# Celery failures mentioning a traceback, last day
+.venv/bin/python scripts/loki_logs.py celery_default --since 1d --grep Traceback
+
+# All 5xx responses, last 2h
+.venv/bin/python scripts/loki_logs.py web --status-code 500 --since 2h
+
+# Everything a user triggered
+.venv/bin/python scripts/loki_logs.py --user-id <uuid> --since 12h
+
+# Discover what labels/values exist
+.venv/bin/python scripts/loki_logs.py --labels
+.venv/bin/python scripts/loki_logs.py --label-values service_name
+```
+
+## Workflow when debugging from a symptom
+
+1. Start broad: `web --level error --since <window>` to find the failure.
+2. Grab the `trace_id`/`request_id` from the metadata line.
+3. Re-query by that id with `--forward` to read the full request in order,
+   spanning `web` → `celery_default` if work was dispatched.
+4. Use `--print-query` to inspect/borrow the LogQL; use `--json` when you need
+   exact timestamps or fields the pretty output omits.
+
+## Notes
+
+- Retention is **30 days**; queries older than that return nothing.
+- A query needs at least one matcher — with no `SERVICE`/`--level` the script
+  defaults to `{service_name=~".+"}` (all app streams).
+- Hitting `--limit` prints a stderr hint; narrow `--since` or raise `-n`.
+- Read-only. The token is Viewer-scoped; this cannot modify anything.

--- a/.env.example
+++ b/.env.example
@@ -73,4 +73,11 @@ EMAIL_USE_TLS=False
 # Discord webhook URL for PII-free admin pings (new user / new organization)
 # DISCORD_ADMIN_WEBHOOK_URL=
 
+# Grafana / Loki log access (scripts/loki_logs.py — read production logs)
+# Service-account token (Viewer role) from grafana.letsrevel.io.
+# GRAFANA_TOKEN=
+# Optional overrides (sane defaults baked in):
+# GRAFANA_URL=https://grafana.letsrevel.io
+# GRAFANA_LOKI_UID=loki
+
 # other stuff

--- a/scripts/loki_logs.py
+++ b/scripts/loki_logs.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Query production logs from Loki through the Grafana datasource-proxy API.
+
+Loki is not exposed publicly; Grafana (https://grafana.letsrevel.io) is. Grafana
+proxies authenticated requests to its Loki datasource, so this tool talks to
+Grafana with a service-account token and asks it to run LogQL against Loki.
+
+Auth: a Grafana service-account token (role *Viewer* is enough), read via
+``python-decouple`` from ``GRAFANA_TOKEN`` (env var or the project ``.env``).
+``GRAFANA_URL`` and ``GRAFANA_LOKI_UID`` are optional overrides with sane defaults.
+
+Log shape (structlog JSON, parsed by Alloy before ingestion):
+  * stream labels:        ``service_name`` (web|celery_default|beat|telegram),
+                          ``level`` (info|warning|error|...), ``environment``
+  * structured metadata:  ``trace_id``, ``request_id``, ``method``, ``path``,
+                          ``status_code``, ``user_id``
+
+Run with the venv interpreter (imports ``python-decouple``). Examples::
+
+    # last hour of web errors
+    .venv/bin/python scripts/loki_logs.py web --level error
+
+    # everything for one request, across services, last 6h
+    .venv/bin/python scripts/loki_logs.py --request-id 9f3c... --since 6h --forward
+
+    # celery failures mentioning "Timeout" in the last day, newest first
+    .venv/bin/python scripts/loki_logs.py celery_default --since 1d --grep Timeout
+
+    # 500s in the API, last 2h
+    .venv/bin/python scripts/loki_logs.py web --status-code 500 --since 2h
+
+    # raw LogQL escape hatch
+    .venv/bin/python scripts/loki_logs.py -q '{service_name="web"} | method=`POST`' --since 2h
+
+    # discover what's available
+    .venv/bin/python scripts/loki_logs.py --labels
+    .venv/bin/python scripts/loki_logs.py --label-values service_name
+"""
+# ruff: noqa: T201  -- this is a CLI; printing to stdout is the whole point.
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import typing as t
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from decouple import config
+
+DEFAULT_GRAFANA_URL = "https://grafana.letsrevel.io"
+DEFAULT_DATASOURCE_UID = "loki"
+USER_AGENT = "revel-loki-logs/1.0 (+scripts/loki_logs.py)"
+KNOWN_SERVICES = ("web", "celery_default", "beat", "telegram")
+# Per-record fields we extract for display beneath each log line.
+METADATA_FIELDS = ("trace_id", "request_id", "method", "path", "status_code", "user_id")
+# Order in which metadata is shown beneath each log line (most useful first).
+META_DISPLAY_ORDER = ("status_code", "method", "path", "user_id", "request_id", "trace_id")
+# Fields the live pipeline promotes to stream labels → queryable as ``| field="x"``.
+LABEL_METADATA = ("trace_id", "request_id", "method", "path")
+# Fields that exist only in the structlog JSON body → matched via a line filter.
+# (renderers reproduce json.dumps' ``"key": value`` spacing, hence the templates.)
+JSON_METADATA: dict[str, t.Callable[[str], str]] = {
+    "status_code": lambda v: f'"status_code": {v}',
+    "user_id": lambda v: f'"user_id": "{v}"',
+}
+DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+
+class LokiError(RuntimeError):
+    """Raised for any user-facing failure (missing token, HTTP error, bad args)."""
+
+
+# --------------------------------------------------------------------------- #
+# Auth / connection
+# --------------------------------------------------------------------------- #
+def resolve_token() -> str:
+    """Read the Grafana service-account token from GRAFANA_TOKEN (env or .env)."""
+    token = str(config("GRAFANA_TOKEN", default="")).strip()
+    if not token:
+        raise LokiError(
+            "GRAFANA_TOKEN is not set. Add it to your .env (or environment).\n"
+            "Create one in Grafana → Administration → Service accounts → add a "
+            "'Viewer' account → Add token, then put it in .env as:\n"
+            "  GRAFANA_TOKEN=<token>"
+        )
+    return token
+
+
+def loki_api_base(grafana_url: str, uid: str) -> str:
+    """Build the Grafana proxy prefix that fronts Loki's HTTP API."""
+    return f"{grafana_url.rstrip('/')}/api/datasources/proxy/uid/{uid}/loki/api/v1"
+
+
+def http_get(url: str, token: str, params: dict[str, t.Any]) -> dict[str, t.Any]:
+    """GET ``url`` with a Bearer token and return the decoded JSON body."""
+    query = urllib.parse.urlencode(params, doseq=True)
+    request = urllib.request.Request(
+        f"{url}?{query}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            # Cloudflare fronts grafana.letsrevel.io and bans the default
+            # Python-urllib UA (error 1010); send a normal browser-ish one.
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return t.cast("dict[str, t.Any]", json.loads(response.read().decode("utf-8")))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:500]
+        hint = ""
+        if exc.code in (401, 403):
+            hint = " (token missing/expired, lacks Viewer access, or blocked by Cloudflare)"
+        elif exc.code == 404:
+            hint = " (wrong GRAFANA_URL or GRAFANA_LOKI_UID? uid defaults to 'loki')"
+        raise LokiError(f"HTTP {exc.code} from Grafana{hint}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise LokiError(f"Could not reach Grafana at {url}: {exc.reason}") from exc
+
+
+# --------------------------------------------------------------------------- #
+# Time helpers
+# --------------------------------------------------------------------------- #
+def parse_duration(value: str) -> int:
+    """Parse a duration like ``90m``, ``2h``, ``1d`` into seconds."""
+    value = value.strip().lower()
+    unit = value[-1:]
+    if unit not in DURATION_UNITS or not value[:-1].isdigit():
+        raise LokiError(f"Invalid duration {value!r}. Use e.g. 30s, 45m, 2h, 1d, 1w.")
+    return int(value[:-1]) * DURATION_UNITS[unit]
+
+
+def to_nanos(value: str) -> int:
+    """Convert an RFC3339 string or unix-seconds string to unix nanoseconds."""
+    value = value.strip()
+    if value.isdigit():
+        # Treat <1e12 as seconds, otherwise assume already finer-grained.
+        seconds = int(value)
+        return seconds * 1_000_000_000 if seconds < 1_000_000_000_000 else seconds
+    import datetime as dt
+
+    text = value.replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.astimezone()
+    return int(parsed.timestamp() * 1_000_000_000)
+
+
+def resolve_window(args: argparse.Namespace) -> tuple[int, int]:
+    """Return (start_ns, end_ns) from --from/--to or --since (default 1h)."""
+    now_ns = int(time.time() * 1_000_000_000)
+    end_ns = to_nanos(args.to) if args.to else now_ns
+    if args.from_:
+        return to_nanos(args.from_), end_ns
+    return end_ns - parse_duration(args.since) * 1_000_000_000, end_ns
+
+
+# --------------------------------------------------------------------------- #
+# LogQL construction
+# --------------------------------------------------------------------------- #
+def _logql_string(value: str) -> str:
+    """Quote a value for LogQL, preferring backticks to dodge escaping."""
+    if "`" not in value:
+        return f"`{value}`"
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def build_query(args: argparse.Namespace) -> str:  # noqa: C901
+    """Assemble a LogQL query from the structured flags, or pass --query through."""
+    if args.query:
+        return args.query
+
+    selectors: list[str] = []
+    if args.service:
+        selectors.append(f"service_name={_logql_string(args.service)}")
+    if args.env:
+        selectors.append(f"environment={_logql_string(args.env)}")
+    if args.level:
+        selectors.append(f"level=~{_logql_string('|'.join(args.level))}")
+    if not selectors:
+        # Loki requires at least one matcher; service_name is on every app stream.
+        selectors.append('service_name=~".+"')
+    query = "{" + ", ".join(selectors) + "}"
+
+    for needle in args.grep or []:
+        query += f" |= {_logql_string(needle)}"
+    for needle in args.exclude or []:
+        query += f" != {_logql_string(needle)}"
+    for pattern in args.regex or []:
+        query += f" |~ {_logql_string(pattern)}"
+
+    # trace_id/request_id/method/path are promoted to stream labels → label filters.
+    for field in LABEL_METADATA:
+        val = getattr(args, field)
+        if val is not None:
+            query += f" | {field}={_logql_string(val)}"
+    # status_code/user_id live only in the structlog JSON body → line filters.
+    for field, render in JSON_METADATA.items():
+        val = getattr(args, field)
+        if val is not None:
+            query += f" |= {_logql_string(render(val))}"
+    return query
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+def _fmt_ts(nanos: str) -> str:
+    """Render a unix-nanosecond string as local ``HH:MM:SS.mmm`` (with date if old)."""
+    import datetime as dt
+
+    moment = dt.datetime.fromtimestamp(int(nanos) / 1_000_000_000).astimezone()
+    today = dt.datetime.now().astimezone().date()
+    fmt = "%H:%M:%S.%f" if moment.date() == today else "%Y-%m-%d %H:%M:%S.%f"
+    return moment.strftime(fmt)[:-3]
+
+
+def _flatten_entries(result: list[dict[str, t.Any]]) -> list[tuple[str, dict[str, str], str]]:
+    """Merge all streams into a single (ts, labels, line) list sorted oldest→newest."""
+    entries: list[tuple[str, dict[str, str], str]] = []
+    for stream in result:
+        labels = stream.get("stream", {})
+        for value in stream.get("values", []):
+            entries.append((value[0], labels, value[1]))
+    entries.sort(key=lambda item: int(item[0]))
+    return entries
+
+
+def _render_entry(labels: dict[str, str], line: str) -> tuple[str, str, dict[str, str]]:
+    """Return (level, message, metadata) for one entry.
+
+    structlog logs the whole record as a JSON object; the human-readable bit is the
+    ``event`` field. Celery also prepends a ``[ts: LEVEL/Worker]`` banner before that
+    JSON, so we extract the first ``{...}`` rather than requiring a pure-JSON line.
+    Parsed values (level, metadata) win over the stream labels, which can be stale or
+    missing fields the live ingestion pipeline didn't promote.
+    """
+    level = labels.get("level", "-")
+    message = line
+    meta = {k: v for k, v in labels.items() if k in METADATA_FIELDS and v}
+    start, end = line.find("{"), line.rfind("}")
+    if start != -1 and end > start:
+        try:
+            obj = json.loads(line[start : end + 1])
+        except ValueError:
+            obj = None
+        if isinstance(obj, dict):
+            message = str(obj.get("event", line))
+            if obj.get("level"):
+                level = str(obj["level"])
+            for field in METADATA_FIELDS:
+                if obj.get(field) not in (None, "") and field not in meta:
+                    meta[field] = str(obj[field])
+    return level, message, meta
+
+
+def print_entries(result: list[dict[str, t.Any]], show_meta: bool) -> int:
+    """Pretty-print log lines; return the count printed."""
+    entries = _flatten_entries(result)
+    for nanos, labels, line in entries:
+        service = labels.get("service_name", "-")
+        level, message, meta = _render_entry(labels, line)
+        print(f"{_fmt_ts(nanos)}  {level.upper():<7} {service:<14} {message}")
+        if show_meta:
+            ordered = [f"{k}={meta[k]}" for k in META_DISPLAY_ORDER if k in meta]
+            if ordered:
+                print(f"{'':>13}  {'  '.join(ordered)}")
+    return len(entries)
+
+
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+def run_discovery(args: argparse.Namespace, base: str, token: str) -> int:
+    """Handle --labels / --label-values without running a log query."""
+    if args.labels:
+        data = http_get(f"{base}/labels", token, {})
+        for name in data.get("data", []):
+            print(name)
+        return 0
+    data = http_get(f"{base}/label/{urllib.parse.quote(args.label_values)}/values", token, {})
+    for value in data.get("data", []):
+        print(value)
+    return 0
+
+
+def run_query(args: argparse.Namespace, base: str, token: str) -> int:
+    """Run a range query and render the results."""
+    query = build_query(args)
+    start_ns, end_ns = resolve_window(args)
+    params = {
+        "query": query,
+        "start": start_ns,
+        "end": end_ns,
+        "limit": args.limit,
+        "direction": "forward" if args.forward else "backward",
+    }
+    if args.print_query:
+        print(f"LogQL : {query}")
+        print(f"start : {start_ns}")
+        print(f"end   : {end_ns}")
+        print(f"limit : {args.limit}")
+        return 0
+
+    data = http_get(f"{base}/query_range", token, params)
+    result = data.get("data", {}).get("result", [])
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return 0
+    count = print_entries(result, show_meta=not args.no_meta)
+    if count == 0:
+        print(f"(no log lines for: {query})", file=sys.stderr)
+    elif count >= args.limit:
+        print(f"\n(hit --limit {args.limit}; narrow the window or raise --limit for more)", file=sys.stderr)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="loki_logs.py",
+        description="Query production logs from Loki via the Grafana proxy API.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "service",
+        nargs="?",
+        help=f"service_name filter (one of: {', '.join(KNOWN_SERVICES)})",
+    )
+
+    flt = parser.add_argument_group("filters")
+    flt.add_argument("-q", "--query", help="raw LogQL (overrides all filter flags below)")
+    flt.add_argument("-g", "--grep", action="append", metavar="TEXT", help="line must contain TEXT (repeatable, AND)")
+    flt.add_argument("-x", "--exclude", action="append", metavar="TEXT", help="line must NOT contain TEXT (repeatable)")
+    flt.add_argument("-r", "--regex", action="append", metavar="RE", help="line matches regex RE (repeatable)")
+    flt.add_argument("-l", "--level", action="append", metavar="LVL", help="level label, e.g. error (repeatable → OR)")
+    flt.add_argument("--env", metavar="ENV", help="environment label, e.g. production")
+    flt.add_argument("--trace-id", dest="trace_id", help="structured-metadata trace_id")
+    flt.add_argument("--request-id", dest="request_id", help="structured-metadata request_id")
+    flt.add_argument("--user-id", dest="user_id", help="structured-metadata user_id")
+    flt.add_argument("--method", help="HTTP method metadata, e.g. POST")
+    flt.add_argument("--path", help="request path metadata (exact match)")
+    flt.add_argument("--status-code", dest="status_code", help="HTTP status_code metadata, e.g. 500")
+
+    win = parser.add_argument_group("time & limit")
+    win.add_argument("-s", "--since", default="1h", metavar="DUR", help="look back this far (default 1h): 30m,2h,1d,1w")
+    win.add_argument(
+        "--from", dest="from_", metavar="TS", help="start time (RFC3339 or unix seconds); overrides --since"
+    )
+    win.add_argument("--to", metavar="TS", help="end time (RFC3339 or unix seconds); default now")
+    win.add_argument("-n", "--limit", type=int, default=100, metavar="N", help="max lines (default 100)")
+    win.add_argument("--forward", action="store_true", help="oldest first (default newest first)")
+
+    out = parser.add_argument_group("output")
+    out.add_argument("--json", action="store_true", help="print raw Loki JSON response")
+    out.add_argument("--no-meta", action="store_true", help="hide the structured-metadata line")
+    out.add_argument("--print-query", action="store_true", help="print the built LogQL and exit (no request)")
+
+    disc = parser.add_argument_group("discovery")
+    disc.add_argument("--labels", action="store_true", help="list available label names and exit")
+    disc.add_argument("--label-values", metavar="LABEL", help="list values for LABEL and exit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    args = build_parser().parse_args(argv)
+    try:
+        token = resolve_token()
+        grafana_url = str(config("GRAFANA_URL", default=DEFAULT_GRAFANA_URL))
+        uid = str(config("GRAFANA_LOKI_UID", default=DEFAULT_DATASOURCE_UID))
+        base = loki_api_base(grafana_url, uid)
+        if args.labels or args.label_values:
+            return run_discovery(args, base, token)
+        return run_query(args, base, token)
+    except LokiError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds a way to read **production logs** from Loki without exposing Loki publicly — it queries through Grafana's datasource-proxy API with a Viewer service-account token.

Three pieces:
- **`scripts/loki_logs.py`** — stdlib + `python-decouple` CLI. Reads `GRAFANA_TOKEN` from `.env`.
- **`.claude/skills/loki-logs/`** — skill so Claude can pull logs when debugging.
- **`.claude/commands/logs.md`** — `/logs` slash command for manual use.
- **`.env.example`** — documents `GRAFANA_TOKEN` (+ optional `GRAFANA_URL` / `GRAFANA_LOKI_UID`).

## Usage

```bash
.venv/bin/python scripts/loki_logs.py web --level error                 # API errors, last 1h
.venv/bin/python scripts/loki_logs.py --request-id <id> --forward       # trace one request across services
.venv/bin/python scripts/loki_logs.py web --status-code 500 --since 24h
.venv/bin/python scripts/loki_logs.py celery_default --grep Traceback --since 1d
.venv/bin/python scripts/loki_logs.py --user-id <uuid> --since 12h
.venv/bin/python scripts/loki_logs.py --labels                          # discovery
```

Filters: service, `--level`, `--grep`/`--exclude`/`--regex`, and per-request fields. `trace_id`/`request_id`/`method`/`path` are label filters; `status_code`/`user_id` are matched as JSON line filters (they aren't promoted to labels on the live stack). Also `--json`, `--print-query`, `--labels`/`--label-values`.

## How it works

Loki is internal-only (`expose`d, not published). Grafana *is* public and already proxies to its Loki datasource (uid `loki`). The script hits `…/api/datasources/proxy/uid/loki/loki/api/v1/query_range` with a Bearer token. Output parses the structlog JSON (and Celery's `[ts: LEVEL/Worker]` prefix) to show the clean `event` message + a metadata line. Sends a real `User-Agent` to get past Cloudflare (which 1010-bans the default urllib UA).

## Verified

Tested end-to-end against live production Loki: discovery, level/grep/metadata filters, and request tracing (traced a real 500 showing both the `ERROR` and the `status_code=500` line in order). `ruff` / `ruff format` / `mypy` all clean.

## Related findings

Building/testing this surfaced four issues, filed separately:
- #478 — Celery logs not emitted as JSON
- #479 — logged client IP is the Cloudflare edge IP, not the visitor
- #480 — 500 tracebacks not captured anywhere
- letsrevel/infra#2 — production Alloy not applying the latest log pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production log querying capability via Grafana/Loki integration.
  * New CLI tool for accessing and filtering production logs with support for multiple filtering options and debugging workflows.

* **Documentation**
  * Added command and skill guides for log access with ready-to-use query recipes.

* **Chores**
  * Added Grafana authentication configuration template to environment example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->