### PR TITLE
feat(events): sortable admin ticket list (#517)

### DIFF
--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -2,6 +2,7 @@ import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 from ninja import Body, Query
 from ninja_extra import api_controller, route
@@ -29,7 +30,35 @@ TicketOrdering = t.Literal[
     "-status",
     "tier__payment_method",
     "-tier__payment_method",
+    "price",
+    "-price",
+    "price_paid",
+    "-price_paid",
 ]
+
+# Effective amount actually taken per ticket: the Stripe payment amount (online),
+# else the recorded PWYC amount (offline/at-the-door), else the tier list price
+# (fixed-price tiers, where neither of the former is set). tier.price is non-nullable
+# (defaults to 0), so the result is never NULL — no NULLS FIRST/LAST handling needed.
+# All three operands are already joined via Ticket.objects.full(), but the COALESCE
+# itself must be annotated so it appears in the SELECT list (required for SELECT DISTINCT).
+EFFECTIVE_PRICE_PAID = Coalesce("payment__amount", "price_paid", "tier__price")
+
+# Maps the public ``order_by`` value to the actual queryset ordering field.
+TICKET_ORDER_FIELDS: dict[TicketOrdering, str] = {
+    "created_at": "created_at",
+    "-created_at": "-created_at",
+    "tier__name": "tier__name",
+    "-tier__name": "-tier__name",
+    "status": "status",
+    "-status": "-status",
+    "tier__payment_method": "tier__payment_method",
+    "-tier__payment_method": "-tier__payment_method",
+    "price": "tier__price",
+    "-price": "-tier__price",
+    "price_paid": "effective_price_paid",
+    "-price_paid": "-effective_price_paid",
+}
 
 
 @api_controller(
@@ -145,13 +174,16 @@ class EventAdminTicketsController(EventAdminBaseController):
         - tier__name: Ticket tier, alphabetically
         - status: Ticket status, by stored value
         - tier__payment_method: Payment method, by stored value
+        - price: Tier list price
+        - price_paid: Effective amount actually paid (online payment, else PWYC amount, else tier price)
         """
         event = self.get_one(event_id)
         # Use full() for AdminTicketSchema (includes user, tier, venue, sector, seat, payment)
         # with_org_membership() prefetches user's membership for "Make Member" feature
         qs = models.Ticket.objects.full().with_org_membership(event.organization_id).filter(event=event)
+        qs = params.filter(qs).annotate(effective_price_paid=EFFECTIVE_PRICE_PAID)
         # "-id" is a stable tiebreaker so pagination stays deterministic across equal sort keys.
-        return params.filter(qs).distinct().order_by(order_by, "-id")
+        return qs.distinct().order_by(TICKET_ORDER_FIELDS[order_by], "-id")
 
     @route.get(
         "/tickets/{ticket_id}",

--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -20,6 +20,17 @@ from .base import EventAdminBaseController
 if t.TYPE_CHECKING:
     from common.models import FileExport
 
+TicketOrdering = t.Literal[
+    "created_at",
+    "-created_at",
+    "tier__name",
+    "-tier__name",
+    "status",
+    "-status",
+    "tier__payment_method",
+    "-tier__payment_method",
+]
+
 
 @api_controller(
     "/event-admin/{event_id}",
@@ -121,18 +132,26 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         params: filters.TicketFilterSchema = Query(...),  # type: ignore[type-arg]
+        order_by: TicketOrdering = "-created_at",
     ) -> QuerySet[models.Ticket]:
         """List tickets for an event with optional filters.
 
         Supports filtering by:
         - status: Filter by ticket status (PENDING, ACTIVE, CANCELLED, CHECKED_IN)
         - tier__payment_method: Filter by payment method (ONLINE, OFFLINE, AT_THE_DOOR, FREE)
+
+        Ordering (prefix with '-' for descending):
+        - created_at: Purchase date (default: -created_at, newest first)
+        - tier__name: Ticket tier, alphabetically
+        - status: Ticket status, by stored value
+        - tier__payment_method: Payment method, by stored value
         """
         event = self.get_one(event_id)
         # Use full() for AdminTicketSchema (includes user, tier, venue, sector, seat, payment)
         # with_org_membership() prefetches user's membership for "Make Member" feature
         qs = models.Ticket.objects.full().with_org_membership(event.organization_id).filter(event=event)
-        return params.filter(qs).distinct()
+        # "-id" is a stable tiebreaker so pagination stays deterministic across equal sort keys.
+        return params.filter(qs).distinct().order_by(order_by, "-id")
 
     @route.get(
         "/tickets/{ticket_id}",

--- a/src/events/tests/test_controllers/test_event_admin/test_tickets/test_ticket_operations.py
+++ b/src/events/tests/test_controllers/test_event_admin/test_tickets/test_ticket_operations.py
@@ -199,6 +199,49 @@ def test_list_tickets_filter_by_payment_method(
     assert data["results"][0]["id"] == str(active_online_ticket.id)
 
 
+def test_list_tickets_ordering(
+    organization_owner_client: Client,
+    event: Event,
+    pending_offline_ticket: Ticket,
+    pending_at_door_ticket: Ticket,
+    active_online_ticket: Ticket,
+) -> None:
+    """Tickets can be ordered by date, tier, status, and payment method (asc/desc)."""
+    url = reverse("api:list_tickets", kwargs={"event_id": event.pk})
+
+    def values(order_by: str | None, key: str) -> list[str]:
+        params = {"order_by": order_by} if order_by else {}
+        response = organization_owner_client.get(url, params)
+        assert response.status_code == 200
+        results = response.json()["results"]
+        return [r["tier"][key] if key in ("name", "payment_method") else r[key] for r in results]
+
+    # Default ordering is newest first (-created_at).
+    default_dates = values(None, "created_at")
+    assert default_dates == sorted(default_dates, reverse=True)
+
+    # Date ascending.
+    assert (asc := values("created_at", "created_at")) == sorted(asc)
+
+    # Tier name, both directions — and reversing actually reorders.
+    tiers_asc = values("tier__name", "name")
+    tiers_desc = values("-tier__name", "name")
+    assert tiers_asc == sorted(tiers_asc)
+    assert tiers_desc == sorted(tiers_desc, reverse=True)
+    assert tiers_asc == list(reversed(tiers_desc))
+
+    # Status, both directions.
+    assert (st_asc := values("status", "status")) == sorted(st_asc)
+    assert (st_desc := values("-status", "status")) == sorted(st_desc, reverse=True)
+
+    # Payment method, both directions.
+    assert (pm_asc := values("tier__payment_method", "payment_method")) == sorted(pm_asc)
+    assert (pm_desc := values("-tier__payment_method", "payment_method")) == sorted(pm_desc, reverse=True)
+
+    # An unsupported ordering value is rejected.
+    assert organization_owner_client.get(url, {"order_by": "bogus"}).status_code == 422
+
+
 def test_list_tickets_pagination(organization_owner_client: Client, event: Event, offline_tier: TicketTier) -> None:
     """Test pagination of tickets."""
     # Create multiple pending tickets

--- a/src/events/tests/test_controllers/test_event_admin/test_tickets/test_ticket_operations.py
+++ b/src/events/tests/test_controllers/test_event_admin/test_tickets/test_ticket_operations.py
@@ -1,6 +1,7 @@
 """Tests for ticket operations (list, confirm, check-in, unconfirm)."""
 
 import json
+import typing as t
 from decimal import Decimal
 
 import pytest
@@ -11,6 +12,7 @@ from accounts.models import RevelUser
 from events.models import (
     Event,
     OrganizationStaff,
+    Payment,
     Ticket,
     TicketTier,
 )
@@ -214,7 +216,7 @@ def test_list_tickets_ordering(
         response = organization_owner_client.get(url, params)
         assert response.status_code == 200
         results = response.json()["results"]
-        return [r["tier"][key] if key in ("name", "payment_method") else r[key] for r in results]
+        return [r["tier"][key] if key in ("name", "payment_method", "price") else r[key] for r in results]
 
     # Default ordering is newest first (-created_at).
     default_dates = values(None, "created_at")
@@ -238,8 +240,47 @@ def test_list_tickets_ordering(
     assert (pm_asc := values("tier__payment_method", "payment_method")) == sorted(pm_asc)
     assert (pm_desc := values("-tier__payment_method", "payment_method")) == sorted(pm_desc, reverse=True)
 
+    # Tier list price, both directions (cast — JSON serializes Decimal as a string).
+    price_asc = [Decimal(p) for p in values("price", "price")]
+    price_desc = [Decimal(p) for p in values("-price", "price")]
+    assert price_asc == sorted(price_asc)
+    assert price_desc == sorted(price_desc, reverse=True)
+
     # An unsupported ordering value is rejected.
     assert organization_owner_client.get(url, {"order_by": "bogus"}).status_code == 422
+
+
+def test_list_tickets_ordering_by_price_paid(
+    organization_owner_client: Client,
+    event: Event,
+    active_online_ticket: Ticket,
+    pending_at_door_ticket: Ticket,
+    pending_pwyc_offline_ticket_with_price: Ticket,
+    payment_factory: t.Callable[..., Payment],
+) -> None:
+    """price_paid orders by effective amount: payment.amount, else price_paid, else tier.price.
+
+    Each fixture exercises a different COALESCE branch:
+    - active_online_ticket: online payment -> payment.amount (40.00)
+    - pending_at_door_ticket: no payment, no price_paid -> tier.price (30.00)
+    - pending_pwyc_offline_ticket_with_price: PWYC tier (price 0), price_paid set (10.00)
+    """
+    payment_factory(active_online_ticket, amount=Decimal("40.00"))
+    url = reverse("api:list_tickets", kwargs={"event_id": event.pk})
+
+    expected_asc = [
+        str(pending_pwyc_offline_ticket_with_price.id),  # 10.00
+        str(pending_at_door_ticket.id),  # 30.00
+        str(active_online_ticket.id),  # 40.00
+    ]
+
+    asc = organization_owner_client.get(url, {"order_by": "price_paid"})
+    assert asc.status_code == 200
+    assert [r["id"] for r in asc.json()["results"]] == expected_asc
+
+    desc = organization_owner_client.get(url, {"order_by": "-price_paid"})
+    assert desc.status_code == 200
+    assert [r["id"] for r in desc.json()["results"]] == list(reversed(expected_asc))
 
 
 def test_list_tickets_pagination(organization_owner_client: Client, event: Event, offline_tier: TicketTier) -> None:


### PR DESCRIPTION
## Summary

Adds server-side ordering to the admin ticket-list endpoint (`GET /event-admin/{event_id}/tickets`), addressing #517.

Organizers can now sort tickets by:
- **date** (`created_at` / `-created_at`) — default is newest first
- **tier** (`tier__name` / `-tier__name`, alphabetical)
- **status** (`status` / `-status`, by stored enum value)
- **payment method** (`tier__payment_method` / `-tier__payment_method`)
- **price** (`price` / `-price`) — the tier list price (`tier.price`)
- **price paid** (`price_paid` / `-price_paid`) — the *effective* amount actually taken: `COALESCE(payment.amount, ticket.price_paid, tier.price)` (online uses the Stripe amount, PWYC uses the recorded amount, fixed-price falls back to the tier price)

A new `order_by` query param (typed `t.Literal`) maps to the queryset ordering field and drives `.order_by(..., "-id")`. The `-id` is a stable tiebreaker so pagination stays deterministic across rows with equal sort keys.

### Notes on `price_paid`
`Ticket.price_paid` is null for online and fixed-price tickets (it only holds PWYC offline/at-the-door amounts), so a raw-column sort would be misleading. Instead we sort by an annotated `COALESCE(payment__amount, price_paid, tier__price)`. The COALESCE is annotated (not inlined in ORDER BY) so it appears in the `SELECT DISTINCT` list — required by Postgres. Since the chain ends in non-nullable `tier.price` (default 0), the result is never NULL, so no `NULLS FIRST/LAST` handling is needed.

## Tests
- `test_list_tickets_ordering` covers default order + both directions for date, tier, status, payment method, and price; asserts an invalid `order_by` returns 422.
- `test_list_tickets_ordering_by_price_paid` exercises all three `price_paid` COALESCE branches (online payment / PWYC amount / tier-price fallback) and asserts exact asc/desc order.

## Coordination
Frontend counterpart: letsrevel/revel-frontend#452 (will run `pnpm generate:api` once this merges).

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)