### PR TITLE
feat(stripe): hardening phase 4 — host-as-org binding + platform-self guard (#483)

### DIFF
--- a/docs/architecture/billing-and-vat.md
+++ b/docs/architecture/billing-and-vat.md
@@ -27,8 +27,20 @@ flowchart TD
     end
 ```
 
-!!! danger "Stripe webhook: own events vs. connected accounts"
-    A Stripe webhook endpoint can listen to **either** events on the platform's own account **or** events on connected accounts — not both simultaneously. This means the platform host's Stripe account (`STRIPE_ACCOUNT`) **must not** also be used as a connected organization account. If the host also runs an organization that sells tickets, that organization must connect a **separate** Stripe account. Otherwise, checkout webhooks (e.g., `checkout.session.completed`) will not be delivered correctly. This is a Stripe-level limitation configured in the Stripe Dashboard under **Developers > Webhooks**.
+!!! info "Stripe webhooks: two endpoints, one URL"
+    A Stripe webhook endpoint listens to **either** the platform's own account events
+    **or** connected-account events — never both. Revel therefore provisions **two**
+    endpoints (via `python manage.py provision_stripe_webhooks`), both pointing at
+    `/api/stripe/webhook`: one for "Your account" (platform) deliveries and one for
+    "Connected accounts" deliveries. Each has its own signing secret; the webhook
+    handler tries every entry of `STRIPE_WEBHOOK_SECRETS` until one verifies.
+    This is what allows the platform host's own Stripe account (`STRIPE_ACCOUNT`) to be
+    bound to an organization (superuser admin action on Organization): that org's
+    checkout events arrive via the platform endpoint, while Connect orgs' events arrive
+    via the Connect endpoint. Application fees are not collected for the host org
+    (Stripe does not permit application fees on own-account charges).
+    See the [webhook endpoints runbook](../runbooks/stripe-webhook-endpoints.md) for the
+    steady-state reference.
 
 ## VAT Calculation
 

--- a/docs/runbooks/stripe-webhook-endpoints.md
+++ b/docs/runbooks/stripe-webhook-endpoints.md
@@ -1,0 +1,82 @@
+# Stripe webhook endpoints
+
+Steady-state reference for Revel's Stripe webhook setup. For the one-time
+migration that established it, see
+[stripe-hardening-rollout.md](stripe-hardening-rollout.md).
+
+## Topology
+
+Two Stripe webhook endpoints, both pointing at the same URL
+(`https://<host>/api/stripe/webhook`), distinguished by Stripe's `connect`
+flag. Stripe delivers an event to every endpoint subscribed to it; the two
+endpoints never overlap because platform-account events and connected-account
+events are disjoint by construction.
+
+| Endpoint | `connect` | Subscribed events | Delivers |
+|---|---|---|---|
+| Platform ("Your account") | `false` | `checkout.session.completed`, `charge.refunded`, `payment_intent.canceled` | Events on `STRIPE_ACCOUNT` itself — i.e. the host-bound organization's sales |
+| Connect ("Connected accounts") | `true` | same + `account.updated` | Events on organizations' connected accounts (`event.account` is set) |
+
+Both endpoints are pinned to `STRIPE_API_VERSION` — webhook payload shapes
+follow the **endpoint's** pinned version, while outbound call/response shapes
+follow the `stripe.api_version` set in code. Keep them the same version; a
+future bump is a deliberate two-step (outbound pin first, then re-provision
+endpoints) with a compat audit in between.
+
+The subscribed event lists live in
+`events/management/commands/provision_stripe_webhooks.py` and **must stay in
+sync** with the dispatch map in
+`events/service/stripe_webhooks.py::StripeEventHandler.handle` — Stripe only
+delivers events you subscribe to, and unmapped deliveries land as `unhandled`
+rows in the event log.
+
+## Secrets
+
+- `STRIPE_WEBHOOK_SECRETS` (CSV, no spaces) holds one `whsec_*` per endpoint;
+  `verify_webhook` tries each in order, first HMAC match wins. Order them
+  most-traffic-first (Connect endpoint first in practice).
+- Secrets are shown by Stripe **exactly once**, at endpoint creation (the
+  provisioning command prints them). If one is lost: delete that endpoint in
+  the dashboard and re-provision.
+- The legacy single `STRIPE_WEBHOOK_SECRET` is only a fallback when the CSV is
+  unset; steady state does not use it.
+
+## Provisioning / rotation
+
+```bash
+# Preview
+docker compose exec web python manage.py provision_stripe_webhooks \
+  --url https://<host>/api/stripe/webhook --dry-run
+
+# Create the pair (--force if endpoints already target the URL, e.g. rotation)
+docker compose exec web python manage.py provision_stripe_webhooks \
+  --url https://<host>/api/stripe/webhook --force
+```
+
+Rotation = provision a new pair with `--force`, add the new secrets to the CSV
+*alongside* the old ones, restart, verify deliveries, then disable the old
+endpoints in the dashboard and drop their secrets. The event-log dedup
+(`StripeWebhookEvent.event_id` unique) makes the overlap window harmless.
+
+## Host-as-org binding
+
+Exactly one organization may use the platform's own Stripe account:
+Django admin → Organizations → select one → **"Bind to platform Stripe
+account (superuser only)"**. Its checkout/refund events arrive via the
+*platform* endpoint (`event.account` empty, stored as `""` in the event log).
+No application fee is charged (Stripe forbids fees on own-account charges).
+**"Unbind platform Stripe account"** reverses it and refuses to touch real
+Connect bindings. The unique constraint on `stripe_account_id` prevents
+double-binding.
+
+## Observability
+
+- Event log: `/admin/events/stripewebhookevent/` — every verified delivery,
+  with outcome (`handled`/`unhandled`), `account`, full payload; pruned after
+  `STRIPE_WEBHOOK_EVENT_RETENTION_DAYS` (default 90 — keep ≥ 30, the manual
+  resend window).
+- Logs: `scripts/loki_logs.py web -g stripe_webhook --since 1h` — key events:
+  `stripe_webhook_duplicate` (dedup hit; expected during rotation overlap),
+  `stripe_webhook_signature_failed` (no secret matched → 403; investigate if
+  persistent), `stripe_webhook_unhandled_event` (subscribed-but-unmapped type).
+- Stripe side: Workbench → Webhooks shows per-endpoint delivery success rates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - runbooks/dependency-audit.md
       - runbooks/admin-groups.md
       - runbooks/stripe-hardening-rollout.md
+      - runbooks/stripe-webhook-endpoints.md
   - Post-Mortems:
       - postmortems/index.md
       - postmortems/0001-guest-user-verification-bypass.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.62.7"
+version = "1.63.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -3,7 +3,8 @@
 
 import typing as t
 
-from django.contrib import admin
+from django.conf import settings
+from django.contrib import admin, messages
 from django.db.models import Count, OuterRef, QuerySet, Subquery
 from django.http import HttpRequest
 from django.urls import reverse
@@ -58,6 +59,7 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
     search_fields = ["name", "slug", "owner__username"]
     autocomplete_fields = ["owner", "city", "staff_members", "members"]
     prepopulated_fields = {"slug": ("name",)}
+    actions = ["bind_platform_stripe_account", "unbind_platform_stripe_account"]
 
     tabs = [
         ("Settings", ["Settings"]),
@@ -110,6 +112,59 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
         OrganizationQuestionnaireInline,
         VenueInline,
     ]
+
+    @admin.action(description="Bind to platform Stripe account (superuser only)")
+    def bind_platform_stripe_account(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> None:
+        """Point ONE org at the platform's own Stripe account.
+
+        Connect onboarding always creates a NEW account, so the host operator
+        binds the platform account explicitly here. Webhook delivery for this
+        org rides the platform ("Your account") endpoint — see
+        docs/architecture/billing-and-vat.md.
+        """
+        if not request.user.is_superuser:
+            self.message_user(request, "Superuser required.", level=messages.ERROR)
+            return
+        if queryset.count() != 1:
+            self.message_user(request, "Select exactly one organization.", level=messages.ERROR)
+            return
+        org = queryset.get()
+        if org.stripe_account_id:
+            self.message_user(
+                request, f"{org.slug} already has a Stripe account ({org.stripe_account_id}).", level=messages.ERROR
+            )
+            return
+        org.stripe_account_id = settings.STRIPE_ACCOUNT
+        org.stripe_charges_enabled = True
+        org.stripe_details_submitted = True
+        org.save(
+            update_fields=org._stripe_update_fields(
+                "stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"
+            )
+        )
+        self.message_user(request, f"{org.slug} bound to platform Stripe account.", level=messages.SUCCESS)
+
+    @admin.action(description="Unbind platform Stripe account (superuser only)")
+    def unbind_platform_stripe_account(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> None:
+        """Clear a platform-account binding. Refuses to touch real Connect accounts."""
+        if not request.user.is_superuser:
+            self.message_user(request, "Superuser required.", level=messages.ERROR)
+            return
+        for org in queryset:
+            if org.stripe_account_id != settings.STRIPE_ACCOUNT:
+                self.message_user(
+                    request, f"{org.slug} is not bound to the platform account — skipped.", level=messages.WARNING
+                )
+                continue
+            org.stripe_account_id = None
+            org.stripe_charges_enabled = False
+            org.stripe_details_submitted = False
+            org.save(
+                update_fields=org._stripe_update_fields(
+                    "stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"
+                )
+            )
+            self.message_user(request, f"{org.slug} unbound from platform Stripe account.", level=messages.SUCCESS)
 
     def get_queryset(self, request: HttpRequest) -> QuerySet[models.Organization]:
         qs: QuerySet[models.Organization] = super().get_queryset(request)

--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -125,6 +125,15 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
         if not request.user.is_superuser:
             self.message_user(request, "Superuser required.", level=messages.ERROR)
             return
+        # The settings default is a "test_..." placeholder; real Stripe account
+        # ids always start with acct_. Never bind a placeholder to an org.
+        if not settings.STRIPE_ACCOUNT.startswith("acct_"):
+            self.message_user(
+                request,
+                f"STRIPE_ACCOUNT is not configured ({settings.STRIPE_ACCOUNT!r} is a placeholder) — refusing to bind.",
+                level=messages.ERROR,
+            )
+            return
         if queryset.count() != 1:
             self.message_user(request, "Select exactly one organization.", level=messages.ERROR)
             return

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -275,6 +275,13 @@ class StripeEventHandler:
         charges_enabled and details_submitted status change during onboarding.
         Syncs the status on whichever model owns the account (Organization or RevelUser).
         """
+        if not getattr(event, "account", None):
+            # account.updated for the platform's OWN account (only possible if
+            # the platform endpoint ever subscribes to it) — nothing to mirror;
+            # host-org binding is managed via the admin action.
+            logger.debug("stripe_account_updated_platform_self_skipped", event_id=event.id)
+            return
+
         account_data = event.data.object
         account_id = account_data["id"]
 

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -279,7 +279,10 @@ class StripeEventHandler:
             # account.updated for the platform's OWN account (only possible if
             # the platform endpoint ever subscribes to it) — nothing to mirror;
             # host-org binding is managed via the admin action.
-            logger.debug("stripe_account_updated_platform_self_skipped", event_id=event.id)
+            # warning, not debug: reaching this branch means the platform
+            # endpoint is subscribed to account.updated, which the provisioning
+            # command never does — surface the misconfiguration in prod logs.
+            logger.warning("stripe_account_updated_platform_self_skipped", event_id=event.id)
             return
 
         account_data = event.data.object

--- a/src/events/tests/test_admin/test_organization_platform_binding.py
+++ b/src/events/tests/test_admin/test_organization_platform_binding.py
@@ -1,0 +1,125 @@
+"""Tests for binding an Organization to the platform Stripe account."""
+
+import typing as t
+
+import pytest
+from django.contrib.admin.sites import site
+from django.contrib.messages.storage.fallback import FallbackStorage
+
+from accounts.models import RevelUser
+from events.admin.organization import OrganizationAdmin
+from events.models import Organization
+
+pytestmark = pytest.mark.django_db
+
+
+def _admin() -> OrganizationAdmin:
+    return t.cast(OrganizationAdmin, site._registry[Organization])
+
+
+def _request_with_messages(rf: t.Any, user: RevelUser) -> t.Any:
+    request = rf.post("/")
+    request.user = user
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def test_bind_sets_platform_account(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """Binding points the org at STRIPE_ACCOUNT with both flags enabled."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.bind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id == "acct_platform"
+    assert organization.stripe_charges_enabled is True
+    assert organization.stripe_details_submitted is True
+
+
+def test_bind_refuses_already_connected_org(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """An org with a real Connect account must not be silently rebound."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    organization.stripe_account_id = "acct_real_connect"
+    organization.save(update_fields=["stripe_account_id"])
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.bind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id == "acct_real_connect"  # unchanged
+
+
+def test_bind_requires_superuser(
+    rf: t.Any, organization: Organization, organization_owner_user: RevelUser, settings: t.Any
+) -> None:
+    """Non-superusers cannot bind, even with admin access."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    admin_instance = _admin()
+    request = _request_with_messages(rf, organization_owner_user)
+
+    admin_instance.bind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id is None
+
+
+def test_bind_requires_exactly_one_org(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """Selecting zero or multiple orgs is refused."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.bind_platform_stripe_account(request, Organization.objects.none())
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id is None
+
+
+def test_unbind_clears_platform_binding(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """Unbinding a platform-bound org clears the account and flags."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    organization.stripe_account_id = "acct_platform"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.unbind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    # Re-fetch: mypy narrows stripe_account_id to str after the assignment
+    # above, so asserting None on the same instance reads as unreachable.
+    fresh = Organization.objects.get(pk=organization.pk)
+    assert fresh.stripe_account_id is None
+    assert fresh.stripe_charges_enabled is False
+    assert fresh.stripe_details_submitted is False
+
+
+def test_unbind_refuses_real_connect_binding(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """A real Connect binding must never be cleared by the unbind action."""
+    settings.STRIPE_ACCOUNT = "acct_platform"
+    organization.stripe_account_id = "acct_real_connect"
+    organization.stripe_charges_enabled = True
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled"])
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.unbind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id == "acct_real_connect"  # untouched
+    assert organization.stripe_charges_enabled is True

--- a/src/events/tests/test_admin/test_organization_platform_binding.py
+++ b/src/events/tests/test_admin/test_organization_platform_binding.py
@@ -57,6 +57,20 @@ def test_bind_refuses_already_connected_org(
     assert organization.stripe_account_id == "acct_real_connect"  # unchanged
 
 
+def test_bind_refuses_placeholder_platform_account(
+    rf: t.Any, organization: Organization, superuser: RevelUser, settings: t.Any
+) -> None:
+    """The "test_..." settings default must never be bound to an org."""
+    settings.STRIPE_ACCOUNT = "test_..."
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.bind_platform_stripe_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id is None
+
+
 def test_bind_requires_superuser(
     rf: t.Any, organization: Organization, organization_owner_user: RevelUser, settings: t.Any
 ) -> None:

--- a/src/events/tests/test_service/test_stripe_service/test_webhooks.py
+++ b/src/events/tests/test_service/test_stripe_service/test_webhooks.py
@@ -464,6 +464,7 @@ class TestStripeEventHandler:
         organization.stripe_account_id = "acct_org_test"
         organization.save(update_fields=["stripe_account_id"])
 
+        handler.event.account = "acct_org_test"
         handler.event.data.object = {
             "id": "acct_org_test",
             "charges_enabled": True,
@@ -485,6 +486,7 @@ class TestStripeEventHandler:
         organization_owner_user.stripe_account_id = "acct_user_test"
         organization_owner_user.save(update_fields=["stripe_account_id"])
 
+        handler.event.account = "acct_user_test"
         handler.event.data.object = {
             "id": "acct_user_test",
             "charges_enabled": True,
@@ -503,6 +505,7 @@ class TestStripeEventHandler:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test that an unknown account ID is logged and does not raise."""
+        handler.event.account = "acct_unknown_999"
         handler.event.data.object = {
             "id": "acct_unknown_999",
             "charges_enabled": True,
@@ -512,3 +515,28 @@ class TestStripeEventHandler:
         handler.handle_account_updated(handler.event)
 
         assert "stripe_account_updated_unknown" in caplog.text
+
+    def test_handle_account_updated_platform_self_is_skipped(
+        self,
+        organization: Organization,
+    ) -> None:
+        """An account.updated with no event.account (platform self) must not touch the DB."""
+        organization.stripe_account_id = "acct_platform"
+        organization.save(update_fields=["stripe_account_id"])
+
+        event = stripe.Event.construct_from(
+            {
+                "id": "evt_self",
+                "object": "event",
+                "type": "account.updated",
+                "livemode": False,
+                # No "account" key: the event concerns the platform's own account.
+                "data": {"object": {"id": "acct_platform", "charges_enabled": True, "details_submitted": True}},
+            },
+            "sk_test_x",
+        )
+
+        StripeEventHandler(event).handle()
+
+        organization.refresh_from_db()
+        assert organization.stripe_charges_enabled is False, "platform-self event must not sync flags"

--- a/src/events/tests/test_service/test_stripe_webhook_dispatch.py
+++ b/src/events/tests/test_service/test_stripe_webhook_dispatch.py
@@ -105,6 +105,30 @@ def test_handle_event_records_and_marks_handled() -> None:
     assert row.payload["id"] == "evt_dedup_1"
 
 
+def test_handle_event_platform_shaped_event_records_empty_account() -> None:
+    """An event with no "account" key (platform endpoint delivery) processes fine.
+
+    Host-as-org checkouts arrive via the platform endpoint, whose events carry
+    no account attribute — the log row stores an empty string and dispatch
+    proceeds normally.
+    """
+    event = stripe.Event.construct_from(
+        {
+            "id": "evt_platform_shaped",
+            "object": "event",
+            "type": "payment_intent.canceled",
+            "livemode": False,
+            # No "account" key, unlike Connect-endpoint deliveries.
+            "data": {"object": {"id": "pi_none", "object": "payment_intent"}},
+        },
+        "sk_test_x",
+    )
+    stripe_webhooks.handle_event(event)
+    row = StripeWebhookEvent.objects.get(event_id="evt_platform_shaped")
+    assert row.account == ""
+    assert row.outcome == StripeWebhookEvent.Outcome.HANDLED
+
+
 def test_handle_event_unknown_type_marked_unhandled() -> None:
     """An unmapped event type is logged as UNHANDLED, not an error."""
     stripe_webhooks.handle_event(_make_event(event_id="evt_unknown", event_type="customer.created"))

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.62.7"
+version = "1.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary

Phase 4 of #483 — the final code phase. Allows the platform host's own Stripe account (`STRIPE_ACCOUNT`) to be bound to exactly one organization, which the two-endpoint webhook setup (Phase 3) makes deliverable.

- **Admin actions** (superuser-only, on Organization):
  - **Bind to platform Stripe account**: requires exactly one selected org with no existing Stripe account; sets `stripe_account_id = STRIPE_ACCOUNT` with `charges_enabled`/`details_submitted` true. The unique constraint on `stripe_account_id` backstops double-binding. Saves via `_stripe_update_fields()` so `updated_at` is maintained.
  - **Unbind platform Stripe account**: clears the binding; refuses to touch real Connect bindings.
- **Platform-self guard**: `handle_account_updated` skips events with no `event.account` (the platform's own account) — nothing to mirror, binding is admin-managed.
- **Docs**: the `billing-and-vat.md` danger note ("host must not be an org") is replaced with the two-endpoints-one-URL architecture note; new steady-state runbook `docs/runbooks/stripe-webhook-endpoints.md` (topology, secrets/rotation, host-as-org, observability), wired into mkdocs nav.
- **Version**: 1.62.7 → 1.63.0 (`uv version --bump minor`), ready for the demo deploy.

Checkout/refund code already supports the host-account path (drops `stripe_account` header and application fee when `org.stripe_account_id == STRIPE_ACCOUNT`) — this PR adds the missing binding mechanism and webhook guard.

## Test plan

- [x] 6 binding tests: bind happy path, refuses already-connected org, requires superuser, requires exactly one org, unbind happy path, unbind refuses real Connect bindings
- [x] platform-self `account.updated` skip test; existing `account.updated` tests now set explicit `event.account`
- [x] platform-shaped `handle_event` regression test (no `account` key → `account=""`, handled)
- [x] `make check` green; suite green locally

## After merge (operator)

Deploy to demo and run the runbook end-to-end: Phase 1–2 verification, Phase 3 cutover, then Phase 4 binding + live test purchase and dashboard refund. Prod follows once demo is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI: actions to bind/unbind an organization to the platform Stripe account.

* **Bug Fixes**
  * Safer handling of platform-shaped Stripe events to avoid unintended updates.

* **Documentation**
  * Clarified billing & VAT webhook behavior and added a detailed Stripe webhook runbook with provisioning/rotation guidance and observability notes.

* **Tests**
  * Added tests covering admin binding/unbinding and webhook account-shape cases.

* **Chores**
  * Project version bumped and docs navigation updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->