### PR TITLE
fix(events): owner-only authorization for revenue_report_cadence (closes #570)

### DIFF
--- a/src/events/controllers/organization_admin/core.py
+++ b/src/events/controllers/organization_admin/core.py
@@ -48,7 +48,7 @@ class OrganizationAdminCoreController(OrganizationAdminBaseController):
         Use the update-contact-email endpoint instead for email changes.
         """
         organization = self.get_one(slug)
-        return organization_service.update_organization(organization, payload)
+        return organization_service.update_organization(organization, payload, requester=self.user())
 
     @route.post(
         "/update-contact-email",

--- a/src/events/exception_handlers.py
+++ b/src/events/exception_handlers.py
@@ -33,6 +33,7 @@ from events.exceptions import (
     OrganizationTokenMembershipTierRequiredError,
     OrganizationTokenStaffGrantForbidden,
     PendingMembershipRequestExistsError,
+    RevenueReportCadenceOwnerOnlyError,
     StripeNotConnectedError,
     TicketAlreadyCancelledError,
     TooManyItemsError,
@@ -41,6 +42,7 @@ from events.service.event_manager import UserIsIneligibleError
 from events.service.organization_service import (
     GRANT_INVARIANT_MESSAGE,
     MEMBERSHIP_TIER_REQUIRED_MESSAGE,
+    REVENUE_CADENCE_OWNER_ONLY_MESSAGE,
     STAFF_GRANT_FORBIDDEN_MESSAGE,
 )
 from events.service.ticket_service import (
@@ -82,6 +84,9 @@ HANDLERS: dict[type[Exception], ExceptionHandler] = {
     OrganizationTokenStaffGrantForbidden: make_static_handler(403, STAFF_GRANT_FORBIDDEN_MESSAGE),
     OrganizationTokenGrantInvariantError: make_static_handler(422, GRANT_INVARIANT_MESSAGE),
     OrganizationTokenMembershipTierRequiredError: make_static_handler(422, MEMBERSHIP_TIER_REQUIRED_MESSAGE),
+    # revenue_report_cadence is owner-only (financially sensitive); staff-grantable
+    # edit_organization must not reach it → 403.
+    RevenueReportCadenceOwnerOnlyError: make_static_handler(403, REVENUE_CADENCE_OWNER_ONLY_MESSAGE),
     # Ticket/tier guards (formerly mapped via try/except in the tickets controller).
     TicketAlreadyCancelledError: make_static_handler(409, TICKET_ALREADY_CANCELLED_MESSAGE),
     StripeNotConnectedError: make_static_handler(400, STRIPE_NOT_CONNECTED_MESSAGE),

--- a/src/events/exceptions.py
+++ b/src/events/exceptions.py
@@ -29,6 +29,10 @@ class OrganizationTokenMembershipTierRequiredError(Exception):
     """Raised when an organization-token update would leave ``grants_membership=True`` with no ``membership_tier``."""
 
 
+class RevenueReportCadenceOwnerOnlyError(Exception):
+    """Raised when a non-owner attempts to change an organization's ``revenue_report_cadence``."""
+
+
 class TicketAlreadyCancelledError(Exception):
     """Raised when attempting to cancel/refund a ticket that is already in CANCELLED state."""
 

--- a/src/events/service/organization_service.py
+++ b/src/events/service/organization_service.py
@@ -23,6 +23,7 @@ from events.exceptions import (
     OrganizationTokenMembershipTierRequiredError,
     OrganizationTokenStaffGrantForbidden,
     PendingMembershipRequestExistsError,
+    RevenueReportCadenceOwnerOnlyError,
 )
 from events.models import (
     MembershipTier,
@@ -46,6 +47,7 @@ from notifications.signals import notification_requested
 STAFF_GRANT_FORBIDDEN_MESSAGE = _("Only the organization owner can manage staff-granting tokens.")
 GRANT_INVARIANT_MESSAGE = _("At least one of grants_membership or grants_staff_status must be True.")
 MEMBERSHIP_TIER_REQUIRED_MESSAGE = _("membership_tier_id is required when grants_membership is True.")
+REVENUE_CADENCE_OWNER_ONLY_MESSAGE = _("Only the organization owner can change the revenue report cadence.")
 
 
 def _create_and_send_contact_email_verification(
@@ -686,18 +688,32 @@ def validate_contact_method(organization: Organization, contact_method: Organiza
 
 
 @transaction.atomic
-def update_organization(organization: Organization, payload: schema.OrganizationEditSchema) -> Organization:
+def update_organization(
+    organization: Organization, payload: schema.OrganizationEditSchema, *, requester: RevelUser
+) -> Organization:
     """Update an organization's editable fields.
 
     Validates ``contact_method`` against the organization's verified-email state
     and ``revenue_report_cadence`` against the presence of ``billing_email``
     before persisting. Other fields are applied via ``update_db_instance``.
+
+    ``revenue_report_cadence`` controls scheduled financial-report delivery and is
+    owner-only, consistent with the owner-only org revenue endpoints. ``edit_organization``
+    is staff-grantable, so a non-owner attempting to change the cadence is rejected here
+    regardless of which permission got them to this endpoint.
     """
     from events.service import update_db_instance
 
     data = payload.model_dump(exclude_unset=True)
     if "contact_method" in data:
         validate_contact_method(organization, Organization.ContactMethod(data["contact_method"]))
+
+    if (
+        "revenue_report_cadence" in data
+        and data["revenue_report_cadence"] != organization.revenue_report_cadence
+        and organization.owner_id != requester.pk
+    ):
+        raise RevenueReportCadenceOwnerOnlyError
 
     # Apply cadence from payload (if present) before the billing_email check,
     # so the check reflects the intended post-save state.

--- a/src/events/tests/test_controllers/test_organization_admin/test_core.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_core.py
@@ -260,6 +260,40 @@ def test_update_organization_by_staff_without_permission(
     assert response.status_code == 403
 
 
+def test_staff_with_edit_permission_cannot_change_revenue_cadence(
+    organization_staff_client: Client, organization: Organization, staff_member: OrganizationStaff
+) -> None:
+    """revenue_report_cadence is owner-only: staff with edit_organization gets a 403 (issue #570)."""
+    perms = staff_member.permissions
+    perms["default"]["edit_organization"] = True
+    staff_member.permissions = perms
+    staff_member.save()
+    organization.billing_email = "billing@example.com"
+    organization.save()
+
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public", "revenue_report_cadence": "monthly"}
+    response = organization_staff_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 403
+    organization.refresh_from_db()
+    assert organization.revenue_report_cadence == Organization.RevenueReportCadence.NONE
+
+
+def test_owner_can_change_revenue_cadence(organization_owner_client: Client, organization: Organization) -> None:
+    """The owner can still change revenue_report_cadence (issue #570)."""
+    organization.billing_email = "billing@example.com"
+    organization.save()
+
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public", "revenue_report_cadence": "monthly"}
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 200
+    organization.refresh_from_db()
+    assert organization.revenue_report_cadence == Organization.RevenueReportCadence.MONTHLY
+
+
 @pytest.mark.parametrize(
     "client_fixture,expected_status_code",
     [("member_client", 403), ("nonmember_client", 403), ("client", 401)],

--- a/src/events/tests/test_service/test_organization_contact_service.py
+++ b/src/events/tests/test_service/test_organization_contact_service.py
@@ -112,7 +112,7 @@ class TestUpdateOrganizationContactMethod:
             contact_method=Organization.ContactMethod.EMAIL,
         )
         with pytest.raises(HttpError) as exc_info:
-            organization_service.update_organization(organization, payload)
+            organization_service.update_organization(organization, payload, requester=organization.owner)
         assert exc_info.value.status_code == 400
 
     def test_update_rejects_form_without_verified_email(self, organization: Organization) -> None:
@@ -125,7 +125,7 @@ class TestUpdateOrganizationContactMethod:
             contact_method=Organization.ContactMethod.FORM,
         )
         with pytest.raises(HttpError) as exc_info:
-            organization_service.update_organization(organization, payload)
+            organization_service.update_organization(organization, payload, requester=organization.owner)
         assert exc_info.value.status_code == 400
 
     def test_update_allows_form_with_verified_email(self, organization: Organization) -> None:
@@ -137,7 +137,7 @@ class TestUpdateOrganizationContactMethod:
             visibility=Organization.Visibility.PUBLIC,
             contact_method=Organization.ContactMethod.FORM,
         )
-        organization_service.update_organization(organization, payload)
+        organization_service.update_organization(organization, payload, requester=organization.owner)
         organization.refresh_from_db()
         assert organization.contact_method == Organization.ContactMethod.FORM
 

--- a/src/events/tests/test_service/test_organization_revenue_cadence.py
+++ b/src/events/tests/test_service/test_organization_revenue_cadence.py
@@ -6,6 +6,7 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from accounts.models import RevelUser
+from events.exceptions import RevenueReportCadenceOwnerOnlyError
 from events.models import Organization
 from events.schema import OrganizationEditSchema
 from events.service import organization_service
@@ -20,7 +21,7 @@ def test_enabling_cadence_without_billing_email_is_rejected(db: t.Any) -> None:
         revenue_report_cadence=Organization.RevenueReportCadence.QUARTERLY,
     )
     with pytest.raises(ValidationError):
-        organization_service.update_organization(org, payload)
+        organization_service.update_organization(org, payload, requester=owner)
 
 
 @pytest.mark.django_db
@@ -31,5 +32,35 @@ def test_enabling_cadence_with_billing_email_succeeds(db: t.Any) -> None:
         visibility=Organization.Visibility.STAFF_ONLY,
         revenue_report_cadence=Organization.RevenueReportCadence.MONTHLY,
     )
-    updated = organization_service.update_organization(org, payload)
+    updated = organization_service.update_organization(org, payload, requester=owner)
     assert updated.revenue_report_cadence == Organization.RevenueReportCadence.MONTHLY
+
+
+@pytest.mark.django_db
+def test_non_owner_cannot_change_cadence(db: t.Any) -> None:
+    owner = RevelUser.objects.create_user(username="o", email="o@example.com", password="x")
+    staff = RevelUser.objects.create_user(username="s", email="s@example.com", password="x")
+    org = Organization.objects.create(name="Org", slug="org", owner=owner, billing_email="b@example.com")
+    payload = OrganizationEditSchema(
+        visibility=Organization.Visibility.STAFF_ONLY,
+        revenue_report_cadence=Organization.RevenueReportCadence.MONTHLY,
+    )
+    with pytest.raises(RevenueReportCadenceOwnerOnlyError):
+        organization_service.update_organization(org, payload, requester=staff)
+    org.refresh_from_db()
+    assert org.revenue_report_cadence == Organization.RevenueReportCadence.NONE
+
+
+@pytest.mark.django_db
+def test_non_owner_noop_cadence_is_allowed(db: t.Any) -> None:
+    """A non-owner submitting the unchanged cadence (e.g. echoing the form) is not blocked."""
+    owner = RevelUser.objects.create_user(username="o", email="o@example.com", password="x")
+    staff = RevelUser.objects.create_user(username="s", email="s@example.com", password="x")
+    org = Organization.objects.create(name="Org", slug="org", owner=owner)
+    payload = OrganizationEditSchema(
+        visibility=Organization.Visibility.PUBLIC,
+        revenue_report_cadence=Organization.RevenueReportCadence.NONE,
+    )
+    updated = organization_service.update_organization(org, payload, requester=staff)
+    assert updated.visibility == Organization.Visibility.PUBLIC
+    assert updated.revenue_report_cadence == Organization.RevenueReportCadence.NONE

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1428,6 +1428,11 @@ msgstr ""
 msgid "membership_tier_id is required when grants_membership is True."
 msgstr "membership_tier_id ist erforderlich, wenn grants_membership True ist."
 
+msgid "Only the organization owner can change the revenue report cadence."
+msgstr ""
+"Nur der:die Organisationsinhaber:in kann den Turnus der Umsatzberichte "
+"ändern."
+
 #, python-format
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -1440,6 +1440,11 @@ msgstr ""
 msgid "membership_tier_id is required when grants_membership is True."
 msgstr "membership_tier_id est requis lorsque grants_membership est True."
 
+msgid "Only the organization owner can change the revenue report cadence."
+msgstr ""
+"Seul·e le·la propriétaire de l'organisation peut modifier la cadence des "
+"rapports de revenus."
+
 #, python-format
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -1403,6 +1403,11 @@ msgstr ""
 msgid "membership_tier_id is required when grants_membership is True."
 msgstr "membership_tier_id è obbligatorio quando grants_membership è True."
 
+msgid "Only the organization owner can change the revenue report cadence."
+msgstr ""
+"Solo il proprietario dell'organizzazione può modificare la cadenza dei "
+"report sui ricavi."
+
 #, python-format
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "


### PR DESCRIPTION
## Summary

`revenue_report_cadence` controls scheduled financial-report delivery and is **owner-only**, consistent with the owner-only org revenue endpoints. It was writable via `PUT /organization-admin/{slug}` (`update_organization`) under `edit_organization` — a **staff-grantable** permission. A staff member granted `edit_organization` could enable/disable/change an org's revenue-report cadence even though they cannot **read** any financial data.

This adds the server-side defense-in-depth so the authorization holds regardless of client (the frontend already hides the control for non-owners, PR letsrevel/revel-frontend#496).

## Changes

- **`events/exceptions.py`** — new `RevenueReportCadenceOwnerOnlyError`.
- **`events/service/organization_service.py`** — `update_organization` now takes a `requester` and rejects a non-owner who attempts to **change** the cadence. A no-op submission of the current value still passes, so a staff member's normal edit-form save is not falsely blocked. The guard runs before the `billing_email` check so staff get a clean 403 regardless of billing state.
- **`events/exception_handlers.py`** — registered the exception → **403** with a translatable message.
- **`events/controllers/organization_admin/core.py`** — passes `requester=self.user()`.

Follows the existing `OrganizationTokenStaffGrantForbidden` owner-guard pattern.

## Tests

- API-level (`test_core.py`): staff with `edit_organization` → **403**, cadence unchanged in DB; owner can still change it → 200.
- Service-level (`test_organization_revenue_cadence.py`): non-owner change rejected; non-owner no-op allowed.
- Updated the 5 existing callers for the new required `requester` kwarg.

All 52 touched tests pass; mypy `--strict`, ruff format + lint clean.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Restricted revenue report cadence modifications to organization owners only. Non-owner staff members will now receive an authorization error when attempting to change this setting.

* **Localization**
  * Added translations for the new authorization restriction message in German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->