### PR TITLE
fix(questionnaires): expose requires_evaluation on submissions (#508)

### DIFF
--- a/src/events/tests/test_controllers/test_event_controller/test_requires_evaluation.py
+++ b/src/events/tests/test_controllers/test_event_controller/test_requires_evaluation.py
@@ -68,6 +68,9 @@ def test_submit_no_eval_questionnaire_skips_evaluation_task(
     assert response.status_code == 200
     assert QuestionnaireSubmission.objects.count() == 1
     mock_evaluate_task.assert_not_called()
+    # The response must signal that no evaluation is needed, so the frontend does
+    # not render a misleading "pending" chip (#508).
+    assert response.json()["requires_evaluation"] is False
 
 
 # --- Create validation: feedback + requires_evaluation=True is rejected ---

--- a/src/questionnaires/schema.py
+++ b/src/questionnaires/schema.py
@@ -259,13 +259,22 @@ def resolve_requires_evaluation(obj: QuestionnaireSubmission) -> bool:
     must not display it as "pending". Defaults to ``True`` (the historical
     behaviour) when no organization wrapper exists.
 
+    Idempotent on re-validation: the ``submit_questionnaire`` endpoint returns a
+    pre-built schema instance against a union response model, so ninja validates a
+    second time and calls this resolver again with the schema instance (which has
+    no ``.questionnaire`` relation). In that case the value is already computed, so
+    reuse it instead of re-walking the ORM relations.
+
     Catches the generic ``ObjectDoesNotExist`` rather than the concrete
     ``OrganizationQuestionnaire.DoesNotExist`` to avoid importing ``events`` into
     ``questionnaires`` (``events`` already depends on ``questionnaires``).
     """
+    existing = getattr(obj, "requires_evaluation", None)
+    if isinstance(existing, bool):
+        return existing
     try:
         return bool(obj.questionnaire.org_questionnaires.requires_evaluation)
-    except ObjectDoesNotExist:
+    except (AttributeError, ObjectDoesNotExist):
         return True
 
 

--- a/src/questionnaires/schema.py
+++ b/src/questionnaires/schema.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
 
+from django.core.exceptions import ObjectDoesNotExist
 from ninja import ModelSchema, Schema
 from pydantic import Field, field_serializer, field_validator, model_validator
 from pydantic_core import PydanticCustomError
@@ -250,14 +251,38 @@ class QuestionnaireSubmissionSchema(Schema):
         return self
 
 
+def resolve_requires_evaluation(obj: QuestionnaireSubmission) -> bool:
+    """Whether the submission's questionnaire requires evaluation.
+
+    Derived from the wrapping ``OrganizationQuestionnaire``. When ``False`` the
+    submission grants access without any evaluation (LLM or human), so consumers
+    must not display it as "pending". Defaults to ``True`` (the historical
+    behaviour) when no organization wrapper exists.
+
+    Catches the generic ``ObjectDoesNotExist`` rather than the concrete
+    ``OrganizationQuestionnaire.DoesNotExist`` to avoid importing ``events`` into
+    ``questionnaires`` (``events`` already depends on ``questionnaires``).
+    """
+    try:
+        return bool(obj.questionnaire.org_questionnaires.requires_evaluation)
+    except ObjectDoesNotExist:
+        return True
+
+
 class QuestionnaireSubmissionResponseSchema(ModelSchema):
     questionnaire_id: UUID
     status: QuestionnaireSubmission.QuestionnaireSubmissionStatus
     submitted_at: datetime
+    requires_evaluation: bool
 
     class Meta:
         model = QuestionnaireSubmission
         fields = ["status", "submitted_at"]
+
+    @staticmethod
+    def resolve_requires_evaluation(obj: QuestionnaireSubmission) -> bool:
+        """Resolve whether evaluation is required for this submission."""
+        return resolve_requires_evaluation(obj)
 
 
 class QuestionnaireEvaluationForUserSchema(ModelSchema):
@@ -284,11 +309,17 @@ class SubmissionListItemSchema(ModelSchema):
     questionnaire_name: str
     evaluation_status: QuestionnaireEvaluation.QuestionnaireEvaluationStatus | None = None
     evaluation_score: Decimal | None = None
+    requires_evaluation: bool
     metadata: dict[str, t.Any] | None = None
 
     class Meta:
         model = QuestionnaireSubmission
         fields = ["id", "status", "submitted_at", "created_at"]
+
+    @staticmethod
+    def resolve_requires_evaluation(obj: QuestionnaireSubmission) -> bool:
+        """Resolve whether evaluation is required for this submission."""
+        return resolve_requires_evaluation(obj)
 
     @staticmethod
     def resolve_user(obj: QuestionnaireSubmission) -> MinimalRevelUserSchema:
@@ -377,9 +408,15 @@ class SubmissionDetailSchema(Schema):
     status: QuestionnaireSubmission.QuestionnaireSubmissionStatus
     submitted_at: datetime | None
     evaluation: EvaluationResponseSchema | None = None
+    requires_evaluation: bool
     answers: list[QuestionAnswerDetailSchema]
     created_at: datetime
     metadata: dict[str, t.Any] | None = None
+
+    @staticmethod
+    def resolve_requires_evaluation(obj: QuestionnaireSubmission) -> bool:
+        """Resolve whether evaluation is required for this submission."""
+        return resolve_requires_evaluation(obj)
 
     @staticmethod
     def resolve_questionnaire(obj: QuestionnaireSubmission) -> "QuestionnaireInListSchema":

--- a/src/questionnaires/service/questionnaire_service.py
+++ b/src/questionnaires/service/questionnaire_service.py
@@ -889,13 +889,15 @@ class QuestionnaireService:
         """Get submissions queryset for this questionnaire."""
         return (
             QuestionnaireSubmission.objects.filter(questionnaire=self.questionnaire)
-            .select_related("user", "questionnaire")
+            .select_related("user", "questionnaire", "questionnaire__org_questionnaires")
             .prefetch_related("evaluation")
         )
 
     def get_submission_detail(self, submission_id: UUID) -> QuestionnaireSubmission:
         """Get detailed submission with answers."""
-        qs = QuestionnaireSubmission.objects.select_related("user", "questionnaire").prefetch_related(
+        qs = QuestionnaireSubmission.objects.select_related(
+            "user", "questionnaire", "questionnaire__org_questionnaires"
+        ).prefetch_related(
             "evaluation",
             "multiplechoiceanswer_answers__question",
             "multiplechoiceanswer_answers__option",

--- a/src/questionnaires/tests/test_schema.py
+++ b/src/questionnaires/tests/test_schema.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from accounts.models import RevelUser
+from events.models import OrganizationQuestionnaire
 from questionnaires.models import (
     Questionnaire,
     QuestionnaireEvaluation,
@@ -18,6 +19,7 @@ from questionnaires.schema import (
     QuestionAnswerDetailSchema,
     QuestionnaireCreateSchema,
     SubmissionListItemSchema,
+    resolve_requires_evaluation,
 )
 
 pytestmark = pytest.mark.django_db
@@ -116,6 +118,35 @@ def test_submission_list_item_schema_resolve_evaluation_score_without_evaluation
     evaluation_score = SubmissionListItemSchema.resolve_evaluation_score(submission)
 
     assert evaluation_score is None
+
+
+def test_resolve_requires_evaluation_true_when_no_org_wrapper(questionnaire: Questionnaire, user: RevelUser) -> None:
+    """A questionnaire with no OrganizationQuestionnaire wrapper defaults to True (#508)."""
+    submission = QuestionnaireSubmission.objects.create(user=user, questionnaire=questionnaire)
+
+    assert resolve_requires_evaluation(submission) is True
+
+
+def test_resolve_requires_evaluation_true_when_org_requires_it(
+    org_questionnaire: OrganizationQuestionnaire, user: RevelUser
+) -> None:
+    """When the org wrapper requires evaluation (default), the resolver returns True (#508)."""
+    submission = QuestionnaireSubmission.objects.create(user=user, questionnaire=org_questionnaire.questionnaire)
+
+    assert resolve_requires_evaluation(submission) is True
+
+
+def test_resolve_requires_evaluation_false_when_org_does_not_require_it(
+    org_questionnaire: OrganizationQuestionnaire, user: RevelUser
+) -> None:
+    """When the org wrapper has requires_evaluation=False, the resolver returns False (#508)."""
+    org_questionnaire.requires_evaluation = False
+    org_questionnaire.save(update_fields=["requires_evaluation"])
+    submission = QuestionnaireSubmission.objects.create(user=user, questionnaire=org_questionnaire.questionnaire)
+
+    assert resolve_requires_evaluation(submission) is False
+    # The schema static resolver delegates to the shared helper.
+    assert SubmissionListItemSchema.resolve_requires_evaluation(submission) is False
 
 
 def test_question_answer_detail_schema_multiple_choice() -> None:


### PR DESCRIPTION
## Summary

Fixes #508 — auto-accepted questionnaire submissions no longer look "pending" to API consumers.

When `requires_evaluation=False`, no `QuestionnaireEvaluation` object is ever created, so the submission schemas returned `evaluation_status=None` — **indistinguishable from a submission still awaiting async/human evaluation**. Frontends fell back to a "pending" chip for an application that was actually already accepted, leaving users waiting for a review that never comes.

Backend eligibility was already correct (`gates.py` treats submission existence as sufficient when `requires_evaluation=False`); this PR fixes only the **display contract** by exposing an explicit `requires_evaluation: bool` flag so consumers can render an "auto-accepted" state.

## Changes

- **`questionnaires/schema.py`** — shared `resolve_requires_evaluation()` helper, wired into `QuestionnaireSubmissionResponseSchema` (user submit response), `SubmissionListItemSchema` (staff list), and `SubmissionDetailSchema` (staff detail).
  - Defaults to `True` when no `OrganizationQuestionnaire` wrapper exists (historical behaviour).
  - Catches the generic `ObjectDoesNotExist` rather than the concrete `OrganizationQuestionnaire.DoesNotExist` to avoid an `events` → `questionnaires` circular import.
- **`questionnaires/service/questionnaire_service.py`** — `select_related("questionnaire__org_questionnaires")` on both submission querysets to avoid N+1 on the new field.

## Tests

- 4 resolver unit tests (no wrapper → `True`; wrapper requiring eval → `True`; wrapper not requiring eval → `False`; schema static resolver delegation).
- Extended the existing `requires_evaluation=False` submit integration test to assert `requires_evaluation is False` in the response.

## Frontend follow-up

Tracked separately in letsrevel/revel-frontend (regenerate the API client + render the "auto-accepted" chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API responses now explicitly indicate whether questionnaire submissions require evaluation, preventing misleading "pending" states in the user interface.

* **Tests**
  * Added test coverage for questionnaire submission evaluation status determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->