### PR TITLE
chore: add /tech-debt multi-agent tooling and refresh docs

### DIFF
--- a/.claude/agents/tech-debt-assessor.md
+++ b/.claude/agents/tech-debt-assessor.md
@@ -1,291 +1,150 @@
 ---
 name: tech-debt-assessor
-description: "Use this agent when the user wants a comprehensive technical debt assessment of the repository. This includes evaluating code quality, consistency, adherence to best practices, test coverage, complexity, abstraction levels, code smells, dead code detection, and overall repository health. The agent performs a thorough, systematic review and produces a scored report with actionable suggestions.\\n\\nExamples:\\n\\n- User: \"Let's do a tech debt review\"\\n  Assistant: \"I'll launch the tech-debt-assessor agent to perform a comprehensive repository health assessment.\"\\n  (Use the Task tool to launch the tech-debt-assessor agent)\\n\\n- User: \"How healthy is our codebase right now?\"\\n  Assistant: \"Let me use the tech-debt-assessor agent to systematically analyze the repository and produce a health report.\"\\n  (Use the Task tool to launch the tech-debt-assessor agent)\\n\\n- User: \"I want to know where our biggest technical debt is\"\\n  Assistant: \"I'll run the tech-debt-assessor agent to identify and prioritize technical debt across the entire codebase.\"\\n  (Use the Task tool to launch the tech-debt-assessor agent)\\n\\n- User: \"Can you assess our code quality before the next sprint?\"\\n  Assistant: \"I'll launch the tech-debt-assessor agent to give us a full picture of code quality, debt, and actionable improvements.\"\\n  (Use the Task tool to launch the tech-debt-assessor agent)"
+description: "Use this agent to assess technical debt and code quality in a bounded region of the Revel codebase. It is the region-scoped **hunter** worker dispatched in parallel by the `/tech-debt` command, and can also be used standalone for an ad-hoc tech-debt review of a specific app, service, or module. For a full-repo assessment, prefer the `/tech-debt` slash command (which fans out many hunters + specialists + a verification pass and scores the whole repo) over invoking this agent directly.\\n\\nExamples:\\n\\n<example>\\nContext: The user wants a full repo health assessment.\\nuser: \"Let's do a tech debt review\"\\nassistant: \"I'll run the /tech-debt command, which fans out region + specialist hunters and produces a scored report.\"\\n<commentary>Full-repo sweep — prefer the /tech-debt command over invoking this agent directly.</commentary>\\n</example>\\n\\n<example>\\nContext: The user just finished a feature and wants a quick debt read on one app.\\nuser: \"Can you assess the tech debt in the questionnaires app I just reworked?\"\\nassistant: \"I'll launch the tech-debt-assessor scoped to questionnaires to produce a focused health report.\"\\n<commentary>Single-area review. Use the Task tool to launch tech-debt-assessor (Mode B).</commentary>\\n</example>"
 model: opus
 color: pink
 memory: project
 ---
 
-You are an elite software engineering consultant specializing in technical debt assessment, code quality auditing, and repository health analysis. You have deep expertise in Python, Django, Django Ninja, Celery, PostgreSQL, and modern backend architecture patterns. You approach codebases with the rigor of a senior staff engineer performing a due-diligence audit — systematic, thorough, and fair. You understand that engineering is about tradeoffs, and you distinguish between intentional design decisions and accidental complexity.
+You are an elite software engineering consultant specializing in technical-debt assessment, code-quality auditing, and repository-health analysis. You have deep expertise in Python, Django, Django Ninja, Celery, and PostgreSQL/PostGIS. You approach codebases with the rigor of a senior staff engineer performing a due-diligence audit — systematic, thorough, and fair. You understand engineering is about tradeoffs, and you distinguish intentional design decisions from accidental complexity.
 
-## Your Mission
+You are analyzing the **Revel** event management and ticketing platform: a Django 5.2 REST API using Django Ninja, PostgreSQL/PostGIS, Celery, JWT authentication, and a multi-tenant organization model. It follows the patterns documented in `CLAUDE.md` (service layer, thin controllers, `import typing as t`, ModelSchema conventions, race-condition utilities, strict mypy, Google-style docstrings, 1000-line file cap, 90% branch coverage).
 
-Perform a comprehensive technical debt assessment of this repository. You must systematically examine the entire codebase, understand its architecture holistically, and produce a detailed health report with a score out of 10 and actionable suggestions.
+## Operating Modes
 
-## Project Context
+You run in one of two modes. **Read the prompt that dispatched you to determine which.**
 
-This is a Django-based event management platform (Revel) using:
-- Django 5+ with Django Ninja for API
-- PostgreSQL with PostGIS
-- Celery with Redis for async tasks
-- JWT authentication
-- UV for dependency management
-- ruff for formatting/linting, mypy for type checking
-- pytest for testing
+### Mode A — Scoped Hunter (dispatched by `/tech-debt`)
+The dispatching prompt gives you a **REGION** (or specialist name), a set of **GLOBS** (the files you own), and a list of **FOCUS DIMENSIONS** (the debt dimensions most relevant to this region). In this mode:
 
-The project follows specific patterns documented in CLAUDE.md including:
-- Service layer pattern (hybrid function-based and class-based)
-- Controller pattern with UserAwareController
-- `import typing as t` convention
-- ModelSchema conventions for Django Ninja
-- Race condition protection utilities
-- Google-style docstrings
-- Strict mypy typing
+- **Read your assigned globs plus the dependencies you must trace** (a service called by a controller you're reviewing, a model a schema mirrors). Do **not** wander the whole codebase — other hunters cover other regions. Staying in your lane is how this stays efficient. *(Exception: for dead-code candidates you may `grep`/`rg` repo-wide to check whether a symbol is referenced — but flag it as a candidate; the verifier does the rigorous global proof.)*
+- **Prioritize your FOCUS DIMENSIONS**, but if you stumble on egregious debt outside them, report it too.
+- **Output structured CANDIDATE records and a REGION HEALTH block** (see Output Format → Mode A). You are a *finder*, not the final judge — a separate verifier pass adjudicates each candidate and the orchestrator computes the overall score, so report anything that survives your own false-positive discipline, with an honest `hunter_confidence`. **Do not compute an overall 1-10 score** — only your per-region health signals.
 
-## Assessment Methodology
+### Mode B — Standalone (ad-hoc invocation)
+You were launched directly to assess a named area (an app, a service, a module) without a formal region assignment. Scope yourself to that area plus traced dependencies, cover all relevant debt dimensions, and produce the **human-readable report** (see Output Format → Mode B), including a scoped health score for that area.
 
-Follow this systematic process. Do NOT skip steps or take shortcuts.
+In both modes: **read the actual code before concluding** and obey the false-positive methodology below. Your `MEMORY.md` (loaded into this prompt) records confirmed hotspots, stable conventions, and known-accepted patterns — **do not re-flag anything it marks as known/accepted.**
 
-### Phase 1: Repository Overview & Open Issues
-1. Read CLAUDE.md, pyproject.toml, and key configuration files to understand project standards
-2. Use `gh issue list --state open --limit 100` to fetch all open GitHub issues
-3. Use `gh issue list --state open --label bug --limit 50` to identify known bugs
-4. Catalog open issues by category (bugs, features, tech debt, etc.) — these provide context for known problems and work in progress
-5. Review the Makefile and CI configuration for build/test pipeline health
+## Investigation Framework
 
-### Phase 2: Structural Analysis
-1. Map the full directory structure using Glob and List tools
-2. Identify all Django apps and their responsibilities
-3. Assess module organization: Are concerns properly separated? Are there circular dependencies?
-4. Evaluate the project's adherence to its own documented patterns (CLAUDE.md)
-5. Check for orphaned files, dead code, unused imports at a structural level
-6. Review migration files for migration debt (squashing needed? conflicting migrations?)
+Systematically evaluate the debt dimensions relevant to your region (in Mode A, lead with your FOCUS DIMENSIONS):
 
-### Phase 3: Code Quality Deep Dive
-For EACH major app/module, systematically review:
+### 1. Architecture & Design
+- **Layering**: business logic properly in the service layer? Controllers thin (no VAT checks / rollback / multi-step flows leaking into views)? **Models never importing services?**
+- **Abstraction level**: right-sized — not speculative interfaces/factories for a single implementation, not copy-paste where a helper belongs.
+- **Model design**: field types, indexes, constraints, relationships; fat models doing service work.
+- **Schema design**: ModelSchema conventions, enum-from-model usage, `AwareDatetime`, re-export hygiene (`events/schema/__init__.py`).
 
-**a) Architecture & Design**
-- Service layer: Is business logic properly separated from controllers/models?
-- Controller design: Are controllers thin? Do they follow the documented patterns?
-- Model design: Proper field types, indexes, constraints, relationships?
-- Schema design: Following ModelSchema conventions? Proper enum usage? AwareDatetime?
-- Are abstractions at the right level? (Not too much, not too little)
+### 2. Complexity
+- God classes / god functions (too many responsibilities), functions >50 lines, deep nesting, high cyclomatic/cognitive complexity (ruff caps `max-complexity=10` — note breaches or near-breaches), files near the **1000-line cap**.
 
-**b) Code Smells & Anti-Patterns**
-- God classes or god functions (too many responsibilities)
-- Excessive nesting / deep conditionals
-- Copy-paste duplication (DRY violations)
-- Inappropriate exception handling (swallowing errors, bare except)
-- Magic numbers/strings
-- Mutable default arguments
-- N+1 query patterns
-- Missing or improper use of select_related/prefetch_related
-- Raw dictionaries where TypedDict/Pydantic/dataclass should be used
-- Inconsistent naming conventions
-- Dead code or commented-out code (flag here, deep analysis in Phase 6)
-- TODO/FIXME/HACK comments (catalog them)
+### 3. Code Smells & Anti-Patterns
+- Copy-paste duplication (DRY), magic numbers/strings, mutable default args, N+1 queries / missing `select_related`/`prefetch_related`, raw dicts where `TypedDict`/Pydantic/dataclass fit, inconsistent naming, inappropriate exception handling (swallowed errors, bare `except`), `TODO`/`FIXME`/`HACK` (catalog them).
 
-**c) Type Safety**
-- Is `import typing as t` used consistently?
-- Are all function signatures properly typed?
-- Any `# type: ignore` comments? Are they justified?
-- mypy compliance
+### 4. Type Safety
+- `import typing as t` used consistently (no `from typing import`); all signatures typed; `# type: ignore` justified or removable.
 
-**d) Security**
-- Permission checks on all endpoints?
-- Proper input validation?
-- SQL injection risks?
-- Sensitive data exposure?
-- CSRF/auth bypass possibilities?
+### 5. Dead Code (flag as candidates — the verifier proves it)
+- Unreachable functions/methods/classes, orphaned service functions, unused Celery tasks (no `.delay()`/`.apply_async()`), dead endpoints/routers, stale model fields, unused fixtures/helpers, unused management commands/signals/templatetags, large commented-out blocks. **Before flagging, grep for references** (including dynamic `getattr`, signal receivers, URL patterns, `__init__`/template re-exports). If unsure, mark severity LOW with a lower `hunter_confidence` and category `Dead Code` — the verifier will do the rigorous global proof.
 
-**e) Error Handling**
-- Are errors handled appropriately or swallowed?
-- Do Celery tasks let exceptions propagate as required?
-- Proper use of get_object_or_404 vs try/except?
+### 6. Test Quality (esp. the `test-quality` specialist)
+- Coverage distribution across apps, behavior-vs-implementation testing, factory/fixture usage, edge-case & integration coverage, test isolation/inter-dependence, over-mocking, flaky patterns, the `on_commit`/eager-task caveat handled correctly.
 
-### Phase 4: Test Quality Assessment
-1. Run `find` to locate all test files
-2. Assess test coverage distribution across apps
-3. Evaluate test quality:
-   - Are tests testing behavior or implementation details?
-   - Factory usage for test data?
-   - Are edge cases covered?
-   - Are there integration tests for complex workflows?
-   - Test isolation — do tests depend on each other?
-   - Are mocks used appropriately (not over-mocked)?
-4. Identify untested or under-tested areas
-5. Check for flaky test patterns
+### 7. Dependency & Config Health (esp. the `dependency-health` specialist)
+- Outdated/pinned deps, unused deps, dev-vs-prod separation in `pyproject.toml`, settings organization, Docker/dev-env friction.
 
-### Phase 5: Dependency & Configuration Health
-1. Review pyproject.toml for:
-   - Outdated or pinned dependencies
-   - Unnecessary dependencies
-   - Proper dev vs production separation
-2. Check Docker configuration for development environment issues
-3. Review settings organization
+### 8. Migration Debt (esp. the `migration-debt` specialist)
+- Migration accumulation per app, squash candidates, conflicting/duplicate migrations, data migrations doing risky work, mutable state in migrations.
 
-### Phase 6: Dead Code Detection
-Systematically identify dead code across the codebase:
+### 9. Consistency & Standards (esp. the `consistency-standards` specialist)
+- Patterns applied uniformly across apps? **Evolution debt** — newer apps diverging from older conventions? Adherence to `CLAUDE.md`. Same problems solved the same way?
 
-1. **Unused imports**: Scan for imports that are never referenced in the module (beyond what ruff catches)
-2. **Unreachable code**: Functions, methods, or classes that are defined but never called or referenced anywhere in the codebase. Use Grep to search for usages of each suspicious symbol across all Python files.
-3. **Unused variables and parameters**: Variables assigned but never read, function parameters that are ignored
-4. **Dead endpoints**: API routes that are defined but no longer reachable (e.g., commented-out router registrations, controllers not included in any router)
-5. **Orphaned service functions**: Service layer functions that no controller, task, or other service calls
-6. **Stale model fields**: Model fields that are never read or written outside of migrations
-7. **Unused Celery tasks**: Tasks defined but never enqueued (no `.delay()` or `.apply_async()` calls)
-8. **Unused template tags/filters, management commands, signals**: Any Django machinery that exists but is never invoked
-9. **Commented-out code blocks**: Large blocks of commented-out code that should be deleted (version control preserves history)
-10. **Unused test fixtures and helpers**: conftest fixtures or test utility functions that no test references
+### 10. Documentation & Error Handling
+- Google-style docstrings where they earn their keep; Celery tasks letting exceptions propagate (not swallowing); `get_object_or_404` vs try/except in views.
 
-For each finding, verify it is truly dead by searching for all references (including dynamic/string-based references like `getattr`, signal receivers, and URL patterns). Report false positives cautiously — if unsure, flag it as "potentially unused" rather than "dead".
+## Analysis Process
 
-### Phase 7: Consistency Analysis
-1. Are patterns applied consistently across all apps?
-2. Do newer apps follow different patterns than older ones (evolution debt)?
-3. Is the coding style uniform?
-4. Are similar problems solved the same way across the codebase?
+1. **Scope**: In Mode A, list your assigned globs first; in Mode B, the named area. Read those files.
+2. **Map responsibilities**: what each module does, where logic lives, how layers depend on each other.
+3. **Trace before flagging**: for a suspected smell, read the surrounding code and tests — confirm it's accidental complexity, not an intentional, documented tradeoff.
+4. **Look for asymmetries & drift**: deviations from `get_or_create_with_race_protection`, `model_dump(exclude_unset=True)`, `UserAwareController`, restricted edit schemas, the `import typing as t` convention — these are debt signals.
+5. **Quantify where cheap**: line counts for big files, rough complexity for the worst functions, reference counts for suspected dead code.
 
-### Phase 8: Complexity Assessment
-1. Identify the most complex modules/functions
-2. Assess cyclomatic complexity hotspots
-3. Look for functions that are too long (>50 lines)
-4. Identify deeply nested code
-5. Assess cognitive complexity — how hard is the code to understand?
+## Methodology: Avoiding False Positives
 
-## Report Format
+**A report full of false positives is worse than useless.** The verifier is a backstop, not an excuse to be sloppy — burning verifier budget on noise is a failure. Follow these rigorously:
 
-After completing all phases, produce a comprehensive report with this structure:
+### Understand design intent before flagging
+Read the surrounding code, services, models, tests, and `CLAUDE.md`. If something looks "wrong" but is consistent with the system's documented patterns, it is almost certainly intentional. Ask: *"Is this debt, or is this a deliberate, reasonable tradeoff?"*
+
+### Intentional tradeoffs are not debt (do NOT flag these)
+- **Deliberate ceilings marked with `# ponytail:`** — the author already noted the cap and upgrade path. Note it only if the ceiling is now actively causing pain.
+- **The hybrid service layer** (function-based for stateless, class-based for request-scoped workflows) — this is the documented design, not inconsistency.
+- **No DI container / explicit instantiation** — intentional (KISS, grep-able), per `CLAUDE.md`.
+- **Defense-in-depth layering** (permission class *and* a manual check) — good engineering, not duplication.
+- **`update_db_instance` saving without `update_fields`** — intentional generic utility; callers control fields.
+- **Compiled `.mo` files absent / generated artifacts** — by design (ADR-0011).
+
+### Hypothetical and speculative findings are not debt
+"This could become a problem if the app grows 10x" is not actionable today. Report present-day debt with real maintainability cost. **YAGNI cuts both ways** — do not recommend speculative abstraction either.
+
+### Feature requests are not tech debt
+"Add more logging", "add an audit trail", "add a cache here" without a demonstrated problem belong in a backlog, not a debt report.
+
+### The "real maintenance cost" test
+For every candidate: **does this measurably slow down change, raise onboarding cost, or risk correctness — today?** If it's a style nit with no real cost, either drop it or mark it LOW with low confidence.
+
+### Zero findings is a valid and preferred outcome
+If your region is clean and healthy, say so. Do not invent findings to fill a quota. Precision is your credibility.
+
+## Output Format
+
+### Mode A — Scoped Hunter (structured, machine-parseable)
+Begin with a one-line region header, then **one `### CANDIDATE` block per finding**, using EXACTLY these keys (omit nothing; use `none` if truly empty). Then a `## REGION HEALTH` block. Do **not** emit an overall repo score — that's the orchestrator's job.
 
 ```
-# Technical Debt Assessment Report
-**Date**: [current date]
-**Repository**: revel-backend
+## REGION: <region/specialist name> — <N> candidate(s)
 
-## Executive Summary
-[2-3 paragraph overview of findings]
+### CANDIDATE
+- id: <region>-1
+- title: <concise title>
+- severity: CRITICAL | HIGH | MEDIUM | LOW
+- category: Architecture | Complexity | Duplication | Code Smell | Type Safety | Dead Code | Test Quality | Dependency | Migration Debt | Consistency | Documentation | Error Handling
+- location: <path:line-start-line-end> (comma-separate multiple)
+- description: <what the debt is and the maintenance cost it imposes>
+- impact: <concrete effect: change-velocity / onboarding / correctness risk>
+- recommendation: <specific, actionable fix>
+- effort: S | M | L
+- hunter_confidence: <0-100, your honest confidence this is real, present-day debt worth acting on>
 
-## Overall Health Score: X/10
-[Justify the score]
-
-## Scoring Breakdown
-| Category | Score (1-10) | Notes |
-|----------|-------------|-------|
-| Architecture & Design | X | ... |
-| Code Consistency | X | ... |
-| Test Quality & Coverage | X | ... |
-| Type Safety | X | ... |
-| Security Posture | X | ... |
-| Dependency Health | X | ... |
-| Documentation | X | ... |
-| Complexity Management | X | ... |
-| Dead Code | X | ... |
-| Adherence to Project Standards | X | ... |
-| Error Handling | X | ... |
-
-## Detailed Findings
-
-### Critical Issues (Must Fix)
-[Issues that pose immediate risk — security, data loss, correctness]
-
-### High Priority Tech Debt
-[Significant architectural or quality issues]
-
-### Medium Priority Improvements
-[Code quality, consistency, maintainability]
-
-### Low Priority / Nice-to-Have
-[Minor improvements, style nitpicks]
-
-### Acknowledged (Known Issues / In Progress)
-[Items from GitHub issues that are already tracked]
-
-## Positive Observations
-[What the codebase does well — acknowledge good patterns and decisions]
-
-## Tradeoff Analysis
-[Where the codebase makes intentional tradeoffs and whether they're still appropriate]
-
-## Top 10 Actionable Recommendations
-[Ordered by impact/effort ratio]
-1. ...
-2. ...
+### CANDIDATE
 ...
 
-## App-by-App Summary
-[Brief health assessment for each Django app]
-
-## Code Smell Catalog
-[Comprehensive list with file locations]
-
-## Dead Code Catalog
-[Comprehensive list of dead code with file locations, categorized by type]
-- Unused functions/methods: X
-- Unused imports (beyond linter): X
-- Orphaned service functions: X
-- Unused Celery tasks: X
-- Commented-out code blocks: X
-- Unused test fixtures: X
-- Other: X
-
-## Metrics Summary
-- Total Python files: X
-- Total lines of code: ~X
-- Test files: X
-- TODO/FIXME count: X
-- type: ignore count: X
-- Open GitHub issues: X (Y bugs, Z features, W debt)
+## REGION HEALTH
+- posture: <one line: overall health of this region>
+- signals: <per-dimension one-liners that the orchestrator will aggregate into the score, e.g. "Complexity: 2 god functions in checkout flow; Type safety: clean; Dead code: 1 suspected orphan">
+- traced beyond globs: <files you read outside your region, or "none">
 ```
 
-## Critical Rules
+If the region is clean: emit `## REGION: <name> — 0 candidates`, then the `## REGION HEALTH` block only.
 
-1. **Be thorough**: Read files systematically. Do not skim or skip apps. Use Glob to find all Python files and review them.
-2. **Be fair**: Acknowledge good decisions and intentional tradeoffs. Not everything is debt.
-3. **Be specific**: Always reference specific files, line numbers, and code snippets in findings.
-4. **Be actionable**: Every issue should come with a concrete suggestion for improvement.
-5. **Understand context**: This is a real production project with real constraints. Pragmatic advice over ivory-tower perfection.
-6. **Account for open issues**: Cross-reference your findings with GitHub issues. Don't flag something as a discovery if it's already tracked.
-7. **Score honestly**: A 10/10 codebase doesn't exist. A 7/10 is a healthy, well-maintained project. Be calibrated.
-8. **Do NOT run tests or make code changes**: This is a read-only assessment. Do not execute make commands, run tests, or modify any files except for writing the final report.
-9. **Use TodoWrite**: Track your progress through the phases using the todo system so you don't lose track of where you are in the assessment.
+### Mode B — Standalone (human-readable report)
+Produce: an **Executive Summary** (scoped posture + finding count by severity); a **Scoped Health Score (X/10)** for the area with a short justification; a **Findings** section grouped by priority (Critical / High / Medium / Low) using the same fields as a CANDIDATE block but in prose, plus an **Acknowledged** band for anything already tracked in open issues; **Positive Observations** (good patterns to replicate); a **Dead Code** list (only what you verified by grepping references); and **Top Recommendations** ordered by impact/effort. Use the severity scale below.
 
-## Scoring Calibration Guide
-- **9-10**: Exemplary. Could be used as a teaching reference. Virtually no debt.
-- **7-8**: Healthy. Well-maintained with minor, manageable debt. Good engineering culture evident.
-- **5-6**: Moderate debt. Some systemic issues but functional. Needs dedicated cleanup effort.
-- **3-4**: Significant debt. Architectural problems, inconsistency, poor test coverage. Velocity likely impacted.
-- **1-2**: Critical. Major rewrites needed. Active risk to business.
+Severity scale (both modes): **CRITICAL** (correctness/security risk or imminent forced change, e.g. a file at the line cap), **HIGH** (significant architectural/quality debt slowing change), **MEDIUM** (real maintainability cost), **LOW** (minor / style with small cost).
 
-**Update your agent memory** as you discover architectural patterns, code quality hotspots, recurring issues, codebase conventions, and areas of technical debt. This builds up institutional knowledge across assessments so you can track improvement or regression over time. Write concise notes about what you found and where.
+## Critical Reminders
 
-Examples of what to record:
-- Architectural patterns and where they're applied consistently vs inconsistently
-- Recurring code smells and which apps they appear in
-- Test coverage gaps and quality patterns
-- Areas of high complexity
-- Previous assessment scores for trend tracking
-- Known tradeoffs and their rationale
+- **Do NOT run tests, migrations, or make code changes.** This is a read-only assessment. Read-only tools (Read, Grep, Glob, read-only Bash like `git log`/`git blame`/`wc`) are fine; in Mode A the only thing you produce is your structured output.
+- **Be specific**: exact file paths, function names, line numbers, and counts.
+- **Be fair**: acknowledge good decisions and intentional tradeoffs — not everything is debt.
+- **Prioritize ruthlessly**: a god function in the checkout flow outranks a missing docstring in an admin helper.
 
-# Persistent Agent Memory
+# Persistent Agent Memory (READ-ONLY for you in Mode A)
 
-You have a Persistent Agent Memory directory at `.claude/agent-memory/tech-debt-assessor/`. Its contents persist across conversations.
+You have a project-scoped memory directory at `.claude/agent-memory/tech-debt-assessor/`. `MEMORY.md` is loaded into this prompt automatically and records **confirmed hotspots**, **stable conventions**, **known-accepted patterns/tradeoffs**, and **previous assessment scores** for trend tracking.
 
-As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
-
-Guidelines:
-- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
-- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
-- Update or remove memories that turn out to be wrong or outdated
-- Organize memory semantically by topic, not chronologically
-- Use the Write and Edit tools to update your memory files
-
-What to save:
-- Stable patterns and conventions confirmed across multiple interactions
-- Key architectural decisions, important file paths, and project structure
-- User preferences for workflow, tools, and communication style
-- Solutions to recurring problems and debugging insights
-
-What NOT to save:
-- Session-specific context (current task details, in-progress work, temporary state)
-- Information that might be incomplete — verify against project docs before writing
-- Anything that duplicates or contradicts existing CLAUDE.md instructions
-- Speculative or unverified conclusions from reading a single file
-
-Explicit user requests:
-- When the user asks you to remember something across sessions (e.g., "always use bun", "never auto-commit"), save it — no need to wait for multiple interactions
-- When the user asks to forget or stop remembering something, find and remove the relevant entries from your memory files
-- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
-
-## MEMORY.md
-
-Your MEMORY.md is currently empty. When you notice a pattern worth preserving across sessions, save it here. Anything in MEMORY.md will be included in your system prompt next time.
+- **Consult it to suppress false positives** — never re-flag a pattern it marks as known/accepted, and use prior hotspots to track whether debt is improving or worsening.
+- **Do NOT write to memory in Mode A.** Under `/tech-debt` fan-out, the **orchestrator owns all memory writes** to avoid concurrent-write conflicts; it consolidates new hotspots, conventions, and the dated score after each sweep. If you discover something memory-worthy, include it in your `## REGION HEALTH` block so the orchestrator can record it.
+- **In Mode B (standalone)** you may surface suggested memory updates to the user, but ask before writing.

--- a/.claude/agents/tech-debt-verifier.md
+++ b/.claude/agents/tech-debt-verifier.md
@@ -1,0 +1,65 @@
+---
+name: tech-debt-verifier
+description: "Adjudicates a single candidate tech-debt finding produced by the tech-debt-assessor hunter. Independently re-reads the cited code, confirms the debt is real and present-day (and for dead-code candidates, proves no references exist anywhere), and returns a verdict with a 0-100 confidence score. Dispatched in parallel (one per candidate) by the `/tech-debt` command's verification phase. Not intended for standalone use — it expects a single candidate finding as input."
+model: sonnet
+color: pink
+---
+
+You are a skeptical senior staff engineer acting as the **adjudicator** for a single candidate technical-debt finding in the **Revel** platform (Django 5.2 + Django Ninja, PostgreSQL/PostGIS, Celery, JWT, multi-tenant orgs). A hunter agent flagged this candidate; your job is to independently decide whether it is **real, present-day debt worth acting on** — or a false positive / intentional tradeoff.
+
+Your default posture is **skeptical**. Most flagged candidates that are wrong are wrong because the "debt" is actually a documented, deliberate design decision, is contradicted by the surrounding code/tests, or is a style nit with no real maintenance cost. You are the precision gate: it is better to correctly reject a false positive than to pass through noise that inflates the report.
+
+## Input
+
+The dispatching prompt contains one or more candidate findings, each with these fields: `id`, `title`, `severity`, `category`, `location`, `description`, `impact`, `recommendation`, `effort`, `hunter_confidence`. Treat the hunter's description as a **claim to be tested**, not a fact. Emit one `### VERDICT` block per `id`.
+
+## Verification Process
+
+1. **Read the cited code yourself.** Open every file/line in `location`. Re-derive what the code does from the source — do not trust the hunter's summary.
+2. **Check intent.** Read the surrounding module, related services/models, tests, and the relevant parts of `CLAUDE.md`. Is this accidental complexity, or a deliberate, documented tradeoff? Look for a `# ponytail:` ceiling marker, an ADR, or a pattern that's consistent across the app.
+3. **Confirm present-day cost.** Does this measurably slow change, raise onboarding cost, or risk correctness *today*? Quantify where you can (line count, function length, number of duplicated sites, reference count).
+4. **For `Dead Code` candidates — prove it.** Grep/`rg` the **entire** repo for the symbol, including dynamic references: `getattr`/`setattr` by string, signal receivers (`@receiver`, `Signal.connect`), URL patterns and router registration, `__init__.py` / template / templatetag re-exports, settings strings, Celery task-name strings, and admin registration. A symbol is dead only if **none** of these reference it. If you cannot fully rule out a dynamic reference, it is NOT confirmed dead.
+5. **Check the false-positive rules** (below) and `.claude/agent-memory/tech-debt-assessor/MEMORY.md` — read it. If the candidate matches a known-accepted pattern or intentional tradeoff, it is a FALSE_POSITIVE regardless of how plausible the prose sounds.
+
+## False-Positive Rules (these are FALSE_POSITIVE, not findings)
+
+- Deliberate ceilings marked with `# ponytail:` (author noted the cap + upgrade path) — unless the ceiling is actively causing pain today.
+- The **hybrid service layer** (function-based stateless + class-based request-scoped) — documented design, not inconsistency.
+- **No DI container / explicit instantiation** — intentional per `CLAUDE.md`.
+- **Defense-in-depth layering** (permission class *and* manual check) described as "duplication".
+- **`update_db_instance` saving without `update_fields`** — intentional generic utility; callers control fields.
+- Generated/by-design artifacts (e.g. compiled `.mo` files absent per ADR-0011).
+- Hypothetical/speculative debt ("a problem if the app grows 10x") and pure YAGNI-violating "add an abstraction" requests.
+- Feature requests dressed as debt: "add logging / audit trail / cache" without a demonstrated present-day problem.
+- Style nits with no measurable maintenance cost.
+
+## Confidence Rubric (score 0-100 — your confidence the candidate is REAL, present-day debt worth acting on)
+
+- **0** — Clearly not debt. Intentional, documented tradeoff; matches a known-accepted memory pattern; or purely speculative. Doesn't survive light scrutiny.
+- **25** — Possibly real, but you could not confirm present-day cost, or (for dead code) could not rule out a dynamic reference.
+- **50** — Real debt, but low practical cost or narrow scope: a localized smell, a single duplicated pair, a long-but-readable function.
+- **75** — Confirmed present-day debt with concrete maintenance cost you verified (measured complexity/duplication, proven-dead symbol), and the recommendation is sound.
+- **100** — Certain. You directly verified the debt and its cost (e.g. a file 2 lines from the 1000-line cap; a symbol with zero references anywhere).
+
+Interpolate freely (e.g. 60, 85). Anchor your number to evidence you actually read, not to the hunter's confidence.
+
+## Output Format (machine-parseable — emit ONLY these blocks, one per candidate id)
+
+```
+### VERDICT
+- id: <copy the candidate id exactly>
+- verdict: CONFIRMED | FALSE_POSITIVE | UNCERTAIN
+- confidence: <0-100>
+- severity: <confirmed or corrected: CRITICAL|HIGH|MEDIUM|LOW>
+- category: <confirmed or corrected category>
+- reasoning: <2-5 sentences citing the specific code you read (path:line) and the decisive fact: the measured cost, the documented intent, or — for dead code — the reference-search result that confirms or refutes it.>
+```
+
+Mapping: `confidence >= 75` → `CONFIRMED`; `confidence` 40-74 → `UNCERTAIN`; `confidence < 40` → `FALSE_POSITIVE`. Set `verdict` consistent with your score. If you adjust severity or category from the hunter's, say why in `reasoning`.
+
+## Hard Rules
+
+- **Read-only.** Do not run tests, migrations, or mutating commands. `Read`, `Grep`, `Glob`, and read-only `git` are allowed.
+- **Decide on evidence you gathered**, not on the persuasiveness of the candidate's prose.
+- **One candidate, one verdict.** Do not invent additional findings; if you spot an unrelated issue, mention it in one sentence at the end of `reasoning`, but still verdict the candidate you were given.
+- **Dead code demands proof, not suspicion.** When in doubt about a reference, return UNCERTAIN — never CONFIRMED.

--- a/.claude/commands/tech-debt.md
+++ b/.claude/commands/tech-debt.md
@@ -1,0 +1,208 @@
+---
+description: Multi-agent technical-debt assessment — fans out region-scoped + specialist hunters, verifies findings, scores repo health, and writes a report
+argument-hint: "[scope: full (default) | <app/path> | diff] [--fast | --deep] [--report <file>]"
+allowed-tools: Bash(git ls-files:*), Bash(git diff:*), Bash(git merge-base:*), Bash(git log:*), Bash(git rev-parse:*), Bash(gh issue list:*), Bash(grep:*), Bash(rg:*), Bash(find:*), Bash(wc:*), Bash(cloc:*), Bash(date:*)
+disable-model-invocation: true
+---
+
+You are the **orchestrator** for a multi-agent technical-debt assessment of the Revel backend. You run in the main session (you can fan out parallel sub-agents; the workers cannot). Your job is to partition the work, dispatch `tech-debt-assessor` **hunters** and `tech-debt-verifier` **verifiers**, then consolidate a precise, scored, false-positive-free report and **write it to disk by default**. Follow these phases **in order**. Make a task list first.
+
+User arguments (may be empty): **$ARGUMENTS**
+
+---
+
+## Phase 0 — Parse args, gather metrics & triage (you do this inline; no agent)
+
+**Parse `$ARGUMENTS`:**
+- **scope** (first non-flag token):
+  - empty or `full` → **full-repo sweep** (default): dispatch a hunter for every region in the map below **plus** all specialist hunters.
+  - an app or path (e.g. `accounts`, `events/service`, `src/wallet`) → **single-region**: dispatch one hunter scoped to that path (pick its model tier from the map, or by size/risk if it's a sub-path). Skip the specialists unless the path is repo-wide.
+  - `diff` → **branch-diff scope**: run `git merge-base main HEAD` then `git diff --name-only $(git merge-base main HEAD) HEAD -- src/`. Map each changed file to its region; dispatch hunters **only** for regions with changes, instructing each to focus on the changed files **plus** the dependencies they trace into. Also run the `consistency-standards` specialist if more than one region changed.
+- **flags:**
+  - `--fast` → override all hunter models to **sonnet**.
+  - `--deep` → override all hunter models to **opus**.
+  - `--report <file>` → override the default output path (see Phase 5).
+  - default (no model flag) → use the **tiered** models in the region/specialist maps.
+
+**Gather cheap deterministic metrics inline** (these need no agent — do them with the allowed read-only Bash tools, and feed the results to Phase 5 so findings already tracked aren't reported as "new"):
+- `date +%F` for the report date.
+- Production LOC & file count: e.g. `git ls-files 'src/**/*.py' | grep -v migrations | grep -v tests | wc -l` and a `cloc src` if available (else `wc -l`).
+- `grep -rEc "TODO|FIXME|HACK|XXX" src` (sum), `grep -rc "type: ignore" src`, `grep -rc "from typing import" src`, count of `# ponytail:` ceilings.
+- Migration count per app: `git ls-files 'src/*/migrations/0*.py' | sed ...` (rough per-app tally).
+- Files near the 1000-line cap: `git ls-files 'src/**/*.py' | xargs wc -l | sort -rn | head -20`.
+- Open issues for context: `gh issue list --state open --limit 100` and `gh issue list --state open --label bug --limit 50`. Catalog by category. **Cross-reference in Phase 5** — don't report a known, tracked issue as a fresh discovery.
+
+**Reconcile the region map with the live tree** (catches newly-added apps/modules):
+- Run `git ls-files 'src/*/apps.py'` to list Django apps.
+- If an app/module exists in the tree but is **not** covered by any region's globs below, create an ad-hoc region for it: globs `src/<name>/**`, default model **sonnet**, focus = full framework. Note in the final report that an unmapped module was discovered (so the map can be updated).
+
+**Region map** (code regions; `model` is the default/tiered choice, overridden by `--fast`/`--deep`). FOCUS DIMENSIONS lead the hunter's attention but it reports any egregious debt it finds:
+
+| Region | Globs | Focus dimensions | Model |
+|---|---|---|---|
+| accounts | `src/accounts/**` | Service/controller layering, auth-flow complexity, type safety, dead code, GDPR-flow duplication | sonnet |
+| events-service | `src/events/service/**` | God functions, cyclomatic/cognitive complexity hotspots, duplication, service-pattern adherence, error handling | opus |
+| events-controllers | `src/events/controllers/**` | Thin-controller adherence (business logic leaking into views), duplication across controllers, pattern consistency, permission-chain clarity | opus |
+| events-models | `src/events/models/**`, `src/events/constants/**` | Fat models, model-design quality, indexes/constraints, dead model fields, models importing services | sonnet |
+| events-schema | `src/events/schema/**` | ModelSchema conventions, enum/AwareDatetime adherence, schema duplication, re-export hygiene | sonnet |
+| events-support | `src/events/admin/**`, `src/events/utils/**`, `src/events/management/**`, `src/events/tasks/**`, `src/events/templatetags/**` | Dead code, utils sprawl, management-command quality, Celery-task hygiene | sonnet |
+| questionnaires | `src/questionnaires/**` | Complexity, LLM-eval code quality, layering, dead code | sonnet |
+| common | `src/common/**` | Utility sprawl, base-model & mixin design, dead helpers, abstraction level | sonnet |
+| notifications | `src/notifications/**` | Channel-abstraction quality, digest/preference complexity, duplication | sonnet |
+| wallet+telegram | `src/wallet/**`, `src/telegram/**` | FSM complexity, dead code, file-handling clarity | sonnet |
+| geo+polls+moderation | `src/geo/**`, `src/polls/**`, `src/moderation/**` | Layering, dead code, cross-app consistency | sonnet |
+| api+config | `src/api/**`, `src/revel/**` | Settings organization, global config sprawl, exception-handler wiring | sonnet |
+
+**Specialist map** (cross-cutting hunters; run on `full` scope, and selectively on `diff`). These read broadly but shallowly and own a single dimension across the whole tree:
+
+| Specialist | Globs / scope | Focus | Model |
+|---|---|---|---|
+| dependency-health | `pyproject.toml`, `uv.lock` | Outdated/pinned deps, unused deps, dev-vs-prod separation, dependency risk | sonnet |
+| consistency-standards | `src/**` (broad, shallow) | Pattern drift across apps, CLAUDE.md adherence, naming consistency, **evolution debt** (newer apps diverging from older patterns) | opus |
+| test-quality | `src/**/tests/**`, `tests/**`, `conftest.py` | Coverage distribution, behavior-vs-implementation testing, over-mocking, factory/fixture usage, flaky-test & test-isolation patterns | sonnet |
+| migration-debt | `src/*/migrations/**` | Migration accumulation, squash candidates, conflicting/data migrations, mutable-state-in-migration smells | sonnet |
+
+For a single-region scope that is a sub-path not listed, use globs = that path, focus = full framework, model = sonnet (or per `--deep`).
+
+Build the **dispatch plan**: a list of `(region/specialist, globs, focus dimensions, model)`. Show it to the user as a short table before dispatching.
+
+---
+
+## Phase 1 — Fan out HUNTERS (parallel, in waves)
+
+Dispatch one `tech-debt-assessor` agent per planned region/specialist using the **Agent tool** with `subagent_type: "tech-debt-assessor"` and the assigned `model`. **Cap concurrency at ~6 agents per wave** — send the first wave (largest/highest-tier regions first), wait for it, then the next, until all are done. Launch the agents in a wave as multiple tool calls in a **single message** so they run concurrently.
+
+Use this prompt template for each hunter (fill the placeholders):
+
+> **Mode A — Scoped Hunter.**
+> REGION: `<region/specialist name>`
+> GLOBS (the files you own — read these plus dependencies you must trace; for dead-code candidates you may grep wider but do not deep-read other regions): `<globs>`
+> FOCUS DIMENSIONS (lead with these, but report any egregious debt): `<focus dimensions>`
+> SCOPE NOTE: `<for diff scope: "Focus on these changed files and what they touch: <files>". For full/region scope: "Review the whole region.">`
+> OPEN ISSUES CONTEXT (do not re-report as new discoveries): `<short list of relevant open issue titles/numbers from Phase 0, or "none">`
+> Consult your MEMORY.md and do NOT re-flag confirmed/known-accepted patterns. Output structured `### CANDIDATE` blocks and a `## REGION HEALTH` block exactly as specified in your Output Format (Mode A), with an honest `hunter_confidence`. Do not run tests or mutating commands.
+
+Collect every CANDIDATE block **and** every REGION HEALTH block from every hunter. Preserve each candidate's `id` (they're region-prefixed, so unique). Keep the REGION HEALTH notes — you need them for scoring in Phase 5.
+
+---
+
+## Phase 2 — Dedup (you do this inline)
+
+Hunters and specialists overlap (a complexity hotspot may be flagged by both the region hunter and `consistency-standards`). Merge candidates that point at the **same root cause** (same code location / same smell, even if titled differently): keep the higher-severity / higher-`hunter_confidence` one, and note the merge. Do **not** merge distinct issues that merely sit in the same file.
+
+If there are **zero** candidates after dedup, skip to Phase 5 and report a clean, healthy sweep (you still compute the score and write the report).
+
+---
+
+## Phase 3 — Fan out VERIFIERS (parallel)
+
+For each surviving candidate, dispatch a `tech-debt-verifier` agent via the **Agent tool** with `subagent_type: "tech-debt-verifier"` (default model sonnet; you may use opus for CRITICAL-severity or repo-wide-impact candidates). One verifier per candidate; you may batch up to 3 closely-related candidates into a single verifier call, but ask it to emit one `### VERDICT` block per `id`. Cap concurrency at ~6 per wave.
+
+Pass each verifier the **complete candidate block verbatim** (all fields). It independently re-reads the code and returns a `### VERDICT` with `verdict`, `confidence`, `severity`, `category`, and `reasoning`. **Dead-code candidates get special rigor** — the verifier must prove no references exist anywhere (including dynamic `getattr`, signal receivers, URL patterns, template/`__init__` re-exports) before confirming.
+
+Collect all verdicts and join them back to their candidates by `id`.
+
+---
+
+## Phase 4 — Filter (category-aware threshold; you do this inline)
+
+Using the verifier's **corrected `severity`/`category`** and **`confidence`**, keep a finding only if:
+
+- **Dead Code** (any severity) → confidence **≥ 85** (false positives here are costly and embarrassing).
+- **CRITICAL or HIGH** → confidence **≥ 60**.
+- **MEDIUM** → confidence **≥ 70**.
+- **LOW** → confidence **≥ 85**.
+
+Drop everything else (and any `verdict: FALSE_POSITIVE` regardless of score). Count what you dropped — it goes in the summary as "screened out". Sort surviving findings by severity (CRITICAL→LOW), then confidence descending.
+
+---
+
+## Phase 5 — Score, report & consolidate memory
+
+**Compute the health score yourself** (hunters give per-region signals; only you have the aggregate). Use the REGION HEALTH notes + confirmed findings + Phase-0 metrics to fill the category breakdown, then derive the overall score.
+
+Scoring calibration: **9-10** exemplary, near-zero debt · **7-8** healthy, minor manageable debt · **5-6** moderate debt, needs dedicated cleanup · **3-4** significant debt, velocity impacted · **1-2** critical, rewrites needed. A 7-8 is a healthy production codebase; be calibrated and honest. If a previous score exists in memory, report the **trend** (improved / held / regressed) and why.
+
+**Write the report to disk by default.** Path: `<--report value>` if given, else `./<YYYY-MM-DD>-TECH-DEBT_REPORT.md` (date from Phase 0) at the repo root. Use the Write tool. Then also print a condensed summary in-session.
+
+Report format:
+
+```
+# Technical Debt Assessment Report
+**Date**: <YYYY-MM-DD>
+**Repository**: revel-backend
+**Version assessed**: <version> (HEAD <short-sha>)
+**Scope**: <full | path | diff> · <N> region(s) + <M> specialist(s) reviewed (<models used>)
+**Previous assessments**: <from memory, e.g. 8.2/10 (2026-06-23) · 8.0/10 (2026-05-15)>
+
+## Executive Summary
+<2-3 paragraphs: overall posture, what changed since last assessment, the single most actionable signal>
+
+## Overall Health Score: X/10
+<justify the score; state the trend vs the previous assessment>
+
+## Scoring Breakdown
+| Category | Score (1-10) | Notes |
+|----------|-------------|-------|
+| Architecture & Design | X | ... |
+| Code Consistency | X | ... |
+| Test Quality & Coverage | X | ... |
+| Type Safety | X | ... |
+| Dependency Health | X | ... |
+| Documentation | X | ... |
+| Complexity Management | X | ... |
+| Dead Code | X | ... |
+| Adherence to Project Standards | X | ... |
+| Error Handling | X | ... |
+
+## Detailed Findings
+### Critical Issues (Must Fix)
+### High Priority Tech Debt
+### Medium Priority Improvements
+### Low Priority / Nice-to-Have
+### Acknowledged (Known Issues / In Progress)   <- cross-referenced GitHub issues
+(each finding: title · category · location path:lines · description · impact · recommendation · effort (S/M/L) · confidence · verifier note. If none in a band, say so.)
+
+## Positive Observations
+<what the codebase does well — acknowledge good patterns and intentional tradeoffs>
+
+## Tradeoff Analysis
+<intentional tradeoffs and whether they're still appropriate>
+
+## Top 10 Actionable Recommendations
+<ordered by impact/effort ratio>
+
+## App-by-App Summary
+<one health line per region, from the REGION HEALTH notes>
+
+## Dead Code Catalog
+<confirmed dead code only, categorized: unused functions/methods, orphaned service fns, unused Celery tasks, commented-out blocks, unused fixtures, other — with file locations>
+
+## Coverage
+<table: region/specialist · model · candidates · confirmed · screened out>
+
+## Metrics Summary
+- Total production Python files / LOC
+- Test files
+- TODO/FIXME/HACK count · type: ignore count · from-typing-import violations · ponytail ceilings
+- Files within 50 lines of the 1000-line cap
+- Open GitHub issues: X (Y bugs, Z features, W debt)
+
+## Notes
+<unmapped modules discovered, regions skipped, anything the user should know>
+```
+
+**Then consolidate memory (you are the sole writer):**
+- Read `.claude/agent-memory/tech-debt-assessor/MEMORY.md`.
+- Propose updates to the user first, then write them in **one** edit:
+  - Replace/append the dated **assessment outcome** line (score + date + version) so trend tracking works.
+  - Add genuinely new **confirmed hotspots** (god classes, complexity, files near the cap) and **stable conventions** confirmed across regions.
+  - Add genuinely new **confirmed-clean / known-accepted patterns** surfaced by hunters so future sweeps don't re-flag them.
+- Keep `MEMORY.md` concise (it loads into every hunter's prompt; content past ~200 lines is truncated). Do not record session-specific or speculative notes.
+
+## Guardrails
+
+- **Never run tests, migrations, or mutating commands.** This assessment is static analysis only (plus the cheap read-only metrics in Phase 0). The only file you write is the report (and, after approval, memory).
+- **Precision over volume.** A short report on a healthy codebase is a success, not a failure. Do not pad findings to fill sections.
+- **Be fair.** Acknowledge good decisions and intentional tradeoffs — not everything is debt. Cross-reference open issues so tracked work isn't reported as a discovery.
+- **Respect MEMORY.md** — if a candidate matches a confirmed-clean / known-accepted pattern, it should not survive verification; if one slips through, drop it and note why.

--- a/.claude/commands/vuln-scan.md
+++ b/.claude/commands/vuln-scan.md
@@ -1,7 +1,7 @@
 ---
 description: Multi-agent security vulnerability sweep — fans out region-scoped hunters, verifies findings, and reports
 argument-hint: "[scope: full (default) | <app/path> | diff] [--fast | --deep] [--report <file>]"
-allowed-tools: Bash(git ls-files:*), Bash(git diff:*), Bash(git merge-base:*), Bash(git log:*), Bash(git rev-parse:*)
+allowed-tools: Bash(git ls-files:*), Bash(git diff:*), Bash(git merge-base:*), Bash(git log:*), Bash(git rev-parse:*), Bash(date:*)
 disable-model-invocation: true
 ---
 
@@ -21,7 +21,7 @@ User arguments (may be empty): **$ARGUMENTS**
 - **flags:**
   - `--fast` → override all hunter models to **sonnet**.
   - `--deep` → override all hunter models to **opus**.
-  - `--report <file>` → in Phase 5, also write the full report to `<file>` (markdown).
+  - `--report <file>` → override the default report path (see Phase 5).
   - default (no model flag) → use the **tiered** models in the region map.
 
 **Reconcile the region map with the live tree** (catches newly-added apps/modules):
@@ -100,7 +100,7 @@ Drop everything else (and any `verdict: FALSE_POSITIVE` regardless of score). Co
 
 ## Phase 5 — Report & consolidate memory
 
-**Report to the user** in the session (and to `--report <file>` if given) using this format:
+**Write the report to disk by default.** Path: `<--report value>` if given, else `./<YYYY-MM-DD>-VULNERABILITY_REPORT.md` (date from `date +%F`) at the repo root. Use the Write tool. **Then also print a condensed summary in-session**, using this format (the on-disk file uses the same format in full):
 
 ```
 # Security sweep — <scope> — <date>

--- a/README.md
+++ b/README.md
@@ -189,10 +189,12 @@ The project uses multiple Docker Compose files for different purposes:
 
 | File | Purpose | Usage |
 |------|---------|-------|
-| `compose.yaml` | **Local development** - includes Mailpit for email testing | `docker compose up -d` |
-| `docker-compose-ci.yml` | **CI/CD pipeline** - minimal services for testing | `docker compose -f docker-compose-ci.yml up -d` |
-| `docker-compose-base.yml` | **Shared services** - extended by other compose files | Not used directly |
-| `docker-compose-observability.yml` | **Full stack with observability** - standalone (includes core services + Grafana, Prometheus, Loki, etc.) | Alternative to `compose.yaml` |
+| `compose.yaml` | **Local development** — PostgreSQL, Redis, ClamAV + Mailpit (email testing) | `docker compose up -d` |
+| `docker-compose-ci.yml` | **CI** — minimal services for tests (PostgreSQL, Redis, ClamAV, no Mailpit) | `docker compose -f docker-compose-ci.yml up -d` |
+| `docker-compose-base.yml` | **Service definitions** — every service the other files extend (core + observability stack); not run directly | — |
+| `docker-compose-observability.yml` | **Standalone** — core services + the full observability stack (Grafana, Prometheus, Loki, Tempo, …). Replaces `compose.yaml`; does **not** include Mailpit | `docker compose -f docker-compose-observability.yml up -d` |
+
+The application itself (Django + Celery) runs on the host via `make run` — Docker only provides the backing services. For production (app, frontend, reverse proxy, TLS) use the [infra](https://github.com/letsrevel/infra) repo.
 
 For local development, simply run:
 ```bash
@@ -217,18 +219,18 @@ Revel includes a comprehensive observability stack built on the LGTM (Loki, Graf
 
 ### Available Services
 
-The observability stack requires a separate Docker Compose file. After `make setup`, only the core services (PostgreSQL, Redis, ClamAV, Mailpit) are running. To enable full observability:
+The observability stack lives in a separate Docker Compose file. After `make setup`, only the core services (PostgreSQL, Redis, ClamAV, Mailpit) are running. To enable full observability:
 
 ```bash
+docker compose down                                          # stop compose.yaml first
 docker compose -f docker-compose-observability.yml up -d
 ```
 
 !!! note
-    `docker-compose-observability.yml` is a **standalone** compose file that includes both core services and the observability stack. Do not run it alongside `compose.yaml`.
+    `docker-compose-observability.yml` is **standalone**: it bundles the core services *and* the observability stack, so it **replaces** `compose.yaml` (same container names — don't run both). Note it does **not** include Mailpit, so email testing is unavailable while it's running.
 
 | Service | Purpose | URL | Credentials |
 |---------|---------|-----|-------------|
-| **Mailpit** | Email testing - catches all outgoing emails | [http://localhost:8025](http://localhost:8025) | - |
 | **Grafana** | Unified dashboard for logs, traces, and metrics | [http://localhost:3000](http://localhost:3000) | admin / admin |
 | **Prometheus** | Metrics collection and querying | [http://localhost:9090](http://localhost:9090) | - |
 | **Loki** | Log aggregation | [http://localhost:3100](http://localhost:3100) | - |

--- a/USER_JOURNEYS.md
+++ b/USER_JOURNEYS.md
@@ -2,7 +2,7 @@
 
 This document maps every user journey through the Revel platform, organized by persona. Its purpose is to serve as the source of truth for Playwright E2E test cases on the frontend. Each journey describes the **what** and **why** from the user's perspective — the exact UI steps and assertions will live in the test suite.
 
-> **Last updated**: 2026-04-01 (v1.47.0)
+> **Last updated**: 2026-06-23 (v1.65.0)
 
 ---
 
@@ -27,11 +27,14 @@ This document maps every user journey through the Revel platform, organized by p
 - [Journey 15: Notifications & Communication](#journey-15-notifications--communication)
 - [Journey 16: Billing, Payments & VAT](#journey-16-billing-payments--vat)
 - [Journey 17: Account Lifecycle (Security, GDPR, Deletion)](#journey-17-account-lifecycle-security-gdpr-deletion)
-- [Journey 18: Event Series & Following](#journey-18-event-series--following)
+- [Journey 18: Event Series, Recurring Events & Following](#journey-18-event-series-recurring-events--following)
 - [Journey 19: Venue & Seating](#journey-19-venue--seating)
 - [Journey 20: Discount Codes](#journey-20-discount-codes)
 - [Journey 21: Referral Program](#journey-21-referral-program)
 - [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing)
+- [Journey 23: Membership Subscriptions](#journey-23-membership-subscriptions)
+- [Journey 24: Polls](#journey-24-polls)
+- [Journey 25: Revenue & VAT Reporting](#journey-25-revenue--vat-reporting)
 - [Cross-Cutting Concerns](#cross-cutting-concerns)
 - [Gap-Fill Interview Questions](#gap-fill-interview-questions)
 
@@ -43,13 +46,15 @@ Revel is a privacy-focused, community-first event management and ticketing platf
 
 **Core differentiators** (inferred — to be validated):
 - Privacy-first: no tracking, minimal data collection, GDPR-native
-- Self-hostable: organizations own their data and infrastructure
+- Self-hostable: organizations own their data and infrastructure; single-org instances run without ClamAV, Telegram, or the full geo dataset, tailored via feature flags
 - Questionnaire-based access control: events can screen attendees via questionnaires
-- Flexible attendance models: free RSVP, ticketed (fixed, PWYC, offline), invitation-only, members only
-- Community features: potluck coordination, dietary tracking, membership tiers
+- Flexible attendance models: free RSVP, ticketed (fixed, PWYC, offline, at-the-door), invitation-only, members only
+- Recurring events: first-class recurring series with rolling-window materialization (each occurrence is a real, independent event)
+- Community features: potluck coordination, dietary tracking, membership tiers, recurring membership subscriptions, organization-managed polls
 - Blacklist/whitelist system with fuzzy name matching for safer spaces
-- Multi-channel notifications: in-app, email, Telegram
-- Internationalized: English, German, Italian
+- Organizer financial tooling: VAT-precise revenue reporting, attendee invoicing, referral payouts
+- Multi-channel notifications: in-app, email, Telegram (immediate transactional emails + grouped digests)
+- Internationalized: English, German, Italian, French
 
 ---
 
@@ -65,8 +70,9 @@ Revel is a privacy-focused, community-first event management and ticketing platf
 | **Guest Attendee** | Attends event without account (guest checkout / guest RSVP) | Not logged in |
 | **Organization Owner** | Created the org, has all permissions implicitly | Fully authenticated |
 | **Organization Staff** | Assigned staff role with granular JSON-based permissions | Fully authenticated |
-| **Waitlisted User** | Joined waitlist for a full event | Fully authenticated |
+| **Waitlisted User** | Joined waitlist for a full event; may hold a time-limited waitlist offer | Fully authenticated |
 | **Referrer** | Has a referral code and earns payouts from referred users' ticket purchases | Fully authenticated |
+| **Subscriber** | Member with an active (currently OFFLINE) recurring membership subscription tied to a plan/tier | Fully authenticated |
 
 ---
 
@@ -111,7 +117,19 @@ Revel is a privacy-focused, community-first event management and ticketing platf
 
 ### 1.7 Marketing Pages
 - Visit various marketing pages (`/community-first-event-platform`, etc.)
-- Localized variants exist for de/it
+- Localized variants exist for de/it/fr
+
+### 1.8 Contact an Organization
+- Org has `contact_method` set to `email` or `form` (with a verified contact email)
+- `none` → no contact UI shown; `email` → org's verified address is exposed on the public org schema
+- Submit a message via the public contact form (`POST /organizations/{slug}/contact`)
+  - Requires a verified-email account; throttled
+  - Delivered as a single transactional email to the org's mailbox (`Reply-To: <sender>`)
+  - Org staff with `edit_organization` also receive an in-platform `ORG_CONTACT_MESSAGE_RECEIVED` notification
+
+### 1.9 Feature-Flag-Aware UI
+- `GET /version` (anonymous) returns a `features` object: `organization_creation`, `telegram`, `google_sso`, `llm_evaluation`
+- Frontend hides gated UI (e.g. Google SSO button, "Create organization" CTA, Telegram linking) instead of letting users hit a 403/404
 
 ---
 
@@ -157,12 +175,13 @@ Revel is a privacy-focused, community-first event management and ticketing platf
 - Navigate to `/dashboard`
 - See: personalized greeting, quick actions (create event, create org)
 - See: empty state for events/invitations (if no activity yet)
-- Filter events by: owner, staff, member, RSVP, ticketed, invited, subscribed
+- Filter events by: owner, staff, member, RSVP, ticketed, invited, subscribed, **bookmarked**
+- Bookmarked **unlisted** events surface in the `bookmarked` facet even though they stay hidden from discovery
 
 ### 3.2 Profile Management
 - Navigate to `/account/profile`
 - Edit: first name, last name, preferred name, pronouns
-- Edit: language preference (en/de/it)
+- Edit: language preference (en/de/it/fr)
 - Edit: bio (Markdown)
 - Upload/change profile picture
 - View email and verification status
@@ -219,6 +238,18 @@ Revel is a privacy-focused, community-first event management and ticketing platf
 - Submit optional message
 - Wait for approval → notification when approved/rejected
 
+### 3.11 Bookmark Events
+- Click the bookmark icon on an event (list or detail)
+- `POST /api/events/{event_id}/bookmark` → `201` for a new bookmark, `200` if it already existed
+- `is_bookmarked` reflected on event list/detail responses
+- Unbookmark (`DELETE`) is idempotent and works even for events you can no longer see
+- Bookmarks are private — they do not sign you up or affect eligibility
+- Find bookmarked events via the `bookmarked` facet on `/dashboard/events`
+
+### 3.12 View Memberships & Subscriptions
+- `GET /me/memberships` — unified, paginated list of every org membership for the user, inlining the most recent non-terminal subscription per org when one exists
+- See [Journey 23: Membership Subscriptions](#journey-23-membership-subscriptions) for the subscriber flow
+
 ---
 
 ## Journey 4: Organization Member
@@ -242,6 +273,7 @@ Multiple paths:
 - Certain ticket tiers restricted to specific membership tiers
 - Announcements can target specific tiers
 - Tier assignment set by staff on approval or later
+- A tier can be backed by a recurring **membership subscription** (currently OFFLINE) — see [Journey 23](#journey-23-membership-subscriptions)
 
 ### 4.4 Membership Status Changes
 - ACTIVE → PAUSED (by staff): limited access
@@ -271,6 +303,8 @@ User sees one of:
 - "Join waitlist" button (if at capacity and waitlist_open)
 - Error explaining why they can't attend
 
+`EventUserEligibility` carries a stable, machine-readable `reason_code` (`ReasonCode` enum) alongside the human-readable `reason` string — clients should branch on `reason_code`, not on localized prose.
+
 ### 5.3 RSVP
 - Click YES → RSVP confirmed, attendee_count incremented
 - Click MAYBE → recorded but doesn't count toward capacity
@@ -295,6 +329,15 @@ If event at capacity and waitlist_open:
 ### 5.6 Leave Waitlist
 - Click "Leave Waitlist"
 - Removed from waitlist
+
+### 5.7 Receive a Waitlist Offer (Advanced Waitlist)
+When the event opts in via `waitlist_time_window`:
+- Capacity opening triggers a **batch** of offers (FIFO or lottery, per `waitlist_lottery_mode`), sized by `waitlist_batch_size`
+- The offered spot is **reserved** for the duration of the window — non-waitlist users can't take it
+- User receives an offer notification with an expiry deadline (`WaitlistOffer`)
+- Accept before expiry → proceed with RSVP/ticket flow
+- Let it expire → spot released to the next batch; the user stays eligible for future batches
+- `waitlist_cutoff_date` / `waitlist_cutoff_window` stop new offers close to the event
 
 ---
 
@@ -369,6 +412,18 @@ Depends on tier's seat_assignment_mode:
 - Code validated: active, within dates, not exceeded max_uses, applicable to tier/event
 - Discount applied: percentage or fixed amount off
 
+### 6.12 Cancel Ticket & Refund (Self-Service)
+Opt-in per tier via `allow_user_cancellation`, `cancellation_deadline_hours`, and `refund_policy`:
+- Buyers see the cancellation terms **before purchase** — `TicketTierSchema` exposes `allow_user_cancellation`, `cancellation_deadline_hours`, and `refund_policy` (tiered % by hours-before-event + flat fee)
+- The active policy is snapshotted onto the ticket at purchase time (`refund_policy_snapshot`), so later policy changes never retroactively affect issued tickets
+- **Preview**: `GET /events/tickets/{id}/cancellation-preview` returns the policy windows + a live refund quote for this ticket
+- **Cancel**: `POST /events/tickets/{id}/cancel` works for free, offline, at-the-door, and online (Stripe) tickets
+  - Online tickets trigger a Stripe refund (per-`Payment`, partial-amount aware)
+  - Blocked cases return `409 CancellationBlockedErrorSchema` with a stable `code` (already cancelled, checked-in, event started, past deadline, etc.)
+- Cancelling an already-cancelled ticket returns **409**
+- Receive a `TICKET_CANCELLED` / `TICKET_REFUNDED` notification (immediate transactional email); copy branches on `cancellation_source` (user-initiated / organizer / stripe_dashboard)
+- Refund notifications report the actual `refund_amount` (partial-refund accurate), not the full ticket price
+
 ---
 
 ## Journey 7: Guest Attendee (No Account)
@@ -403,6 +458,8 @@ Depends on tier's seat_assignment_mode:
 - Fill required fields (name, contact email, city)
 - Auto-become owner with all permissions
 - Contact email auto-verified if matches user's verified email
+- Name is rejected if it slugifies to a **reserved slug token** — a hardcoded platform set (`admin`, `api`, `www`, `revel`, …) plus a DB-managed `ReservedSlugToken` soft list (`demo`, `test`, …); message localized in en/de/it
+- On single-org / self-hosted instances, `FEATURE_ORGANIZATION_CREATION=off` returns `403` for non-staff (staff/superusers bypass)
 
 ### 8.2 Organization Settings
 - Navigate to `/org/[slug]/admin/settings`
@@ -410,6 +467,10 @@ Depends on tier's seat_assignment_mode:
 - Upload: logo, cover art
 - Set visibility: PUBLIC, UNLISTED, PRIVATE, MEMBERS_ONLY
 - Toggle: accept_membership_requests
+- Set `contact_method`: `none` / `email` / `form` (both `email` and `form` require a verified `contact_email`)
+  - Changing `contact_email` to a new (unverified) address auto-forces `contact_method=none`
+- Set `revenue_report_cadence`: `NONE` / `QUARTERLY` / `MONTHLY` (**owner-only** — non-owners get a `403`; see [Journey 25](#journey-25-revenue--vat-reporting))
+- Set membership-subscription policy: `membership_grace_period_days` (default 7), `membership_refund_policy`
 
 ### 8.3 Stripe Connect Setup
 - Navigate to billing settings
@@ -424,6 +485,7 @@ Depends on tier's seat_assignment_mode:
 - Configure billing address and email
 - Set VAT rate
 - View platform fee invoices
+- Access live financials and downloadable revenue & VAT reports (see [Journey 25](#journey-25-revenue--vat-reporting))
 
 ### 8.5 Staff Management
 - Navigate to `/org/[slug]/admin/members` → Staff tab
@@ -437,9 +499,12 @@ Depends on tier's seat_assignment_mode:
   - edit_organization, manage_members
   - manage_potluck
   - create/edit/delete/evaluate_questionnaire
+  - manage_polls
+  - manage_subscriptions
   - send_announcements
 - Set per-event permission overrides
 - Remove staff
+- Sales-specific permissions are also configurable from the admin panel
 
 ### 8.6 Member Management
 - View members list with search/pagination
@@ -516,14 +581,16 @@ Same as owner event management but filtered by permissions.
   - RSVP before deadline
   - Max attendees
   - Max tickets per user
-  - Waitlist open: yes/no
+  - Waitlist open: yes/no (+ advanced waitlist window/batch/lottery/cutoff config — see [Journey 5.7](#57-receive-a-waitlist-offer-advanced-waitlist))
   - Potluck open: yes/no
+  - Open-ended: `is_open_ended` — mark an event with no fixed end. `end` is still set (defaults to start + 24h) and used internally for ICS/Wallet/upcoming gates; the flag is a display signal (render "Ongoing", hide the end time)
   - Address visibility rules
   - Check-in window (starts_at, ends_at)
   - Invitation message (default message for invitations)
 - Link to: venue, event series
 - Upload: logo, cover art
 - Add tags
+- Authoring also exposes: resolved IANA `timezone` (UTC fallback) on list/detail; event `schedule` / timeline (see [10.14](#1014-event-schedule--timeline))
 
 ### 10.2 Event Lifecycle
 ```
@@ -535,6 +602,7 @@ DRAFT → OPEN → CLOSED
 - **OPEN**: Visible per event_type rules. Accepts RSVPs/tickets.
 - **CLOSED**: No new RSVPs/tickets. Event still visible.
 - **CANCELLED**: Event cancelled. Notifications sent.
+- **Cancellation reason** (optional, ≤1000 chars): accepted on `POST /actions/update-status/{status}` only when transitioning to `cancelled`; auto-cleared on un-cancel. Included in the `EVENT_CANCELLED` notification and returned on event list/detail — but readable only by **attendees** (ticket holders, confirmed YES RSVPs, staff/owners); merely-invited or anonymous users receive `null`.
 
 ### 10.3 Edit Event
 - All fields editable while in DRAFT
@@ -561,12 +629,13 @@ DRAFT → OPEN → CLOSED
 - Reorder tiers (display_order)
 
 ### 10.5 Manage Tickets
-- View all tickets with status, search, filters
+- View all tickets with status, search, filters; list is **sortable**
+- Each ticket row shows the **discount code** applied (if any)
 - Create tickets manually (on behalf of users)
 - Update ticket status
 - Bulk update tickets
 - Check in tickets (mark CHECKED_IN)
-- Cancel tickets
+- Cancel / mark-refunded tickets — admin actions record `cancelled_at`, `cancelled_by`, `cancellation_source=ORGANIZER`, optional reason, and (on refund) `refund_amount` / `refund_status` / `refunded_at`
 - View payment details
 
 ### 10.6 Manage RSVPs
@@ -604,6 +673,10 @@ DRAFT → OPEN → CLOSED
 - View waitlist entries
 - Remove users from waitlist
 - Waitlist auto-processed when capacity increases or cancellations occur
+- **Advanced waitlist offers** (when `waitlist_time_window` configured): batched, time-limited offers (FIFO or lottery), reserved spots during the window
+  - Admin offer-management endpoints: manually create / reactivate / revoke offers; `WaitlistOfferSchema.user` is a nested `MinimalRevelUserSchema` (no follow-up lookup)
+  - Manual create / reactivate accept a payload `expires_at` even when no global window is set; they only 400 when neither event nor payload defines an expiry
+  - Revoked offers are excluded from auto-reoffering (soft-skip until reactivated); expired users stay eligible for future batches
 
 ### 10.11 Announcements
 - Create draft announcement
@@ -611,6 +684,9 @@ DRAFT → OPEN → CLOSED
 - Preview recipient count before sending
 - Send → notification dispatched to all targets
 - Past visibility flag: controls if announcement visible after event
+- **Schedule** a send for a future absolute time, or relative to event start/end (auto-shifts when the event moves) — adds a `SCHEDULED` status with `/schedule` and `/unschedule` endpoints; delivered by a background sweep
+- **Resend to new sign-ups**: re-deliver an event announcement to attendees who join after the first send, until the event ends, without double-notifying
+- Public announcement schema carries an `audience` descriptor
 
 ### 10.12 Event Resources
 - Attach files, links, or text to event
@@ -621,6 +697,16 @@ DRAFT → OPEN → CLOSED
 - Dietary summary (aggregated restrictions/preferences)
 - Pronoun distribution (visible to non-staff only when `public_pronoun_distribution=True`)
 - Ticket sales by tier
+
+### 10.14 Event Schedule / Timeline
+- Author an ordered list of display-only sessions via `PUT /event-admin/{event_id}/schedule`
+- Each session: title, markdown description, relative start offset, optional duration/location, `is_required` badge
+- Exposed on the public event detail; copied verbatim on event duplication and recurring-series materialization
+
+### 10.15 Event Revenue (per event)
+- `GET /event-admin/{event_id}/tickets/revenue` returns `EventFinancialsSchema`: `sold_count` (incl. later refunded/cancelled), `refunds`, `refunded_count`, and VAT detail (`net_taxable`, `vat`, `rate_buckets`)
+- Tracks both online (Stripe) and offline/at-the-door ticket refunds
+- Org-wide financials live in [Journey 25](#journey-25-revenue--vat-reporting)
 
 ---
 
@@ -659,8 +745,10 @@ DRAFT → OPEN → CLOSED
 - Navigate to `/events/[org_slug]/[event_slug]/questionnaire/[id]`
 - Answer all required questions
 - Conditional questions appear/disappear based on selections
-- Upload files if required (ClamAV scanned)
+- Upload files if required (ClamAV scanned, unless `FEATURE_MALWARE_SCAN` is off)
+- Question/section shuffling is **stable per viewer** across reloads (varies between users), not re-randomized on every load
 - Submit
+- Single-answer questions (`allow_multiple_answers=False`) reject submissions with more than one selected option — enforced at the service layer, closing an admission-gate bypass that `bulk_create` previously skipped
 
 ### 11.4 Automatic Evaluation
 - Celery task picks up submission
@@ -686,6 +774,15 @@ DRAFT → OPEN → CLOSED
 
 ### 11.7 Export Submissions
 - Organizer exports all submissions (for offline review, record-keeping)
+- Submissions expose `requires_evaluation` so the UI can distinguish auto-scored from review-pending
+
+### 11.8 Duplicate Questionnaire
+- `POST /api/questionnaires/{org_questionnaire_id}/duplicate` deep-copies sections, questions, options, and intra-questionnaire dependencies into a new **DRAFT** in the same org (requires `create_questionnaire`)
+- Pass `copy_associations: true` to also link the copy to the template's events/series (unattached by default)
+- Votes, submissions, answers, evaluations, and uploaded files are never copied
+
+### 11.9 Access Control (Answer Key)
+- `GET /api/questionnaires/{id}` and the list endpoint require **org admin** permission — the full answer key (`is_correct`, weights, `min_score`, `reviewer_notes`, `llm_guidelines`) is no longer readable by arbitrary authenticated users
 
 ---
 
@@ -767,6 +864,17 @@ DRAFT → OPEN → CLOSED
 - Active organization members bypass fuzzy blacklist matching
 - Only hard blacklist (with FK) blocks members
 
+### 13.6 Unban Behavior
+- Removing a blacklist entry clears the stale `BANNED` `OrganizationMember` row the ban created
+- Membership transitions to `CANCELLED` (not `ACTIVE` — avoids implicitly re-granting prior privileges); the org and its events become visible again
+- If another blacklist entry still covers the user in the org, `BANNED` is preserved
+- Hard-blacklisted users can no longer reclaim a staff-granting org invitation token to regain access
+
+### 13.7 Content Moderation (Platform / Staff)
+- Offensive **food-item names** are blocked at creation across all languages (new `moderation` app)
+- Staff can delete offensive food items via the admin
+- Quarantined (malware-flagged) uploads are stored behind the protected, signed-URL media path — never publicly downloadable; staff retrieve them via a signed admin link
+
 ---
 
 ## Journey 14: Potluck Coordination
@@ -804,19 +912,25 @@ FOOD, MAIN_COURSE, SIDE_DISH, DESSERT, DRINK, ALCOHOL, NON_ALCOHOLIC, SUPPLIES, 
 ### 15.1 Notification Channels
 - **In-app**: Bell icon with unread count, notification list
 - **Email**: Immediate or digest (hourly, daily, weekly)
-- **Telegram**: Via connected Telegram account
+  - **Transactional emails always deliver immediately**, bypassing the digest: `PAYMENT_CONFIRMATION`, `TICKET_CREATED`, `TICKET_CANCELLED`, `TICKET_REFUNDED`
+  - **Digest** is grouped by human-readable type label; each item carries a body, timestamp, and a "View details" link, styled to match the transactional emails
+- **Telegram**: Via connected Telegram account (unavailable when `FEATURE_TELEGRAM` is off — linking endpoints 404)
+- All event times in notifications/emails render in the **event's own timezone**
 
 ### 15.2 Notification Types (non-exhaustive)
-- Account: registration welcome, email verified, password reset
-- Events: created, opened, closed, cancelled, reminder
-- Tickets: created, purchased, cancelled, refunded, checked in
+- Account: registration welcome, email verified, email change in-flight/completed, password reset
+- Events: created, opened, closed, cancelled (with reason for attendees), reminder, series events generated
+- Tickets: created, purchased, cancelled, refunded (note: on-check-in `TICKET_CHECKED_IN` is **no longer sent** — the holder is already there)
 - Invitations: sent, accepted, pending conversion
 - Memberships: granted, request created/approved/rejected
+- Subscriptions: payment recorded, lifecycle changes (cancel/pause/resume), expiry/past-due
 - Questionnaires: submitted, evaluation complete
+- Polls: (organization-managed; see [Journey 24](#journey-24-polls))
 - RSVPs: confirmed
 - Potluck: item claimed/unclaimed
 - Whitelist: request created/approved/rejected
-- Announcements: new announcement
+- Announcements: new announcement (immediate, scheduled, or resent to new sign-ups)
+- Organization: contact message received (`ORG_CONTACT_MESSAGE_RECEIVED` — Telegram body omits subject/preview since chats aren't E2E-encrypted)
 
 ### 15.3 Notification Preferences
 - Silence all notifications (global toggle)
@@ -889,6 +1003,14 @@ FOOD, MAIN_COURSE, SIDE_DISH, DESSERT, DRINK, ALCOHOL, NON_ALCOHOLIC, SUPPLIES, 
 ### 16.6 Attendee Invoicing
 See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the full flow.
 
+### 16.7 Revenue & VAT Reporting
+See [Journey 25: Revenue & VAT Reporting](#journey-25-revenue--vat-reporting) for live financials, downloadable reports, and scheduled delivery.
+
+### 16.8 Stripe Webhook Reliability (Behind the Scenes)
+- Multiple rotating signing secrets (`STRIPE_WEBHOOK_SECRETS`); invalid signatures fail closed with `403`
+- DB-level idempotency (`StripeWebhookEvent` log) so redeliveries replay task dispatches instead of being dropped or double-processed
+- Stripe API version pinned for predictable behaviour; `provision_stripe_webhooks` management command for setup
+
 ---
 
 ## Journey 17: Account Lifecycle (Security, GDPR, Deletion)
@@ -922,13 +1044,20 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 - System tracks: last_reminder_sent_at, final_warning_sent_at, deactivation_email_sent_at
 - Unverified users receive escalating reminders
 
+### 17.6 Self-Served Email Change
+- `POST /account/email-change-request` — requires the current password; sends a single-use confirmation link to the **new** address (proof of control)
+- `POST /account/email-change-confirm` — swaps `email` + `username`, **blacklists every outstanding JWT** for the user, and returns a fresh token pair so the confirming device stays signed in
+- Both addresses receive completion emails; the old address also gets an in-flight notice with a masked rendering of the new address
+- Rejected with clear `400`s for Google-SSO accounts and same-email / already-taken targets; globally-banned targets silently no-op
+
 ---
 
-## Journey 18: Event Series & Following
+## Journey 18: Event Series, Recurring Events & Following
 
 ### 18.1 View Event Series
 - Browse series at `/events/[org_slug]/series/[series_slug]`
 - See: series info, list of events, shared branding
+- `is_recurring` exposed on series list/retrieve schemas
 
 ### 18.2 Follow Event Series
 - Click "Follow" on series page
@@ -941,6 +1070,23 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 - User completes once → valid for all events in series
 - Unless per_event=True (then must complete per event)
 - max_submission_age can expire old submissions
+
+### 18.4 Recurring Events (Organizer)
+First-class recurring series with rolling-window materialization:
+- Define a `RecurrenceRule` (frequency, interval, weekdays, monthly params, boundaries) → emits an RFC 5545 `RRULE`
+- Series config: `template_event`, `recurrence_rule`, `exdates`, `auto_publish`, `generation_window_weeks`
+- Each occurrence is a **real materialized `Event`** (independent tickets, payments, capacity) duplicated from the template; safe template edits propagate via a `PROPAGATABLE_FIELDS` whitelist
+- A daily Celery beat task drives rolling-window generation
+- 7 admin endpoints: create recurring series, edit template with propagation, update recurrence, cancel occurrence, manual generate, pause/resume
+- `GET /organization-admin/{slug}/event-series/{series_id}` returns the full `EventSeriesRecurrenceDetailSchema`
+- `GET .../template-event` returns the template's `EventDetailSchema` (the public detail route filters templates out by design)
+
+### 18.5 Cadence-Drift Detection
+- `GET /organization-admin/{slug}/event-series/{series_id}/drift` returns the IDs of future occurrences that no longer match the current `RRULE` after a cadence change (excludes manually-modified and cancelled occurrences)
+
+### 18.6 Series Notifications
+- A single digest `SERIES_EVENTS_GENERATED` notification per generated batch (not one per occurrence)
+- Series-followed (staff) and series-events-generated (follower) notifications link to the public `/events/[org_slug]/series/[series_slug]` route
 
 ---
 
@@ -978,6 +1124,8 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 - Limits: max uses total, max uses per user, min purchase amount
 - Validity: start date, end date
 - Activate/deactivate
+- Creating a code with a **duplicate code** returns a clear `409` (was an opaque 500)
+- `currency` is validated against the supported `Currencies` whitelist on both create and update
 
 ### 20.2 Apply Discount Code (Attendee)
 - During ticket checkout
@@ -987,6 +1135,10 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 ### 20.3 Track Usage (Organizer)
 - View usage count per code
 - See which users used which codes
+
+### 20.4 Delete vs Deactivate
+- Deleting a code that has **never been used** hard-deletes it
+- Deleting a code that **has been used** deactivates it instead, preserving usage history
 
 ---
 
@@ -1029,6 +1181,10 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 - Navigate to `/account/referral/payouts`
 - See all payouts: period, amount, status (CALCULATED, PAID, FAILED, ROLLED_OVER)
 - Download statement PDFs for issued payouts
+
+### 21.7 Manual Referral Recording (Platform Admin)
+- Referral admin supports full create / edit / delete, so staff can manually record a referral win when the referred user never used the referrer's link
+- `referrer` stays auto-derived from the referral code; double-referrals and referrals that already have payouts remain protected
 
 ---
 
@@ -1081,11 +1237,95 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 
 ---
 
+## Journey 23: Membership Subscriptions
+
+> **Phase 1 — OFFLINE only.** Subscriptions are currently staff-managed (recorded payments), not self-served Stripe billing. Online/auto-renew is future work.
+
+### 23.1 Configure Subscription Plans (Organizer)
+- Requires the `manage_subscriptions` permission (owner ✓, staff ✓ by default, member ✗)
+- Create plans per membership tier: `MembershipSubscriptionPlan` CRUD scoped to a tier
+- Org-level policy: `membership_grace_period_days` (default 7), `membership_refund_policy`
+- `GET /organization-admin/{slug}/plans` lists every plan across the org (optional `is_active` filter); `tier_name` resolved on `PlanSchema` so UIs render the plan→tier link without a join
+
+### 23.2 Create & Manage a Subscription (Organizer)
+- Staff endpoints: subscription create / list / get
+- Lifecycle: cancel / pause / resume
+- Record a payment (`MembershipPayment`); record-only refund
+- `occurred_at` lets staff backfill OFFLINE payments with the real payment date — it anchors `period_start` / `period_end` math when set
+- `GET /organization-admin/{slug}/subscriptions/{sub_id}/payments` — paginated payment history (newest first)
+- A partial-unique constraint enforces at most one non-terminal subscription per `(user, org)`
+
+### 23.3 Membership Sync (Behind the Scenes)
+- A `post_save` signal syncs `OrganizationMember.status + tier` from the subscription
+- It never **creates** members and never touches a `BANNED` member
+- Daily Celery beat `events.expire_subscriptions_past_grace` transitions `ACTIVE → PAST_DUE → EXPIRED` once past the org's grace period
+
+### 23.4 Member View
+- `GET /me/membership-subscriptions` — the caller's subscriptions
+- `GET /me/organizations/{org_id}/subscription` — the caller's subscription for one org
+- `GET /me/memberships` — unified memberships list, inlining the most recent non-terminal subscription per org
+- `MySubscriptionSchema` resolves `organization_name`, `organization_slug`, `organization_logo_url` so dashboards render a card without N+1 org lookups
+
+---
+
+## Journey 24: Polls
+
+> Organization-managed polls, built on the questionnaire pipeline. A `Poll` is 1:1 with a `Questionnaire`; votes are stored as `QuestionnaireSubmission` rows.
+
+### 24.1 Create & Manage a Poll (Organizer)
+- Requires the `manage_polls` permission (JSONField-backed, no migration)
+- `/api/polls/` endpoint group: list, detail, results, create, patch, open, close, reopen, delete
+- Configure: audience/visibility (PUBLIC / UNLISTED / …), lifecycle (open/close timestamps), anonymity (`staff_anonymous`, `public_anonymous`), result visibility/timing, vote-change policy, membership-tier restrictions
+- Lifecycle is row-locked to serialize close-vs-vote races; a `polls.close_polls_due` beat task auto-closes due polls
+
+### 24.2 Duplicate a Poll
+- `POST /api/polls/{poll_id}/duplicate` clones a poll and its wrapped questionnaire into a new **DRAFT** poll
+- Copies visibility, result timing, anonymity, vote-change policy, and tier restrictions while resetting the lifecycle (status + open/close timestamps)
+- `staff_anonymous` / `public_anonymous` — normally immutable after creation — may be overridden on the copy
+- Votes, submissions, answers, evaluations, and uploaded files are never copied
+
+### 24.3 Vote (Member / Eligible User)
+- `POST` vote and `POST` withdraw on `/api/polls/...`
+- Vote-change policy controls whether a cast vote can be changed
+- A DRAFT poll's detail endpoint never leaks unpublished questions/options to non-staff (even with the UUID) — hidden until published
+
+### 24.4 View Results
+- `GET /api/polls/{id}/results` — visibility and timing governed by the poll's result settings and anonymity flags
+
+---
+
+## Journey 25: Revenue & VAT Reporting
+
+> A VAT-precise financial-reporting suite for organizers, all driven by one tax engine so every view reconciles. Aggregates online (Stripe) and offline/at-the-door payments per currency and per VAT rate; refunds attributed to the period they occurred.
+
+### 25.1 Live Org Financials
+- `GET /organization-admin/{slug}/revenue` — per-event revenue
+  - Sortable (`sort=revenue|event_start`)
+  - Period-filtered (`year` + optional `month` / `quarter`)
+  - Currency switching (`available_currencies`, `?currency=`)
+
+### 25.2 Downloadable Revenue & VAT Report
+- `POST /organization-admin/{slug}/revenue-report` kicks off generation; poll via `GET /organization-admin/{slug}/revenue-reports/{id}`
+- Output is a **ZIP** bundling:
+  - an **XLSX** (Summary + Transactions sheets)
+  - a **PDF** (per-VAT-rate table, refunds, net taxable turnover)
+- Cached and reused unless `?refresh=true`
+
+### 25.3 Scheduled Delivery
+- Org-level `revenue_report_cadence`: `NONE` / `QUARTERLY` / `MONTHLY` (**owner-only** to change — see [Journey 8.2](#82-organization-settings))
+- Emails the just-closed period's report ZIP to the org `billing_email` and owner
+- Computed in the org's timezone; empty periods are skipped
+
+### 25.4 Per-Event Revenue
+- `GET /event-admin/{event_id}/tickets/revenue` → `EventFinancialsSchema` (see [Journey 10.15](#1015-event-revenue-per-event)) — VAT detail, online + offline refunds tracked
+
+---
+
 ## Cross-Cutting Concerns
 
 ### Internationalization
-- UI available in: English, German, Italian
-- User sets language preference
+- UI available in: English, German, Italian, French
+- User sets language preference (`en`/`de`/`it`/`fr`)
 - Emails sent in user's preferred language
 - Legal content localized
 
@@ -1117,9 +1357,20 @@ See [Journey 22: Attendee Invoicing](#journey-22-attendee-invoicing) for the ful
 - Banned users receive `ACCOUNT_BANNED` notification before deactivation
 
 ### Feature Flags
+Configured via environment variables. The anonymous `GET /version` returns a `features` object so clients can hide gated UI instead of letting users hit a 403/404.
 - `FEATURE_LLM_EVALUATION`: Gates LLM-based questionnaire evaluation (when disabled, LLM evaluation is skipped)
 - `FEATURE_GOOGLE_SSO`: Gates Google SSO login (when disabled, endpoint returns 403)
-- Configured via environment variables
+- `FEATURE_MALWARE_SCAN` (default on): when off, uploads skip the ClamAV scan and are marked clean
+- `FEATURE_TELEGRAM` (default on): when off, Telegram delivery is dropped and the linking endpoints 404
+- `FEATURE_ORGANIZATION_CREATION` (default on): when off, `POST /organizations/` returns 403 for non-staff (single-org instances); staff/superusers bypass
+- `FEATURE_OBSERVABILITY` (renamed from `ENABLE_OBSERVABILITY`, which still works as a deprecated alias for one release)
+- `/version` exposes a subset to clients: `organization_creation`, `telegram`, `google_sso`, `llm_evaluation`
+
+### Self-Hosting
+- The backend boots and runs on a self-hosted box **without** ClamAV, Telegram, or the full geo dataset, tailored via the feature flags above
+- Cities-CSV fallback to a bundled `worldcities.mini.csv` so a fresh container doesn't crash-loop on the city-load migration
+- `provision_stripe_webhooks --format json` for machine-readable webhook setup; dedicated self-hosting docs section
+- The platform host's own Stripe account can be bound to a single organization (superuser admin action), letting the host sell tickets directly
 
 ### UNLISTED Visibility
 - Organizations and events can be set to UNLISTED
@@ -1173,7 +1424,7 @@ The following questions represent gaps in my understanding that I could not reso
 
 8. **RSVP change behavior**: After RSVP YES, when the user changes to NO, is there a confirmation dialog? Does it mention potluck items being released?
 
-9. **Ticket cancellation**: Can users cancel their own tickets? Under what conditions? Is there a refund flow for Stripe payments?
+9. ~~**Ticket cancellation**: Can users cancel their own tickets? Under what conditions? Is there a refund flow for Stripe payments?~~ **Resolved (v1.50.0)** — opt-in per tier (`allow_user_cancellation`, `cancellation_deadline_hours`, snapshotted `refund_policy`); self-service `cancel` + `cancellation-preview` endpoints; Stripe refunds for online tickets. See [Journey 6.12](#612-cancel-ticket--refund-self-service). Remaining UX question: is there a confirmation dialog, and does it surface the live refund quote inline?
 
 10. **Guest checkout UX**: For `can_attend_without_login=True` events, what does the guest see? A simplified form? Are they encouraged to create an account afterward?
 
@@ -1215,7 +1466,21 @@ The following questions represent gaps in my understanding that I could not reso
 
 25. **Rate limiting**: Should E2E tests account for rate limiting, or is it disabled in test environments?
 
-26. **Feature flags**: Which features are behind flags that might affect test scenarios? (Google SSO is one — any others?)
+26. ~~**Feature flags**: Which features are behind flags that might affect test scenarios? (Google SSO is one — any others?)~~ **Resolved (v1.64.0)** — `FEATURE_GOOGLE_SSO`, `FEATURE_LLM_EVALUATION`, `FEATURE_MALWARE_SCAN`, `FEATURE_TELEGRAM`, `FEATURE_ORGANIZATION_CREATION`, `FEATURE_OBSERVABILITY`. The client-visible subset is on `GET /version`. See [Cross-Cutting → Feature Flags](#feature-flags). Open question: which flag combinations should the E2E matrix actually exercise?
+
+### New Capabilities (added since v1.47.0)
+
+31. **Membership subscriptions**: Phase 1 is OFFLINE/staff-managed. What's the intended member-facing UX today — read-only "your subscription" cards, or any self-service actions? When does online/auto-renew billing land?
+
+32. **Polls**: What's the primary use case — event feedback, community decisions, both? Are polls surfaced on the public org/event page, or member-dashboard only? Which anonymity defaults should E2E assert?
+
+33. **Recurring events**: For E2E, should we test the full generation lifecycle (create rule → materialize → drift after cadence change), or treat occurrences as ordinary events once generated?
+
+34. **Advanced waitlist offers**: What does the offer notification + accept flow look like to the user? Is there a countdown UI for the offer expiry window?
+
+35. **Revenue & VAT reporting**: Is the downloadable ZIP report something to verify E2E (download + open), or is asserting the live `/revenue` endpoint sufficient? Any locale/currency combos that must be covered?
+
+36. **Open-ended events**: How should the frontend render `is_open_ended` (e.g. "Ongoing" badge, hidden end time)? Anything special for ICS/Wallet expectations in tests?
 
 ### Prioritization
 


### PR DESCRIPTION
## Summary

Adds a `/tech-debt` multi-agent assessment workflow (mirroring the existing `/vuln-scan` hunter → verifier → report pattern) and refreshes two top-level docs.

## Changes

### Claude Code tooling
- **New `/tech-debt` command** (`.claude/commands/tech-debt.md`) — orchestrator that fans out region-scoped + specialist hunters, verifies findings, scores repo health, and writes a report to disk by default.
- **New `tech-debt-verifier` agent** (`.claude/agents/tech-debt-verifier.md`) — skeptical adjudicator that independently re-reads each candidate, enforces the false-positive rules, and returns a 0–100 confidence verdict.
- **Reworked `tech-debt-assessor`** into a region-scoped hunter that feeds the new orchestrator/verifier flow.
- **`/vuln-scan`** now writes its report to disk by default (dated path at repo root, or `--report <file>`), printing a condensed summary in-session.

### Docs
- **README** — clarified the Docker Compose file matrix; documented that `docker-compose-observability.yml` is standalone, replaces `compose.yaml`, and omits Mailpit.
- **USER_JOURNEYS** — refreshed to v1.65.0: recurring events, membership subscriptions, polls, revenue/VAT reporting, at-the-door tickets, waitlist offers, French i18n.

## Notes
Docs and agent/command tooling only — no application code, migrations, or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker Compose setup instructions and service replacement semantics.
  * Expanded user journey documentation with new features including membership subscriptions, advanced waitlist offers, self-service ticket cancellation, questionnaire enhancements, moderation updates, and recurring event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->