### PR TITLE
fix(observability): loki_logs metadata filters + user_id binding for JWT requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.4"
+version = "1.62.5"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/scripts/loki_logs.py
+++ b/scripts/loki_logs.py
@@ -59,14 +59,10 @@ KNOWN_SERVICES = ("web", "celery_default", "beat", "telegram")
 METADATA_FIELDS = ("trace_id", "request_id", "method", "path", "status_code", "user_id")
 # Order in which metadata is shown beneath each log line (most useful first).
 META_DISPLAY_ORDER = ("status_code", "method", "path", "user_id", "request_id", "trace_id")
-# Fields the live pipeline promotes to stream labels → queryable as ``| field="x"``.
-LABEL_METADATA = ("trace_id", "request_id", "method", "path")
-# Fields that exist only in the structlog JSON body → matched via a line filter.
-# (renderers reproduce json.dumps' ``"key": value`` spacing, hence the templates.)
-JSON_METADATA: dict[str, t.Callable[[str], str]] = {
-    "status_code": lambda v: f'"status_code": {v}',
-    "user_id": lambda v: f'"user_id": "{v}"',
-}
+# Fields the live pipeline promotes to structured metadata → queryable as
+# ``| field="x"`` (since the single-render structlog fix, v1.62.4, all six are
+# promoted — including status_code and user_id).
+LABEL_METADATA = ("trace_id", "request_id", "method", "path", "status_code", "user_id")
 DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
 
 
@@ -194,16 +190,11 @@ def build_query(args: argparse.Namespace) -> str:  # noqa: C901
     for pattern in args.regex or []:
         query += f" |~ {_logql_string(pattern)}"
 
-    # trace_id/request_id/method/path are promoted to stream labels → label filters.
+    # All request-metadata fields are promoted to structured metadata → label filters.
     for field in LABEL_METADATA:
         val = getattr(args, field)
         if val is not None:
             query += f" | {field}={_logql_string(val)}"
-    # status_code/user_id live only in the structlog JSON body → line filters.
-    for field, render in JSON_METADATA.items():
-        val = getattr(args, field)
-        if val is not None:
-            query += f" |= {_logql_string(render(val))}"
     return query
 
 

--- a/src/common/auth_base.py
+++ b/src/common/auth_base.py
@@ -2,6 +2,8 @@
 
 import typing as t
 
+import structlog
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
@@ -71,5 +73,13 @@ class BaseJWTAuth(JWTAuth):
             # Check superuser status
             if self.is_superuser and not getattr(user, "is_superuser", False):
                 raise PermissionDenied(str(_("Superuser access required.")))
+
+            # Bind the user to the structlog request context. JWT auth runs at
+            # the view layer, *after* StructlogContextMiddleware has bound the
+            # request context (where request.user is still anonymous), so this
+            # is the earliest point the user is known for API requests. The
+            # middleware clears contextvars at the end of every request.
+            if settings.ENABLE_OBSERVABILITY:
+                structlog.contextvars.bind_contextvars(user_id=str(user.pk))
 
         return user

--- a/src/common/tests/test_auth_base.py
+++ b/src/common/tests/test_auth_base.py
@@ -2,7 +2,7 @@
 
 import pytest
 import structlog
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from ninja_jwt.tokens import RefreshToken
 
 from accounts.models import RevelUser
@@ -11,6 +11,7 @@ from common.authentication import I18nJWTAuth
 pytestmark = pytest.mark.django_db
 
 
+@override_settings(ENABLE_OBSERVABILITY=True)
 def test_jwt_auth_binds_user_id_contextvar(user: RevelUser) -> None:
     """Successful JWT auth binds user_id into the structlog request context.
 
@@ -27,6 +28,22 @@ def test_jwt_auth_binds_user_id_contextvar(user: RevelUser) -> None:
 
         assert authenticated == user
         assert structlog.contextvars.get_contextvars().get("user_id") == str(user.pk)
+    finally:
+        structlog.contextvars.clear_contextvars()
+
+
+@override_settings(ENABLE_OBSERVABILITY=False)
+def test_jwt_auth_skips_binding_when_observability_disabled(user: RevelUser) -> None:
+    """With observability disabled, nothing is bound (contextvars are never cleared either)."""
+    token = str(RefreshToken.for_user(user).access_token)  # type: ignore[attr-defined]
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    structlog.contextvars.clear_contextvars()
+    try:
+        authenticated = I18nJWTAuth().authenticate(request, token)
+
+        assert authenticated == user
+        assert "user_id" not in structlog.contextvars.get_contextvars()
     finally:
         structlog.contextvars.clear_contextvars()
 

--- a/src/common/tests/test_auth_base.py
+++ b/src/common/tests/test_auth_base.py
@@ -1,0 +1,45 @@
+"""Tests for BaseJWTAuth observability context binding."""
+
+import pytest
+import structlog
+from django.test import RequestFactory
+from ninja_jwt.tokens import RefreshToken
+
+from accounts.models import RevelUser
+from common.authentication import I18nJWTAuth
+
+pytestmark = pytest.mark.django_db
+
+
+def test_jwt_auth_binds_user_id_contextvar(user: RevelUser) -> None:
+    """Successful JWT auth binds user_id into the structlog request context.
+
+    JWT auth runs at the view layer, after StructlogContextMiddleware has bound
+    the request context (where request.user is still anonymous) — so the auth
+    layer is responsible for making API request logs attributable to a user.
+    """
+    token = str(RefreshToken.for_user(user).access_token)  # type: ignore[attr-defined]
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    structlog.contextvars.clear_contextvars()
+    try:
+        authenticated = I18nJWTAuth().authenticate(request, token)
+
+        assert authenticated == user
+        assert structlog.contextvars.get_contextvars().get("user_id") == str(user.pk)
+    finally:
+        structlog.contextvars.clear_contextvars()
+
+
+def test_failed_jwt_auth_binds_nothing(user: RevelUser) -> None:
+    """An invalid token must not bind a user_id."""
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION="Bearer not-a-token")
+
+    structlog.contextvars.clear_contextvars()
+    try:
+        with pytest.raises(Exception):  # noqa: B017 - ninja_jwt raises its own error types
+            I18nJWTAuth().authenticate(request, "not-a-token")
+
+        assert "user_id" not in structlog.contextvars.get_contextvars()
+    finally:
+        structlog.contextvars.clear_contextvars()

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.4"
+version = "1.62.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

Two follow-ups from verifying #484 in production:

### 1. `loki_logs.py`: filter `status_code`/`user_id` via structured metadata
Since the single-render structlog fix (#484), `status_code` and `user_id` are promoted to structured metadata by the Alloy pipeline. The script's `--status-code`/`--user-id` flags still line-grepped the old double-rendered JSON blob format (`|= '"status_code": 404'`), which no longer exists — they now use label filters like the other metadata fields. Verified against production: `--status-code 404` returns entries again.

### 2. Bind `user_id` to the log context on JWT auth
`user_id` was almost never populated for API traffic: `StructlogContextMiddleware` binds it only when `request.user.is_authenticated`, which is true for session auth (Django admin) but not for JWT — Ninja's auth runs at the view layer, *after* the middleware. Now `BaseJWTAuth.authenticate` binds `user_id` into the structlog contextvars on success (guarded by `ENABLE_OBSERVABILITY`; the middleware still clears contextvars at request start/end), so every log emitted during an authenticated API request — including `request_finished` and unhandled-exception logs — is attributable to the user and filterable in Loki via `--user-id`.

Covers `I18nJWTAuth` and `OptionalAuth` (both subclass `BaseJWTAuth`); anonymous requests bind nothing.

## Verification

- `make check` clean (ruff, mypy --strict, migrations, i18n, file-length)
- New unit tests: successful auth binds `user_id`, failed auth binds nothing
- Script fix verified against live production Loki

Refs #479, #480, #484, letsrevel/infra#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.62.5

* **New Features**
  * Log queries now treat status and user identifiers as first-class, queryable labels for easier filtering.
  * Auth observability: authenticated user ID is injected into request logging context when observability is enabled.

* **Tests**
  * Added tests covering auth observability binding and its behavior when enabled/disabled or on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->