### PR TITLE
fix(observability): real client IP via X-Real-IP + single-render structlog JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.3"
+version = "1.62.4"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/admin/user.py
+++ b/src/accounts/admin/user.py
@@ -35,6 +35,7 @@ from accounts.models import (
 from accounts.service.account import request_password_reset, send_verification_email_for_user
 from accounts.service.impersonation import can_impersonate, create_impersonation_request
 from accounts.utils.email_normalization import normalize_email_for_matching
+from common.client_ip import get_client_ip
 from common.models import SiteSettings
 from common.signing import get_file_url
 from events.models import GeneralUserPreferences
@@ -528,7 +529,7 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
 
         if request.method == "POST" and allowed:
             # Get client info for audit
-            ip_address = self._get_client_ip(request)
+            ip_address = get_client_ip(request) or None
             user_agent = request.META.get("HTTP_USER_AGENT", "")
 
             # Generate impersonation token
@@ -553,14 +554,6 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
             "error": error if not allowed else None,
         }
         return TemplateResponse(request, "admin/accounts/impersonate_confirm.html", context)
-
-    def _get_client_ip(self, request: HttpRequest) -> str | None:
-        """Extract client IP address from request."""
-        x_forwarded_for: str | None = request.META.get("HTTP_X_FORWARDED_FOR")
-        if x_forwarded_for:
-            return x_forwarded_for.split(",")[0].strip()
-        remote_addr: str | None = request.META.get("REMOTE_ADDR")
-        return remote_addr
 
 
 @admin.register(UserDataExport)

--- a/src/common/client_ip.py
+++ b/src/common/client_ip.py
@@ -1,0 +1,28 @@
+"""Single source of truth for resolving the real client IP of a request.
+
+Production network path: Cloudflare → Caddy → gunicorn. Caddy is configured
+(infra ``Caddyfile``) with ``trusted_proxies`` for Cloudflare's ranges and
+``client_ip_headers Cf-Connecting-Ip``, and overwrites both ``X-Real-IP`` and
+``X-Forwarded-For`` with the single resolved visitor IP on every request. That
+makes ``X-Real-IP`` trustworthy: a client can never set it, and a peer hitting
+the origin directly gets its own socket IP.
+
+Do NOT read ``CF-Connecting-IP`` here: Caddy strips it, and trusting it in
+Django would be spoofable by anyone reaching the origin directly. Do NOT trust
+arbitrary ``X-Forwarded-For`` positions either — the first entry is
+client-controlled in generic setups. See backend issue #479 / infra #3.
+"""
+
+from django.http import HttpRequest
+
+
+def get_client_ip(request: HttpRequest) -> str:
+    """Return the real client IP for a request, or ``""`` if unknown.
+
+    Trusts ``X-Real-IP`` (set by Caddy from the Cloudflare-resolved client IP),
+    falling back to ``REMOTE_ADDR`` for local development, tests, and internal
+    calls that don't pass through Caddy's Django proxy block.
+    """
+    if x_real_ip := request.META.get("HTTP_X_REAL_IP"):
+        return str(x_real_ip).strip()
+    return str(request.META.get("REMOTE_ADDR", ""))

--- a/src/common/middleware/observability.py
+++ b/src/common/middleware/observability.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from opentelemetry import trace
 
+from common.client_ip import get_client_ip
+
 logger = structlog.get_logger("common.middleware.observability")
 
 _SKIP_LOG_PATHS: frozenset[str] = frozenset({"/metrics", "/health", "/api/healthcheck"})
@@ -60,7 +62,7 @@ class StructlogContextMiddleware:
             "request_id": request_id,
             "method": request.method,
             "path": request.path,
-            "ip_address": self._get_client_ip(request),
+            "ip_address": get_client_ip(request) or "unknown",
         }
 
         # Add trace_id if available (for log-to-trace correlation)
@@ -121,21 +123,3 @@ class StructlogContextMiddleware:
         structlog.contextvars.clear_contextvars()
 
         return response
-
-    def _get_client_ip(self, request: HttpRequest) -> str:
-        """Extract client IP address from request.
-
-        Checks X-Forwarded-For header first (for proxied requests),
-        then falls back to REMOTE_ADDR.
-
-        Args:
-            request: Django HttpRequest
-
-        Returns:
-            str: Client IP address
-        """
-        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-        if x_forwarded_for:
-            # X-Forwarded-For can contain multiple IPs, take the first
-            return str(x_forwarded_for.split(",")[0].strip())
-        return str(request.META.get("REMOTE_ADDR", "unknown"))

--- a/src/common/tests/test_client_ip.py
+++ b/src/common/tests/test_client_ip.py
@@ -1,0 +1,42 @@
+"""Tests for the single source of truth for client IP resolution."""
+
+from django.http import HttpRequest
+from django.test import RequestFactory
+
+from common.client_ip import get_client_ip
+
+
+def test_trusts_x_real_ip() -> None:
+    """X-Real-IP (set by Caddy from the Cloudflare-resolved IP) wins."""
+    request: HttpRequest = RequestFactory().get("/", HTTP_X_REAL_IP="203.0.113.7", REMOTE_ADDR="10.0.0.1")
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_strips_whitespace() -> None:
+    """Header values are stripped."""
+    request: HttpRequest = RequestFactory().get("/", HTTP_X_REAL_IP=" 203.0.113.7 ")
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_ignores_x_forwarded_for() -> None:
+    """X-Forwarded-For is client-controllable and must not be trusted."""
+    request: HttpRequest = RequestFactory().get("/", HTTP_X_FORWARDED_FOR="6.6.6.6, 7.7.7.7", REMOTE_ADDR="10.0.0.1")
+    assert get_client_ip(request) == "10.0.0.1"
+
+
+def test_ignores_cf_connecting_ip() -> None:
+    """CF-Connecting-IP is spoofable by direct-to-origin peers; Caddy resolves it for us."""
+    request: HttpRequest = RequestFactory().get("/", HTTP_CF_CONNECTING_IP="6.6.6.6", REMOTE_ADDR="10.0.0.1")
+    assert get_client_ip(request) == "10.0.0.1"
+
+
+def test_falls_back_to_remote_addr() -> None:
+    """Without X-Real-IP (dev, tests, internal calls), REMOTE_ADDR is used."""
+    request: HttpRequest = RequestFactory().get("/", REMOTE_ADDR="192.0.2.1")
+    assert get_client_ip(request) == "192.0.2.1"
+
+
+def test_returns_empty_string_when_unknown() -> None:
+    """No headers and no REMOTE_ADDR yields an empty string."""
+    request: HttpRequest = RequestFactory().get("/", REMOTE_ADDR="")
+    assert get_client_ip(request) == ""

--- a/src/geo/middleware.py
+++ b/src/geo/middleware.py
@@ -2,6 +2,7 @@ import typing as t
 
 from django.http import HttpRequest, HttpResponse
 
+from common.client_ip import get_client_ip
 from geo.ip2 import LazyGeoPoint
 
 
@@ -12,15 +13,6 @@ class GeoPointMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         """Add the user location to the request."""
-        ip = self._get_ip(request)
+        ip = get_client_ip(request)
         request.user_location = LazyGeoPoint(ip)  # type: ignore[attr-defined]
         return self.get_response(request)
-
-    @staticmethod
-    def _get_ip(request: HttpRequest) -> str:
-        # return "188.23.209.25"
-        # return "63.116.61.253"
-        xff = request.META.get("HTTP_X_FORWARDED_FOR")
-        if xff:
-            return t.cast(str, xff.split(",")[0].strip())
-        return t.cast(str, request.META.get("REMOTE_ADDR", ""))

--- a/src/geo/tests/test_middleware.py
+++ b/src/geo/tests/test_middleware.py
@@ -6,13 +6,14 @@ from geo.ip2 import LazyGeoPoint
 from geo.middleware import GeoPointMiddleware
 
 
-def test_geo_point_middleware_x_forwarded_for() -> None:
+def test_geo_point_middleware_x_real_ip() -> None:
     """
     Tests that the middleware correctly extracts the IP from the
-    HTTP_X_FORWARDED_FOR header and attaches a LazyGeoPoint to the request.
+    HTTP_X_REAL_IP header (set by Caddy from the Cloudflare-resolved
+    client IP) and attaches a LazyGeoPoint to the request.
     """
     factory = RequestFactory()
-    request: HttpRequest = factory.get("/", HTTP_X_FORWARDED_FOR="8.8.8.8, 1.1.1.1")
+    request: HttpRequest = factory.get("/", HTTP_X_REAL_IP="8.8.8.8")
 
     def get_response(req: HttpRequest) -> HttpResponse:
         return HttpResponse()
@@ -29,6 +30,26 @@ def test_geo_point_middleware_x_forwarded_for() -> None:
     assert isinstance(point, Point)
     assert point.x == 16.3738
     assert point.y == 48.2082
+
+
+def test_geo_point_middleware_ignores_x_forwarded_for() -> None:
+    """
+    Tests that the middleware does NOT trust X-Forwarded-For (its first
+    entry is client-controlled in generic setups) and falls back to
+    REMOTE_ADDR instead.
+    """
+    factory = RequestFactory()
+    request: HttpRequest = factory.get("/", HTTP_X_FORWARDED_FOR="8.8.8.8, 1.1.1.1", REMOTE_ADDR="8.8.4.4")
+
+    def get_response(req: HttpRequest) -> HttpResponse:
+        return HttpResponse()
+
+    middleware = GeoPointMiddleware(get_response)
+    middleware(request)
+
+    user_location = getattr(request, "user_location", None)
+    assert isinstance(user_location, LazyGeoPoint)
+    assert user_location.ip == "8.8.4.4"
 
 
 def test_geo_point_middleware_remote_addr() -> None:

--- a/src/revel/settings/observability.py
+++ b/src/revel/settings/observability.py
@@ -95,7 +95,17 @@ def add_app_context(logger: t.Any, method_name: str, event_dict: dict[str, t.Any
     return event_dict
 
 
-# Structlog processors for direct use
+# Structlog processors for structlog-native loggers.
+#
+# The chain must NOT end with a renderer: these loggers hand their event dict to
+# the stdlib logging machinery, whose ``ProcessorFormatter`` (see LOGGING below)
+# does the one and only JSON rendering. Ending with ``JSONRenderer()`` here used
+# to double-render every structlog-native line: the formatter received an
+# already-serialized JSON string as the ``event``, re-applied the foreign chain
+# (second timestamp, contextvars duplicated at the top level) and wrapped it in
+# a second JSON object — so Loki stored ``{"event": "{\"status_code\": ...}"}``
+# and Alloy could neither promote ``status_code``/``user_id`` nor reduce the
+# line to the message. ``wrap_for_formatter`` passes the dict through intact.
 STRUCTLOG_PROCESSORS = [
     structlog.contextvars.merge_contextvars,  # Merge context variables
     structlog.stdlib.add_logger_name,  # Add logger name
@@ -107,7 +117,7 @@ STRUCTLOG_PROCESSORS = [
     structlog.processors.UnicodeDecoder(),  # Decode unicode
     add_app_context,  # Add service/version/environment
     scrub_pii,  # Scrub PII before serialization
-    structlog.processors.JSONRenderer(),  # Render as JSON for Loki
+    structlog.stdlib.ProcessorFormatter.wrap_for_formatter,  # Hand off to ProcessorFormatter (renders JSON once)
 ]
 
 # Processors for foreign loggers (Django, Celery, etc.)

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.3"
+version = "1.62.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

Two observability fixes that complete today's infra work (infra#4):

### 1. Centralized client IP resolution (closes #479)
New `common/client_ip.get_client_ip()` — trusts **`X-Real-IP`** (which Caddy now sets from the Cloudflare-resolved visitor IP, see infra#4), falls back to `REMOTE_ADDR`. Replaces the three duplicated XFF-first derivations:
- `common/middleware/observability.py` (request logs)
- `geo/middleware.py` (geolocation)
- `accounts/admin/user.py` (impersonation audit)

Deliberately **not** trusted: `X-Forwarded-For` (first entry is client-controlled in generic setups) and `CF-Connecting-IP` (forgeable by direct-to-origin peers; Caddy both resolves and strips it).

### 2. Structlog double-rendering fix (refs #480, fixes letsrevel/infra#2's remaining symptom)
`STRUCTLOG_PROCESSORS` ended with `JSONRenderer()` **and** the stdlib `ProcessorFormatter` rendered JSON again, so every structlog-native line reached stdout as:

```json
{"event": "{\"status_code\": 200, ... \"event\": \"request_finished\", ...}", "timestamp": "<2nd ts>", ...}
```

— an outer wrapper with the real log as an escaped string, a second timestamp, and contextvars duplicated at the top level (but **not** `status_code`/`user_id`). This is why Loki appeared to show "raw JSON lines" and why `status_code`/`user_id` were never filterable: the Alloy pipeline was working correctly all along — it rewrote the line to the `event` message, which *was* the inner JSON blob.

Fix: end the processor chain with `ProcessorFormatter.wrap_for_formatter` so the event dict is rendered exactly once.

## Verification

Ran the production logging config locally:
- native `request_finished` log → single JSON, `event="request_finished"`, `status_code=200` and contextvars at top level
- `django.request` error with `exc_info` → structured `exception` field with full traceback (the "verify rendering" half of #480; the error-tracker half stays open)

After deploy, Loki lines will be clean event messages with `status_code`/`user_id` filterable — closing the loop on letsrevel/infra#2.

`make check` clean (ruff, mypy --strict, migrations, i18n, file-length). Geo middleware tests updated to the new contract (X-Real-IP trusted, XFF ignored); new unit tests for the helper.

Closes #479. Refs #480, letsrevel/infra#2, letsrevel/infra#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
