### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Read version from pyproject.toml
         id: get_version
         run: echo "VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -29,10 +29,10 @@ jobs:
   licensecheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -48,10 +48,10 @@ jobs:
   pip-audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install MkDocs
         run: pip install mkdocs-material mkdocs-minify-plugin mkdocs-redirects

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -30,7 +30,7 @@ jobs:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true
@@ -95,7 +95,7 @@ jobs:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -25,12 +25,12 @@ jobs:
     name: pip-audit (main)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -45,7 +45,7 @@ jobs:
 
       - name: Open tracker issue on failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = `Nightly pip-audit failure (${new Date().toISOString().slice(0, 10)})`;
@@ -90,12 +90,12 @@ jobs:
     name: licensecheck (main)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -110,7 +110,7 @@ jobs:
 
       - name: Open tracker issue on failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = `Nightly license-check failure (${new Date().toISOString().slice(0, 10)})`;

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Validate tag format
         run: |
@@ -43,7 +43,7 @@ jobs:
         run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Free up disk space
         run: |
@@ -68,7 +68,7 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.6.10"
           enable-cache: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,10 +33,10 @@ jobs:
     name: Lint, type & schema checks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -72,7 +72,7 @@ jobs:
         run: cp geo/data/worldcities.mini.csv geo/data/worldcities.csv
 
       - name: Restore mypy cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .mypy_cache
           key: mypy-${{ runner.os }}-${{ hashFiles('uv.lock') }}-${{ github.sha }}
@@ -113,10 +113,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -167,7 +167,7 @@ jobs:
             src
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-shard-${{ matrix.shard }}
           path: .coverage.shard-${{ matrix.shard }}
@@ -184,10 +184,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           version: "0.6.10"
           enable-cache: true
@@ -196,7 +196,7 @@ jobs:
         run: uv sync
 
       - name: Download all coverage shards
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-shard-*
           merge-multiple: true
@@ -213,6 +213,6 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Why

GitHub is retiring the Node.js 20 runtime on Actions runners:

- **2026-06-16** — Node 20 JS actions are *force-migrated* to Node 24 by default
- **2026-09-16** — Node 20 removed from runners entirely

Our nightly audit run already surfaced the deprecation annotation (`actions/checkout@v4`, `astral-sh/setup-uv@v6` running on Node 20). Several other actions across the workflows are on Node-20 majors too.

## Change

Bumped every action to a current Node-24 major (moving major tags where published):

| Action | From | To |
|---|---|---|
| actions/checkout | v3, v4 | v6 |
| astral-sh/setup-uv | v6 | v7 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/github-script | v8 | v9 |
| codecov/codecov-action | v5 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |

> **setup-uv → v7, not v8:** astral-sh/setup-uv only publishes moving major tags through `v7`; v8 ships as full-version tags (`v8.2.0`) with no rolling `v8`. `v7` is already on the node24 runtime (`v6` was node20), so it satisfies the migration while keeping the moving-major-tag style used everywhere else.

## Compatibility

Verified that every input we actually pass is still supported in the target majors:

- `upload-artifact@v7`: name, path, include-hidden-files, retention-days, if-no-files-found ✓
- `download-artifact@v8`: pattern, merge-multiple ✓
- `codecov-action@v7`: token ✓
- `setup-uv@v7`: version, enable-cache ✓

So this is a runtime-only migration — no workflow logic changes. The `test.yaml`/`deps.yaml` checks exercise the bumped actions directly on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline dependencies to latest action versions, including checkout, setup utilities, Docker build tools, and code coverage services. These infrastructure updates enhance build reliability, security scanning capabilities, and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->