### PR TITLE
chore: update Discord invite link

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -32,5 +32,5 @@ We welcome contributions! Whether you're reporting a bug, suggesting a feature, 
 
 ## Community
 
-- **Discord**: [Join us](https://discord.gg/zy8nTDqQ) for questions and discussion
+- **Discord**: [Join us](https://discord.gg/Rnwbzuvxvn) for questions and discussion
 - **Issues**: [GitHub Issues](https://github.com/letsrevel/revel-backend/issues) for bugs and features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,5 +154,5 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/letsrevel
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/zy8nTDqQ
+      link: https://discord.gg/Rnwbzuvxvn
   generator: false


### PR DESCRIPTION
The Discord invite in `mkdocs.yml` and the contributing docs was expired. Replaces it with the permanent invite `discord.gg/Rnwbzuvxvn` (the README already had it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)