### PR TITLE
fix(stripe): replay idempotent task dispatches on duplicate webhooks (#483)

### DIFF
--- a/docs/runbooks/stripe-hardening-rollout.md
+++ b/docs/runbooks/stripe-hardening-rollout.md
@@ -27,7 +27,7 @@ host-as-org binding.
 
 | structlog key | Meaning |
 |---|---|
-| `stripe_webhook_duplicate` | Redelivered event id no-opped. **Expected noise during Phase 3 overlap.** |
+| `stripe_webhook_duplicate` | Redelivered event id: full handler skipped, idempotent invoice/credit-note dispatches replayed. **Expected noise during Phase 3 overlap.** |
 | `stripe_webhook_signature_failed` | No configured secret matched → 403. Investigate if persistent. |
 | `stripe_webhook_secret_missing` | Only placeholder secrets configured → everything 403s. Config error. |
 | `stripe_webhook_malformed_json` | Valid HMAC but unparseable body. Should never happen from Stripe. |

--- a/src/events/admin/stripe_webhook_event.py
+++ b/src/events/admin/stripe_webhook_event.py
@@ -31,6 +31,10 @@ class StripeWebhookEventAdmin(ModelAdmin):  # type: ignore[misc]
         """Rows are recorded by the webhook handler; humans don't add them."""
         return False
 
+    def has_change_permission(self, request: HttpRequest, obj: models.StripeWebhookEvent | None = None) -> bool:
+        """The log is an audit trail; rows are immutable once recorded."""
+        return False
+
     def has_delete_permission(self, request: HttpRequest, obj: models.StripeWebhookEvent | None = None) -> bool:
         """Deleting the idempotency log would invite double-processing."""
         return False

--- a/src/events/apps.py
+++ b/src/events/apps.py
@@ -6,7 +6,15 @@ class EventsConfig(AppConfig):
     name = "events"
 
     def ready(self) -> None:
-        """Import signals/tasks and register the per-app exception handlers."""
+        """Run startup-time side effects for the events app.
+
+        Imports the signal handlers and the ``tasks_stripe`` module (so the
+        Celery worker registers its tasks) and installs the per-app exception
+        handlers on the global Ninja API.
+
+        Returns:
+            None: Performs registration side effects only.
+        """
         from . import signals, tasks_stripe  # noqa: F401
         from .exception_handlers import register as register_exception_handlers
 

--- a/src/events/exception_handlers.py
+++ b/src/events/exception_handlers.py
@@ -49,7 +49,15 @@ from events.service.ticket_service import (
 
 
 def handle_user_is_ineligible_error(request: HttpRequest, exc: Exception | t.Type[Exception]) -> Response:
-    """Handle a user is-ineligible error by returning the eligibility payload."""
+    """Handle a user is-ineligible error by returning the eligibility payload.
+
+    Args:
+        request: The current HTTP request (unused; required by the handler signature).
+        exc: The raised ``UserIsIneligibleError`` carrying the eligibility report.
+
+    Returns:
+        Response: A 400 response whose body is the serialized eligibility payload.
+    """
     return Response(status=400, data=t.cast(UserIsIneligibleError, exc).eligibility.model_dump(mode="json"))
 
 

--- a/src/events/models/stripe_webhook_event.py
+++ b/src/events/models/stripe_webhook_event.py
@@ -10,9 +10,11 @@ class StripeWebhookEvent(TimeStampedModel):
 
     The unique ``event_id`` doubles as the idempotency token: ``handle_event``
     inserts the row *before* dispatching, so Stripe redeliveries trip the
-    unique constraint and no-op. If a handler raises, the surrounding request
-    transaction rolls this row back too, so the Stripe retry reprocesses the
-    event instead of being swallowed by the dedup gate.
+    unique constraint and skip the full handler (only the idempotent
+    post-commit task dispatches are replayed — see
+    ``StripeEventHandler.replay``). If a handler raises, the surrounding
+    request transaction rolls this row back too, so the Stripe retry
+    reprocesses the event instead of being swallowed by the dedup gate.
 
     Rows are pruned after ``settings.STRIPE_WEBHOOK_EVENT_RETENTION_DAYS``
     (Stripe retries deliveries for at most 3 days, so pruned ids can never be

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -61,11 +61,17 @@ def handle_event(event: stripe.Event) -> None:
     """Route a verified event to its handler, idempotent on Stripe's event id.
 
     The ``StripeWebhookEvent`` INSERT is the idempotency token: Stripe
-    redeliveries trip the unique constraint and return silently. The insert
-    runs in a nested atomic block (savepoint) so a duplicate-key violation
-    doesn't poison the outer transaction. If the handler raises, the whole
-    request transaction (ATOMIC_REQUESTS) rolls back including this row, so
-    the next Stripe retry reprocesses the event.
+    redeliveries trip the unique constraint and skip the full handler. The
+    insert runs in a nested atomic block (savepoint) so a duplicate-key
+    violation doesn't poison the outer transaction. If the handler raises, the
+    whole request transaction (ATOMIC_REQUESTS) rolls back including this row,
+    so the next Stripe retry reprocesses the event.
+
+    A duplicate is not a pure no-op: the first delivery's ``on_commit``
+    ``.delay()`` calls ran *after* its commit and may have failed (e.g. broker
+    outage) without rolling anything back, so redelivery is Stripe's retry
+    mechanism for exactly that window — :meth:`StripeEventHandler.replay`
+    re-enqueues the idempotent downstream tasks.
     """
     try:
         with transaction.atomic():
@@ -79,8 +85,10 @@ def handle_event(event: stripe.Event) -> None:
     except (IntegrityError, DjangoValidationError):
         # IntegrityError = DB unique violation (race past full_clean);
         # ValidationError = TimeStampedModel.save's full_clean caught the
-        # duplicate first. Either way: redelivery, no-op.
+        # duplicate first. Either way: redelivery — retry the post-commit
+        # task dispatches, then stop.
         logger.info("stripe_webhook_duplicate", event_id=event.id, event_type=event.type)
+        StripeEventHandler(event).replay()
         return
 
     handled = StripeEventHandler(event).handle()
@@ -113,6 +121,74 @@ class StripeEventHandler:
     def handle_unknown_event(self, event: stripe.Event) -> None:
         """Log unhandled event types for future development."""
         logger.info("stripe_webhook_unhandled_event", event_type=event.type, event_id=event.id)
+
+    def replay(self) -> None:
+        """Re-enqueue idempotent downstream tasks for a redelivered event.
+
+        The dedup gate in :func:`handle_event` stops the full handler from
+        re-running, but the first delivery's ``transaction.on_commit``
+        ``.delay()`` calls fired after that commit and may have failed (e.g.
+        broker outage) without rolling the dedup row back. Stripe redelivery
+        is the retry mechanism for that window, so re-enqueue the tasks here;
+        downstream is idempotent and skips work already done.
+        """
+        replayers: dict[str, t.Callable[[stripe.Event], None]] = {
+            "checkout.session.completed": self.replay_checkout_session_completed,
+            "charge.refunded": self.replay_charge_refunded,
+        }
+        replayer = replayers.get(self.event.type)
+        if replayer is not None:
+            replayer(self.event)
+
+    def replay_checkout_session_completed(self, event: stripe.Event) -> None:
+        """Re-enqueue invoice generation for a redelivered checkout completion.
+
+        Mirrors the unconditional enqueue (and its guards) in
+        :meth:`handle_checkout_session_completed` so a ``.delay()`` that
+        failed on the first delivery gets retried.
+        """
+        session = event.data.object
+        session_id = session["id"]
+        if session["payment_status"] not in {"paid", "no_payment_required"}:
+            return
+        if not Payment.objects.filter(stripe_session_id=session_id).exists():
+            return
+
+        def _trigger_invoice() -> None:
+            from events.tasks import generate_attendee_invoice_task
+
+            generate_attendee_invoice_task.delay(session_id)
+
+        transaction.on_commit(_trigger_invoice)
+
+    def replay_charge_refunded(self, event: stripe.Event) -> None:
+        """Re-enqueue credit-note generation for a redelivered refund.
+
+        Mirrors the "pure duplicate webhook" branch of
+        :meth:`_schedule_credit_note`: the payments the first delivery
+        refunded are ``refund_status=SUCCEEDED`` by now, so retry the credit
+        note for exactly those.
+        """
+        payment_intent_id = event.data.object.get("payment_intent")
+        if not payment_intent_id:
+            return
+        refunded = list(
+            Payment.objects.filter(
+                stripe_payment_intent_id=payment_intent_id,
+                refund_status=Payment.RefundStatus.SUCCEEDED,
+            )
+        )
+        if not refunded:
+            return
+        sid = refunded[0].stripe_session_id
+        ids = [str(p.id) for p in refunded]
+
+        def _retry_credit_note() -> None:
+            from events.tasks import generate_attendee_credit_note_task
+
+            generate_attendee_credit_note_task.delay(sid, ids)
+
+        transaction.on_commit(_retry_credit_note)
 
     @transaction.atomic
     def handle_checkout_session_completed(self, event: stripe.Event) -> None:

--- a/src/events/tests/test_admin/test_stripe_webhook_event_admin.py
+++ b/src/events/tests/test_admin/test_stripe_webhook_event_admin.py
@@ -11,8 +11,9 @@ pytestmark = pytest.mark.django_db
 
 
 def test_registered_and_read_only(rf: t.Any) -> None:
-    """The event log admin is registered and rejects add/delete."""
+    """The event log admin is registered and rejects add/change/delete."""
     admin_instance = site._registry[StripeWebhookEvent]
     request = rf.get("/")
     assert admin_instance.has_add_permission(request) is False
+    assert admin_instance.has_change_permission(request) is False
     assert admin_instance.has_delete_permission(request) is False

--- a/src/events/tests/test_service/test_stripe_webhook_dispatch.py
+++ b/src/events/tests/test_service/test_stripe_webhook_dispatch.py
@@ -11,7 +11,7 @@ from django.db import transaction
 from django.test import override_settings
 
 from events.exceptions import InvalidStripeWebhookSignatureError
-from events.models import StripeWebhookEvent
+from events.models import Payment, StripeWebhookEvent, Ticket
 from events.service import stripe_webhooks
 
 pytestmark = pytest.mark.django_db
@@ -113,12 +113,107 @@ def test_handle_event_unknown_type_marked_unhandled() -> None:
 
 
 def test_handle_event_duplicate_is_noop() -> None:
-    """A redelivered event id must not reach the handler a second time."""
+    """A redelivered event id must not reach the full handler a second time."""
     stripe_webhooks.handle_event(_make_event(event_id="evt_dup"))
     with patch.object(stripe_webhooks.StripeEventHandler, "handle") as spy:
         stripe_webhooks.handle_event(_make_event(event_id="evt_dup"))
     spy.assert_not_called()
     assert StripeWebhookEvent.objects.filter(event_id="evt_dup").count() == 1
+
+
+def _make_checkout_event(session_id: str, event_id: str = "evt_checkout_replay") -> stripe.Event:
+    return stripe.Event.construct_from(
+        {
+            "id": event_id,
+            "object": "event",
+            "type": "checkout.session.completed",
+            "livemode": False,
+            "data": {
+                "object": {
+                    "id": session_id,
+                    "object": "checkout.session",
+                    "payment_status": "paid",
+                    "payment_intent": "pi_replay_checkout",
+                }
+            },
+        },
+        "sk_test_x",
+    )
+
+
+def _make_refund_event(payment_intent_id: str, event_id: str = "evt_refund_replay") -> stripe.Event:
+    return stripe.Event.construct_from(
+        {
+            "id": event_id,
+            "object": "event",
+            "type": "charge.refunded",
+            "livemode": False,
+            "data": {
+                "object": {
+                    "id": "ch_replay",
+                    "object": "charge",
+                    "payment_intent": payment_intent_id,
+                    "refunds": {"data": []},
+                }
+            },
+        },
+        "sk_test_x",
+    )
+
+
+def test_duplicate_checkout_replay_reenqueues_invoice(
+    ticket: Ticket,
+    payment_factory: t.Callable[..., Payment],
+    django_capture_on_commit_callbacks: t.Any,
+) -> None:
+    """A redelivered checkout completion retries the invoice dispatch.
+
+    The first delivery's on_commit ``.delay()`` runs after the dedup row has
+    committed and may fail (e.g. broker outage); the redelivery must
+    re-enqueue the idempotent invoice task instead of pure no-oping.
+    """
+    payment_factory(ticket, stripe_session_id="cs_replay_1")
+    stripe_webhooks.handle_event(_make_checkout_event("cs_replay_1"))
+    with (
+        patch("events.tasks.generate_attendee_invoice_task.delay") as delay_spy,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        stripe_webhooks.handle_event(_make_checkout_event("cs_replay_1"))
+    delay_spy.assert_called_once_with("cs_replay_1")
+
+
+def test_duplicate_checkout_replay_skips_unknown_session(
+    django_capture_on_commit_callbacks: t.Any,
+) -> None:
+    """Replaying a checkout completion with no matching payments enqueues nothing."""
+    StripeWebhookEvent.objects.create(event_id="evt_checkout_orphan", event_type="checkout.session.completed")
+    with (
+        patch("events.tasks.generate_attendee_invoice_task.delay") as delay_spy,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        stripe_webhooks.handle_event(_make_checkout_event("cs_orphan", event_id="evt_checkout_orphan"))
+    delay_spy.assert_not_called()
+
+
+def test_duplicate_refund_replay_reenqueues_credit_note(
+    ticket: Ticket,
+    payment_factory: t.Callable[..., Payment],
+    django_capture_on_commit_callbacks: t.Any,
+) -> None:
+    """A redelivered charge.refunded retries the credit-note dispatch for refunded payments."""
+    payment = payment_factory(
+        ticket,
+        stripe_session_id="cs_replay_refund",
+        stripe_payment_intent_id="pi_replay_refund",
+        refund_status=Payment.RefundStatus.SUCCEEDED,
+    )
+    StripeWebhookEvent.objects.create(event_id="evt_refund_replay", event_type="charge.refunded")
+    with (
+        patch("events.tasks.generate_attendee_credit_note_task.delay") as delay_spy,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        stripe_webhooks.handle_event(_make_refund_event("pi_replay_refund"))
+    delay_spy.assert_called_once_with("cs_replay_refund", [str(payment.id)])
 
 
 def test_handler_error_rolls_back_dedup_row() -> None:


### PR DESCRIPTION
## Summary

Code-review follow-ups to #491 that missed the merge (they were uncommitted when the PR was merged).

- **Redelivery replay**: `handle_event` no longer treats a redelivered event id as a pure no-op. The first delivery's `transaction.on_commit` `.delay()` calls run *after* the dedup row commits and can fail without rollback (e.g. broker outage) — previously the redelivery would be no-oped and the invoice/credit-note never generated, silently breaking the recovery path that commit e632582 established ("This must run even on duplicate webhooks…"). Duplicates now go through `StripeEventHandler.replay()`, which re-enqueues only the idempotent downstream dispatches (`generate_attendee_invoice_task`, `generate_attendee_credit_note_task`); the full handlers still never re-run, so the #491 dedup goal is preserved.
- **Admin**: `StripeWebhookEventAdmin` now forbids change as well as add/delete, matching the read-only admin precedent (`EmailLogAdmin`, `ReferralPayoutAdmin`).
- **Docstrings**: Google-style docstrings for `EventsConfig.ready` and `handle_user_is_ineligible_error`, resolving the open PR #452 review comments.
- **Docs**: runbook log-key table and the `StripeWebhookEvent` model docstring updated to describe the replay semantics instead of "no-op".

## Test plan

- [ ] `make test` — new tests cover: duplicate checkout redelivery re-enqueues the invoice task (via `django_capture_on_commit_callbacks`), replay with no matching payments enqueues nothing, duplicate `charge.refunded` re-enqueues the credit note with the refunded payment ids, and the admin rejects add/change/delete.
- [x] `make format lint mypy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duplicate Stripe webhook event handling to replay idempotent tasks instead of silently skipping.
  * Prevented accidental modifications to Stripe webhook event logs in the admin interface.

* **Documentation**
  * Updated runbooks and internal documentation clarifying Stripe webhook idempotency behavior during event redeliveries.

* **Tests**
  * Added test coverage for Stripe webhook duplicate event handling and task replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->