### PR TITLE
chore: document 1.64.1 and 1.65.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.65.0] - 2026-06-22
+
+### Added
+- `is_open_ended` flag on events: organizers can mark an event as having no fixed end. `end` is still set (defaulting to start + 24h) and used internally for ICS generation, Wallet expiry, and the "upcoming"/"event ended" gates; the flag is a display signal for the frontend (e.g. render "Ongoing", hide the end time). Settable on events and on recurring-series templates, where it propagates to existing occurrences.
+
+### Security
+- `revenue_report_cadence` is now owner-only on organization updates. It was writable via `PUT /organization-admin/{slug}` under the staff-grantable `edit_organization` permission; a non-owner attempting to change the cadence now gets a `403` (no-op submissions of the current value still pass).
+
+## [1.64.1] - 2026-06-22
+
 ### Added
 - French (`fr`) is now an accepted value for the user's preferred language in the profile and language-update endpoints, matching the languages already configured for the site.
 


### PR DESCRIPTION
## Summary

Reconciles `CHANGELOG.md` against shipped tags.

- Promotes the French preferred-language entry (was in `[Unreleased]`) to **`[1.64.1] - 2026-06-22`**, where it actually shipped.
- Adds **`[1.65.0] - 2026-06-22`**:
  - **Added** — `is_open_ended` event flag (#569): display-only signal; `end` stays set and all operational uses (ICS, Wallet, upcoming/ended gates) are unchanged. Propagates on recurring-series templates.
  - **Security** — `revenue_report_cadence` is now owner-only on org updates (#571): previously reachable via the staff-grantable `edit_organization` permission; non-owners now get a `403`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `is_open_ended` event flag affecting event end time, ICS generation, wallet expiry, and UI display
  * Added French (fr) as a supported user preferred language option

* **Security**
  * `revenue_report_cadence` now restricted to organization owners; non-owners receive 403 error when attempting changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->