### PR TITLE
feat: /whats-new community update command + skill

### DIFF
--- a/.claude/commands/whats-new.md
+++ b/.claude/commands/whats-new.md
@@ -1,0 +1,15 @@
+---
+description: Draft a "What's New" Discord community update across backend, frontend & infra for a time window
+argument-hint: "[window: number + w|m, e.g. 1w, 2m, 6w — default 1m]"
+---
+
+Invoke the `whats-new` skill via the Skill tool and follow its workflow to produce a Discord-ready
+"What's New" community update and archive it on the docs site.
+
+Window from the user (may be empty): $ARGUMENTS
+
+- The window is `number + w|m` (e.g. `1w`, `2m`, `6w`). If `$ARGUMENTS` is empty or unrecognized,
+  default to the **last month** (`1m`).
+- Research changelog-first (backend `CHANGELOG.md`, frontend `CHANGELOG.md` if it exists), digging
+  into git/PRs only for gaps and for repos without a changelog (infra; frontend until it has one).
+- Do not commit — print the Discord draft, update `docs/whats-new/index.md`, then offer to commit.

--- a/.claude/skills/whats-new/SKILL.md
+++ b/.claude/skills/whats-new/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: whats-new
+description: Draft a "What's New" community update for the Revel Discord covering changes across backend, frontend, and infra over a time window. Use when the user runs /whats-new or asks for a community changelog/release-roundup post for organizers (and the programmers in the room).
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(date:*), Bash(grep:*), Bash(ls:*), Bash(test:*), Read, Edit, Write, Glob, Grep
+---
+
+# What's New
+
+Produces a Discord-ready "What's New" post for the Revel community and archives it on the
+published docs site. Audience: **mostly organizers, but programmers too** — every item leads
+with the organizer-facing benefit and carries a light technical detail (a flag, an endpoint, a
+behavior change) for the developers reading along.
+
+Three repos, all **public**, all siblings of the cwd (`revel-backend`):
+
+| Repo | Path | Primary source |
+|------|------|----------------|
+| Backend | `.` (cwd) | `CHANGELOG.md` (rich, dated, user-facing prose) |
+| Frontend | `../revel-frontend` | `CHANGELOG.md` **if present**, else git/PR digging |
+| Infra | `../infra` | git/PR digging (no changelog) |
+
+> The frontend is adopting the backend's changelog process. **Always check for
+> `../revel-frontend/CHANGELOG.md` first** and use it changelog-first when it exists; only fall
+> back to git/PR digging for repos that have no changelog yet.
+
+## 1. Parse the window
+
+The argument is `number + w|m` (e.g. `1w`, `2m`, `6w`). **Default `1m`** if empty/unrecognized.
+
+Compute the cutoff date (this is darwin/BSD `date`; for GNU use `date -d "-2 months" +%F`):
+
+```bash
+# N and UNIT parsed from the arg; UNIT is w (weeks) or m (months)
+date -v-${N}${UNIT} +%F        # e.g. date -v-1m +%F  → cutoff YYYY-MM-DD
+date +%F                       # today, for the edition header
+```
+
+Keep the human label for the header: "Last month" (1m), "Last 2 weeks" (2w), etc.
+
+## 2. Gather changes (changelog-first, dig only gaps)
+
+**Backend** — primary, already curated prose:
+
+```bash
+grep -nE '^## \[' CHANGELOG.md          # locate version sections + dates
+```
+
+Read every `## [X.Y.Z] - DATE` section with `DATE >= cutoff`, plus `[Unreleased]`. These bullets
+are already user-facing — reuse their substance. Open a PR (`gh pr view <n>`) **only** when an
+entry is too terse to translate for a community audience.
+
+**Frontend** — changelog-first if present, else git/PR:
+
+```bash
+test -f ../revel-frontend/CHANGELOG.md && echo "use changelog" || echo "dig git/PRs"
+# changelog path: same as backend, against ../revel-frontend/CHANGELOG.md
+# fallback path:
+git -C ../revel-frontend log --since="<cutoff>" --first-parent --merges --pretty='%h %s'
+gh -R letsrevel/revel-frontend pr list --state merged --search "merged:>=<cutoff>" \
+   --limit 50 --json number,title,body,mergedAt
+```
+
+**Infra** — git/PR only:
+
+```bash
+git -C ../infra log --since="<cutoff>" --first-parent --merges --pretty='%h %s'
+gh -R letsrevel/infra pr list --state merged --search "merged:>=<cutoff>" \
+   --limit 50 --json number,title,body,mergedAt
+```
+
+When a PR title is opaque, read its body for the user-facing description. **Drop the noise**:
+pure CI/lint/test/dependency-bump/refactor commits unless they change observable behavior.
+
+## 3. Compose — grouped by area
+
+Group items into emoji-headed areas chosen from what's actually in the window. Suggested palette
+(use only the ones that apply; invent others as needed):
+
+- `## 🎟️ Events & Tickets`
+- `## 💳 Payments, VAT & Reporting`
+- `## 🔔 Notifications & Comms`
+- `## 📋 Questionnaires & Polls`
+- `## 🌍 Self-hosting & Infrastructure`
+- `## 🛠️ Under the Hood` (perf, security, developer-facing)
+
+Per bullet: **organizer benefit first, light tech detail inline.** Example:
+
+> - Mark an event as **open-ended** when there's no fixed finish — the page shows "Ongoing"
+>   instead of an end time (`is_open_ended` flag, propagates to recurring series).
+
+Rules:
+- **Discord markdown only**: `##`/`###` headers, `**bold**`, `-` bullets, `` `code` ``. No tables,
+  no collapsibles.
+- Confident and community-friendly, concise, no marketing fluff.
+- Don't surface internal refactors, secrets, or per-PR links in the body.
+
+## 4. The changelog footer (REQUIRED on every edition page)
+
+Every edition page **must** end with a footer linking the changelog(s) — include a repo only if it
+has a changelog. mkdocs has no auto-link extension, so use **markdown links**:
+
+```markdown
+**📋 Full changelogs:** [Backend](https://github.com/letsrevel/revel-backend/blob/main/CHANGELOG.md) · [Frontend](https://github.com/letsrevel/revel-frontend/blob/main/CHANGELOG.md)
+```
+
+Only list Frontend once `../revel-frontend/CHANGELOG.md` exists; add Infra if/when it gets one.
+
+## 5. Deliver
+
+The published docs page is the canonical artifact; the Discord message is a short teaser that
+links to it.
+
+**a. Write a new edition page** (one file per run):
+`docs/whats-new/<today>-last-<slug>.md`, where `<slug>` is the window label kebab-cased —
+`1m`→`last-month`, `2m`→`last-2-months`, `1w`→`last-week`, `2w`→`last-2-weeks`. Example:
+`docs/whats-new/2026-06-22-last-month.md`. Structure: `# What's New — <date range>` H1, the
+area sections (`##`), then the §4 changelog footer.
+
+**b. Index it** — prepend a bullet to `docs/whats-new/index.md` right after the
+`<!-- EDITIONS BELOW ... -->` marker, newest first:
+
+```markdown
+- [<date> — Last <window>](<filename-without-.md>.md) — <one-line teaser of the headline items>
+```
+
+(Dated pages are kept out of the nav via `not_in_nav: whats-new/20*.md` in `mkdocs.yml`; the index
+is their table of contents. New files are reachable by URL and from the index — no nav edit needed.)
+
+**c. Print the Discord message in chat**, inside a fenced block so it's copy-pasteable — a SHORT
+teaser, not the full post: a punchy intro line, **4–6 headline bullets** (the biggest items only),
+and a link to the published edition page:
+
+```
+📖 Full update → https://docs.letsrevel.io/whats-new/<slug>/
+```
+
+(The `<slug>` is the filename without `.md`. The URL goes live when docs deploy — that's expected;
+say so.) Keep it comfortably under Discord's 2000-char limit.
+
+**d. Do not commit** (project rule: always ask first). Report the new file, the index update, and
+print the Discord teaser, then offer to commit.
+
+## Notes
+
+- The docs publish to https://docs.letsrevel.io under the "What's New" nav tab; each edition lives
+  at `https://docs.letsrevel.io/whats-new/<slug>/`.
+- The edition page carries the full detail; the Discord teaser only summarizes and links to it.

--- a/docs/whats-new/2026-06-22-last-month.md
+++ b/docs/whats-new/2026-06-22-last-month.md
@@ -1,0 +1,50 @@
+# What's New — 22 May → 22 June 2026
+
+_Last month across backend, frontend, and infrastructure._
+
+## 💳 Payments, VAT & Reporting
+
+- **Full revenue & VAT reporting for organizers** — a new owner-only **Financials** page showing revenue, refunds, net income, and per-VAT-rate breakdowns by currency and event, filterable by year/quarter/month. Download a tax-precise report bundle (XLSX + PDF) for any period, or have it emailed automatically each month/quarter (`revenue_report_cadence`). One engine drives every view, so the numbers always reconcile.
+- **Richer per-event financials** — now break out online (Stripe) vs at-the-door payments, VAT detail, and both online and offline refunds.
+- **Ticket admin upgrades** — a sortable ticket list (tier, price, status, payment method, date — persisted in the URL), a per-ticket discount-code badge, and a "Total earned" gross/net/refunded box per currency.
+
+## 🎟️ Events & Tickets
+
+- **Open-ended events** — mark an event with no fixed finish; it shows "Open-ended"/"Ongoing" everywhere instead of an end time (`is_open_ended`, propagates to recurring series). The end is still tracked internally for calendar/Wallet.
+- **Event schedule / timeline** — author an ordered list of display-only sessions (title, description, start offset, duration, location, optional **Required** badge), shown on the public page and copied on duplication/recurrence.
+- **Event bookmarks** — privately bookmark events to find later, with a Bookmarked dashboard filter; no effect on eligibility or sign-ups.
+- **Cancellation reason** — attach an optional message when cancelling; shown to participants and included in the notification.
+- **Image cropping for all uploads** — event/org/series logos and banners now open a crop-and-reposition modal (PNG transparency preserved) instead of server auto-cropping.
+- **Check-in resilience** — manual ticket-code entry when the scanner camera fails, with clearer per-error messages.
+
+## 🗳️ Polls & Questionnaires
+
+- **Polls** — a brand-new polls system: create polls with audience, anonymity, scheduling, and result-visibility controls; lifecycle actions; and a public voter page with its own nav item and dashboard tile.
+- **Duplicate questionnaires & polls** — deep-copy one as a starting point instead of rebuilding by hand (clones into a DRAFT; votes and submissions are never copied).
+- **Smoother review** — Next/Previous navigation when reviewing submissions, plus an instant "you're all set" confirmation when a submission is auto-accepted.
+
+## 🔔 Notifications & Comms
+
+- **Scheduled announcements** — send at a future time or relative to event start/end (auto-shifts if the event moves), plus an option to re-send to people who sign up later.
+- **Instant transactional emails** — payment/ticket emails (confirmation, created, cancelled, refunded) now skip the digest and arrive immediately.
+- **Digest overhaul** — grouped by type with a body, timestamp, and "View details" links, restyled to match the transactional emails.
+- Event times in every notification and email now render in the **event's own timezone**.
+
+## 🌍 Self-hosting & Infrastructure
+
+- **Self-hosting support** — Revel now boots on a single self-hosted box without ClamAV, Telegram, or the full geo dataset, via feature flags (`FEATURE_MALWARE_SCAN`, `FEATURE_TELEGRAM`, `FEATURE_ORGANIZATION_CREATION`). Infra ships compose profiles, a parameterized Caddyfile, and a `setup.sh` wizard; the frontend resolves its API URL at runtime so one build can target any backend.
+- **Feature flags on `GET /version`** — clients hide gated features (org creation, Telegram, Google SSO, LLM evaluation) instead of letting users hit a 403/404.
+- **Observability** — a new system-health overview dashboard (with `node_exporter`), a slowest-endpoints (p95) ranking, frontend logs/metrics, and a login canary with alerts.
+
+## 🌐 Localization & Polish
+
+- **French** is now fully supported — translation catalog, language switcher, and French SEO landing pages (joining EN/DE/IT), with ~1,265 more strings translated across the app.
+- **Rich-text editor** — every description field (events, orgs, tiers, questionnaires, polls, resources, venues, profiles, announcements) now has a WYSIWYG editor with a formatting toolbar, link dialog, and source toggle.
+- Fixed the dark-mode flash (FOUC) on load, and the navbar now reflects login immediately (including 2FA) without a manual refresh.
+
+## 🛠️ Under the Hood
+
+- **Security hardening** — questionnaire answer-key and unscoped-list reads locked to org admins; admission-gate bypasses closed; DRAFT poll/question leaks fixed; forged-IP throttle evasion blocked; banned users can no longer reclaim invite tokens; and venue addresses no longer leak in update notifications.
+- **Geolocation correctness** — "Nearest First" sorting now works in production (real visitor IP via Cloudflare, fixed IP2Location DB extraction), plus single-render JSON logging and a Loki query CLI for operators.
+
+**📋 Full changelogs:** [Backend](https://github.com/letsrevel/revel-backend/blob/main/CHANGELOG.md) · [Frontend](https://github.com/letsrevel/revel-frontend/blob/main/CHANGELOG.md)

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -1,0 +1,10 @@
+# What's New
+
+Recent changes across the Revel platform — backend, frontend, and infrastructure —
+written for organizers, with the technical detail developers want.
+
+Each edition covers a time window and is generated with the `/whats-new` command. Newest first.
+
+<!-- EDITIONS BELOW — the /whats-new skill prepends a bullet here -->
+
+- [2026-06-22 — Last month](2026-06-22-last-month.md) — Revenue & VAT reporting, French support, open-ended events, event timelines, the new Polls system, and self-hosting.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ theme:
 
 nav:
   - Home: index.md
+  - What's New: whats-new/index.md
   - Getting Started:
       - getting-started/index.md
       - Quick Start: getting-started/quickstart.md
@@ -123,6 +124,11 @@ nav:
 # Internal agent plans/specs live under docs/superpowers/ — kept in git but not published.
 exclude_docs: |
   superpowers/
+
+# Dated "What's New" editions are published & linked from whats-new/index.md, but kept out of
+# the nav sidebar (the index page IS their table of contents).
+not_in_nav: |
+  whats-new/20*.md
 
 plugins:
   - search


### PR DESCRIPTION
## What

Adds a `/whats-new` slash command and backing skill that drafts a **"What's New"** community update for the Discord, covering changes across **backend, frontend, and infra** over a time window.

Usage: `/whats-new [N][w|m]` (e.g. `/whats-new 1w`, `/whats-new 2m`) — **defaults to the last month** if unspecified.

## How it works

- **Changelog-first research**: backend `CHANGELOG.md` is the primary source; the frontend `CHANGELOG.md` is used automatically *the moment it exists* (FE is adopting the BE changelog process), falling back to `git`/`gh` PR digging for gaps and changelog-less repos (infra). PRs are opened only to fill gaps.
- **Audience**: mostly organizers, but programmers too — each item leads with the organizer benefit and carries a light technical detail (a flag, an endpoint, a behavior).
- **Grouped by area**: 🎟️ Events · 💳 Payments & VAT · 🔔 Notifications · 🗳️ Polls · 🌍 Self-hosting · 🛠️ Under the Hood.
- **Output**: each run writes a dated edition page under `docs/whats-new/`, indexed from `whats-new/index.md` and published under a new **"What's New"** docs nav tab. Dated pages are kept out of the sidebar via `not_in_nav` (the index is their table of contents). The Discord message is a short teaser linking to the published edition.
- Every edition links the relevant changelog(s).

## Files

| File | Purpose |
|------|---------|
| `.claude/commands/whats-new.md` | Slash command (parses `$ARGUMENTS`, delegates to the skill) |
| `.claude/skills/whats-new/SKILL.md` | The workflow |
| `docs/whats-new/index.md` | Editions index |
| `docs/whats-new/2026-06-22-last-month.md` | First generated edition (22 May – 22 June 2026) |
| `mkdocs.yml` | New nav tab + `not_in_nav` for dated editions |

`mkdocs build --strict` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "What's New" section to the documentation site.
  * Published release notes covering product updates across payments, events, notifications, polls, self-hosting, and localization (May 22–June 22, 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->