### PR TITLE
docs: document runtime-configurable frontend image for self-hosting (#396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ This starts PostgreSQL, Redis, ClamAV, and **Mailpit**. All emails sent by the a
 
 ---
 
+## 🏠 Self-Hosting (Production)
+
+For a full production deployment — reverse proxy, TLS, the SvelteKit frontend, and the observability stack — use the **[infra](https://github.com/letsrevel/infra)** repository, which ships a turn-key Docker Compose setup and a documented `.env.example`.
+
+The published frontend image (`ghcr.io/letsrevel/revel-frontend`) is **environment-agnostic**: it reads its backend API URL from `PUBLIC_API_URL` at **runtime**, so a single prebuilt image can point at any backend. Set `PUBLIC_API_URL` (and `ORIGIN`) in your deployment environment — no rebuild required. See `letsrevel/infra`'s `.env.example` for the canonical configuration.
+
+---
+
 ## 📊 Observability
 
 Revel includes a comprehensive observability stack built on the LGTM (Loki, Grafana, Tempo, Mimir) framework.


### PR DESCRIPTION
## Summary

Companion docs change for runtime-configurable `PUBLIC_API_URL` (revel-frontend#396 / revel-frontend#416).

Adds a **Self-Hosting (Production)** section to the README clarifying that the published frontend image (`ghcr.io/letsrevel/revel-frontend`) is now environment-agnostic — it reads `PUBLIC_API_URL` (and `ORIGIN`) at **runtime**, so a single prebuilt image can point at any backend with no rebuild. Points self-hosters to `letsrevel/infra` for the canonical compose + `.env` setup.

## Lands together with
- revel-frontend#416 — the runtime-config implementation
- letsrevel/infra — compose + `.env.example` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)