### PR TITLE
fix(notifications): always render event times in the event's timezone (#511)

### DIFF
--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -36,7 +36,7 @@ from events.tasks import (
     notify_admin_new_organization_discord,
     notify_admin_new_organization_pushover,
 )
-from events.utils import get_invitation_message
+from events.utils import format_event_datetime, get_invitation_message
 from events.utils.reserved_slug_tokens import invalidate_reserved_tokens_cache
 from notifications.enums import NotificationType
 from notifications.signals import notification_requested
@@ -415,7 +415,7 @@ def handle_event_opened_notify_followers(sender: type[Event], instance: Event, c
                 "event_name": instance.name,
                 "event_description": instance.description or "",
                 "event_start": instance.start.isoformat() if instance.start else "",
-                "event_start_formatted": (instance.start.strftime("%B %d, %Y at %I:%M %p") if instance.start else ""),
+                "event_start_formatted": format_event_datetime(instance.start, instance),
                 "event_location": event_location,
                 "event_url": f"{frontend_base_url}/events/{instance.id}",
             }

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1010,7 +1010,8 @@ msgstr ""
 "Ankündigung hinzukommen (nur für Event-Ankündigungen)."
 
 msgid "Relative scheduling requires both an anchor and an offset."
-msgstr "Die relative Planung erfordert sowohl einen Anker als auch einen Versatz."
+msgstr ""
+"Die relative Planung erfordert sowohl einen Anker als auch einen Versatz."
 
 msgid "Provide either an absolute time or a relative schedule, not both."
 msgstr ""
@@ -1018,7 +1019,8 @@ msgstr ""
 "nicht beides."
 
 msgid "Relative scheduling requires an event-targeted announcement."
-msgstr "Die relative Planung erfordert eine auf ein Event gerichtete Ankündigung."
+msgstr ""
+"Die relative Planung erfordert eine auf ein Event gerichtete Ankündigung."
 
 msgid "Re-sending to new sign-ups requires an event-targeted announcement."
 msgstr ""
@@ -2177,6 +2179,9 @@ msgstr "Abbestellen oder Benachrichtigungseinstellungen verwalten"
 
 msgid "Unsubscribe or manage notification preferences:"
 msgstr "Abbestellen oder Benachrichtigungseinstellungen verwalten:"
+
+msgid "All times are shown in the event's local timezone."
+msgstr "Alle Zeiten werden in der lokalen Zeitzone der Veranstaltung angezeigt."
 
 msgid "Your account has been suspended for violating our Terms of Service."
 msgstr ""

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -1021,7 +1021,8 @@ msgstr ""
 "annonce (annonces d'événement uniquement)."
 
 msgid "Relative scheduling requires both an anchor and an offset."
-msgstr "La programmation relative nécessite à la fois une ancre et un décalage."
+msgstr ""
+"La programmation relative nécessite à la fois une ancre et un décalage."
 
 msgid "Provide either an absolute time or a relative schedule, not both."
 msgstr ""
@@ -2186,6 +2187,9 @@ msgstr "Se désabonner ou gérer les préférences de notification"
 
 msgid "Unsubscribe or manage notification preferences:"
 msgstr "Se désabonner ou gérer les préférences de notification :"
+
+msgid "All times are shown in the event's local timezone."
+msgstr "Toutes les heures sont affichées dans le fuseau horaire local de l'événement."
 
 msgid "Your account has been suspended for violating our Terms of Service."
 msgstr ""

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -996,13 +996,11 @@ msgstr ""
 "annuncio (solo per annunci di evento)."
 
 msgid "Relative scheduling requires both an anchor and an offset."
-msgstr ""
-"La programmazione relativa richiede sia un'ancora sia uno scostamento."
+msgstr "La programmazione relativa richiede sia un'ancora sia uno scostamento."
 
 msgid "Provide either an absolute time or a relative schedule, not both."
 msgstr ""
-"Fornisci un orario assoluto oppure una programmazione relativa, non "
-"entrambi."
+"Fornisci un orario assoluto oppure una programmazione relativa, non entrambi."
 
 msgid "Relative scheduling requires an event-targeted announcement."
 msgstr "La programmazione relativa richiede un annuncio rivolto a un evento."
@@ -2147,6 +2145,9 @@ msgstr "Annulla l'iscrizione o gestisci le preferenze di notifica"
 
 msgid "Unsubscribe or manage notification preferences:"
 msgstr "Annulla l'iscrizione o gestisci le preferenze di notifica:"
+
+msgid "All times are shown in the event's local timezone."
+msgstr "Tutti gli orari sono indicati nel fuso orario locale dell'evento."
 
 msgid "Your account has been suspended for violating our Terms of Service."
 msgstr ""

--- a/src/notifications/context_schemas.py
+++ b/src/notifications/context_schemas.py
@@ -282,9 +282,12 @@ class InvitationReceivedContext(BaseNotificationContext):
     event_id: str
     event_name: str
     invitation_message: str
-    event_start: str
-    event_end: str
+    event_start: str  # ISO format
+    event_end: str  # ISO format
+    event_start_formatted: str  # User-friendly format, in event TZ
+    event_end_formatted: t.NotRequired[str]  # User-friendly format, in event TZ
     event_location: str
+    event_url: str
     organization_id: str
     organization_name: str
     rsvp_required: bool

--- a/src/notifications/signals/invitation.py
+++ b/src/notifications/signals/invitation.py
@@ -12,6 +12,7 @@ from events.models import EventInvitation, EventInvitationRequest, PendingEventI
 from events.tasks import build_attendee_visibility_flags
 from notifications.enums import NotificationType
 from notifications.service.eligibility import get_staff_for_notification
+from notifications.service.notification_helpers import format_event_datetime
 from notifications.signals import notification_requested
 
 logger = structlog.get_logger(__name__)
@@ -48,12 +49,14 @@ def handle_invitation_save(
                 "invitation_message": instance.custom_message or "",
                 "event_start": event.start.isoformat() if event.start else "",
                 "event_end": event.end.isoformat() if event.end else "",
+                "event_start_formatted": format_event_datetime(event.start, event),
+                "event_end_formatted": format_event_datetime(event.end, event),
                 "event_location": event_location,
                 "organization_id": str(event.organization.id),
                 "organization_name": event.organization.name,
                 "rsvp_required": not event.requires_ticket,
                 "tickets_required": event.requires_ticket,
-                "frontend_url": frontend_url,
+                "event_url": frontend_url,
             },
         )
 

--- a/src/notifications/templates/notifications/email/_footer.html
+++ b/src/notifications/templates/notifications/email/_footer.html
@@ -1,4 +1,5 @@
 {% load i18n %}<div class="footer">
+    {% if context.event_start_formatted %}{% include "notifications/email/_timezone_note.html" %}{% endif %}
     {{ context.org_signature_html|safe }}
     <div style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd;">
         <p style="font-size: 12px; color: #999;">

--- a/src/notifications/templates/notifications/email/_footer.txt
+++ b/src/notifications/templates/notifications/email/_footer.txt
@@ -1,4 +1,5 @@
-{% load i18n %}{{ context.org_signature_md }}
+{% load i18n %}{% if context.event_start_formatted %}{% include "notifications/email/_timezone_note.txt" %}
+{% endif %}{{ context.org_signature_md }}
 
 ---
 {% trans "Unsubscribe or manage notification preferences:" %} {{ context.unsubscribe_link }}

--- a/src/notifications/templates/notifications/email/_timezone_note.html
+++ b/src/notifications/templates/notifications/email/_timezone_note.html
@@ -1,0 +1,1 @@
+{% load i18n %}<p style="margin:8px 0 0;font-size:12px;color:#999;">🕒 {% trans "All times are shown in the event's local timezone." %}</p>

--- a/src/notifications/templates/notifications/email/_timezone_note.txt
+++ b/src/notifications/templates/notifications/email/_timezone_note.txt
@@ -1,0 +1,1 @@
+{% load i18n %}🕒 {% trans "All times are shown in the event's local timezone." %}

--- a/src/notifications/templates/notifications/email/pending_invitation.html
+++ b/src/notifications/templates/notifications/email/pending_invitation.html
@@ -32,6 +32,7 @@
                 {% if event_start_formatted %}<div class="info-row">📅 {{ event_start_formatted }}</div>{% endif %}
                 {% if event_end_formatted %}<div class="info-row">{%trans "Until:"%} {{ event_end_formatted }}</div>{% endif %}
                 {% if event_location %}<div class="info-row">📍 {{ event_location }}</div>{% endif %}
+                {% if event_start_formatted %}{% include "notifications/email/_timezone_note.html" %}{% endif %}
             </div>
             {% endif %}
             <p>{%trans "Sign up to accept this invitation and join the event:"%}</p>

--- a/src/notifications/templates/notifications/email/pending_invitation.txt
+++ b/src/notifications/templates/notifications/email/pending_invitation.txt
@@ -7,5 +7,6 @@
 {% endif %}{% if event_start_formatted %}📅 {{ event_start_formatted }}
 {% endif %}{% if event_end_formatted %}{%trans "Until:"%} {{ event_end_formatted }}
 {% endif %}{% if event_location %}📍 {{ event_location }}
+{% endif %}{% if event_start_formatted %}{% include "notifications/email/_timezone_note.txt" %}
 {% endif %}
 {%trans "Sign up to accept this invitation:" %} {{ signup_url }}

--- a/src/notifications/tests/test_timezone_emails.py
+++ b/src/notifications/tests/test_timezone_emails.py
@@ -1,0 +1,254 @@
+"""Regression tests for issue #511 — event times always rendered in the event's timezone.
+
+Covers the two context-builders that historically bypassed ``format_event_datetime``
+(the INVITATION_RECEIVED signal, which sent raw ISO strings, and the
+NEW_EVENT_FROM_FOLLOWED_* signal, which used a tz-naive ``strftime``), plus the
+shared "all times are in the event's local timezone" disclaimer partial.
+"""
+
+import typing as t
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.contrib.gis.geos import Point
+from django.template.loader import render_to_string
+
+from accounts.models import RevelUser
+from events.models import Event, EventInvitation, Organization
+from events.models.follow import OrganizationFollow
+from geo.models import City
+from notifications.enums import NotificationType
+
+pytestmark = pytest.mark.django_db
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def owner(django_user_model: type[RevelUser]) -> RevelUser:
+    """Organization owner."""
+    return django_user_model.objects.create_user(
+        username="owner@example.com",
+        email="owner@example.com",
+        password="password",
+        first_name="Org",
+        last_name="Owner",
+    )
+
+
+@pytest.fixture
+def invited(django_user_model: type[RevelUser]) -> RevelUser:
+    """A user who receives an invitation / follows the org."""
+    return django_user_model.objects.create_user(
+        username="invited@example.com",
+        email="invited@example.com",
+        password="password",
+        first_name="In",
+        last_name="Vited",
+    )
+
+
+@pytest.fixture
+def vienna(db: None) -> City:
+    """Vienna (Europe/Vienna, CET in winter)."""
+    return City.objects.create(
+        name="Vienna",
+        ascii_name="Vienna",
+        country="Austria",
+        iso2="AT",
+        iso3="AUT",
+        city_id=511001,
+        location=Point(16.3738, 48.2082, srid=4326),
+        timezone="Europe/Vienna",
+    )
+
+
+@pytest.fixture
+def org(owner: RevelUser) -> Organization:
+    """Public organization."""
+    return Organization.objects.create(
+        name="TZ Org",
+        slug="tz-org",
+        owner=owner,
+        visibility=Organization.Visibility.PUBLIC,
+    )
+
+
+@pytest.fixture
+def vienna_event(org: Organization, vienna: City) -> Event:
+    """Event in Vienna starting 18:00 UTC (== 19:00 CET) and ending 21:00 UTC (== 22:00 CET)."""
+    start = datetime(2026, 2, 6, 18, 0, 0, tzinfo=ZoneInfo("UTC"))
+    return Event.objects.create(
+        organization=org,
+        name="Vienna Gala",
+        slug="vienna-gala",
+        city=vienna,
+        visibility=Event.Visibility.PUBLIC,
+        event_type=Event.EventType.PUBLIC,
+        max_attendees=100,
+        status=Event.EventStatus.DRAFT,
+        start=start,
+        end=start + timedelta(hours=3),
+    )
+
+
+# --- Signal context: INVITATION_RECEIVED ---
+
+
+class TestInvitationContextTimezone:
+    """The INVITATION_RECEIVED signal must emit formatted, event-local times and a working URL."""
+
+    def test_context_has_event_local_formatted_times_and_url(
+        self,
+        vienna_event: Event,
+        invited: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Regression: signal previously sent raw ISO ``event_start`` and a ``frontend_url`` the
+        templates never read, so invite emails showed no time and a dead button."""
+        with patch("notifications.signals.invitation.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                EventInvitation.objects.create(user=invited, event=vienna_event)
+
+        calls = [
+            c
+            for c in mock_send.call_args_list
+            if c.kwargs.get("notification_type") == NotificationType.INVITATION_RECEIVED
+        ]
+        assert len(calls) == 1
+        context = calls[0].kwargs["context"]
+
+        # 18:00 UTC -> 19:00 CET, 21:00 UTC -> 22:00 CET
+        assert "7:00 PM" in context["event_start_formatted"]
+        assert "CET" in context["event_start_formatted"]
+        assert "10:00 PM" in context["event_end_formatted"]
+        # The "4:00 PM to 4:00 PM" bug: start and end must not collapse to the same string.
+        assert context["event_start_formatted"] != context["event_end_formatted"]
+        # Templates read context.event_url (not frontend_url).
+        assert context["event_url"].endswith(f"/events/{vienna_event.id}")
+
+
+# --- Signal context: NEW_EVENT_FROM_FOLLOWED_ORG ---
+
+
+class TestFollowerContextTimezone:
+    """The follower "new event" signal must format the start in the event's tz, not UTC."""
+
+    def test_context_start_is_event_local_not_utc(
+        self,
+        org: Organization,
+        vienna_event: Event,
+        invited: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Regression: signal previously used ``start.strftime(...)`` which renders in UTC."""
+        OrganizationFollow.objects.create(
+            user=invited,
+            organization=org,
+            is_archived=False,
+            notify_new_events=True,
+        )
+
+        with patch("events.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                vienna_event.status = Event.EventStatus.OPEN
+                vienna_event.save(update_fields=["status"])
+
+        calls = [
+            c
+            for c in mock_send.call_args_list
+            if c.kwargs.get("notification_type") == NotificationType.NEW_EVENT_FROM_FOLLOWED_ORG
+        ]
+        assert len(calls) == 1
+        formatted = calls[0].kwargs["context"]["event_start_formatted"]
+        # Event-local (19:00 CET), never the 6:00 PM UTC wall time.
+        assert "7:00 PM" in formatted
+        assert "CET" in formatted
+        assert "6:00 PM" not in formatted
+
+
+# --- Disclaimer partial ---
+
+
+class TestTimezoneDisclaimer:
+    """The shared disclaimer must appear only when an email renders event times."""
+
+    NOTE = "All times are shown in the event's local timezone."
+
+    def test_footer_shows_note_when_event_time_present(self) -> None:
+        rendered = render_to_string(
+            "notifications/email/_footer.html",
+            {"context": {"event_start_formatted": "Friday, February 6, 2026 at 7:00 PM CET"}},
+        )
+        assert self.NOTE in rendered
+
+    def test_footer_hides_note_without_event_time(self) -> None:
+        rendered = render_to_string("notifications/email/_footer.html", {"context": {}})
+        assert self.NOTE not in rendered
+
+    def test_footer_txt_shows_note_when_event_time_present(self) -> None:
+        rendered = render_to_string(
+            "notifications/email/_footer.txt",
+            {"context": {"event_start_formatted": "Friday, February 6, 2026 at 7:00 PM CET"}},
+        )
+        assert self.NOTE in rendered
+
+    def test_time_bearing_email_includes_note(self) -> None:
+        """A full time-bearing email (ticket_created) surfaces the disclaimer via the footer."""
+        rendered = render_to_string(
+            "notifications/email/ticket_created.html",
+            {
+                "user": {"display_name": "Test User"},
+                "context": {
+                    "event_name": "Vienna Gala",
+                    "event_start_formatted": "Friday, February 6, 2026 at 7:00 PM CET",
+                    "event_url": "https://example.com",
+                },
+            },
+        )
+        assert self.NOTE in rendered
+
+    def test_non_time_email_omits_note(self) -> None:
+        """A membership email carries no event time, so the disclaimer must not appear."""
+        rendered = render_to_string(
+            "notifications/email/membership_granted.html",
+            {
+                "user": {"display_name": "Test User"},
+                "context": {"organization_name": "TZ Org"},
+            },
+        )
+        assert self.NOTE not in rendered
+
+    def test_pending_invitation_includes_note(self) -> None:
+        """pending_invitation has its own footer; the note is included in its details card."""
+        rendered = render_to_string(
+            "notifications/email/pending_invitation.html",
+            {
+                "event_name": "Vienna Gala",
+                "event_start_formatted": "Friday, February 6, 2026 at 7:00 PM CET",
+                "signup_url": "https://example.com/signup",
+            },
+        )
+        assert self.NOTE in rendered
+
+    def test_invitation_email_renders_distinct_start_and_end(self) -> None:
+        """invitation_received shows both start and end when provided (regression for blank times)."""
+        rendered = render_to_string(
+            "notifications/email/invitation_received.html",
+            {
+                "user": {"display_name": "Test User"},
+                "context": {
+                    "event_name": "Vienna Gala",
+                    "event_start_formatted": "Friday, February 6, 2026 at 7:00 PM CET",
+                    "event_end_formatted": "Friday, February 6, 2026 at 10:00 PM CET",
+                    "event_url": "https://example.com/events/1",
+                },
+            },
+        )
+        assert "7:00 PM CET" in rendered
+        assert "10:00 PM CET" in rendered
+        assert "https://example.com/events/1" in rendered
+        assert self.NOTE in rendered


### PR DESCRIPTION
Closes #511.

International attendees saw event times in confusing forms (e.g. blank times on invite emails, and follower "new event" emails rendered in UTC). The fix makes every email/notification render event times in the **event's** timezone and adds a Google-Calendar-style disclaimer.

## What changed

**The two bypass bugs (root cause)**
- `notifications/signals/invitation.py` — `INVITATION_RECEIVED` sent raw ISO `event_start`/`event_end`, but templates expect `event_start_formatted`/`event_end_formatted` → invite emails **and telegram** showed no times. Now formatted via `format_event_datetime`. Also renamed `frontend_url` → `event_url` (every channel template reads `context.event_url`), fixing a dead "View Details" link.
- `events/signals.py` — `NEW_EVENT_FROM_FOLLOWED_*` used a tz-naive `strftime` that renders in UTC. Now uses `format_event_datetime`.
- `notifications/context_schemas.py` — `InvitationReceivedContext` updated to declare the now-sent keys (the runtime validator checks required keys).

The existing `format_event_datetime` helper already emits the tz abbreviation (e.g. `7:00 PM CET`) and was already used by every other email path, so no other context-builders needed changes.

**Disclaimer (shared partial, time-bearing emails only)**
- New `_timezone_note.{html,txt}`: _"🕒 All times are shown in the event's local timezone."_
- Included via `_footer.{html,txt}` guarded by `{% if context.event_start_formatted %}` — one edit covers all 17 footer-using time emails, stays absent on non-time emails. `pending_invitation` has its own footer, so the partial is included directly in its details card.
- Translated in de/it/fr (`.mo` built in Docker, not committed; i18n gate passes).

## Notes
- **Scope:** backend only. Frontend display counterpart is a separate follow-up per the issue.
- **One judgment call:** the `frontend_url` → `event_url` rename is strictly a dead-link bug, not a timezone one, but it lives in the same broken context block — easy to split out if preferred.

## Tests
`notifications/tests/test_timezone_emails.py`:
- Signal regressions for both fixes (asserts event-local `CET`, never the UTC wall time; distinct start≠end for the "4:00 PM to 4:00 PM" bug; `event_url` present).
- Disclaimer presence/absence across footer, full time email, non-time email, pending invitation, and invitation.

### Verification
- `ruff check` ✅ · `mypy --strict` ✅ · `i18n-check` ✅
- New tests: 9 passed · `test_signals_follow` + `test_dispatcher`: 32 passed · end-to-end invitation tests: 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event times in notification emails now display in the event's local timezone, providing accurate local scheduling information.
  * Added a timezone disclaimer to event-related email notifications clarifying that times are shown in the event's local timezone.

* **Documentation**
  * Added translations for the timezone note in German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->