### PR TITLE
fix(events): stop caching the IP-derived location fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.6"
+version = "1.62.7"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/service/location_service.py
+++ b/src/events/service/location_service.py
@@ -50,8 +50,21 @@ def get_user_location_from_preferences(user: RevelUser) -> Point | None:
     return None
 
 
+# Cached when the user has no saved city preference: ``cache.get_or_set`` cannot
+# distinguish a cached ``None`` from a miss, and we still want to skip the
+# preferences query for users without one.
+_NO_PREFERENCE: t.Final[str] = "NO_PREFERENCE"
+
+
 def get_cached_user_location(user: RevelUser, fallback_location: Point | None = None) -> Point | None:
-    """Get user's location with caching, prioritizing saved city preference.
+    """Get user's location, prioritizing their saved city preference.
+
+    Only the preference lookup is cached: it is stable and explicitly
+    invalidated when preferences change (see ``invalidate_user_location_cache``).
+    The fallback — typically the per-request IP-derived location — is volatile
+    and essentially free to compute (in-process IP2Location lookup), so it is
+    deliberately NEVER cached: freezing it for the TTL pins users to a stale
+    location (a VPN, hotel, or proxy IP) for up to an hour.
 
     Args:
         user: The user whose location to retrieve.
@@ -60,16 +73,11 @@ def get_cached_user_location(user: RevelUser, fallback_location: Point | None = 
     Returns:
         Point | None: The user's location (from preference or fallback), or None.
     """
-
-    def _get_location() -> Point | None:
-        """Callback to compute location when cache miss occurs."""
-        # Try to get from user preferences first
-        location = get_user_location_from_preferences(user)
-        if location:
-            return location
-
-        # Fall back to provided fallback (e.g., IP-based detection)
-        return fallback_location
-
-    # Use cache.get_or_set with a 1-hour timeout (invalidated on preference change)
-    return cache.get_or_set(get_user_location_cache_key(user.id), _get_location, timeout=3600)
+    preference = cache.get_or_set(
+        get_user_location_cache_key(user.id),
+        lambda: get_user_location_from_preferences(user) or _NO_PREFERENCE,
+        timeout=3600,
+    )
+    if isinstance(preference, Point):
+        return preference
+    return fallback_location

--- a/src/events/tests/test_service/test_location_service.py
+++ b/src/events/tests/test_service/test_location_service.py
@@ -1,5 +1,7 @@
 """Tests for location caching service."""
 
+import typing as t
+
 import pytest
 from django.contrib.gis.geos import Point
 from django.core.cache import cache
@@ -165,22 +167,48 @@ class TestGetCachedUserLocation:
         assert location.x == fallback.x
         assert location.y == fallback.y
 
-    def test_caches_fallback_location(self, revel_user_factory: RevelUserFactory) -> None:
-        """Test that fallback location is also cached."""
+    def test_does_not_cache_fallback_location(self, revel_user_factory: RevelUserFactory) -> None:
+        """The IP-derived fallback must never be cached.
+
+        Regression test: caching the fallback froze a user's location to
+        whatever IP they happened to have (VPN, proxy, or — in the original
+        incident — the server's own egress IP) for the full TTL.
+        """
         user = revel_user_factory()
-        fallback = Point(50.0, 60.0)
         cache_key = get_user_location_cache_key(user.id)
         cache.delete(cache_key)
 
-        # First call with fallback
-        location1 = get_cached_user_location(user, fallback_location=fallback)
-        assert location1 == fallback
+        # First call with one fallback
+        location1 = get_cached_user_location(user, fallback_location=Point(50.0, 60.0))
+        assert location1 is not None
+        assert (location1.x, location1.y) == (50.0, 60.0)
 
-        # Second call without fallback should still return cached fallback
-        location2 = get_cached_user_location(user, fallback_location=None)
+        # A later call with a different fallback (user's IP changed) must
+        # reflect the new fallback, not the first one.
+        location2 = get_cached_user_location(user, fallback_location=Point(70.0, 80.0))
         assert location2 is not None
-        assert location2.x == fallback.x
-        assert location2.y == fallback.y
+        assert (location2.x, location2.y) == (70.0, 80.0)
+
+        # And no fallback means no location — nothing lingers in the cache.
+        assert get_cached_user_location(user, fallback_location=None) is None
+
+    def test_no_preference_lookup_is_cached(
+        self, revel_user_factory: RevelUserFactory, django_assert_num_queries: t.Any
+    ) -> None:
+        """The absence of a city preference is cached (as a sentinel), so
+        repeat calls skip the preferences query while still using the fresh
+        per-request fallback."""
+        user = revel_user_factory()
+        cache_key = get_user_location_cache_key(user.id)
+        cache.delete(cache_key)
+
+        get_cached_user_location(user, fallback_location=None)
+        assert cache.get(cache_key) == "NO_PREFERENCE"
+
+        with django_assert_num_queries(0):
+            location = get_cached_user_location(user, fallback_location=Point(1.0, 2.0))
+        assert location is not None
+        assert (location.x, location.y) == (1.0, 2.0)
 
     def test_returns_none_when_no_preference_and_no_fallback(self, revel_user_factory: RevelUserFactory) -> None:
         """Test that None is returned when there's no preference and no fallback."""

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.6"
+version = "1.62.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

Follow-up to today's #487 rollout: `get_cached_user_location` cached **whatever** location it resolved — including the volatile IP-derived fallback — under `user_location:<id>` for 1 hour with no invalidation path. Observed in production: a logged-in user browsed during the window when SSR requests still carried the server's egress IP, got geolocated to Nuremberg, and stayed sorted from Nuremberg for the full TTL even after the IP forwarding was fixed. The everyday variant: a VPN/hotel/mobile IP pins the user's "Nearest First" to the wrong city for an hour.

## Change

Cache **only the city-preference lookup** — it's stable, and `invalidate_user_location_cache` already covers preference changes. Users without a preference get a `"NO_PREFERENCE"` sentinel cached (so the preferences query is still skipped on repeat calls — `cache.get_or_set` can't distinguish a cached `None` from a miss). The fallback is evaluated fresh per request: it's an in-process IP2Location lookup, effectively free.

Behavior matrix (unchanged → fixed):
- preference set → preference location, cached ✓ (unchanged)
- no preference + IP fallback → fallback returned, **no longer cached**
- no preference, no fallback → `None` (unchanged)
- preference change → invalidation works as before (unchanged)

## Tests

- `test_caches_fallback_location` (asserted the buggy behavior) replaced by `test_does_not_cache_fallback_location` — regression test: a second call with a different fallback must reflect the new one.
- New `test_no_preference_lookup_is_cached` — sentinel is cached and repeat calls run 0 queries while still honoring the fresh fallback.
- Existing preference-caching/invalidations tests pass unchanged.

`make check` clean. Refs #487, #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed location preference caching to properly distinguish between no saved city preference and actual cached values, preventing fallback locations from being incorrectly retained across requests.

* **Chores**
  * Version updated to 1.62.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->