### PR TITLE
feat(scripts): add --ip and --user-agent filters to loki_logs.py

### DIFF
--- a/.claude/skills/loki-logs/SKILL.md
+++ b/.claude/skills/loki-logs/SKILL.md
@@ -29,7 +29,7 @@ If it errors with "GRAFANA_TOKEN is not set", it isn't configured yet — tell t
 |------|-------|-------|
 | Stream labels | `SERVICE`, `--level error` (repeatable), `--env production` | indexed, cheap |
 | Line content | `--grep TEXT`, `--exclude TEXT`, `--regex RE` (all repeatable) | substring / regex |
-| Request metadata | `--trace-id`, `--request-id`, `--user-id`, `--method`, `--path`, `--status-code` | structlog fields |
+| Request metadata | `--trace-id`, `--request-id`, `--user-id`, `--method`, `--path`, `--status-code`, `--ip`, `--user-agent` | structlog fields |
 | Raw escape hatch | `--query '{service_name="web"} \| status_code="500"'` | any LogQL |
 
 Logs are structlog JSON; the displayed line is the `event` message, with a
@@ -53,6 +53,9 @@ metadata line beneath it (suppress with `--no-meta`, get raw JSON with `--json`)
 # Everything a user triggered
 .venv/bin/python scripts/loki_logs.py --user-id <uuid> --since 12h
 
+# Everything from one client IP (e.g. chasing a scraper/429 burst)
+.venv/bin/python scripts/loki_logs.py web --ip <ip> --since 6h
+
 # Discover what labels/values exist
 .venv/bin/python scripts/loki_logs.py --labels
 .venv/bin/python scripts/loki_logs.py --label-values service_name
@@ -73,4 +76,6 @@ metadata line beneath it (suppress with `--no-meta`, get raw JSON with `--json`)
 - A query needs at least one matcher — with no `SERVICE`/`--level` the script
   defaults to `{service_name=~".+"}` (all app streams).
 - Hitting `--limit` prints a stderr hint; narrow `--since` or raise `-n`.
+- `--ip`/`--user-agent` only match lines ingested after the Alloy config that
+  promotes `ip_address`/`user_agent`; older lines won't match those filters.
 - Read-only. The token is Viewer-scoped; this cannot modify anything.

--- a/scripts/loki_logs.py
+++ b/scripts/loki_logs.py
@@ -13,7 +13,7 @@ Log shape (structlog JSON, parsed by Alloy before ingestion):
   * stream labels:        ``service_name`` (web|celery_default|beat|telegram),
                           ``level`` (info|warning|error|...), ``environment``
   * structured metadata:  ``trace_id``, ``request_id``, ``method``, ``path``,
-                          ``status_code``, ``user_id``
+                          ``status_code``, ``user_id``, ``ip_address``, ``user_agent``
 
 Run with the venv interpreter (imports ``python-decouple``). Examples::
 
@@ -56,13 +56,14 @@ DEFAULT_DATASOURCE_UID = "loki"
 USER_AGENT = "revel-loki-logs/1.0 (+scripts/loki_logs.py)"
 KNOWN_SERVICES = ("web", "celery_default", "beat", "telegram")
 # Per-record fields we extract for display beneath each log line.
-METADATA_FIELDS = ("trace_id", "request_id", "method", "path", "status_code", "user_id")
+METADATA_FIELDS = ("trace_id", "request_id", "method", "path", "status_code", "user_id", "ip_address", "user_agent")
 # Order in which metadata is shown beneath each log line (most useful first).
-META_DISPLAY_ORDER = ("status_code", "method", "path", "user_id", "request_id", "trace_id")
+META_DISPLAY_ORDER = ("status_code", "method", "path", "user_id", "ip_address", "user_agent", "request_id", "trace_id")
 # Fields the live pipeline promotes to structured metadata → queryable as
-# ``| field="x"`` (since the single-render structlog fix, v1.62.4, all six are
-# promoted — including status_code and user_id).
-LABEL_METADATA = ("trace_id", "request_id", "method", "path", "status_code", "user_id")
+# ``| field="x"`` (since the single-render structlog fix, v1.62.4, all are
+# promoted — ip_address/user_agent only on lines ingested after the matching
+# alloy-config update; older lines simply won't match those filters).
+LABEL_METADATA = ("trace_id", "request_id", "method", "path", "status_code", "user_id", "ip_address", "user_agent")
 DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
 
 
@@ -337,6 +338,8 @@ def build_parser() -> argparse.ArgumentParser:
     flt.add_argument("--method", help="HTTP method metadata, e.g. POST")
     flt.add_argument("--path", help="request path metadata (exact match)")
     flt.add_argument("--status-code", dest="status_code", help="HTTP status_code metadata, e.g. 500")
+    flt.add_argument("--ip", dest="ip_address", help="client ip_address metadata (exact match)")
+    flt.add_argument("--user-agent", dest="user_agent", help="user_agent metadata (exact match)")
 
     win = parser.add_argument_group("time & limit")
     win.add_argument("-s", "--since", default="1h", metavar="DUR", help="look back this far (default 1h): 30m,2h,1d,1w")


### PR DESCRIPTION
## Why

While chasing today's `ElevatedRateLimiting` Pushover alert, the 429 bursts could not be attributed from Loki: the backend logs `ip_address` and `user_agent` on every `request_finished`, but Alloy discarded both before ingestion. The source (Azure-hosted Node.js clients hammering one org endpoint) had to be recovered by grepping raw docker logs on the host.

letsrevel/infra#10 (merged & deployed) now promotes both fields to Loki structured metadata. This PR exposes them in the log-query CLI.

## What

- `--ip` and `--user-agent` filter flags on `scripts/loki_logs.py`, built into LogQL exactly like the existing metadata filters (`--user-id`, `--status-code`, …)
- `ip_address` and `user_agent` are displayed on the metadata line beneath each log entry
- `loki-logs` skill doc updated: flag table, an "everything from one client IP" recipe, and a note that lines ingested before the Alloy change won't match the new filters

## Verification

Tested against production Loki after deploying infra#10:

```
$ loki_logs.py web --ip 2001:871:...:742e --since 5m
19:19:14.800  INFO  web  request_finished
              status_code=200  method=GET  path=/api/version  ip_address=2001:871:...:742e  user_agent=curl/8.7.1  ...
```

`--user-agent curl/8.7.1` returns the same entry; ruff lint + format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)