### PR TITLE
feat(api): expose event timezone and announcement audience (#548, #543)

### DIFF
--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -527,6 +527,7 @@ class OrganizationController(UserAwareController):
                 status=models.Announcement.AnnouncementStatus.SENT,
             )
             .select_related("organization")
+            .prefetch_related("target_tiers")
             .order_by("-sent_at")
         )
 

--- a/src/events/models/announcement.py
+++ b/src/events/models/announcement.py
@@ -100,6 +100,12 @@ class Announcement(TimeStampedModel):
         EVENT_START = "event_start", _("Event start")
         EVENT_END = "event_end", _("Event end")
 
+    class Audience(models.TextChoices):
+        EVENT = "event", _("Event attendees")
+        MEMBERS = "members", _("All members")
+        TIERS = "tiers", _("Specific membership tiers")
+        STAFF = "staff", _("Staff only")
+
     organization = models.ForeignKey(
         "events.Organization",
         on_delete=models.CASCADE,
@@ -188,6 +194,24 @@ class Announcement(TimeStampedModel):
 
     def __str__(self) -> str:
         return f"{self.title} ({self.organization.name})"
+
+    @property
+    def audience(self) -> "Announcement.Audience":
+        """Coarse descriptor of who can see this announcement.
+
+        Mirrors the targeting precedence used by ``get_recipients`` so the
+        public card can pick an icon + label without exposing any PII. Uses the
+        prefetched ``target_tiers`` cache (``len(... .all())``) to avoid an
+        extra query when tiers are prefetched. Defaults to ``STAFF`` for the
+        (validation-prevented) no-target case.
+        """
+        if self.event_id:
+            return self.Audience.EVENT
+        if self.target_all_members:
+            return self.Audience.MEMBERS
+        if len(self.target_tiers.all()):
+            return self.Audience.TIERS
+        return self.Audience.STAFF
 
     @property
     def effective_send_at(self) -> dt.datetime | None:

--- a/src/events/schema/announcement.py
+++ b/src/events/schema/announcement.py
@@ -248,6 +248,7 @@ class AnnouncementPublicSchema(Schema):
     id: UUID
     title: str
     body: str
+    audience: Announcement.Audience
     sent_at: AwareDatetime | None = None
     organization_name: str | None = None
     event_name: str | None = None

--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -110,6 +110,7 @@ class EventBaseSchema(TaggableSchemaMixin, LogoCoverArtThumbnailMixin):
     waitlist_open: bool | None = None
     start: AwareDatetime
     end: AwareDatetime
+    timezone: str
     rsvp_before: AwareDatetime | None = None
     logo: str | None = None
     cover_art: str | None = None
@@ -134,6 +135,18 @@ class EventBaseSchema(TaggableSchemaMixin, LogoCoverArtThumbnailMixin):
     seats_held: int = 0
     is_bookmarked: bool = False
     cancellation_reason: str | None = None
+
+    @staticmethod
+    def resolve_timezone(obj: "Event") -> str:
+        """Expose the event's IANA timezone (e.g. ``Europe/Vienna``).
+
+        Mirrors the timezone the backend uses to format emails/notifications
+        (``get_event_timezone``), derived from the event's city with a UTC
+        fallback. The frontend renders the abbreviation/offset from this.
+        """
+        from events.utils import get_event_timezone
+
+        return str(get_event_timezone(obj))
 
     @staticmethod
     def resolve_cancellation_reason(obj: "Event", context: t.Any) -> str | None:

--- a/src/events/tests/test_controllers/test_event_public/test_event_timezone.py
+++ b/src/events/tests/test_controllers/test_event_public/test_event_timezone.py
@@ -1,0 +1,47 @@
+"""Tests for the event ``timezone`` field exposed on event schemas (BE #548).
+
+The frontend renders event datetimes in the event's own timezone. The backend
+exposes the resolved IANA timezone (matching ``get_event_timezone`` / the email
+formatting) so the FE never has to re-derive tz from coordinates.
+"""
+
+import pytest
+from django.contrib.gis.geos import Point
+from django.test import Client
+from django.urls import reverse
+
+from events.models import Event
+from geo.models import City
+
+pytestmark = pytest.mark.django_db
+
+
+def test_timezone_falls_back_to_utc_without_city(public_event: Event) -> None:
+    """An event without a city reports the UTC fallback."""
+    url = reverse("api:get_event", kwargs={"event_id": str(public_event.id)})
+
+    response = Client().get(url)
+
+    assert response.status_code == 200
+    assert response.json()["timezone"] == "UTC"
+
+
+def test_timezone_reflects_event_city(public_event: Event) -> None:
+    """An event in a city reports that city's IANA timezone."""
+    # City.save() auto-populates timezone from the coordinates (Vienna).
+    public_event.city = City.objects.create(
+        name="Vienna",
+        ascii_name="Vienna",
+        country="AT",
+        city_id=99001,
+        location=Point(16.3738, 48.2082),
+    )
+    public_event.save(update_fields=["city"])
+    assert public_event.city.timezone == "Europe/Vienna"
+
+    url = reverse("api:get_event", kwargs={"event_id": str(public_event.id)})
+
+    response = Client().get(url)
+
+    assert response.status_code == 200
+    assert response.json()["timezone"] == "Europe/Vienna"

--- a/src/events/tests/test_controllers/test_member_announcements.py
+++ b/src/events/tests/test_controllers/test_member_announcements.py
@@ -172,6 +172,7 @@ class TestMemberAnnouncementsEndpoint:
         assert len(data) == 1
         assert data[0]["id"] == str(announcement.id)
         assert data[0]["title"] == "Members Announcement"
+        assert data[0]["audience"] == Announcement.Audience.MEMBERS.value
 
     def test_new_member_sees_announcement_with_past_visibility(
         self,
@@ -295,6 +296,7 @@ class TestMemberAnnouncementsEndpoint:
         data = response.json()
         assert len(data) == 1
         assert data[0]["id"] == str(announcement.id)
+        assert data[0]["audience"] == Announcement.Audience.STAFF.value
 
     def test_member_does_not_see_staff_only_announcement(
         self,

--- a/src/events/tests/test_models/test_announcement.py
+++ b/src/events/tests/test_models/test_announcement.py
@@ -633,3 +633,48 @@ class TestAnnouncementClean:
         )
         with pytest.raises(ValidationError):
             ann.full_clean()
+
+
+class TestAnnouncementAudience:
+    """Tests for the audience property (mirrors get_recipients precedence)."""
+
+    def test_event_targeting_is_event_audience(self, org: Organization, org_owner: RevelUser, event: Event) -> None:
+        """An event-scoped announcement resolves to the EVENT audience."""
+        ann = Announcement.objects.create(organization=org, event=event, title="t", body="b", created_by=org_owner)
+        assert ann.audience == Announcement.Audience.EVENT
+
+    def test_all_members_targeting_is_members_audience(self, org: Organization, org_owner: RevelUser) -> None:
+        """A target_all_members announcement resolves to the MEMBERS audience."""
+        ann = Announcement.objects.create(
+            organization=org, title="t", body="b", target_all_members=True, created_by=org_owner
+        )
+        assert ann.audience == Announcement.Audience.MEMBERS
+
+    def test_tier_targeting_is_tiers_audience(self, org: Organization, org_owner: RevelUser) -> None:
+        """A tier-targeted announcement resolves to the TIERS audience."""
+        tier = MembershipTier.objects.create(organization=org, name="VIP")
+        ann = Announcement.objects.create(organization=org, title="t", body="b", created_by=org_owner)
+        ann.target_tiers.add(tier)
+        assert ann.audience == Announcement.Audience.TIERS
+
+    def test_staff_only_targeting_is_staff_audience(self, org: Organization, org_owner: RevelUser) -> None:
+        """A staff-only announcement resolves to the STAFF audience."""
+        ann = Announcement.objects.create(
+            organization=org, title="t", body="b", target_staff_only=True, created_by=org_owner
+        )
+        assert ann.audience == Announcement.Audience.STAFF
+
+    def test_event_takes_precedence_over_member_flags(
+        self, org: Organization, org_owner: RevelUser, event: Event
+    ) -> None:
+        """Event scope wins over member/staff flags, mirroring get_recipients."""
+        ann = Announcement.objects.create(
+            organization=org,
+            event=event,
+            title="t",
+            body="b",
+            target_all_members=True,
+            target_staff_only=True,
+            created_by=org_owner,
+        )
+        assert ann.audience == Announcement.Audience.EVENT

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -973,6 +973,18 @@ msgstr "Eventbeginn"
 msgid "Event end"
 msgstr "Eventende"
 
+msgid "Event attendees"
+msgstr "Eventteilnehmer"
+
+msgid "All members"
+msgstr "Alle Mitglieder"
+
+msgid "Specific membership tiers"
+msgstr "Bestimmte Mitgliedschaftsstufen"
+
+msgid "Staff only"
+msgstr "Nur Staff"
+
 msgid "Target all active organization members"
 msgstr "Alle aktiven Organisationsmitglieder als Zielgruppe"
 

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -985,6 +985,18 @@ msgstr "Début de l'événement"
 msgid "Event end"
 msgstr "Fin de l'événement"
 
+msgid "Event attendees"
+msgstr "Participants à l'événement"
+
+msgid "All members"
+msgstr "Tous les membres"
+
+msgid "Specific membership tiers"
+msgstr "Niveaux d'adhésion spécifiques"
+
+msgid "Staff only"
+msgstr "Staff uniquement"
+
 msgid "Target all active organization members"
 msgstr "Cibler tout·e·s les membres actif·ve·s de l'organisation"
 

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -961,6 +961,18 @@ msgstr "Inizio dell'evento"
 msgid "Event end"
 msgstr "Fine dell'evento"
 
+msgid "Event attendees"
+msgstr "Partecipanti all'evento"
+
+msgid "All members"
+msgstr "Tutti i membri"
+
+msgid "Specific membership tiers"
+msgstr "Livelli di iscrizione specifici"
+
+msgid "Staff only"
+msgstr "Solo staff"
+
 msgid "Target all active organization members"
 msgstr "Invia a tutti i membri attivi dell'organizzazione"
 


### PR DESCRIPTION
Bundles two read-only API additions the frontend needs but the backend didn't expose. Both validated against `main`.

Closes #548. Closes #543.

## #548 — event timezone (FE letsrevel/revel-frontend#474)
The backend already derives the event timezone server-side (`get_event_timezone`, UTC fallback) and uses it to format emails/notifications, but no schema exposed it — so the FE couldn't render event-local times without re-deriving tz from coordinates.

- Added resolved `timezone: str` to `EventBaseSchema` → appears on both `EventInListSchema` and `EventDetailSchema`.
- IANA string (e.g. `Europe/Vienna`) with the UTC fallback baked in; survives a null `city`. The FE derives the `CET`/`CEST` abbreviation from the IANA name + the datetime.

## #543 — announcement audience (FE letsrevel/revel-frontend#456)
`AnnouncementPublicSchema` exposed no audience field, so the public card couldn't show who can see an announcement.

- New `Announcement.Audience` TextChoices (`event`/`members`/`tiers`/`staff`) + `audience` property mirroring `get_recipients` precedence.
- Exposed as `audience` on `AnnouncementPublicSchema` (machine enum — FE owns icon + i18n label).
- `prefetch_related("target_tiers")` on the org `member-announcements` endpoint to avoid N+1; the event endpoint short-circuits on `event_id`.

## Notes
- No migration: `Audience` is a standalone inner enum + property, no DB field touched.
- No PII exposed — audience is a coarse descriptor only.

## Tests
- `test_models/test_announcement.py`: `TestAnnouncementAudience` — all four audiences + event precedence over member/staff flags.
- `test_member_announcements.py`: audience assertions on the members/staff endpoint tests.
- `test_event_public/test_event_timezone.py` (new): UTC fallback (no city) + Vienna city → `Europe/Vienna`.

Verification: `make format`/`lint`/`mypy` pass; `makemigrations --check` → no changes; OpenAPI dump confirms `timezone` on both event schemas and the `Audience` enum on the public announcement schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)