### PR TITLE
fix(perf): cache django-solo singletons to kill SiteSettings N+1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.63.0"
+version = "1.63.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/common/tests/test_solo_cache.py
+++ b/src/common/tests/test_solo_cache.py
@@ -1,0 +1,38 @@
+"""Tests for django-solo singleton caching (SOLO_CACHE).
+
+Regression coverage for the N+1 where every ``SingletonModel.get_solo()`` ran a
+``get_or_create()``: notification-dispatch loops issued one identical
+``SELECT ... FROM common_sitesettings`` per recipient (observed as 100+ duplicate
+queries in a single event-status-change request). With ``SOLO_CACHE`` enabled the
+singleton is served from the cache after the first read.
+"""
+
+import typing as t
+
+import pytest
+
+from common.models import SiteSettings
+
+
+@pytest.mark.django_db
+def test_get_solo_is_cached_after_first_call(django_assert_num_queries: t.Any) -> None:
+    """Repeated get_solo() reads must not touch the DB once the singleton is cached."""
+    # Prime the cache. The first call may SELECT (+ INSERT) the singleton row.
+    SiteSettings.get_solo()
+
+    with django_assert_num_queries(0):
+        for _ in range(10):
+            SiteSettings.get_solo()
+
+
+@pytest.mark.django_db
+def test_get_solo_cache_refreshes_on_save(django_assert_num_queries: t.Any) -> None:
+    """Saving the singleton refreshes the cache: subsequent reads are correct and query-free."""
+    site_settings = SiteSettings.get_solo()
+    site_settings.notify_user_joined = True
+    site_settings.save()
+
+    with django_assert_num_queries(0):
+        refreshed = SiteSettings.get_solo()
+
+    assert refreshed.notify_user_joined is True

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -70,18 +70,30 @@ def enable_celery_eager_mode(settings: t.Any) -> None:
 
 
 @pytest.fixture(autouse=True)
-def use_locmem_cache(settings: t.Any) -> None:
+def use_locmem_cache(settings: t.Any) -> t.Generator[None]:
     """Use in-memory cache for tests to avoid Redis sharing issues in parallel runs.
 
     This ensures each test worker has its own isolated cache, preventing race
     conditions when running tests in parallel with pytest-xdist.
+
+    The store is cleared around each test: LocMemCache keyed by ``"test-cache"``
+    is shared process-wide, so without an explicit clear, cached values survive
+    across sequential tests in the same worker. That matters in particular for
+    django-solo (``SOLO_CACHE``), which caches whole singleton model instances —
+    a cached SiteSettings/Legal row tied to a rolled-back DB row would otherwise
+    leak into the next test.
     """
+    from django.core.cache import cache
+
     settings.CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "test-cache",
         }
     }
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/src/revel/settings/base.py
+++ b/src/revel/settings/base.py
@@ -259,6 +259,16 @@ CACHES = {
     }
 }
 
+# django-solo: cache the singleton rows (SiteSettings, Legal) in Redis instead of
+# hitting the DB on every SingletonModel.get_solo() call. Without this, get_solo()
+# runs a get_or_create() per call — which fanned out into 100+ identical
+# SELECT common_sitesettings queries inside notification-dispatch loops.
+# django-solo refreshes the cache on .save() and clears it on .delete(), so admin
+# edits invalidate automatically; the timeout is only a backstop against rows
+# mutated directly in the DB (bypassing .save()).
+SOLO_CACHE = "default"
+SOLO_CACHE_TIMEOUT = 60 * 60  # 1 hour
+
 
 # GENERAL
 VERSION = version("revel")

--- a/uv.lock
+++ b/uv.lock
@@ -3932,7 +3932,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.63.0"
+version = "1.63.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Problem

`SingletonModel.get_solo()` (django-solo) ran a `get_or_create()` on **every** call because `SOLO_CACHE` was never configured — django-solo's caching is opt-in and defaults to `None`.

There are 50+ `SiteSettings.get_solo()` / `Legal.get_solo()` call sites, several inside per-recipient loops. Production profiling of `POST /api/event-admin/{uuid}/actions/update-status/open` showed **162 identical `SELECT … FROM common_sitesettings`** in a single request (~420 queries total, ~1.8s) — the singleton was re-fetched once per attendee/notification.

## Fix

Enable django-solo's built-in Redis caching:

```python
SOLO_CACHE = "default"
SOLO_CACHE_TIMEOUT = 60 * 60  # 1 hour
```

This collapses the N+1 at **every** `get_solo()` call site at once, not just the one loop. The cache backend (Redis) was already configured and in use by Celery/throttling.

**Invalidation is automatic:** django-solo refreshes the cache in `SingletonModel.save()` and clears it in `delete()`. All `SiteSettings`/`Legal` writes go through `.save()` (no `.objects.update()` bypasses exist in the codebase), so admin edits propagate immediately. The 1h timeout is only a backstop against rows mutated directly in the DB.

## Test isolation

The autouse `use_locmem_cache` fixture reassigned `CACHES` but never cleared the store — `LocMemCache` keyed by `"test-cache"` is shared process-wide, so a cached singleton instance (tied to a rolled-back DB row) could leak across sequential tests in the same xdist worker once `SOLO_CACHE` is on. The fixture now clears the cache around each test.

## Regression test

`src/common/tests/test_solo_cache.py` asserts `get_solo()` is query-free after the first read, and that `.save()` refreshes the cache without re-querying.

## Notes

- Patch bump `1.63.0 → 1.63.1` (via `uv version --bump patch`).
- This surfaced from an exploratory caching review; production traffic is low (~1.6 req/min, zero 5xx), so this is the one DB-load win actually worth doing right now — a real N+1 bug rather than a speculative cache layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)