### PR TITLE
fix(observability): cut redundant 4xx log noise, lock in 500 traceback capture (#480)

### DIFF
--- a/src/common/tests/test_logging_config.py
+++ b/src/common/tests/test_logging_config.py
@@ -1,0 +1,108 @@
+"""Regression tests for the production logging configuration.
+
+These lock in two related observability guarantees that are easy to break with a
+one-line settings edit:
+
+1. **#480 — every 500 keeps its traceback.** Django logs unhandled exceptions in
+   admin / non-API views to the stdlib ``django.request`` logger with ``exc_info``.
+   Our ``json`` formatter (a structlog ``ProcessorFormatter`` with ``format_exc_info``
+   in its ``foreign_pre_chain``) must serialize that traceback into the JSON line so it
+   reaches Loki. Without an error tracker (Sentry/GlitchTip — deliberately not added;
+   Loki + Grafana alerting is the chosen sink), this rendering is the *only* thing that
+   makes production 500s debuggable.
+
+2. **4xx log-noise reduction.** ``django.request`` is configured at ``ERROR`` (not
+   ``WARNING``) so it no longer duplicates our structured ``request_finished`` middleware
+   log for every 4xx. Django's ``log_response`` emits 5xx at ERROR (kept) and 4xx at
+   WARNING (dropped); django-ninja-extra's access logger is also ``django.request``.
+"""
+
+import json
+import logging
+import sys
+import typing as t
+
+from django.conf import settings
+
+
+def _build_json_formatter() -> logging.Formatter:
+    """Instantiate the real ``json`` formatter from the configured LOGGING dict.
+
+    Uses the exact ``processor`` + ``foreign_pre_chain`` from settings rather than a
+    hand-rolled copy, so the test fails if either is changed in a way that drops
+    traceback rendering.
+    """
+    logging_config = t.cast(dict[str, t.Any], settings.LOGGING)
+    spec = logging_config["formatters"]["json"]
+    factory = t.cast(t.Callable[..., logging.Formatter], spec["()"])
+    return factory(processor=spec["processor"], foreign_pre_chain=spec["foreign_pre_chain"])
+
+
+def test_django_request_error_with_exc_info_renders_traceback() -> None:
+    """A ``django.request`` ERROR carrying ``exc_info`` serializes the full traceback (#480).
+
+    Mirrors what Django's ``log_response`` emits for an unhandled admin/non-API 500.
+    """
+    formatter = _build_json_formatter()
+
+    try:
+        raise ValueError("boom in admin delete")
+    except ValueError:
+        record = logging.LogRecord(
+            name="django.request",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="Internal Server Error: /admin/accounts/reveluser/",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    rendered = formatter.format(record)
+    payload = json.loads(rendered)
+
+    # The traceback lands in the structured ``exception`` field (format_exc_info), not
+    # just the human message — this is the exact guarantee #420/#484 introduced.
+    assert "exception" in payload, f"no traceback field in rendered log line: {payload}"
+    assert "ValueError" in payload["exception"]
+    assert "boom in admin delete" in payload["exception"]
+    assert payload["event"] == "Internal Server Error: /admin/accounts/reveluser/"
+
+
+def test_json_line_is_single_render() -> None:
+    """The formatter emits one parseable JSON object, not a double-encoded string (#484)."""
+    formatter = _build_json_formatter()
+    record = logging.LogRecord(
+        name="django.request",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="Internal Server Error: /admin/",
+        args=(),
+        exc_info=None,
+    )
+
+    payload = json.loads(formatter.format(record))
+
+    # A double-render regression would make ``event`` a JSON-encoded string instead of
+    # the dict we assert on here.
+    assert isinstance(payload, dict)
+    assert payload["event"] == "Internal Server Error: /admin/"
+
+
+def test_django_request_logger_configured_at_error_level() -> None:
+    """``django.request`` is ERROR so redundant 4xx WARNINGs are dropped (noise fix)."""
+    logging_config = t.cast(dict[str, t.Any], settings.LOGGING)
+    assert logging_config["loggers"]["django.request"]["level"] == "ERROR"
+
+
+def test_django_request_4xx_warning_is_filtered_out() -> None:
+    """At ERROR level a 4xx WARNING (e.g. ``Not Found:``) never reaches a handler.
+
+    Django applied ``settings.LOGGING`` via ``dictConfig`` at startup, so the live logger's
+    effective level proves WARNING records are discarded before any handler runs.
+    """
+    logger = logging.getLogger("django.request")
+    assert logger.getEffectiveLevel() == logging.ERROR
+    assert not logger.isEnabledFor(logging.WARNING)
+    assert logger.isEnabledFor(logging.ERROR)

--- a/src/revel/settings/observability.py
+++ b/src/revel/settings/observability.py
@@ -189,9 +189,18 @@ LOGGING = {
         # Django logs unhandled exceptions in views (incl. admin) to ``django.request``
         # with ``exc_info``. Without this entry, Django's default config sends them to
         # ``mail_admins`` only — so 500s outside the Ninja API would never reach Loki.
+        #
+        # Level is ERROR (not WARNING) on purpose: Django's ``log_response`` emits 5xx at
+        # ERROR (with ``exc_info``) and 4xx at WARNING, and django-ninja-extra's access
+        # logger is *also* ``django.request`` (logs 4xx/5xx at WARNING). At WARNING this
+        # logger duplicated our own structured ``request_finished`` middleware log for every
+        # 4xx — e.g. a bare ``Not Found: /path`` with no request context (see #480). ERROR
+        # keeps exactly what this entry exists for (admin/non-API 500 tracebacks) and drops
+        # the redundant 4xx noise; API 500s are still captured separately by
+        # ``handle_general_exception`` (structlog, full traceback).
         "django.request": {
             "handlers": DEFAULT_HANDLERS,
-            "level": "WARNING",
+            "level": "ERROR",
             "propagate": False,
         },
         "django.server": {


### PR DESCRIPTION
## Summary

Production logs carried duplicate, context-less warning lines for every 4xx. A single 404 emitted **three** log lines:

| Line | Logger | Level | Structured context? |
|------|--------|-------|---------------------|
| `request_finished` | our `StructlogContextMiddleware` | INFO | ✅ status, method, path, ip, response_time, trace_id… |
| `"GET - Controller[op]" 404` | `django.request` (ninja-extra's `request_logger`) | WARNING | ✅ full |
| `Not Found: /path` | `django.request` (Django's `log_response`) | WARNING | ❌ none |

The bottom two duplicate `request_finished`; the `Not Found:` line is the context-less noise from the production screenshot that prompted this.

## Change

Raise the `django.request` logger from `WARNING` → `ERROR` (one line + comment in `src/revel/settings/observability.py`).

Django's `log_response` emits **5xx at ERROR** (with `exc_info`) and **4xx at WARNING**; django-ninja-extra's access logger is also `django.request`. So `ERROR`:
- **keeps** admin / non-API **500 tracebacks** reaching Loki — the documented reason the entry exists (#420 / #484);
- **drops** the redundant 4xx warnings.

No loss of error visibility: API 500s are logged independently by `handle_general_exception` (structlog, full traceback + request context), and `validation_error` warnings use a separate structlog logger. Every 4xx is still recorded by `request_finished` with its `status_code`.

## Closes #480

- **Point 1 (tracebacks for all 500s)** — already shipped in #420/#484; this PR adds regression tests so it can't silently regress (the change touches that exact logger).
- **Point 2 (external error tracker)** — **closed by decision:** no Sentry/GlitchTip. We already run Loki + Grafana; error tracking is Grafana alerting on Loki error rates/patterns (as `handle_general_exception`'s docstring already states). Adding external infra isn't warranted.

## Tests

New `src/common/tests/test_logging_config.py` (4 tests, green) asserts against the **real** configured `LOGGING`:
- a `django.request` ERROR with `exc_info` renders a structured `exception` traceback through the actual `json` formatter (#480 pt 1);
- the JSON line is single-rendered (#484);
- `django.request` is configured at ERROR and 4xx WARNINGs are filtered out.

`make check` passes (ruff, mypy --strict, migrations, i18n, file-length).

## Follow-up (not in this PR)

The admin user-deletion 500 that originally motivated #480 has a *speculative* root cause (ProtectedError from referral PROTECT FKs / storage error in `RevelUser.delete()`), but no confirmed traceback and it touches GDPR-erasure behavior — left as a separate issue rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)