### PR TITLE
feat(api): expose user-facing feature flags in /version (closes #563)

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -14,7 +14,7 @@ from accounts.controllers.referral_stripe import ReferralStripeController
 from common.controllers import MediaValidationController, TagController
 from common.exception_handlers import ExceptionHandler, register_handlers
 from common.models import Legal, SiteSettings
-from common.schema import BannerSchema, LegalSchema, ResponseOk, VersionResponse
+from common.schema import BannerSchema, FeaturesSchema, LegalSchema, ResponseOk, VersionResponse
 from common.throttling import AnonDefaultThrottle, UserDefaultThrottle
 from events.controllers.dashboard import DashboardController
 from events.controllers.event_admin import EVENT_ADMIN_CONTROLLERS
@@ -67,7 +67,19 @@ def version(request: HttpRequest) -> tuple[int, VersionResponse]:
         The response status code and message.
     """
     banner = _get_active_banner()
-    return 200, VersionResponse(version=settings.VERSION, demo=settings.DEMO_MODE, banner=banner)
+    return 200, VersionResponse(
+        version=settings.VERSION, demo=settings.DEMO_MODE, banner=banner, features=_get_features()
+    )
+
+
+def _get_features() -> FeaturesSchema:
+    """Expose the user-facing feature flags so clients can hide gated UI."""
+    return FeaturesSchema(
+        organization_creation=settings.FEATURE_ORGANIZATION_CREATION,
+        telegram=settings.FEATURE_TELEGRAM,
+        google_sso=settings.FEATURE_GOOGLE_SSO,
+        llm_evaluation=settings.FEATURE_LLM_EVALUATION,
+    )
 
 
 def _get_active_banner() -> BannerSchema | None:

--- a/src/api/tests/test_version_endpoint.py
+++ b/src/api/tests/test_version_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for the /version endpoint and maintenance banner logic."""
 
+import typing as t
 from datetime import timedelta
 
 import pytest
@@ -34,6 +35,32 @@ class TestVersionEndpointBaseline:
         data = response.json()
 
         assert data["banner"] is None
+
+
+class TestVersionEndpointFeatures:
+    """Tests for the user-facing feature flags exposed in /version."""
+
+    def test_features_reflect_settings(self, client: Client, settings: t.Any) -> None:
+        """Test that the features block mirrors the FEATURE_* settings."""
+        settings.FEATURE_ORGANIZATION_CREATION = True
+        settings.FEATURE_TELEGRAM = False
+        settings.FEATURE_GOOGLE_SSO = True
+        settings.FEATURE_LLM_EVALUATION = False
+
+        data = client.get(VERSION_URL).json()
+
+        assert data["features"] == {
+            "organization_creation": True,
+            "telegram": False,
+            "google_sso": True,
+            "llm_evaluation": False,
+        }
+
+    def test_operational_flags_are_not_exposed(self, client: Client) -> None:
+        """Test that operational flags (malware scan, observability) are not leaked to clients."""
+        data = client.get(VERSION_URL).json()
+
+        assert set(data["features"]) == {"organization_creation", "telegram", "google_sso", "llm_evaluation"}
 
 
 class TestVersionEndpointWithBanner:

--- a/src/common/schema.py
+++ b/src/common/schema.py
@@ -110,10 +110,25 @@ class BannerSchema(Schema):
     ends_at: AwareDatetime | None = None
 
 
+class FeaturesSchema(Schema):
+    """User-facing feature flags so clients can hide gated UI instead of failing on click.
+
+    Reflects the server-side ``FEATURE_*`` settings. Operational flags
+    (``FEATURE_MALWARE_SCAN``, ``FEATURE_OBSERVABILITY``) are intentionally omitted —
+    they do not affect what an end user sees.
+    """
+
+    organization_creation: bool
+    telegram: bool
+    google_sso: bool
+    llm_evaluation: bool
+
+
 class VersionResponse(Schema):
     version: str
     demo: bool = False
     banner: BannerSchema | None = None
+    features: FeaturesSchema
 
 
 class ResponseOk(Schema):


### PR DESCRIPTION
Closes #563. Backend prerequisite for letsrevel/revel-frontend#488 (hide flag-gated UI).

## What

Adds a `features` object to the existing **anonymous** `GET /version` response so clients can discover which capabilities are enabled and hide gated paths (create-org, Telegram linking, Google SSO) instead of letting users click into a `403`/`404`.

```jsonc
// GET /version
{
  "version": "1.63.1",
  "demo": false,
  "banner": null,
  "features": {
    "organization_creation": true,
    "telegram": true,
    "google_sso": false,
    "llm_evaluation": true
  }
}
```

## Details

- `FeaturesSchema` in `common/schema.py`, added to `VersionResponse`.
- `_get_features()` helper in `api/api.py` maps the user-facing `FEATURE_*` settings → schema (mirrors the existing `_get_active_banner()` pattern).
- **Operational flags** (`FEATURE_MALWARE_SCAN`, `FEATURE_OBSERVABILITY`) are intentionally **not** exposed — they don't affect the UI.
- `organization_creation` is the raw flag; the server keeps its staff bypass as the source of truth, so the client can decide whether to still show create-org for staff.

## Tests

- `features` block mirrors the `FEATURE_*` settings (via `override_settings`).
- Operational flags are not leaked (asserts the exact key set).
- Existing `/version` (version/demo/banner) tests unchanged and passing.

`make check` green (ruff, mypy --strict, migrations, i18n, file-length). Endpoint test file: `14 passed`.

> After merge, run `pnpm generate:api` in revel-frontend so the typed client picks up `features` (the spec already regenerates the `FeaturesSchema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/version` endpoint now includes feature availability information, allowing clients to determine which capabilities are currently enabled in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->