### PR TITLE
feat(accounts): accept French as a preferred language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- French (`fr`) is now an accepted value for the user's preferred language in the profile and language-update endpoints, matching the languages already configured for the site.
+
 ## [1.64.0] - 2026-06-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.64.0"
+version = "1.64.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/src/accounts/schema.py
+++ b/src/accounts/schema.py
@@ -235,7 +235,7 @@ class ChangePasswordSchema(PasswordMixin):
     old_password: str
 
 
-SupportedLanguage = t.Literal["en", "de", "it"]
+SupportedLanguage = t.Literal["en", "de", "it", "fr"]
 
 
 class ProfileUpdateSchema(Schema):
@@ -245,7 +245,7 @@ class ProfileUpdateSchema(Schema):
     pronouns: StrippedString = Field(..., max_length=100, description="User's pronouns")
     first_name: StrippedString = Field(..., max_length=30, description="User's first name")
     last_name: StrippedString = Field(..., max_length=150, description="User's last name")
-    language: SupportedLanguage = Field("en", max_length=7, description="User's preferred language (en, de, it)")
+    language: SupportedLanguage = Field("en", max_length=7, description="User's preferred language (en, de, it, fr)")
     bio: str = Field("", max_length=500, description="User's bio (publicly visible)")
 
     @model_validator(mode="after")
@@ -262,7 +262,7 @@ class ProfileUpdateSchema(Schema):
 class LanguageUpdateSchema(Schema):
     """Schema for updating user's preferred language."""
 
-    language: SupportedLanguage = Field(..., description="User's preferred language (en, de, it)")
+    language: SupportedLanguage = Field(..., description="User's preferred language (en, de, it, fr)")
 
 
 class VerifyEmailResponseSchema(Schema):

--- a/src/accounts/tests/test_controllers/test_account_controller.py
+++ b/src/accounts/tests/test_controllers/test_account_controller.py
@@ -229,7 +229,7 @@ def test_update_language_success(auth_client: Client, user: RevelUser) -> None:
 def test_update_language_invalid_language(auth_client: Client) -> None:
     """Test language update with invalid language returns 422."""
     url = reverse("api:update-language")
-    payload = {"language": "fr"}  # Not in supported languages
+    payload = {"language": "es"}  # Not in supported languages
 
     response = auth_client.put(url, data=orjson.dumps(payload), content_type="application/json")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3951,7 +3951,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.64.0"
+version = "1.64.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary
- Adds `fr` (French) to the `SupportedLanguage` literal in `accounts/schema.py`, so the profile update and language-update endpoints accept French.
- `LANGUAGES` in `settings/base.py` already includes `("fr", "Français")`, so this simply brings the API schema in line with the languages the site is already configured for.
- Bumps the patch version `1.64.0` → `1.64.1` and adds a CHANGELOG entry.

## Changes
- `src/accounts/schema.py`: `SupportedLanguage` literal + field descriptions now include `fr`.
- `pyproject.toml` / `uv.lock`: version bump via `uv version --bump patch`.
- `CHANGELOG.md`: `[Unreleased]` → Added entry.

## Testing
No new tests — purely an enum-widening change against an already-supported language code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * French language support now available. Users can select French as their preferred language in account settings.

* **Chores**
  * Version bumped to 1.64.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->