### PR TITLE
feat(notifications): immediate transactional emails + digest overhaul (#506, #507)

### DIFF
--- a/src/notifications/service/digest.py
+++ b/src/notifications/service/digest.py
@@ -10,20 +10,29 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from accounts.models import RevelUser
-from notifications.enums import DeliveryChannel, DeliveryStatus
+from notifications.enums import DeliveryChannel, DeliveryStatus, NotificationType
 from notifications.models import Notification, NotificationPreference
 
 logger = structlog.get_logger(__name__)
 
 
 class DigestNotification(t.TypedDict):
-    """Structure for a notification in a digest."""
+    """Structure for a single notification row in a digest."""
 
     title: str
     body: str
     notification_type: str
     created_at: datetime
     context: dict[str, t.Any]
+    url: str
+
+
+class DigestGroup(t.TypedDict):
+    """A group of digest notifications sharing the same type."""
+
+    label: str
+    notification_type: str
+    notifications: list[DigestNotification]
 
 
 class NotificationDigest:
@@ -45,9 +54,6 @@ class NotificationDigest:
         Returns:
             Tuple of (subject, text_body, html_body)
         """
-        # Group notifications by type
-        grouped = self._group_notifications_by_type()
-
         # Count totals
         total_count = self.notifications.count()
 
@@ -64,6 +70,9 @@ class NotificationDigest:
         site_settings = SiteSettings.get_solo()
         frontend_base_url = site_settings.frontend_base_url
 
+        # Group notifications by type (needs the base URL to build per-item CTAs)
+        groups = self._build_notification_groups(frontend_base_url)
+
         # Generate unsubscribe link
         unsubscribe_token = generate_unsubscribe_token(self.user)
         unsubscribe_link = f"{frontend_base_url}/unsubscribe?token={unsubscribe_token}"
@@ -71,7 +80,7 @@ class NotificationDigest:
         context = {
             "user": self.user,
             "total_count": total_count,
-            "grouped_notifications": grouped,
+            "notification_groups": groups,
             "digest_date": timezone.now(),
             "frontend_url": frontend_base_url,
             "unsubscribe_link": unsubscribe_link,
@@ -83,31 +92,43 @@ class NotificationDigest:
 
         return subject, text_body, html_body
 
-    def _group_notifications_by_type(self) -> dict[str, list[DigestNotification]]:
-        """Group notifications by type for easier rendering.
+    def _build_notification_groups(self, frontend_base_url: str) -> list[DigestGroup]:
+        """Group notifications by type, preserving chronological order within a group.
+
+        Each group carries a human-readable label (the notification type's display
+        name) and each row carries a CTA link derived from its context, so the
+        template can render rich, actionable digest content.
+
+        Args:
+            frontend_base_url: Base URL used to build per-item CTAs and fallbacks.
 
         Returns:
-            Dict of notification_type -> list of notifications
+            List of DigestGroup, ordered by first appearance of each type.
         """
-        grouped: dict[str, list[DigestNotification]] = {}
+        groups: dict[str, DigestGroup] = {}
 
-        for notif in self.notifications.select_related("user"):
+        for notif in self.notifications.select_related("user").order_by("created_at"):
             notif_type = notif.notification_type
 
-            if notif_type not in grouped:
-                grouped[notif_type] = []
+            if notif_type not in groups:
+                groups[notif_type] = {
+                    "label": _humanize_notification_type(notif_type),
+                    "notification_type": notif_type,
+                    "notifications": [],
+                }
 
-            grouped[notif_type].append(
+            groups[notif_type]["notifications"].append(
                 {
                     "title": notif.title,
                     "body": notif.body or "",
-                    "notification_type": notif.notification_type,
+                    "notification_type": notif_type,
                     "created_at": notif.created_at,
                     "context": notif.context,
+                    "url": _build_notification_url(notif.context, frontend_base_url),
                 }
             )
 
-        return grouped
+        return list(groups.values())
 
     def send_digest_email(self) -> bool:
         """Send digest email to user.
@@ -128,6 +149,43 @@ class NotificationDigest:
         )
 
         return True
+
+
+def _humanize_notification_type(notification_type: str) -> str:
+    """Return a human-readable label for a notification type.
+
+    Falls back to a title-cased version of the raw value for any type that is no
+    longer part of the enum (e.g. a deprecated type still present on old rows).
+
+    Args:
+        notification_type: Raw notification type value.
+
+    Returns:
+        Display label, e.g. "Event Reminder".
+    """
+    try:
+        return str(NotificationType(notification_type).label)
+    except ValueError:
+        return notification_type.replace("_", " ").title()
+
+
+def _build_notification_url(context: dict[str, t.Any], frontend_base_url: str) -> str:
+    """Derive a CTA link for a digest row from its notification context.
+
+    Prefers the most specific link available (event, then a generic action URL),
+    falling back to the user's notifications page.
+
+    Args:
+        context: The notification's stored context.
+        frontend_base_url: Base URL used for the fallback link.
+
+    Returns:
+        Absolute URL for the digest row's call to action.
+    """
+    url = context.get("event_url") or context.get("frontend_url") or context.get("action_url")
+    if isinstance(url, str) and url:
+        return url
+    return f"{frontend_base_url}/notifications"
 
 
 def get_pending_notifications_for_digest(user: RevelUser, since: datetime) -> QuerySet[Notification]:

--- a/src/notifications/service/digest.py
+++ b/src/notifications/service/digest.py
@@ -117,9 +117,15 @@ class NotificationDigest:
                     "notifications": [],
                 }
 
+            label = groups[notif_type]["label"]
+            # Resolve the best available title here (not in the template) so a row
+            # always has a heading even when title is unrendered or the context
+            # carries no event name.
+            display_title = notif.title or notif.context.get("event_name") or label
+
             groups[notif_type]["notifications"].append(
                 {
-                    "title": notif.title,
+                    "title": display_title,
                     "body": notif.body or "",
                     "notification_type": notif_type,
                     "created_at": notif.created_at,

--- a/src/notifications/service/dispatcher.py
+++ b/src/notifications/service/dispatcher.py
@@ -12,6 +12,20 @@ from notifications.models import Notification, NotificationPreference
 logger = structlog.get_logger(__name__)
 
 
+# Transactional notification types always send immediately on their enabled channels,
+# bypassing the digest cadence. These are time-/money-sensitive (a ticket sale, a
+# payment, a cancellation or a refund) and must not be held back for the periodic
+# digest sweep. See issue #506.
+TRANSACTIONAL_TYPES: frozenset[str] = frozenset(
+    {
+        NotificationType.PAYMENT_CONFIRMATION,
+        NotificationType.TICKET_CREATED,
+        NotificationType.TICKET_CANCELLED,
+        NotificationType.TICKET_REFUNDED,
+    }
+)
+
+
 class NotificationData(t.NamedTuple):
     """Data for creating a notification."""
 
@@ -132,9 +146,13 @@ def determine_delivery_channels(user: RevelUser, notification_type: str) -> list
     """
     prefs = user.notification_preferences
 
-    # Check if user wants digest
-    if prefs.digest_frequency != NotificationPreference.DigestFrequency.IMMEDIATE:
-        # Only create in-app notification, email will be sent in digest
+    # Transactional notifications (ticket/payment events) always deliver on their
+    # enabled channels immediately and never wait for the digest (issue #506).
+    is_transactional = notification_type in TRANSACTIONAL_TYPES
+
+    # Otherwise, if the user is on a digest cadence, only create the in-app
+    # notification now; the email is bundled into the periodic digest sweep.
+    if not is_transactional and prefs.digest_frequency != NotificationPreference.DigestFrequency.IMMEDIATE:
         return [DeliveryChannel.IN_APP]
 
     # Get enabled channels for this notification type

--- a/src/notifications/signals/ticket.py
+++ b/src/notifications/signals/ticket.py
@@ -142,20 +142,6 @@ def _build_ticket_refunded_context(ticket: Ticket, refund_amount: str | None = N
     }
 
 
-def _build_ticket_checked_in_context(ticket: Ticket) -> dict[str, t.Any]:
-    """Build notification context for TICKET_CHECKED_IN."""
-    event = ticket.event
-    base_context = _build_base_event_context(event)
-
-    checked_in_at_formatted = format_event_datetime(ticket.checked_in_at, event)
-
-    return {
-        **base_context,
-        "ticket_id": str(ticket.id),
-        "checked_in_at": checked_in_at_formatted,
-    }
-
-
 def _send_ticket_created_notifications(ticket: Ticket) -> None:
     """Send notifications for newly created ticket.
 
@@ -383,22 +369,6 @@ def _send_ticket_refunded_notifications(ticket: Ticket) -> None:
             )
 
 
-def _send_ticket_checked_in_notification(ticket: Ticket) -> None:
-    """Send notification when ticket is checked in.
-
-    Args:
-        ticket: The ticket being checked in
-    """
-    context = _build_ticket_checked_in_context(ticket)
-
-    notification_requested.send(
-        sender=Ticket,
-        user=ticket.user,
-        notification_type=NotificationType.TICKET_CHECKED_IN,
-        context=context,
-    )
-
-
 def _handle_ticket_status_change(ticket: Ticket, old_status: str | None) -> None:
     """Handle notifications for ticket status changes."""
     if not old_status or old_status == ticket.status:
@@ -428,8 +398,6 @@ def _handle_ticket_status_change(ticket: Ticket, old_status: str | None) -> None
                         notification_type=NotificationType.TICKET_CREATED,
                         context=staff_context,
                     )
-    elif ticket.status == Ticket.TicketStatus.CHECKED_IN:
-        _send_ticket_checked_in_notification(ticket)
     elif ticket.status == Ticket.TicketStatus.CANCELLED:
         # TICKET_CANCELLED fires for every cancellation. When a Stripe refund is
         # involved, the cancellation_service / Stripe webhook handler set

--- a/src/notifications/templates/notifications/emails/digest.html
+++ b/src/notifications/templates/notifications/emails/digest.html
@@ -1,35 +1,66 @@
-{% load i18n %}<!DOCTYPE html>
+{% load i18n %}{% load markdown_tags %}<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>{% trans "Notification Digest" %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background: #f4f5f7; color: #1a1a1a; }
+        .container { max-width: 600px; margin: 0 auto; background: white; }
+        .header { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 30px 20px; text-align: center; }
+        .header h1 { margin: 0; font-size: 26px; }
+        .header p { margin: 8px 0 0; opacity: 0.9; font-size: 15px; }
+        .content { padding: 24px 20px; }
+        .group { margin: 0 0 28px; }
+        .group-label { font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: #764ba2; font-weight: 700; margin: 0 0 12px; padding-bottom: 6px; border-bottom: 2px solid #eee; }
+        .item { background: #f8f9fa; border-left: 4px solid #667eea; padding: 14px 16px; margin: 0 0 12px; border-radius: 4px; }
+        .item-title { font-weight: 600; font-size: 16px; margin: 0 0 4px; }
+        .item-body { color: #444; font-size: 14px; margin: 0 0 8px; }
+        .item-body p { margin: 0 0 6px; }
+        .item-meta { font-size: 12px; color: #999; }
+        .item-link { display: inline-block; margin-top: 6px; font-size: 13px; color: #667eea; text-decoration: none; font-weight: 600; }
+        .footer-cta { text-align: center; margin: 24px 0 8px; }
+        .button { display: inline-block; padding: 14px 28px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white !important; text-decoration: none; border-radius: 6px; font-weight: 600; }
+        .footer { padding: 20px; text-align: center; }
+    </style>
 </head>
 <body>
-    <h2>{% trans "Notification Digest" %}</h2>
+    <div class="container">
+        <div class="header">
+            <h1>🔔 {% trans "Your Notification Digest" %}</h1>
+            <p>{% blocktranslate count counter=total_count %}{{ counter }} new notification{% plural %}{{ counter }} new notifications{% endblocktranslate %}</p>
+        </div>
+        <div class="content">
+            <p>{% trans "Hi" %} {{ user.get_display_name }},</p>
+            <p>{% trans "Here's what you missed since your last digest:" %}</p>
 
-    <p>{% trans "Dear" %} {{ user.get_display_name }},</p>
+            {% for group in notification_groups %}
+            <div class="group">
+                <div class="group-label">{{ group.label }}</div>
+                {% for item in group.notifications %}
+                <div class="item">
+                    <div class="item-title">{{ item.title|default:item.context.event_name|default:group.label }}</div>
+                    {% if item.body %}<div class="item-body">{{ item.body|markdown }}</div>{% endif %}
+                    <div class="item-meta">{{ item.created_at|date:"M j, Y · g:i A" }}</div>
+                    {% if item.url %}<a class="item-link" href="{{ item.url }}">{% trans "View details →" %}</a>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
 
-    <p>{% trans "Here's a summary of your recent notifications:" %}</p>
+            <div class="footer-cta">
+                <a href="{{ frontend_url }}/notifications" class="button">{% trans "View all notifications" %}</a>
+            </div>
 
-    {% for notification_type, notifications in grouped_notifications.items %}
-    <h3>{{ notification_type }}</h3>
-    <ul>
-        {% for notification in notifications %}
-        <li>{{ notification.title }}</li>
-        {% endfor %}
-    </ul>
-    {% endfor %}
-
-    <p><a href="{{ frontend_url }}/notifications">{% trans "View all notifications" %}</a></p>
-
-    <p>
-        {% trans "Best regards," %}<br>
-        {% trans "The Revel Team" %}
-    </p>
-
-    <hr style="margin: 20px 0; border: none; border-top: 1px solid #ddd;">
-    <p style="font-size: 12px; color: #999; text-align: center;">
-        <a href="{{ unsubscribe_link }}" style="color: #999; text-decoration: underline;">{% trans "Unsubscribe or manage notification preferences" %}</a>
-    </p>
+            <p>
+                {% trans "Best regards," %}<br>
+                {% trans "The Revel Team" %}
+            </p>
+        </div>
+        <div class="footer">
+            <p style="font-size: 12px; color: #999;">
+                <a href="{{ unsubscribe_link }}" style="color: #999; text-decoration: underline;">{% trans "Unsubscribe or manage notification preferences" %}</a>
+            </p>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/notifications/templates/notifications/emails/digest.html
+++ b/src/notifications/templates/notifications/emails/digest.html
@@ -38,7 +38,7 @@
                 <div class="group-label">{{ group.label }}</div>
                 {% for item in group.notifications %}
                 <div class="item">
-                    <div class="item-title">{{ item.title|default:item.context.event_name|default:group.label }}</div>
+                    <div class="item-title">{{ item.title }}</div>
                     {% if item.body %}<div class="item-body">{{ item.body|markdown }}</div>{% endif %}
                     <div class="item-meta">{{ item.created_at|date:"M j, Y · g:i A" }}</div>
                     {% if item.url %}<a class="item-link" href="{{ item.url }}">{% trans "View details →" %}</a>{% endif %}

--- a/src/notifications/templates/notifications/emails/digest.txt
+++ b/src/notifications/templates/notifications/emails/digest.txt
@@ -7,7 +7,7 @@
 {% for group in notification_groups %}
 == {{ group.label }} ==
 {% for item in group.notifications %}
-* {{ item.title|default:item.context.event_name|default:group.label }} ({{ item.created_at|date:"M j, Y · g:i A" }})
+* {{ item.title }} ({{ item.created_at|date:"M j, Y · g:i A" }})
 {% if item.body %}  {{ item.body }}
 {% endif %}{% if item.url %}  {{ item.url }}
 {% endif %}{% endfor %}{% endfor %}

--- a/src/notifications/templates/notifications/emails/digest.txt
+++ b/src/notifications/templates/notifications/emails/digest.txt
@@ -1,17 +1,16 @@
-{% load i18n %}{% trans "Notification Digest" %}
+{% load i18n %}{% trans "Your Notification Digest" %}
+{% blocktranslate count counter=total_count %}{{ counter }} new notification{% plural %}{{ counter }} new notifications{% endblocktranslate %}
 
-{% trans "Dear" %} {{ user.get_display_name }},
+{% trans "Hi" %} {{ user.get_display_name }},
 
-{% trans "Here's a summary of your recent notifications:" %}
-
-{% for notification_type, notifications in grouped_notifications.items %}
-
-{{ notification_type }}:
-{% for notification in notifications %}
-  - {{ notification.title }}
-{% endfor %}
-
-{% endfor %}
+{% trans "Here's what you missed since your last digest:" %}
+{% for group in notification_groups %}
+== {{ group.label }} ==
+{% for item in group.notifications %}
+* {{ item.title|default:item.context.event_name|default:group.label }} ({{ item.created_at|date:"M j, Y · g:i A" }})
+{% if item.body %}  {{ item.body }}
+{% endif %}{% if item.url %}  {{ item.url }}
+{% endif %}{% endfor %}{% endfor %}
 
 {% trans "View all notifications:" %} {{ frontend_url }}/notifications
 

--- a/src/notifications/tests/test_digest.py
+++ b/src/notifications/tests/test_digest.py
@@ -229,8 +229,11 @@ class TestNotificationDigest:
 
         # Assert
         assert "3 new notification" in subject
-        # Check that the notification type appears in the digest
-        assert "EVENT_REMINDER" in text_body or "event_reminder" in text_body
+        # The group heading uses the human-readable type label, not the raw enum value
+        assert "Event Reminder" in text_body
+        assert "Event Reminder" in html_body
+        # Each row carries a CTA link derived from the notification context
+        assert "https://example.com/events/test-0" in text_body
         assert len(text_body) > 0
         assert len(html_body) > 0
 

--- a/src/notifications/tests/test_dispatcher.py
+++ b/src/notifications/tests/test_dispatcher.py
@@ -130,20 +130,47 @@ class TestDetermineDeliveryChannels:
     ) -> None:
         """Test that only in-app channel is used when user wants digest.
 
-        When digest mode is enabled, notifications are created as in-app only.
-        Email delivery happens later via the digest task.
+        When digest mode is enabled, non-transactional notifications are created as
+        in-app only. Email delivery happens later via the digest task.
         """
         # Arrange - Set user to daily digest
         prefs = regular_user.notification_preferences
         prefs.digest_frequency = NotificationPreference.DigestFrequency.DAILY
         prefs.save()
 
-        # Act
-        channels = determine_delivery_channels(regular_user, NotificationType.TICKET_CREATED)
+        # Act - EVENT_REMINDER is not transactional, so it waits for the digest
+        channels = determine_delivery_channels(regular_user, NotificationType.EVENT_REMINDER)
 
         # Assert
         assert channels == [DeliveryChannel.IN_APP]
         assert DeliveryChannel.EMAIL not in channels
+
+    def test_transactional_types_bypass_digest(
+        self,
+        regular_user: RevelUser,
+    ) -> None:
+        """Transactional notifications send immediately even on a digest cadence (#506).
+
+        Ticket/payment events are time-/money-sensitive and must reach the user's
+        enabled channels right away rather than waiting for the periodic digest.
+        """
+        # Arrange - User is on a daily digest
+        prefs = regular_user.notification_preferences
+        prefs.digest_frequency = NotificationPreference.DigestFrequency.DAILY
+        prefs.save()
+
+        transactional = (
+            NotificationType.PAYMENT_CONFIRMATION,
+            NotificationType.TICKET_CREATED,
+            NotificationType.TICKET_CANCELLED,
+            NotificationType.TICKET_REFUNDED,
+        )
+
+        # Act / Assert - each transactional type still delivers email immediately
+        for notification_type in transactional:
+            channels = determine_delivery_channels(regular_user, notification_type)
+            assert DeliveryChannel.EMAIL in channels, notification_type
+            assert DeliveryChannel.IN_APP in channels, notification_type
 
     def test_respects_disabled_channels(
         self,


### PR DESCRIPTION
Bundles #506 and #507, and removes the pointless check-in notification.

## #506 — Transactional emails no longer swallowed by the digest
Routing was global-per-user: any non-IMMEDIATE `digest_frequency` forced **all** emails to wait for the hourly sweep. Now a `TRANSACTIONAL_TYPES` set (`PAYMENT_CONFIRMATION`, `TICKET_CREATED`, `TICKET_CANCELLED`, `TICKET_REFUNDED`) bypasses the digest gate in `determine_delivery_channels()` and delivers on the user's enabled channels immediately. Already-sent notifications stay excluded from the later digest, so no duplicates.

## #507 — Digest overhaul
- Groups by **human-readable type label** (`NotificationType.label`) instead of the raw enum key.
- Each row now carries **body + timestamp + a context-derived CTA link** (`event_url` → `frontend_url` → `/notifications` fallback).
- `digest.html` / `digest.txt` restyled to match the transactional emails (gradient header, cards, per-item "View details", footer CTA).
- Widened `DigestNotification`, added `DigestGroup` TypedDict.

## Check-in notification removed
`TICKET_CHECKED_IN` no longer fires on check-in (the holder is physically at the event). Stop-sending only — the enum value, template, and context schema are retained so existing DB rows and the template unit tests are unaffected.

## Tests
- `test_dispatcher.py`: digest-mode test switched to a non-transactional type; added `test_transactional_types_bypass_digest`.
- `test_digest.py`: assert the friendly group label and per-item CTA link.

## Notes
- New English source strings were added to the digest templates; `makemessages` was intentionally **not** committed (it produced ~1500 lines of unrelated de/fr catalog reordering). Strings fall back to English and `i18n-check` stays green — a dedicated translation pass can pick them up later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment and ticket-related notifications now bypass digest mode and deliver immediately for timely alerts.
  * Digest notifications now include direct action links allowing you to view full details and take action.

* **Style**
  * Email digest templates redesigned with improved visual layout, clear organization by notification type with human-readable category labels, and enhanced formatting throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->