### PR TITLE
feat(events): hard-delete unused discount codes, else deactivate (#519)

### DIFF
--- a/src/events/controllers/organization_admin/discount_codes.py
+++ b/src/events/controllers/organization_admin/discount_codes.py
@@ -92,12 +92,11 @@ class OrganizationAdminDiscountCodesController(OrganizationAdminBaseController):
     @route.delete(
         "/discount-codes/{code_id}",
         url_name="delete_discount_code",
-        response={204: None},
+        response={200: schema.DiscountCodeDeleteResponse},
     )
-    def delete_discount_code(self, slug: str, code_id: UUID) -> tuple[int, None]:
-        """Soft-delete a discount code by deactivating it."""
+    def delete_discount_code(self, slug: str, code_id: UUID) -> schema.DiscountCodeDeleteResponse:
+        """Delete a discount code: hard-delete when unused, otherwise deactivate."""
         organization = self.get_one(slug)
         dc = get_object_or_404(models.DiscountCode, pk=code_id, organization=organization)
-        dc.is_active = False
-        dc.save(update_fields=["is_active"])
-        return 204, None
+        action = discount_code_service.delete_discount_code(dc)
+        return schema.DiscountCodeDeleteResponse(action=action)

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -254,6 +254,7 @@ from .follow import (
 # Discount code schemas
 from .discount_code import (
     DiscountCodeCreateSchema,
+    DiscountCodeDeleteResponse,
     DiscountCodeSchema,
     DiscountCodeUpdateSchema,
     DiscountCodeValidationResponse,
@@ -531,6 +532,7 @@ __all__ = [
     "OrganizationFollowUpdateSchema",
     # Discount codes
     "DiscountCodeCreateSchema",
+    "DiscountCodeDeleteResponse",
     "DiscountCodeSchema",
     "DiscountCodeUpdateSchema",
     "DiscountCodeValidationResponse",

--- a/src/events/schema/discount_code.py
+++ b/src/events/schema/discount_code.py
@@ -121,6 +121,12 @@ class DiscountCodeUpdateSchema(_DiscountCodeValidatorMixin, Schema):
     tier_ids: list[UUID] | None = None
 
 
+class DiscountCodeDeleteResponse(Schema):
+    """Tells the client whether a code was hard-deleted or merely deactivated."""
+
+    action: t.Literal["deleted", "deactivated"]
+
+
 # ---- Public schemas ----
 
 

--- a/src/events/service/discount_code_service.py
+++ b/src/events/service/discount_code_service.py
@@ -133,15 +133,21 @@ def update_discount_code(
     return DiscountCode.objects.prefetch_related("series", "events", "tiers").get(pk=dc.pk)
 
 
+@transaction.atomic
 def delete_discount_code(dc: DiscountCode) -> t.Literal["deleted", "deactivated"]:
     """Delete a discount code, hard-deleting it only when it was never used.
 
     A code is considered unused when its ``times_used`` counter is zero *and* no
-    ticket references it (``times_used`` never decrements, so both checks together
-    guard against a code whose tickets were later cancelled). Unused codes are
-    hard-deleted, which also frees the ``(organization, code)`` slot for reuse.
-    Used codes are deactivated (``is_active = False``) to preserve the redemption
-    history on their tickets.
+    ticket references it at all (any status). ``times_used`` never decrements, so
+    the two checks are belt-and-suspenders: either one being non-empty means the
+    code has redemption history worth keeping. Unused codes are hard-deleted,
+    which also frees the ``(organization, code)`` slot for reuse. Used codes are
+    deactivated (``is_active = False``) to preserve the redemption history on
+    their tickets.
+
+    The row is re-fetched under ``select_for_update`` (mirroring ``apply_discount``)
+    so a concurrent purchase can't slip a ticket past the check and then have its
+    ``Ticket.discount_code`` FK silently nulled by the hard delete (``SET_NULL``).
 
     Args:
         dc: The discount code to delete.
@@ -149,6 +155,7 @@ def delete_discount_code(dc: DiscountCode) -> t.Literal["deleted", "deactivated"
     Returns:
         ``"deleted"`` if the row was hard-deleted, ``"deactivated"`` otherwise.
     """
+    dc = DiscountCode.objects.select_for_update().get(pk=dc.pk)
     if dc.times_used == 0 and not dc.tickets.exists():
         dc.delete()
         return "deleted"

--- a/src/events/service/discount_code_service.py
+++ b/src/events/service/discount_code_service.py
@@ -133,6 +133,30 @@ def update_discount_code(
     return DiscountCode.objects.prefetch_related("series", "events", "tiers").get(pk=dc.pk)
 
 
+def delete_discount_code(dc: DiscountCode) -> t.Literal["deleted", "deactivated"]:
+    """Delete a discount code, hard-deleting it only when it was never used.
+
+    A code is considered unused when its ``times_used`` counter is zero *and* no
+    ticket references it (``times_used`` never decrements, so both checks together
+    guard against a code whose tickets were later cancelled). Unused codes are
+    hard-deleted, which also frees the ``(organization, code)`` slot for reuse.
+    Used codes are deactivated (``is_active = False``) to preserve the redemption
+    history on their tickets.
+
+    Args:
+        dc: The discount code to delete.
+
+    Returns:
+        ``"deleted"`` if the row was hard-deleted, ``"deactivated"`` otherwise.
+    """
+    if dc.times_used == 0 and not dc.tickets.exists():
+        dc.delete()
+        return "deleted"
+    dc.is_active = False
+    dc.save(update_fields=["is_active"])
+    return "deactivated"
+
+
 def _check_scope_applicability(dc: DiscountCode, tier: TicketTier) -> None:
     """Check if the discount code applies to the given tier (union logic).
 

--- a/src/events/tests/test_controllers/test_organization_admin/test_discount_codes.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_discount_codes.py
@@ -5,7 +5,7 @@ Tests cover:
 - Creating discount codes (valid, with M2M, validation errors)
 - Getting discount code detail (exists, not found, wrong organization)
 - Updating discount codes (partial update, M2M update)
-- Deleting discount codes (soft-delete sets is_active=False)
+- Deleting discount codes (hard-delete when unused, otherwise deactivate)
 - Permission checks (owner, staff with manage_events, staff without, non-staff)
 """
 
@@ -541,30 +541,49 @@ class TestUpdateDiscountCode:
 
 
 # ===========================================================================
-# Delete discount code (soft-delete)
+# Delete discount code (hard-delete when unused, otherwise deactivate)
 # ===========================================================================
 
 
 class TestDeleteDiscountCode:
     """Tests for DELETE /organization-admin/{slug}/discount-codes/{code_id}."""
 
-    def test_delete_sets_inactive(
+    def test_delete_unused_code_hard_deletes(
         self,
         organization_owner_client: Client,
         organization: Organization,
         dc_percentage: DiscountCode,
     ) -> None:
-        """Should soft-delete by setting is_active=False."""
+        """An unused code (times_used=0, no tickets) should be hard-deleted."""
         url = reverse(
             "api:delete_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_percentage.id},
         )
         response = organization_owner_client.delete(url)
 
-        assert response.status_code == 204
+        assert response.status_code == 200
+        assert response.json() == {"action": "deleted"}
+        assert not DiscountCode.objects.filter(id=dc_percentage.id).exists()
+
+    def test_delete_used_code_deactivates(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        dc_percentage: DiscountCode,
+    ) -> None:
+        """A used code (times_used>0) should be deactivated, not deleted."""
+        dc_percentage.times_used = 3
+        dc_percentage.save(update_fields=["times_used"])
+        url = reverse(
+            "api:delete_discount_code",
+            kwargs={"slug": organization.slug, "code_id": dc_percentage.id},
+        )
+        response = organization_owner_client.delete(url)
+
+        assert response.status_code == 200
+        assert response.json() == {"action": "deactivated"}
         dc_percentage.refresh_from_db()
         assert dc_percentage.is_active is False
-        # Record still exists in DB
         assert DiscountCode.objects.filter(id=dc_percentage.id).exists()
 
     def test_delete_nonexistent_code(self, organization_owner_client: Client, organization: Organization) -> None:
@@ -583,16 +602,16 @@ class TestDeleteDiscountCode:
         organization: Organization,
         dc_fixed: DiscountCode,
     ) -> None:
-        """Staff with manage_events should be able to soft-delete codes."""
+        """Staff with manage_events should be able to delete codes."""
         url = reverse(
             "api:delete_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_fixed.id},
         )
         response = manage_events_staff_client.delete(url)
 
-        assert response.status_code == 204
-        dc_fixed.refresh_from_db()
-        assert dc_fixed.is_active is False
+        assert response.status_code == 200
+        assert response.json() == {"action": "deleted"}
+        assert not DiscountCode.objects.filter(id=dc_fixed.id).exists()
 
     def test_delete_by_member_forbidden(
         self,
@@ -612,19 +631,19 @@ class TestDeleteDiscountCode:
         dc_percentage.refresh_from_db()
         assert dc_percentage.is_active is True
 
-    def test_delete_already_inactive_code(
+    def test_delete_already_inactive_unused_code_hard_deletes(
         self,
         organization_owner_client: Client,
         organization: Organization,
         dc_inactive: DiscountCode,
     ) -> None:
-        """Should still succeed (204) when deleting an already-inactive code."""
+        """An already-inactive but unused code should still be hard-deleted."""
         url = reverse(
             "api:delete_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_inactive.id},
         )
         response = organization_owner_client.delete(url)
 
-        assert response.status_code == 204
-        dc_inactive.refresh_from_db()
-        assert dc_inactive.is_active is False
+        assert response.status_code == 200
+        assert response.json() == {"action": "deleted"}
+        assert not DiscountCode.objects.filter(id=dc_inactive.id).exists()

--- a/src/events/tests/test_service/test_discount_code_service.py
+++ b/src/events/tests/test_service/test_discount_code_service.py
@@ -537,3 +537,58 @@ class TestApplyDiscount:
 
         with pytest.raises(HttpError):
             discount_code_service.apply_discount(dc, dc_owner, batch_size=1)
+
+
+class TestDeleteDiscountCode:
+    """Tests for delete_discount_code: hard-delete when unused, else deactivate."""
+
+    def test_unused_code_is_hard_deleted(self, dc_percentage: DiscountCode) -> None:
+        """times_used=0 and no tickets → hard delete, returns 'deleted'."""
+        pk = dc_percentage.pk
+        action = discount_code_service.delete_discount_code(dc_percentage)
+
+        assert action == "deleted"
+        assert not DiscountCode.objects.filter(pk=pk).exists()
+
+    def test_code_with_usage_counter_is_deactivated(self, dc_percentage: DiscountCode) -> None:
+        """times_used>0 → deactivate (preserve history), returns 'deactivated'."""
+        dc_percentage.times_used = 1
+        dc_percentage.save(update_fields=["times_used"])
+
+        action = discount_code_service.delete_discount_code(dc_percentage)
+
+        assert action == "deactivated"
+        dc_percentage.refresh_from_db()
+        assert dc_percentage.is_active is False
+
+    def test_code_with_referencing_ticket_is_deactivated(
+        self,
+        dc_percentage: DiscountCode,
+        dc_event: Event,
+        dc_paid_tier: TicketTier,
+        dc_owner: RevelUser,
+    ) -> None:
+        """A code referenced by a ticket is deactivated even if times_used=0.
+
+        times_used never decrements, but a cancelled-ticket scenario could leave
+        times_used=0 while tickets still reference the code; the relation check
+        keeps the redemption link intact.
+        """
+        from events.models import Ticket
+
+        Ticket.objects.create(
+            event=dc_event,
+            tier=dc_paid_tier,
+            user=dc_owner,
+            status=Ticket.TicketStatus.ACTIVE,
+            guest_name="Holder",
+            discount_code=dc_percentage,
+        )
+        assert dc_percentage.times_used == 0
+
+        action = discount_code_service.delete_discount_code(dc_percentage)
+
+        assert action == "deactivated"
+        dc_percentage.refresh_from_db()
+        assert dc_percentage.is_active is False
+        assert dc_percentage.tickets.count() == 1


### PR DESCRIPTION
Closes #519

## Problem
"Delete" on a discount code only soft-deleted it (`is_active = False`), so codes looked gone when they weren't — the trash icon was misleading. It also left the `(organization, code)` slot occupied forever, so an org could never re-create a code string it once "deleted" (e.g. fix a typo'd `SUMMER24`).

## What changed
There is **no Stripe coupon** behind a discount code, so a hard delete is technically safe. The delete endpoint now:

- **Hard-deletes** a code when it was never used (`times_used == 0` **and** no referencing tickets) — this also frees the `(organization, code)` slot for reuse.
- **Deactivates** (`is_active = False`) a used code, preserving the redemption link on its tickets.

The dual guard is belt-and-suspenders: `times_used` never decrements, but a cancelled-ticket scenario could leave `times_used == 0` while tickets still reference the code. Since `Ticket.discount_code` is `on_delete=SET_NULL`, hard-deleting a used code would null out historical attribution — so we don't.

## API change ⚠️
The endpoint switches from `204 No Content` to `200` with a body so the frontend knows which action occurred:

```json
{ "action": "deleted" | "deactivated" }
```

- Requires a regenerated TS client (`pnpm generate:api`).
- **Frontend counterpart** (label/icon) tracked separately per the issue.

## Files
| File | Change |
|------|--------|
| `events/service/discount_code_service.py` | New `delete_discount_code(dc)` returning `"deleted"`/`"deactivated"`. |
| `events/schema/discount_code.py` | New `DiscountCodeDeleteResponse` (+ re-exported from `schema/__init__.py`). |
| `events/controllers/organization_admin/discount_codes.py` | `delete_discount_code` returns `200` + body, delegates to service (thin controller). |
| tests (controller + service) | Rewrote old soft-delete tests; added both branches incl. the "referenced by ticket but `times_used == 0`" edge. |

## Verification
- `make format`, `make lint`, `make mypy` all pass.
- Tests cover hard-delete, deactivate-via-counter, and deactivate-via-referencing-ticket branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Discount code deletion now returns a response indicating the action taken (deleted or deactivated)
  * Unused discount codes are now permanently removed; codes with usage history are deactivated instead
  * HTTP response status for deletion changed from 204 to 200

<!-- end of auto-generated comment: release notes by coderabbit.ai -->