### PR TITLE
feat(stripe): hardening phase 2 — pin API version + charge.refunded compat fix (#483)

### DIFF
--- a/docs/runbooks/stripe-hardening-rollout.md
+++ b/docs/runbooks/stripe-hardening-rollout.md
@@ -83,6 +83,12 @@ place is harmless.
 **Preconditions:** Phase 1 deployed and verified. Compat audit (clover → dahlia for
 Checkout Session, Charge, Refund, PaymentIntent, Account) recorded in PR 2.
 
+PR 2 also ships a `charge.refunded` compat fix: payloads rendered at any API version
+>= 2022-11-15 (so the basil-pinned endpoint today, and the dahlia endpoints from
+Phase 3) do **not** embed the charge's `refunds` list; the handler now fetches the
+refunds outbound (`stripe.Refund.list`) when the payload omits them. The dashboard
+refund in step 2 below is what verifies this path end-to-end.
+
 **Steps (demo, then prod):**
 
 1. Deploy PR 2. No env change needed (`STRIPE_API_VERSION` defaults to

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -803,6 +803,7 @@ def delete_old_inactive_accounts() -> dict[str, t.Any]:
 # ---------------------------------------------------------------------------
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = settings.STRIPE_API_VERSION
 
 
 def _reclaim_stale_payouts() -> None:

--- a/src/common/service/stripe_connect_service.py
+++ b/src/common/service/stripe_connect_service.py
@@ -16,6 +16,7 @@ from pydantic import EmailStr
 from common.models import StripeConnectMixin
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = settings.STRIPE_API_VERSION
 
 
 def get_account_details(account_id: str) -> stripe.Account:

--- a/src/events/models/stripe_webhook_event.py
+++ b/src/events/models/stripe_webhook_event.py
@@ -16,9 +16,11 @@ class StripeWebhookEvent(TimeStampedModel):
     request transaction rolls this row back too, so the Stripe retry
     reprocesses the event instead of being swallowed by the dedup gate.
 
-    Rows are pruned after ``settings.STRIPE_WEBHOOK_EVENT_RETENTION_DAYS``
-    (Stripe retries deliveries for at most 3 days, so pruned ids can never be
-    legitimately redelivered).
+    Rows are pruned after ``settings.STRIPE_WEBHOOK_EVENT_RETENTION_DAYS``.
+    Stripe auto-retries deliveries for at most 3 days, but operators can also
+    manually resend an event for as long as Stripe retains it (up to 30 days),
+    so the retention window must stay >= 30 days for pruned ids to never be
+    legitimately redelivered (default: 90).
     """
 
     class Outcome(models.TextChoices):

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -46,7 +46,11 @@ if t.TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+# Pin both credentials and API version at import time. The pinned version
+# guards outbound response shapes against silent changes when the stripe SDK
+# (whose default version tracks its release) gets bumped by a `uv sync`.
 stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = settings.STRIPE_API_VERSION
 
 
 def create_connect_account(organization: Organization, stripe_account_email: EmailStr) -> str:

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -20,6 +20,12 @@ from events.utils.currency import from_stripe_amount, to_stripe_amount
 
 logger = structlog.get_logger(__name__)
 
+# Pin both credentials and API version at import time (mirrors stripe_service).
+# This module makes its own outbound call (Refund.list in _resolve_refunds), so
+# it must not rely on another module's import side effects to set the pin.
+stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = settings.STRIPE_API_VERSION
+
 # Placeholder values that must never be treated as real signing secrets.
 _PLACEHOLDER_SECRETS = frozenset({"whsec_...", "whsec_placeholder", ""})
 
@@ -330,6 +336,20 @@ class StripeEventHandler:
             logger.warning("stripe_refund_missing_intent", charge_id=charge_data.get("id"))
             return
 
+        # Cheap unlocked probe so unknown intents bail before any outbound call.
+        if not Payment.objects.filter(stripe_payment_intent_id=payment_intent_id).exists():
+            logger.warning("stripe_refund_unknown_intent", payment_intent_id=payment_intent_id)
+            return
+
+        # Resolve refunds BEFORE taking row locks: _resolve_refunds may make an
+        # outbound Stripe call, and holding select_for_update locks across that
+        # network round-trip would block concurrent user-initiated cancels
+        # (cancellation_service locks the same Payment rows) for its duration.
+        refunds = self._resolve_refunds(charge_data)
+        if not refunds:
+            logger.warning("stripe_refund_event_no_refund_data", payment_intent_id=payment_intent_id)
+            return
+
         # Lock Payment rows for the duration of this transaction. Stripe webhooks
         # are at-least-once, and a Stripe-Dashboard refund's webhook can also race
         # against an in-flight user-initiated cancel (which itself locks the same
@@ -347,12 +367,54 @@ class StripeEventHandler:
             logger.warning("stripe_refund_unknown_intent", payment_intent_id=payment_intent_id)
             return
 
-        refunds = self._resolve_refunds(charge_data)
-        if not refunds:
-            logger.warning("stripe_refund_event_no_refund_data", payment_intent_id=payment_intent_id)
-            return
+        newly_refunded_ids, touched_session_id, affected_event_ids = self._process_refunds(
+            refunds=refunds,
+            candidates=candidates,
+            raw_response=dict(event),
+            payment_intent_id=payment_intent_id,
+        )
 
-        raw_response = dict(event)
+        # One enqueue per event regardless of how many tickets cancelled inside it;
+        # the processor scans all freed seats in a single pass.
+        for event_id in affected_event_ids:
+            enqueue_waitlist_processing(event_id)
+
+        self._schedule_credit_note(
+            payment_intent_id=payment_intent_id,
+            candidates=candidates,
+            newly_refunded_ids=newly_refunded_ids,
+            touched_session_id=touched_session_id,
+        )
+
+        logger.info(
+            "stripe_refund_processed",
+            payment_intent_id=payment_intent_id,
+            refund_count=len(refunds),
+            newly_refunded_payment_ids=newly_refunded_ids,
+        )
+
+    def _process_refunds(
+        self,
+        *,
+        refunds: list[dict[str, t.Any]],
+        candidates: list[Payment],
+        raw_response: dict[str, t.Any],
+        payment_intent_id: str,
+    ) -> tuple[list[str], str | None, set[uuid.UUID]]:
+        """Match each refund to its Payment(s) and apply it.
+
+        Args:
+            refunds: The charge's refund object dicts (from _resolve_refunds).
+            candidates: All locked Payment rows for this intent.
+            raw_response: The full serialised webhook event (for audit).
+            payment_intent_id: Stripe payment intent id (logging only).
+
+        Returns:
+            A ``(newly_refunded_ids, touched_session_id, affected_event_ids)``
+            tuple: the Payment ids mutated in this call, the session id of the
+            last mutated Payment (or None), and the event ids whose capacity
+            was freed by a ticket cancellation.
+        """
         touched_session_id: str | None = None
         newly_refunded_ids: list[str] = []
         affected_event_ids: set[uuid.UUID] = set()
@@ -385,24 +447,7 @@ class StripeEventHandler:
                 if cancelled_event_id is not None:
                     affected_event_ids.add(cancelled_event_id)
 
-        # One enqueue per event regardless of how many tickets cancelled inside it;
-        # the processor scans all freed seats in a single pass.
-        for event_id in affected_event_ids:
-            enqueue_waitlist_processing(event_id)
-
-        self._schedule_credit_note(
-            payment_intent_id=payment_intent_id,
-            candidates=candidates,
-            newly_refunded_ids=newly_refunded_ids,
-            touched_session_id=touched_session_id,
-        )
-
-        logger.info(
-            "stripe_refund_processed",
-            payment_intent_id=payment_intent_id,
-            refund_count=len(refunds),
-            newly_refunded_payment_ids=newly_refunded_ids,
-        )
+        return newly_refunded_ids, touched_session_id, affected_event_ids
 
     def _resolve_refunds(self, charge_data: dict[str, t.Any]) -> list[dict[str, t.Any]]:
         """Return the charge's refunds, from the payload or the Stripe API.
@@ -422,8 +467,8 @@ class StripeEventHandler:
             charge_data: The Charge object from the webhook payload.
 
         Returns:
-            The charge's refunds as dicts, newest first. Empty if the charge
-            has none (or the payload carries no charge id).
+            The charge's refunds as dicts. Empty if the charge has none (or
+            the payload carries no charge id).
         """
         embedded = charge_data.get("refunds", {}).get("data", []) or []
         if embedded:
@@ -434,7 +479,9 @@ class StripeEventHandler:
         params: dict[str, t.Any] = {"charge": charge_id, "limit": 100}
         if account := getattr(self.event, "account", None):
             params["stripe_account"] = account
-        return [dict(refund) for refund in stripe.Refund.list(**params).data]
+        # auto_paging_iter walks past the first page (limit is just page size),
+        # so a charge with >100 refunds doesn't silently drop the tail.
+        return [dict(refund) for refund in stripe.Refund.list(**params).auto_paging_iter()]
 
     def _schedule_credit_note(
         self,

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -347,7 +347,7 @@ class StripeEventHandler:
             logger.warning("stripe_refund_unknown_intent", payment_intent_id=payment_intent_id)
             return
 
-        refunds = charge_data.get("refunds", {}).get("data", []) or []
+        refunds = self._resolve_refunds(charge_data)
         if not refunds:
             logger.warning("stripe_refund_event_no_refund_data", payment_intent_id=payment_intent_id)
             return
@@ -403,6 +403,38 @@ class StripeEventHandler:
             refund_count=len(refunds),
             newly_refunded_payment_ids=newly_refunded_ids,
         )
+
+    def _resolve_refunds(self, charge_data: dict[str, t.Any]) -> list[dict[str, t.Any]]:
+        """Return the charge's refunds, from the payload or the Stripe API.
+
+        Payloads rendered at API versions >= 2022-11-15 don't embed the
+        charge's refunds list, so any *pinned* webhook endpoint delivers
+        ``charge.refunded`` without it — fetch it outbound in that case.
+        Embedded refunds (old unpinned endpoints) short-circuit without an
+        API call.
+
+        Connected-account events carry ``event.account``; the refunds then
+        live on that account, so the request needs the ``Stripe-Account``
+        header. A failed call raises, rolling the webhook transaction (and the
+        dedup row) back so the Stripe retry reprocesses the event.
+
+        Args:
+            charge_data: The Charge object from the webhook payload.
+
+        Returns:
+            The charge's refunds as dicts, newest first. Empty if the charge
+            has none (or the payload carries no charge id).
+        """
+        embedded = charge_data.get("refunds", {}).get("data", []) or []
+        if embedded:
+            return list(embedded)
+        charge_id = charge_data.get("id")
+        if not charge_id:
+            return []
+        params: dict[str, t.Any] = {"charge": charge_id, "limit": 100}
+        if account := getattr(self.event, "account", None):
+            params["stripe_account"] = account
+        return [dict(refund) for refund in stripe.Refund.list(**params).data]
 
     def _schedule_credit_note(
         self,

--- a/src/events/tests/test_controllers/test_stripe_webhook_refund_matching.py
+++ b/src/events/tests/test_controllers/test_stripe_webhook_refund_matching.py
@@ -162,7 +162,7 @@ class TestRefundsFetchedOutbound:
         event = _charge_event("pi_pinned", refunds=None)
 
         with patch.object(stripe.Refund, "list") as list_mock:
-            list_mock.return_value.data = [refund]
+            list_mock.return_value.auto_paging_iter.return_value = [refund]
             StripeEventHandler(event).handle_charge_refunded(event)
 
         list_mock.assert_called_once_with(charge="ch_test", limit=100)
@@ -179,7 +179,7 @@ class TestRefundsFetchedOutbound:
         event = _charge_event("pi_pinned_conn", refunds=None, account="acct_conn_42")
 
         with patch.object(stripe.Refund, "list") as list_mock:
-            list_mock.return_value.data = [refund]
+            list_mock.return_value.auto_paging_iter.return_value = [refund]
             StripeEventHandler(event).handle_charge_refunded(event)
 
         list_mock.assert_called_once_with(charge="ch_test", limit=100, stripe_account="acct_conn_42")
@@ -193,10 +193,19 @@ class TestRefundsFetchedOutbound:
         event = _charge_event("pi_pinned_empty", refunds=None)
 
         with patch.object(stripe.Refund, "list") as list_mock:
-            list_mock.return_value.data = []
+            list_mock.return_value.auto_paging_iter.return_value = []
             StripeEventHandler(event).handle_charge_refunded(event)
 
         for payment in payments:
             payment.refresh_from_db()
             assert payment.refund_status is None
             assert payment.status == Payment.PaymentStatus.SUCCEEDED
+
+    def test_unknown_intent_skips_api_fetch(self) -> None:
+        """No Payment rows for the intent → bail before any outbound call."""
+        event = _charge_event("pi_nobody_knows", refunds=None)
+
+        with patch.object(stripe.Refund, "list") as list_mock:
+            StripeEventHandler(event).handle_charge_refunded(event)
+
+        list_mock.assert_not_called()

--- a/src/events/tests/test_controllers/test_stripe_webhook_refund_matching.py
+++ b/src/events/tests/test_controllers/test_stripe_webhook_refund_matching.py
@@ -2,7 +2,7 @@
 
 import typing as t
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import stripe
@@ -14,15 +14,24 @@ from events.service.stripe_webhooks import StripeEventHandler
 pytestmark = pytest.mark.django_db
 
 
-def _charge_event(payment_intent_id: str, refunds: list[dict[str, t.Any]]) -> stripe.Event:
+def _charge_event(
+    payment_intent_id: str,
+    refunds: list[dict[str, t.Any]] | None,
+    account: str | None = None,
+) -> stripe.Event:
     ev = MagicMock(spec=stripe.Event)
     ev.type = "charge.refunded"
+    ev.account = account
     ev.data = MagicMock()
-    ev.data.object = {
+    obj: dict[str, t.Any] = {
         "id": "ch_test",
         "payment_intent": payment_intent_id,
-        "refunds": {"data": refunds},
     }
+    # refunds=None mimics a payload rendered at API >= 2022-11-15 (pinned
+    # endpoint): the refunds list is not embedded at all.
+    if refunds is not None:
+        obj["refunds"] = {"data": refunds}
+    ev.data.object = obj
     # Make dict(event) serializable — tests shouldn't care about exact shape,
     # so patch out raw_response assignment in the handler by providing __iter__.
     ev.__iter__.return_value = iter([])
@@ -139,3 +148,55 @@ class TestChargeRefundedMatching:
         StripeEventHandler(event).handle_charge_refunded(event)
         target.refresh_from_db()
         assert target.status == Payment.PaymentStatus.REFUNDED
+
+
+class TestRefundsFetchedOutbound:
+    """Pinned endpoints (API >= 2022-11-15) deliver charge.refunded without embedded refunds."""
+
+    def test_missing_refunds_list_is_fetched_from_api(self, batch_of_4_online_payments: list[Payment]) -> None:
+        """A payload with no refunds key falls back to stripe.Refund.list."""
+        payments = batch_of_4_online_payments
+        _batch(payments, "pi_pinned")
+        target = payments[1]
+        refund: dict[str, t.Any] = {"id": "re_api_1", "amount": 4000, "metadata": {"ticket_id": str(target.ticket_id)}}
+        event = _charge_event("pi_pinned", refunds=None)
+
+        with patch.object(stripe.Refund, "list") as list_mock:
+            list_mock.return_value.data = [refund]
+            StripeEventHandler(event).handle_charge_refunded(event)
+
+        list_mock.assert_called_once_with(charge="ch_test", limit=100)
+        target.refresh_from_db()
+        assert target.refund_status == Payment.RefundStatus.SUCCEEDED
+        assert target.status == Payment.PaymentStatus.REFUNDED
+
+    def test_connected_account_event_forwards_stripe_account(self, batch_of_4_online_payments: list[Payment]) -> None:
+        """Connect events fetch the refunds with the Stripe-Account header."""
+        payments = batch_of_4_online_payments
+        _batch(payments, "pi_pinned_conn")
+        target = payments[0]
+        refund: dict[str, t.Any] = {"id": "re_api_2", "amount": 4000, "metadata": {"ticket_id": str(target.ticket_id)}}
+        event = _charge_event("pi_pinned_conn", refunds=None, account="acct_conn_42")
+
+        with patch.object(stripe.Refund, "list") as list_mock:
+            list_mock.return_value.data = [refund]
+            StripeEventHandler(event).handle_charge_refunded(event)
+
+        list_mock.assert_called_once_with(charge="ch_test", limit=100, stripe_account="acct_conn_42")
+        target.refresh_from_db()
+        assert target.refund_status == Payment.RefundStatus.SUCCEEDED
+
+    def test_no_refunds_in_payload_or_api_is_a_noop(self, batch_of_4_online_payments: list[Payment]) -> None:
+        """If the API also returns no refunds, the handler warns and mutates nothing."""
+        payments = batch_of_4_online_payments
+        _batch(payments, "pi_pinned_empty")
+        event = _charge_event("pi_pinned_empty", refunds=None)
+
+        with patch.object(stripe.Refund, "list") as list_mock:
+            list_mock.return_value.data = []
+            StripeEventHandler(event).handle_charge_refunded(event)
+
+        for payment in payments:
+            payment.refresh_from_db()
+            assert payment.refund_status is None
+            assert payment.status == Payment.PaymentStatus.SUCCEEDED

--- a/src/events/tests/test_service/test_stripe_integration.py
+++ b/src/events/tests/test_service/test_stripe_integration.py
@@ -1,0 +1,148 @@
+"""Integration tests against the real Stripe sandbox (test mode).
+
+These hit the live Stripe test-mode API and are excluded from normal test
+runs and CI (see ``addopts`` in pyproject.toml). They verify the Phase 2
+(#483) behaviours end-to-end:
+
+- outbound calls succeed with ``stripe.api_version`` pinned to
+  ``settings.STRIPE_API_VERSION`` (a bad pin would 400 on every call);
+- objects rendered at the pinned version carry no embedded ``refunds`` list
+  on Charge — the premise behind ``_resolve_refunds``;
+- a pinned-shape ``charge.refunded`` event (no embedded refunds) is fully
+  processed by fetching the refunds outbound via ``stripe.Refund.list``;
+- ``create_checkout_session`` works against the connected test account.
+
+Run manually with:
+    pytest -m integration src/events/tests/test_service/test_stripe_integration.py -v
+
+Requires real test-mode keys in .env (``STRIPE_SECRET_KEY=sk_test_…``); the
+checkout-session test additionally needs ``CONNECTED_TEST_STRIPE_ID``.
+"""
+
+import typing as t
+import uuid
+
+import pytest
+import stripe
+from django.conf import settings
+
+from events.models import Event, Payment, StripeWebhookEvent, Ticket, TicketTier
+from events.service import stripe_service, stripe_webhooks
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.django_db,
+    pytest.mark.skipif(
+        settings.STRIPE_SECRET_KEY in {"sk_test_...", ""},
+        reason="needs real Stripe test-mode keys in .env",
+    ),
+]
+
+
+def _create_refunded_intent(amount_cents: int) -> tuple[stripe.PaymentIntent, stripe.Refund]:
+    """Create a confirmed test-mode PaymentIntent and refund it in full."""
+    intent = stripe.PaymentIntent.create(
+        amount=amount_cents,
+        currency="eur",
+        payment_method="pm_card_visa",
+        confirm=True,
+        payment_method_types=["card"],
+    )
+    assert intent.status == "succeeded", f"test intent did not confirm: {intent.status}"
+    refund = stripe.Refund.create(payment_intent=intent.id)
+    return intent, refund
+
+
+class TestPinnedApiVersion:
+    def test_pin_accepted_and_charge_renders_without_embedded_refunds(self) -> None:
+        """The pinned version is accepted outbound; Charge has no refunds list.
+
+        The second assertion is the empirical premise behind
+        ``_resolve_refunds``: at API versions >= 2022-11-15 (so at the pinned
+        version too) Stripe no longer embeds the ``refunds`` list on Charge —
+        neither in retrieves nor in webhook payloads rendered at that version.
+        """
+        intent, _refund = _create_refunded_intent(1000)
+        charge = stripe.Charge.retrieve(t.cast(str, intent.latest_charge))
+        assert charge.refunded is True
+        assert "refunds" not in charge
+
+
+class TestChargeRefundedOutboundFetch:
+    def test_pinned_shape_payload_processed_via_refund_list(
+        self,
+        ticket: Ticket,
+        payment_factory: t.Callable[..., Payment],
+    ) -> None:
+        """A charge.refunded payload without embedded refunds is fully handled.
+
+        The refunds come from a real ``stripe.Refund.list`` call against the
+        sandbox; matching, payment/ticket mutation and the event log row all
+        behave as in production.
+        """
+        intent, refund = _create_refunded_intent(4000)  # == payment_factory's 40.00 EUR
+        payment = payment_factory(
+            ticket,
+            stripe_payment_intent_id=intent.id,
+            stripe_session_id=f"cs_integration_{uuid.uuid4().hex}",
+        )
+
+        event = stripe.Event.construct_from(
+            {
+                "id": f"evt_integration_{uuid.uuid4().hex}",
+                "object": "event",
+                "type": "charge.refunded",
+                "livemode": False,
+                # Pinned-version shape: no "refunds" key on the charge at all.
+                "data": {
+                    "object": {
+                        "id": intent.latest_charge,
+                        "object": "charge",
+                        "payment_intent": intent.id,
+                    }
+                },
+            },
+            stripe.api_key,
+        )
+        stripe_webhooks.handle_event(event)
+
+        payment.refresh_from_db()
+        assert payment.refund_status == Payment.RefundStatus.SUCCEEDED
+        assert payment.status == Payment.PaymentStatus.REFUNDED
+        assert payment.stripe_refund_id == refund.id
+        ticket.refresh_from_db()
+        assert ticket.status == Ticket.TicketStatus.CANCELLED
+        row = StripeWebhookEvent.objects.get(event_id=event.id)
+        assert row.outcome == StripeWebhookEvent.Outcome.HANDLED
+
+
+@pytest.mark.skipif(
+    not settings.CONNECTED_TEST_STRIPE_ID,
+    reason="needs CONNECTED_TEST_STRIPE_ID (a real connected test account) in .env",
+)
+class TestCheckoutSessionAtPinnedVersion:
+    def test_create_checkout_session_succeeds(
+        self,
+        event: Event,
+        event_ticket_tier: TicketTier,
+        member_user: t.Any,
+    ) -> None:
+        """The full service-layer Session.create works at the pinned version.
+
+        Exercises line_items/price_data, payment_intent_data with an
+        application fee, metadata, expires_at and the Stripe-Account header —
+        the heaviest outbound call we make.
+        """
+        org = event.organization
+        org.stripe_account_id = settings.CONNECTED_TEST_STRIPE_ID
+        org.stripe_charges_enabled = True
+        org.stripe_details_submitted = True
+        org.save(
+            update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted", "updated_at"]
+        )
+
+        url, payment = stripe_service.create_checkout_session(event, event_ticket_tier, member_user)
+
+        assert url.startswith("https://checkout.stripe.com/")
+        assert payment.status == Payment.PaymentStatus.PENDING
+        assert payment.stripe_session_id.startswith("cs_test_")


### PR DESCRIPTION
## Summary

Phase 2 of #483: pin the Stripe API version for all outbound calls, plus the compat fix the audit mandated.

- `stripe.api_version = settings.STRIPE_API_VERSION` (default `2026-03-25.dahlia`) is now set wherever `stripe.api_key` is set: `events/service/stripe_service.py`, `common/service/stripe_connect_service.py`, `accounts/tasks.py`. Revertible at runtime via the `STRIPE_API_VERSION` env var.
- **`charge.refunded` compat fix**: payloads rendered at any API version ≥ `2022-11-15` do not embed the charge's `refunds` list. `handle_charge_refunded` now resolves refunds via `_resolve_refunds`: embedded payload refunds short-circuit (old unpinned shape), otherwise it fetches `stripe.Refund.list(charge=…, limit=100)`, forwarding `stripe_account=event.account` for Connect events. A failed fetch raises, rolling back the webhook transaction and dedup row so the Stripe retry reprocesses.
- Runbook Phase 2 section updated accordingly.

## Compat audit (recorded per plan Task 9.1)

Windows audited from the official changelog: outbound **`2026-01-28.clover` → `2026-03-25.dahlia`**; inbound **`2025-07-30.basil` → dahlia** (takes effect at the Phase 3 cutover).

| Release | Relevant to our surface | Verdict |
|---|---|---|
| `2025-08-27.basil`, all clover monthlies incl. `2026-02-25.clover` | Additive only | Safe |
| `2025-09-30.clover` (breaking) | Removes Checkout Session `currency_conversion` (unused); decline-code changes (unread); Connect risk-requirement descriptions (we only read `charges_enabled`/`details_submitted`) | Safe |
| `2026-03-25.dahlia` (breaking) | Checkout Session `ui_mode` enum renames — **zero `ui_mode` usage in the codebase** (grepped); Capabilities API risk requirements (doesn't touch our reads); v2 Event Destinations `events_from` (we use v1 `WebhookEndpoint`); Stripe.js removals (client-side only) | Safe |

**Watch-item finding (escalated to the compat fix above):** the embedded `charge.refunds` list was removed from rendered payloads at API `2022-11-15` ("Listen to `refund.created` for information about the refund"), long before our window. Webhook payloads cannot use `expand`, so the current **basil-pinned endpoint already delivers `charge.refunded` without it** — a latent prod bug that simply never fired (zero refund webhooks in 30 days of Loki retention). The fix is required for the current endpoint and for Phase 3's dahlia endpoints alike.

## Verification

- `make check` green; full unit suite passing (3 new unit tests cover the fetch fallback, Connect header forwarding, and empty-everywhere no-op).
- **New sandbox integration tests** (`pytest -m integration src/events/tests/test_service/test_stripe_integration.py`, excluded from CI, 3/3 passed against the live test-mode API):
  - pin accepted outbound + empirical confirmation that a refunded Charge renders with `"refunds" not in charge` at the pinned version;
  - pinned-shape `charge.refunded` event processed end-to-end via a real `Refund.list` (payment `REFUNDED`, ticket `CANCELLED`, event log `handled`);
  - full service-layer `Session.create` (line items, application fee, `Stripe-Account` header) at dahlia.
- Live smoke through the running dev server + `stripe listen`: triggered and organic events verified, logged, and dispatched correctly.

## Rollout

Per the runbook: deploy demo first, full payment loop incl. a dashboard refund (now exercises the outbound fetch path), watch `loki_logs.py web -l error -g stripe`. Rollback = set `STRIPE_API_VERSION=2026-01-28.clover` and restart, or redeploy previous image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refund handling now supports newer Stripe API shapes that may omit embedded refunds by fetching refund data as needed; Stripe API version is now consistently pinned for stable behavior.

* **Tests**
  * Added unit and integration tests validating webhook refund fetching, connected-account behavior, and pinned API-version workflows.

* **Documentation**
  * Updated Stripe hardening runbook with compatibility and verification guidance for webhook refund handling and retention expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->