### PR TITLE
fix(geo): extract IP2Location .BIN from ZIP — nearest-first sorting never worked

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.5"
+version = "1.62.6"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/geo/ip2.py
+++ b/src/geo/ip2.py
@@ -38,7 +38,10 @@ def resolve_ip_to_point(ip: str) -> Point | None:
             return None
         return Point(float(record.longitude), float(record.latitude), srid=4326)
     except Exception:
-        logger.debug("ip_resolution_failed", ip=ip)
+        # warning, not debug: a broken database otherwise fails every lookup
+        # invisibly (a corrupt .BIN disabled nearest-first sorting in
+        # production for months — the downloader saved the ZIP as the .BIN).
+        logger.warning("ip_resolution_failed", ip=ip, exc_info=True)
         return None
 
 

--- a/src/geo/tasks.py
+++ b/src/geo/tasks.py
@@ -32,19 +32,19 @@ def download_ip2location() -> None:
     zip_tmp = IP2LOCATION_DB_PATH.with_suffix(".zip.tmp")
     bin_tmp = IP2LOCATION_DB_PATH.with_suffix(".bin.tmp")
 
-    response = requests.get(
-        "https://www.ip2location.com/download/",
-        params={"token": IP2LOCATION_TOKEN, "file": DB_CODE},
-        stream=True,
-        timeout=300,
-    )
-    response.raise_for_status()
-
     try:
-        # Stream download to avoid loading the archive in memory
-        with zip_tmp.open("wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
+        # Stream download to avoid loading the archive in memory; the context
+        # manager releases the connection even if streaming fails midway.
+        with requests.get(
+            "https://www.ip2location.com/download/",
+            params={"token": IP2LOCATION_TOKEN, "file": DB_CODE},
+            stream=True,
+            timeout=300,
+        ) as response:
+            response.raise_for_status()
+            with zip_tmp.open("wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
 
         with zipfile.ZipFile(zip_tmp) as archive:
             bin_members = [name for name in archive.namelist() if name.upper().endswith(".BIN")]

--- a/src/geo/tasks.py
+++ b/src/geo/tasks.py
@@ -1,26 +1,37 @@
+import shutil
+import zipfile
+
 import requests
+import structlog
 from celery import shared_task
+from IP2Location import IP2Location
 
 from .conf import IP2LOCATION_DB_PATH, IP2LOCATION_TOKEN
 
+logger = structlog.get_logger(__name__)
+
 DB_CODE = "DB5LITEBINIPV6"
+# A lookup that must succeed against a healthy database (Google DNS → US).
+VALIDATION_IP = "8.8.8.8"
 
 
 @shared_task
 def download_ip2location() -> None:
     """Download a fresh IP2Location database.
 
-    Downloads the database to a temporary file and atomically moves it to the
-    final location to avoid disruptions during download.
+    The download endpoint delivers a ZIP archive containing the ``.BIN``
+    database (plus license/readme text files) — saving the response body
+    as-is silently breaks every geolocation lookup. Stream the archive to a
+    temporary file, extract the single ``.BIN`` member, validate it with a
+    real lookup, and only then atomically replace the live database.
 
-    Note: Uses the same directory as the destination for the temporary file
+    Note: Uses the same directory as the destination for the temporary files
     to ensure writability in Docker environments and guarantee atomic move
     (same filesystem).
     """
-    # Create temporary file in the same directory as destination (guaranteed writable)
-    tmp_path = IP2LOCATION_DB_PATH.with_suffix(".bin.tmp")
+    zip_tmp = IP2LOCATION_DB_PATH.with_suffix(".zip.tmp")
+    bin_tmp = IP2LOCATION_DB_PATH.with_suffix(".bin.tmp")
 
-    # Stream download to avoid loading entire file in memory
     response = requests.get(
         "https://www.ip2location.com/download/",
         params={"token": IP2LOCATION_TOKEN, "file": DB_CODE},
@@ -29,10 +40,29 @@ def download_ip2location() -> None:
     )
     response.raise_for_status()
 
-    # Write to temporary file
-    with tmp_path.open("wb") as f:
-        for chunk in response.iter_content(chunk_size=8192):
-            f.write(chunk)
+    try:
+        # Stream download to avoid loading the archive in memory
+        with zip_tmp.open("wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
 
-    # Atomically replace the database file
-    tmp_path.replace(IP2LOCATION_DB_PATH)
+        with zipfile.ZipFile(zip_tmp) as archive:
+            bin_members = [name for name in archive.namelist() if name.upper().endswith(".BIN")]
+            if len(bin_members) != 1:
+                raise ValueError(f"Expected exactly one .BIN member in the IP2Location archive, got: {bin_members}")
+            with archive.open(bin_members[0]) as src, bin_tmp.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+        # Validate before swapping: a broken download must never replace a
+        # working database. A failed lookup raises, leaving the live file
+        # untouched and failing the task loudly.
+        record = IP2Location(str(bin_tmp)).get_all(VALIDATION_IP)
+        if record is None or not record.country_short:
+            raise ValueError("Downloaded IP2Location database failed the validation lookup.")
+
+        # Atomically replace the database file
+        bin_tmp.replace(IP2LOCATION_DB_PATH)
+        logger.info("ip2location_db_updated", member=bin_members[0], size=IP2LOCATION_DB_PATH.stat().st_size)
+    finally:
+        zip_tmp.unlink(missing_ok=True)
+        bin_tmp.unlink(missing_ok=True)

--- a/src/geo/tests/test_tasks.py
+++ b/src/geo/tests/test_tasks.py
@@ -1,0 +1,122 @@
+"""Tests for the IP2Location database download task."""
+
+import io
+import typing as t
+import zipfile
+from pathlib import Path
+
+import pytest
+import requests
+from pytest import MonkeyPatch
+
+from geo import tasks
+
+FAKE_BIN_CONTENT = b"fake-ip2location-binary-database-content"
+
+
+class FakeResponse:
+    """Minimal stand-in for a streaming requests.Response."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int) -> t.Iterator[bytes]:
+        stream = io.BytesIO(self.payload)
+        while chunk := stream.read(chunk_size):
+            yield chunk
+
+
+class FakeRecord:
+    country_short = "US"
+
+
+class FakeIP2Location:
+    """Validation stub: pretends the extracted .BIN is a healthy database."""
+
+    record: t.ClassVar[FakeRecord | None] = FakeRecord()
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def get_all(self, ip: str) -> FakeRecord | None:
+        return self.record
+
+
+def make_zip(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    """Point the task at a temporary database path with a pre-existing live DB."""
+    path = tmp_path / "IP2LOCATION-LITE-DB5.BIN"
+    path.write_bytes(b"previous-live-database")
+    monkeypatch.setattr(tasks, "IP2LOCATION_DB_PATH", path)
+    monkeypatch.setattr(tasks, "IP2Location", FakeIP2Location)
+    monkeypatch.setattr(FakeIP2Location, "record", FakeRecord())
+    return path
+
+
+def _mock_download(monkeypatch: MonkeyPatch, payload: bytes) -> None:
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: FakeResponse(payload))
+
+
+def test_download_extracts_bin_from_zip(db_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """The .BIN member is extracted from the archive and replaces the live file."""
+    payload = make_zip(
+        {
+            "LICENSE_LITE.TXT": b"license",
+            "README_LITE.TXT": b"readme",
+            "IP2LOCATION-LITE-DB5.IPV6.BIN": FAKE_BIN_CONTENT,
+        }
+    )
+    _mock_download(monkeypatch, payload)
+
+    tasks.download_ip2location()
+
+    assert db_path.read_bytes() == FAKE_BIN_CONTENT
+    assert not db_path.with_suffix(".zip.tmp").exists()
+    assert not db_path.with_suffix(".bin.tmp").exists()
+
+
+def test_download_rejects_archive_without_bin(db_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """An archive without exactly one .BIN member fails and keeps the live DB."""
+    _mock_download(monkeypatch, make_zip({"README_LITE.TXT": b"readme"}))
+
+    with pytest.raises(ValueError, match="exactly one .BIN member"):
+        tasks.download_ip2location()
+
+    assert db_path.read_bytes() == b"previous-live-database"
+    assert not db_path.with_suffix(".zip.tmp").exists()
+    assert not db_path.with_suffix(".bin.tmp").exists()
+
+
+def test_download_rejects_non_zip_payload(db_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """A non-zip response body (e.g. an HTML error page) fails loudly."""
+    _mock_download(monkeypatch, b"<html>token expired</html>")
+
+    with pytest.raises(zipfile.BadZipFile):
+        tasks.download_ip2location()
+
+    assert db_path.read_bytes() == b"previous-live-database"
+    assert not db_path.with_suffix(".zip.tmp").exists()
+
+
+def test_download_rejects_database_failing_validation(db_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """A .BIN that fails the validation lookup must not replace the live DB."""
+    payload = make_zip({"IP2LOCATION-LITE-DB5.IPV6.BIN": FAKE_BIN_CONTENT})
+    _mock_download(monkeypatch, payload)
+    monkeypatch.setattr(FakeIP2Location, "record", None)
+
+    with pytest.raises(ValueError, match="validation lookup"):
+        tasks.download_ip2location()
+
+    assert db_path.read_bytes() == b"previous-live-database"
+    assert not db_path.with_suffix(".bin.tmp").exists()

--- a/src/geo/tests/test_tasks.py
+++ b/src/geo/tests/test_tasks.py
@@ -15,10 +15,16 @@ FAKE_BIN_CONTENT = b"fake-ip2location-binary-database-content"
 
 
 class FakeResponse:
-    """Minimal stand-in for a streaming requests.Response."""
+    """Minimal stand-in for a streaming requests.Response used as a context manager."""
 
     def __init__(self, payload: bytes) -> None:
         self.payload = payload
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
 
     def raise_for_status(self) -> None:
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.5"
+version = "1.62.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

**"Nearest First" event sorting has never worked in production** — root cause: `download_ip2location` saves the response from ip2location.com directly to `IP2LOCATION-LITE-DB5.BIN`, but the download endpoint delivers a **ZIP archive** (`.BIN` + license/readme). Every lookup against the zip bytes raises `struct.error`, which `resolve_ip_to_point` swallows at debug level → `user_location = None` for every visitor → no distance sort, ever.

Verified empirically: the prod file began with `PK\x03\x04` (zip magic); extracting the inner `IP2LOCATION-LITE-DB5.IPV6.BIN` makes lookups resolve correctly (tested IPv4 and IPv6 inside the prod container).

## Changes

- **`geo/tasks.py`**: stream the archive to a temp file, extract the single `.BIN` member, **validate the database with a real lookup**, then atomically replace the live file. A failed download/extract/validation raises loudly and leaves the working DB untouched. Temp files always cleaned up.
- **`geo/ip2.py`**: lookup-failure log upgraded `debug` → `warning` (+`exc_info`) so a broken database can never again fail invisibly for months.
- **`geo/tests/test_tasks.py`** (new): the suite never caught this because `conftest.py` autouse-mocks `get_ip2location`. The task tests use a real in-memory zip payload and cover: successful extraction, archive without a `.BIN`, non-zip body (e.g. HTML error page from an expired token), and a database failing validation — asserting the live file survives every failure mode.

## Prod remediation (already applied)

The live `geo-data/IP2LOCATION-LITE-DB5.BIN` was replaced with the extracted database; verified in the prod container:
`2001:871:…` → Vienna (48.209, 16.372) ✓. The weekly cron (Sundays 04:00) would have re-broken it — this fix must deploy before then.

## Note

Even with a healthy DB, `/api/events` is fetched via SvelteKit SSR, so the API sees the server's egress IP (→ Nuremberg) instead of the visitor's. Tracked separately in #487.

`make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geolocation DB update now validates extracted data, performs an atomic swap on success, and ensures temporary files are cleaned up.

* **Bug Fixes**
  * Improved error visibility for IP geolocation lookups—warnings now include full stack traces and diagnostic context.

* **Tests**
  * Added comprehensive tests for database updates covering extraction, validation, non-zip/invalid archives, and cleanup/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->