### PR TITLE
fix(admin): expose SocialMediaMixin fields in Organization admin

### DIFF
--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -62,7 +62,7 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
     actions = ["bind_platform_stripe_account", "unbind_platform_stripe_account"]
 
     tabs = [
-        ("Settings", ["Settings"]),
+        ("Settings", ["Settings", "Social"]),
         ("Billing", ["Billing"]),
         ("People", ["Staff", "Members", "Tiers"]),
         ("Content", ["Series", "Questionnaires", "Venues"]),
@@ -82,6 +82,17 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
                     "accept_membership_requests",
                     "contact_email",
                     "contact_email_verified",
+                ],
+            },
+        ),
+        (
+            "Social",
+            {
+                "fields": [
+                    "instagram_url",
+                    "facebook_url",
+                    "bluesky_url",
+                    "telegram_url",
                 ],
             },
         ),


### PR DESCRIPTION
## Summary

The explicit `fieldsets` on `OrganizationAdmin` omitted the four `SocialMediaMixin` fields (`instagram_url`, `facebook_url`, `bluesky_url`, `telegram_url`), so they were never visible or editable in the admin panel.

This adds a **Social** fieldset (grouped under the existing Settings tab) exposing all four fields. `Organization` is the only model using the mixin, so no other admin needs changes.

## Test plan

- `make check` passes (format, lint, mypy strict, migration check)
- Manual: open an Organization in the admin → Settings tab now shows the Social fieldset with the four URL fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Social tab to the admin interface with fields for managing Instagram, Facebook, Bluesky, and Telegram URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->