### PR TITLE
feat(stripe): hardening phase 3 — webhook endpoint provisioning command (#483)

### DIFF
--- a/src/events/management/commands/provision_stripe_webhooks.py
+++ b/src/events/management/commands/provision_stripe_webhooks.py
@@ -1,0 +1,106 @@
+"""``python manage.py provision_stripe_webhooks --url <https://...>``.
+
+Creates the two Stripe webhook endpoints Revel needs (platform + Connect),
+both pinned to ``settings.STRIPE_API_VERSION``, and prints the resulting
+``whsec_*`` signing secrets so the operator can paste them into
+``STRIPE_WEBHOOK_SECRETS`` (CSV) on the deploy.
+
+Both endpoints target the SAME URL. Stripe distinguishes them by the
+``connect`` flag, so a single ``/api/stripe/webhook`` URL serves both
+"Your account" platform deliveries and "Connected accounts" deliveries,
+each with its own signing secret. ``verify_webhook`` tries each secret in
+turn (see ``events/service/stripe_webhooks.py``).
+
+The command refuses to run if any endpoint already targets the URL, unless
+``--force`` is given (cutover: the old endpoint stays active alongside the
+new ones until the operator disables it in the dashboard — the event-log
+dedup makes the overlap harmless).
+"""
+
+import typing as t
+
+import stripe
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+# Must stay in sync with the dispatch map in
+# events/service/stripe_webhooks.py::StripeEventHandler.handle — Stripe only
+# delivers events you subscribe to.
+PLATFORM_EVENTS: tuple[str, ...] = (
+    "checkout.session.completed",
+    "charge.refunded",
+    "payment_intent.canceled",
+)
+CONNECT_EVENTS: tuple[str, ...] = PLATFORM_EVENTS + ("account.updated",)
+
+
+class Command(BaseCommand):
+    """Provision the platform + Connect webhook endpoints in Stripe."""
+
+    help = (
+        "Create two Stripe webhook endpoints (platform + Connect) at the given "
+        "URL and print the whsec_* signing secrets for STRIPE_WEBHOOK_SECRETS."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Wire ``--url`` (required), ``--dry-run`` and ``--force`` flags."""
+        parser.add_argument(
+            "--url",
+            required=True,
+            help="Public URL of /api/stripe/webhook (e.g. https://api.letsrevel.io/api/stripe/webhook).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would be created without calling the Stripe API.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Create even if endpoints already target this URL (cutover overlap).",
+        )
+
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
+        """Validate ``--url``, then either preview or POST two endpoints to Stripe."""
+        url: str = options["url"]
+        if not url.startswith("https://"):
+            raise CommandError(f"--url must be https:// (Stripe rejects http in live mode). Got: {url}")
+
+        if options["dry_run"]:
+            self.stdout.write("DRY RUN — no API calls.")
+            self.stdout.write(f"Would create platform endpoint at {url}: {', '.join(PLATFORM_EVENTS)}")
+            self.stdout.write(f"Would create Connect endpoint at {url}: {', '.join(CONNECT_EVENTS)}")
+            return
+
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+        stripe.api_version = settings.STRIPE_API_VERSION
+
+        existing = [ep for ep in stripe.WebhookEndpoint.list(limit=100).auto_paging_iter() if ep.url == url]
+        if existing and not options["force"]:
+            ids = ", ".join(ep.id for ep in existing)
+            raise CommandError(
+                f"Endpoint(s) already target {url}: {ids}. Re-run with --force to create "
+                "the new pair alongside them (then disable the old one in the dashboard)."
+            )
+
+        platform = stripe.WebhookEndpoint.create(
+            url=url,
+            enabled_events=list(PLATFORM_EVENTS),
+            connect=False,
+            api_version=settings.STRIPE_API_VERSION,
+            description="Revel platform events",
+        )
+        connect = stripe.WebhookEndpoint.create(
+            url=url,
+            enabled_events=list(CONNECT_EVENTS),
+            connect=True,
+            api_version=settings.STRIPE_API_VERSION,
+            description="Revel Connect events",
+        )
+
+        self.stdout.write(self.style.SUCCESS("Created two webhook endpoints:"))
+        self.stdout.write(f"  Platform: {platform.id}  secret: {platform.secret}")
+        self.stdout.write(f"  Connect:  {connect.id}  secret: {connect.secret}")
+        self.stdout.write("")
+        self.stdout.write(self.style.WARNING("Set in .env (CSV, no spaces — keep the OLD secret during cutover):"))
+        self.stdout.write(f"  STRIPE_WEBHOOK_SECRETS={platform.secret},{connect.secret},<old whsec_ during overlap>")

--- a/src/events/tests/test_provision_stripe_webhooks_command.py
+++ b/src/events/tests/test_provision_stripe_webhooks_command.py
@@ -1,0 +1,92 @@
+"""Tests for the provision_stripe_webhooks management command."""
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.conf import settings
+from django.core.management import CommandError, call_command
+
+pytestmark = pytest.mark.django_db
+
+
+def _endpoint(id_: str, url: str, secret: str = "whsec_x") -> MagicMock:
+    ep = MagicMock()
+    ep.id = id_
+    ep.url = url
+    ep.secret = secret
+    return ep
+
+
+@patch("events.management.commands.provision_stripe_webhooks.stripe")
+def test_creates_both_endpoints(mock_stripe: MagicMock) -> None:
+    """A clean account gets the platform + Connect pair, pinned to the settings version."""
+    mock_stripe.WebhookEndpoint.list.return_value.auto_paging_iter.return_value = iter([])
+    mock_stripe.WebhookEndpoint.create.side_effect = [
+        _endpoint("we_platform", "https://api.example.com/api/stripe/webhook", "whsec_p"),
+        _endpoint("we_connect", "https://api.example.com/api/stripe/webhook", "whsec_c"),
+    ]
+    out = StringIO()
+    call_command("provision_stripe_webhooks", url="https://api.example.com/api/stripe/webhook", stdout=out)
+
+    assert mock_stripe.WebhookEndpoint.create.call_count == 2
+    connect_flags = [c.kwargs["connect"] for c in mock_stripe.WebhookEndpoint.create.call_args_list]
+    assert connect_flags == [False, True]
+    api_versions = {c.kwargs["api_version"] for c in mock_stripe.WebhookEndpoint.create.call_args_list}
+    assert api_versions == {settings.STRIPE_API_VERSION}
+    # The Connect endpoint additionally subscribes to account.updated.
+    platform_events, connect_events = (
+        c.kwargs["enabled_events"] for c in mock_stripe.WebhookEndpoint.create.call_args_list
+    )
+    assert "account.updated" not in platform_events
+    assert "account.updated" in connect_events
+    # Both secrets are printed for the operator (shown exactly once by Stripe).
+    output = out.getvalue()
+    assert "whsec_p" in output
+    assert "whsec_c" in output
+
+
+@patch("events.management.commands.provision_stripe_webhooks.stripe")
+def test_refuses_when_url_already_provisioned(mock_stripe: MagicMock) -> None:
+    """Without --force, an existing endpoint at the URL aborts the command."""
+    existing = _endpoint("we_old", "https://api.example.com/api/stripe/webhook")
+    mock_stripe.WebhookEndpoint.list.return_value.auto_paging_iter.return_value = iter([existing])
+    with pytest.raises(CommandError):
+        call_command("provision_stripe_webhooks", url="https://api.example.com/api/stripe/webhook")
+    mock_stripe.WebhookEndpoint.create.assert_not_called()
+
+
+@patch("events.management.commands.provision_stripe_webhooks.stripe")
+def test_force_creates_alongside_existing(mock_stripe: MagicMock) -> None:
+    """--force creates the new pair even when the old endpoint still exists (cutover overlap)."""
+    existing = _endpoint("we_old", "https://api.example.com/api/stripe/webhook")
+    mock_stripe.WebhookEndpoint.list.return_value.auto_paging_iter.return_value = iter([existing])
+    mock_stripe.WebhookEndpoint.create.side_effect = [
+        _endpoint("we_platform", "https://api.example.com/api/stripe/webhook", "whsec_p"),
+        _endpoint("we_connect", "https://api.example.com/api/stripe/webhook", "whsec_c"),
+    ]
+    call_command("provision_stripe_webhooks", url="https://api.example.com/api/stripe/webhook", force=True)
+    assert mock_stripe.WebhookEndpoint.create.call_count == 2
+
+
+@patch("events.management.commands.provision_stripe_webhooks.stripe")
+def test_dry_run_makes_no_api_calls(mock_stripe: MagicMock) -> None:
+    """--dry-run previews both endpoints without touching the Stripe API."""
+    out = StringIO()
+    call_command(
+        "provision_stripe_webhooks",
+        url="https://api.example.com/api/stripe/webhook",
+        dry_run=True,
+        stdout=out,
+    )
+    mock_stripe.WebhookEndpoint.list.assert_not_called()
+    mock_stripe.WebhookEndpoint.create.assert_not_called()
+    output = out.getvalue()
+    assert "DRY RUN" in output
+    assert "account.updated" in output
+
+
+def test_rejects_http_url() -> None:
+    """Plain http URLs are refused outright."""
+    with pytest.raises(CommandError):
+        call_command("provision_stripe_webhooks", url="http://insecure.example.com/api/stripe/webhook")


### PR DESCRIPTION
## Summary

Phase 3 of #483: the `provision_stripe_webhooks` management command that creates the two webhook endpoints the new setup needs.

- **Platform endpoint** (`connect=False`): `checkout.session.completed`, `charge.refunded`, `payment_intent.canceled`
- **Connect endpoint** (`connect=True`): same + `account.updated`
- Both target the same `/api/stripe/webhook` URL and are pinned to `settings.STRIPE_API_VERSION`; Stripe distinguishes them by the `connect` flag, and `verify_webhook` (Phase 1) tries each endpoint's secret in turn.
- Prints both `whsec_*` secrets exactly once with the ready-to-paste `STRIPE_WEBHOOK_SECRETS` CSV line.
- Refuses to run if any endpoint already targets the URL unless `--force` (the cutover overlap); `--dry-run` previews with zero API calls; non-https URLs rejected.

This PR ships only the command — the actual endpoint cutover is the operator procedure in `docs/runbooks/stripe-hardening-rollout.md` (Phase 3 section) and must not run before Phase 1's dedup is deployed.

## Test plan

- [x] 5 unit tests: pair creation (connect flags, pinned api_version, event lists, secrets printed), refusal without `--force`, `--force` overlap, `--dry-run` makes no API calls, http URL rejected
- [x] `make check` green; suite green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added management command to provision Stripe webhook endpoints (platform and Connect) with support for dry-run preview and force creation options
  * HTTPS URL validation requirement for webhook endpoint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->