### PR TITLE
refactor(api): replace Ninja Query/Body type-arg ignores with Annotated idiom (#557)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,10 +209,18 @@ class MyController(ControllerBase):
         return item
 ```
 
-> **Optional JSON body**: use `Body(None)` (from `ninja`) with `# type: ignore[type-arg]`; a
-> plain `Schema | None = None` raises "Cannot parse request body" when no JSON is sent. Tests
-> must pass `content_type="application/json"` even with an empty body. (`Query(...)` also needs
-> the `# type: ignore[type-arg]`.)
+> **Ninja `Query`/`Body` params — use the `Annotated` idiom** (not a `# type: ignore[type-arg]`):
+> put the real type in the annotation and the `Query()`/`Body()` object in the metadata. This
+> passes `mypy --strict` cleanly and preserves the OpenAPI constraints.
+> - `params: FilterSchema = Query(...)` → `params: t.Annotated[FilterSchema, Query(...)]` (required — drop the `=` default)
+> - `month: int | None = Query(None, ge=1, le=12)` → `month: t.Annotated[int | None, Query(ge=1, le=12)] = None`
+> - `payload: Schema | None = Body(None)` → `payload: t.Annotated[Schema | None, Body(None)] = None`
+>
+> **Optional JSON body**: a plain `Schema | None = None` raises "Cannot parse request body" when
+> no JSON is sent — keep `Body(None)` in the metadata (`t.Annotated[Schema | None, Body(None)] = None`).
+> Tests must pass `content_type="application/json"` even with an empty body. When a whole-schema
+> `Query(...)` param becomes required, make sure it doesn't sit after a defaulted param (Python
+> `SyntaxError`); reorder so it comes first.
 
 ### Exception handling (per-app handlers)
 Ninja Extra has **no per-controller exception hook**, so we keep controllers free of try/except

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -124,7 +124,7 @@ Use the `@searching` decorator to add search capabilities:
 @route.get("", response=list[EventSchema])
 @paginate(PageNumberPaginationExtra)
 @searching(Searching, search_fields=["name", "description"])
-def list_events(self, filters: EventFilterSchema = Query(...)) -> QuerySet[Event]:  # type: ignore[type-arg]
+def list_events(self, filters: t.Annotated[EventFilterSchema, Query(...)]) -> QuerySet[Event]:
     return Event.objects.filter(is_published=True)
 ```
 
@@ -202,13 +202,15 @@ class EventSchema(Schema):
 ### Optional JSON Body
 
 !!! note "Django Ninja quirk"
-    For endpoints with an optional JSON body, use `Body(None)` with a type ignore comment. Plain `Schema | None = None` causes "Cannot parse request body" when no JSON is sent.
+    For endpoints with an optional JSON body, keep `Body(None)` in the metadata via the `Annotated` idiom. Plain `Schema | None = None` causes "Cannot parse request body" when no JSON is sent.
 
 ```python
+import typing as t
+
 from ninja import Body
 
 @route.post("/confirm")
-def confirm(self, payload: ConfirmSchema | None = Body(None)) -> Response:  # type: ignore[type-arg]
+def confirm(self, payload: t.Annotated[ConfirmSchema | None, Body(None)] = None) -> Response:
     ...
 ```
 

--- a/src/accounts/controllers/referral.py
+++ b/src/accounts/controllers/referral.py
@@ -1,5 +1,7 @@
 """Controller for referral code validation."""
 
+import typing as t
+
 from django.utils.translation import gettext_lazy as _
 from ninja import Query, Schema
 from ninja.errors import HttpError
@@ -19,7 +21,7 @@ class ReferralController(ControllerBase):
         response=ReferralValidationResponse,
         url_name="validate-referral-code",
     )
-    def validate(self, code: str = Query(...)) -> ReferralValidationResponse:  # type: ignore[type-arg]
+    def validate(self, code: t.Annotated[str, Query(...)]) -> ReferralValidationResponse:
         """Validate a referral code.
 
         Returns 200 if the code exists and is active, 404 otherwise.

--- a/src/events/controllers/dashboard.py
+++ b/src/events/controllers/dashboard.py
@@ -58,7 +58,7 @@ class DashboardController(UserAwareController):
     @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
     def dashboard_organizations(
         self,
-        params: filters.DashboardOrganizationsFiltersSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.DashboardOrganizationsFiltersSchema, Query(...)],
     ) -> QuerySet[models.Organization]:
         """View organizations for your dashboard filtered by your relationship to them.
 
@@ -84,7 +84,7 @@ class DashboardController(UserAwareController):
     )
     def dashboard_events(
         self,
-        params: filters.DashboardEventsFiltersSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.DashboardEventsFiltersSchema, Query(...)],
         order_by: t.Literal["start", "-start"] = "start",
         include_past: bool = False,
     ) -> QuerySet[models.Event]:
@@ -107,8 +107,8 @@ class DashboardController(UserAwareController):
     @route.get("/calendar", url_name="dashboard_calendar", response=list[schema.EventInListSchema])
     def dashboard_calendar(
         self,
-        params: filters.DashboardEventsFiltersSchema = Query(...),  # type: ignore[type-arg]
-        calendar_params: filters.CalendarParamsSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.DashboardEventsFiltersSchema, Query(...)],
+        calendar_params: t.Annotated[filters.CalendarParamsSchema, Query(...)],
     ) -> QuerySet[models.Event]:
         """View events in a calendar view filtered by your relationship to them.
 
@@ -155,7 +155,7 @@ class DashboardController(UserAwareController):
     @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
     def dashboard_event_series(
         self,
-        params: filters.DashboardEventSeriesFiltersSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.DashboardEventSeriesFiltersSchema, Query(...)],
     ) -> QuerySet[models.EventSeries]:
         """View event series for your dashboard filtered by your relationship to them.
 
@@ -203,7 +203,7 @@ class DashboardController(UserAwareController):
     @searching(Searching, search_fields=["event__name", "event__description", "tier__name"])
     def dashboard_tickets(
         self,
-        params: filters.TicketFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.TicketFilterSchema, Query(...)],
     ) -> QuerySet[models.Ticket]:
         """View your tickets across all events.
 
@@ -226,8 +226,8 @@ class DashboardController(UserAwareController):
     @searching(Searching, search_fields=["event__name", "event__description", "message"])
     def dashboard_invitation_requests(
         self,
+        params: t.Annotated[filters.InvitationRequestFilterSchema, Query(...)],
         event_id: UUID | None = None,
-        params: filters.InvitationRequestFilterSchema = Query(...),  # type: ignore[type-arg]
     ) -> QuerySet[models.EventInvitationRequest]:
         """View your invitation requests across all events.
 
@@ -250,7 +250,7 @@ class DashboardController(UserAwareController):
     @searching(Searching, search_fields=["event__name", "event__description"])
     def dashboard_rsvps(
         self,
-        params: filters.RSVPFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.RSVPFilterSchema, Query(...)],
     ) -> QuerySet[models.EventRSVP]:
         """View your RSVPs across all events.
 

--- a/src/events/controllers/event_admin/invitation_requests.py
+++ b/src/events/controllers/event_admin/invitation_requests.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -38,7 +39,7 @@ class EventAdminInvitationRequestsController(EventAdminBaseController):
     def list_invitation_requests(
         self,
         event_id: UUID,
-        params: filters.InvitationRequestFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.InvitationRequestFilterSchema, Query(...)],
     ) -> QuerySet[models.EventInvitationRequest]:
         """List all invitation requests for an event.
 

--- a/src/events/controllers/event_admin/rsvps.py
+++ b/src/events/controllers/event_admin/rsvps.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -40,7 +41,7 @@ class EventAdminRSVPsController(EventAdminBaseController):
     def list_rsvps(
         self,
         event_id: UUID,
-        params: filters.RSVPFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.RSVPFilterSchema, Query(...)],
     ) -> QuerySet[models.EventRSVP]:
         """List all RSVPs for an event.
 

--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -161,7 +161,7 @@ class EventAdminTicketsController(EventAdminBaseController):
     def list_tickets(
         self,
         event_id: UUID,
-        params: filters.TicketFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.TicketFilterSchema, Query(...)],
         order_by: TicketOrdering = "-created_at",
     ) -> QuerySet[models.Ticket]:
         """List tickets for an event with optional filters.
@@ -208,7 +208,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         ticket_id: UUID,
-        payload: schema.ConfirmPaymentSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.ConfirmPaymentSchema | None, Body(None)] = None,
     ) -> models.Ticket:
         """Confirm payment for a pending offline ticket and activate it."""
         event = self.get_one(event_id)
@@ -256,7 +256,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         ticket_id: UUID,
-        payload: schema.AdminRefundTicketSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.AdminRefundTicketSchema | None, Body(None)] = None,
     ) -> models.Ticket:
         """Mark a manual offline/at-the-door ticket as refunded and cancel it.
 
@@ -290,7 +290,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         ticket_id: UUID,
-        payload: schema.AdminCancelTicketSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.AdminCancelTicketSchema | None, Body(None)] = None,
     ) -> models.Ticket:
         """Cancel an offline/at-the-door ticket and record organizer audit fields.
 
@@ -323,7 +323,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         ticket_id: UUID,
-        payload: schema.ConfirmPaymentSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.ConfirmPaymentSchema | None, Body(None)] = None,
     ) -> models.Ticket:
         """Check in an attendee by scanning their ticket."""
         event = self.get_one(event_id)
@@ -342,8 +342,8 @@ class EventAdminTicketsController(EventAdminBaseController):
         self,
         event_id: UUID,
         year: int | None = None,
-        month: int | None = Query(None, ge=1, le=12),  # type: ignore[type-arg]
-        quarter: int | None = Query(None, ge=1, le=4),  # type: ignore[type-arg]
+        month: t.Annotated[int | None, Query(ge=1, le=12)] = None,
+        quarter: t.Annotated[int | None, Query(ge=1, le=4)] = None,
     ) -> revenue_aggregation.EventFinancials:
         """Per-event financials, all-time by default; optional year/month/quarter filter."""
         event = self.get_one(event_id)

--- a/src/events/controllers/event_admin/tokens.py
+++ b/src/events/controllers/event_admin/tokens.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -116,7 +117,7 @@ class EventAdminTokensController(EventAdminBaseController):
     def list_event_tokens(
         self,
         event_id: UUID,
-        params: filters.EventTokenFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.EventTokenFilterSchema, Query(...)],
     ) -> QuerySet[models.EventToken]:
         """Retrieve all invitation tokens for this event with usage statistics.
 

--- a/src/events/controllers/event_admin/waitlist_offers.py
+++ b/src/events/controllers/event_admin/waitlist_offers.py
@@ -1,5 +1,6 @@
 """Admin endpoints for advanced waitlist configuration and offers."""
 
+import typing as t
 from uuid import UUID
 
 from django.db import IntegrityError, transaction
@@ -114,7 +115,7 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
         self,
         event_id: UUID,
         offer_id: UUID,
-        payload: schema.WaitlistOfferReactivateSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.WaitlistOfferReactivateSchema | None, Body(None)] = None,
     ) -> models.WaitlistOffer:
         """Re-open a previously expired or revoked offer for the same user.
 

--- a/src/events/controllers/event_public/details.py
+++ b/src/events/controllers/event_public/details.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -67,7 +68,7 @@ class EventPublicDetailsController(EventPublicBaseController):
     def list_resources(
         self,
         event_id: UUID,
-        params: filters.ResourceFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.ResourceFilterSchema, Query(...)],
     ) -> QuerySet[models.AdditionalResource]:
         """Get supplementary resources attached to this event.
 

--- a/src/events/controllers/event_public/discovery.py
+++ b/src/events/controllers/event_public/discovery.py
@@ -46,7 +46,7 @@ class EventPublicDiscoveryController(EventPublicBaseController):
     )
     def list_events(
         self,
-        params: filters.EventFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.EventFilterSchema, Query(...)],
         order_by: t.Literal["start", "-start", "distance"] = "distance",
         include_past: bool = False,
     ) -> QuerySet[models.Event]:
@@ -79,8 +79,8 @@ class EventPublicDiscoveryController(EventPublicBaseController):
     @route.get("/calendar", url_name="calendar_events", response=list[schema.EventInListSchema])
     def calendar_events(
         self,
-        params: filters.EventFilterSchema = Query(...),  # type: ignore[type-arg]
-        calendar_params: filters.CalendarParamsSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.EventFilterSchema, Query(...)],
+        calendar_params: t.Annotated[filters.CalendarParamsSchema, Query(...)],
     ) -> QuerySet[models.Event]:
         """Get events for a calendar view (week, month, or year).
 

--- a/src/events/controllers/event_public/tickets.py
+++ b/src/events/controllers/event_public/tickets.py
@@ -381,7 +381,7 @@ class EventPublicTicketsController(EventPublicBaseController):
     def cancel_my_ticket(
         self,
         ticket_id: UUID,
-        payload: schema.TicketCancellationRequestSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.TicketCancellationRequestSchema | None, Body(None)] = None,
     ) -> t.Any:
         """Ticket-holder-initiated cancellation with automatic Stripe refund where applicable.
 

--- a/src/events/controllers/event_series.py
+++ b/src/events/controllers/event_series.py
@@ -38,7 +38,7 @@ class EventSeriesController(UserAwareController):
     @searching(Searching, search_fields=["name", "description", "organization__name", "tags__tag__name"])
     def list_event_series(
         self,
-        params: filters.EventSeriesFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.EventSeriesFilterSchema, Query(...)],
     ) -> QuerySet[models.EventSeries]:
         """Browse event series (recurring event collections) visible to the current user.
 
@@ -67,7 +67,7 @@ class EventSeriesController(UserAwareController):
     def list_resources(
         self,
         series_id: UUID,
-        params: filters.ResourceFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.ResourceFilterSchema, Query(...)],
     ) -> QuerySet[models.AdditionalResource]:
         """Get resources attached to this event series.
 

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -106,7 +106,7 @@ class OrganizationController(UserAwareController):
     @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
     def list_organizations(
         self,
-        params: filters.OrganizationFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.OrganizationFilterSchema, Query(...)],
         order_by: t.Literal["name", "-name", "distance"] = "distance",
     ) -> QuerySet[models.Organization]:
         """Browse and search organizations visible to the current user.
@@ -171,7 +171,7 @@ class OrganizationController(UserAwareController):
     def list_resources(
         self,
         slug: str,
-        params: filters.ResourceFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.ResourceFilterSchema, Query(...)],
     ) -> QuerySet[models.AdditionalResource]:
         """Get resources attached to this organization and marked for display on organization page.
 

--- a/src/events/controllers/organization_admin/announcements.py
+++ b/src/events/controllers/organization_admin/announcements.py
@@ -1,5 +1,7 @@
 """Organization admin announcements controller."""
 
+import typing as t
+
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from ninja import Query
@@ -47,7 +49,7 @@ class OrganizationAdminAnnouncementsController(OrganizationAdminBaseController):
     def list_announcements(
         self,
         slug: str,
-        params: filters.AnnouncementFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.AnnouncementFilterSchema, Query(...)],
     ) -> QuerySet[models.Announcement]:
         """List all announcements for this organization.
 

--- a/src/events/controllers/organization_admin/blacklist.py
+++ b/src/events/controllers/organization_admin/blacklist.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -40,7 +41,7 @@ class OrganizationAdminBlacklistController(OrganizationAdminBaseController):
     def list_blacklist(
         self,
         slug: str,
-        params: filters.BlacklistFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.BlacklistFilterSchema, Query(...)],
     ) -> QuerySet[models.Blacklist]:
         """List all blacklist entries for the organization.
 

--- a/src/events/controllers/organization_admin/discount_codes.py
+++ b/src/events/controllers/organization_admin/discount_codes.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -37,7 +38,7 @@ class OrganizationAdminDiscountCodesController(OrganizationAdminBaseController):
     def list_discount_codes(
         self,
         slug: str,
-        params: filters.DiscountCodeFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.DiscountCodeFilterSchema, Query(...)],
     ) -> QuerySet[models.DiscountCode]:
         """List all discount codes for the organization.
 

--- a/src/events/controllers/organization_admin/members.py
+++ b/src/events/controllers/organization_admin/members.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -45,7 +46,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
     def list_members(
         self,
         slug: str,
-        params: filters.MembershipFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.MembershipFilterSchema, Query(...)],
     ) -> QuerySet[models.OrganizationMember]:
         """List all members of an organization."""
         organization = self.get_one(slug)

--- a/src/events/controllers/organization_admin/membership_requests.py
+++ b/src/events/controllers/organization_admin/membership_requests.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -36,7 +37,7 @@ class OrganizationAdminMembershipRequestsController(OrganizationAdminBaseControl
     def list_membership_requests(
         self,
         slug: str,
-        params: filters.MembershipRequestFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.MembershipRequestFilterSchema, Query(...)],
     ) -> QuerySet[OrganizationMembershipRequest]:
         """List all membership requests for an organization.
 

--- a/src/events/controllers/organization_admin/recurring_events.py
+++ b/src/events/controllers/organization_admin/recurring_events.py
@@ -1,5 +1,6 @@
 """Controller for recurring event management."""
 
+import typing as t
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
@@ -137,7 +138,7 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         self,
         slug: str,
         series_id: UUID,
-        payload: schema.GenerateSeriesEventsSchema | None = Body(None),  # type: ignore[type-arg]
+        payload: t.Annotated[schema.GenerateSeriesEventsSchema | None, Body(None)] = None,
     ) -> list[models.Event]:
         """Manually generate events for the series within the rolling window."""
         series = self._get_series(slug, series_id)

--- a/src/events/controllers/organization_admin/resources.py
+++ b/src/events/controllers/organization_admin/resources.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -32,7 +33,7 @@ class OrganizationAdminResourcesController(OrganizationAdminBaseController):
     def list_resources(
         self,
         slug: str,
-        params: filters.ResourceFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.ResourceFilterSchema, Query(...)],
     ) -> QuerySet[models.AdditionalResource]:
         """List all resources for a specific organization."""
         organization = self.get_one(slug)

--- a/src/events/controllers/organization_admin/revenue.py
+++ b/src/events/controllers/organization_admin/revenue.py
@@ -1,6 +1,7 @@
 """Org-admin revenue & VAT report endpoints (#551)."""
 
 import datetime as dt
+import typing as t
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
@@ -63,11 +64,11 @@ class OrganizationAdminRevenueController(OrganizationAdminBaseController):
         self,
         slug: str,
         year: int | None = None,
-        month: int | None = Query(None, ge=1, le=12),  # type: ignore[type-arg]
-        quarter: int | None = Query(None, ge=1, le=4),  # type: ignore[type-arg]
+        month: t.Annotated[int | None, Query(ge=1, le=12)] = None,
+        quarter: t.Annotated[int | None, Query(ge=1, le=4)] = None,
         currency: str | None = None,
-        sort: str = Query("revenue"),  # type: ignore[type-arg]
-        order: str = Query("desc"),  # type: ignore[type-arg]
+        sort: t.Annotated[str, Query()] = "revenue",
+        order: t.Annotated[str, Query()] = "desc",
     ) -> revenue_aggregation.OrganizationFinancials:
         """Org-wide financials broken down by event, period-filtered and sortable."""
         org = self.get_one(slug)

--- a/src/events/controllers/organization_admin/tokens.py
+++ b/src/events/controllers/organization_admin/tokens.py
@@ -1,3 +1,5 @@
+import typing as t
+
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from ninja import Query
@@ -35,7 +37,7 @@ class OrganizationAdminTokensController(OrganizationAdminBaseController):
     def list_organization_tokens(
         self,
         slug: str,
-        params: filters.OrganizationTokenFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.OrganizationTokenFilterSchema, Query(...)],
     ) -> QuerySet[models.OrganizationToken]:
         """Retrieve all membership invitation tokens for this organization.
 

--- a/src/events/controllers/organization_admin/whitelist.py
+++ b/src/events/controllers/organization_admin/whitelist.py
@@ -1,3 +1,4 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import Count, QuerySet
@@ -41,7 +42,7 @@ class OrganizationAdminWhitelistController(OrganizationAdminBaseController):
     def list_whitelist_requests(
         self,
         slug: str,
-        params: filters.WhitelistRequestFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.WhitelistRequestFilterSchema, Query(...)],
     ) -> QuerySet[models.WhitelistRequest]:
         """List whitelist requests for the organization.
 

--- a/src/events/controllers/questionnaire.py
+++ b/src/events/controllers/questionnaire.py
@@ -59,7 +59,7 @@ class QuestionnaireController(UserAwareController):
     @searching(Searching, search_fields=["questionnaire__name", "events__name", "event_series__name"])
     def list_org_questionnaires(
         self,
-        params: filters.QuestionnaireFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.QuestionnaireFilterSchema, Query(...)],
     ) -> QuerySet[event_models.OrganizationQuestionnaire]:
         """Browse questionnaires you have permission to view or manage.
 
@@ -459,7 +459,7 @@ class QuestionnaireController(UserAwareController):
     def list_submissions(
         self,
         org_questionnaire_id: UUID,
-        params: filters.SubmissionFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[filters.SubmissionFilterSchema, Query(...)],
         order_by: t.Literal["submitted_at", "-submitted_at"] = "-submitted_at",
     ) -> QuerySet[questionnaires_models.QuestionnaireSubmission]:
         """View user submissions for this questionnaire (admin only).

--- a/src/geo/controllers/cities.py
+++ b/src/geo/controllers/cities.py
@@ -25,7 +25,7 @@ class CityController(ControllerBase):
         Searching,
         search_fields=["name", "ascii_name", "country"],
     )
-    def list_cities(self, filters: CityFilterSchema = Query(...)) -> QuerySet[City]:  # type: ignore[type-arg]
+    def list_cities(self, filters: t.Annotated[CityFilterSchema, Query(...)]) -> QuerySet[City]:
         """Search and browse cities from the global database.
 
         Supports filtering by country and searching by city name. Use the 'search' parameter

--- a/src/notifications/controllers/notification_controller.py
+++ b/src/notifications/controllers/notification_controller.py
@@ -1,5 +1,6 @@
 """API controller for notification management."""
 
+import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
@@ -33,7 +34,7 @@ class NotificationController(UserAwareController):
     @paginate(PageNumberPaginationExtra, page_size=20)
     def list_notifications(
         self,
-        params: NotificationFilterSchema = Query(...),  # type: ignore[type-arg]
+        params: t.Annotated[NotificationFilterSchema, Query(...)],
     ) -> QuerySet[Notification]:
         """List user's notifications.
 


### PR DESCRIPTION
Closes #557.

## What
Migrates all **46** Ninja `Query`/`Body` parameter sites from the `# type: ignore[type-arg]` convention to the modern `t.Annotated[...]` idiom, in one focused sweep across 25 controllers. This puts the real type in the annotation and the `Query()`/`Body()` object in the metadata — passing `mypy --strict` with **no ignore** while preserving the OpenAPI constraints (`ge`/`le`/etc.).

| Before | After |
|---|---|
| `params: FilterSchema = Query(...)` | `params: t.Annotated[FilterSchema, Query(...)]` |
| `month: int \| None = Query(None, ge=1, le=12)` | `month: t.Annotated[int \| None, Query(ge=1, le=12)] = None` |
| `sort: str = Query("revenue")` | `sort: t.Annotated[str, Query()] = "revenue"` |
| `payload: Schema \| None = Body(None)` | `payload: t.Annotated[Schema \| None, Body(None)] = None` |

## Notes
- Added `import typing as t` to the 17 files that lacked it (ruff sorted them).
- **Ordering caveat (flagged in the issue) hit once:** in `dashboard_invitation_requests` the now-required whole-schema `params` followed the defaulted `event_id`, causing a `SyntaxError`. Fixed by reordering `params` first — safe, since query params are position-independent in the HTTP API.
- The 8 remaining `[type-arg]` ignores (`File`, celery `Task`, `forms.ModelForm`, `admin.ModelAdmin`) have no `Annotated` equivalent and are **out of scope**; `--warn-unused-ignores` confirms they're still required.
- Updated convention docs: `CLAUDE.md` and `docs/architecture/controllers.md`.

## Verification
- `make check` fully green — format, lint, **mypy `--strict` clean (834 files)**, migration-check, i18n, file-length.
- **Behavior preservation proven via OpenAPI:** regenerated the schema from a clean tree vs. this branch. The only structural diff is the two `invitation-requests` query params swapping array position (semantically irrelevant). The `operationId` churn observed during testing is per-process `PYTHONHASHSEED` noise, present even between two clean-tree generations.

Typing-ergonomics change only — no behavior change. `src/` only; no tests modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations for request parameters across API endpoints using standard Python typing practices, replacing workaround comments with more robust type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->