### PR TITLE
feat(self-hosting): bootstrap_admin command + doc accuracy fixes

### DIFF
--- a/docs/self-hosting/dns-cloudflare.md
+++ b/docs/self-hosting/dns-cloudflare.md
@@ -21,7 +21,6 @@ For a **Full** instance, also add the management subdomains:
 | Type | Name | Value |
 | --- | --- | --- |
 | A | `grafana.<your-domain>` | your server IPv4 |
-| A | `flower.<your-domain>` | your server IPv4 |
 | A | `docs.<your-domain>` | your server IPv4 |
 
 Add the matching AAAA records if you serve over IPv6.

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -18,7 +18,7 @@ Revel scales down a long way. There are two reference sizings:
   only, with conservative resource limits. ClamAV, Telegram, and the observability stack are
   switched off. This is the recommended starting point for a single-org instance.
 - **Full** — **8 vCPU / 32 GB RAM**. Runs every optional profile: antivirus scanning, the LGTM
-  observability stack (Grafana/Loki/Tempo/etc.), Flower, the Telegram bot, and the canary.
+  observability stack (Grafana/Loki/Tempo/etc.), the Telegram bot, and the canary.
   This mirrors a production deployment.
 
 The difference between the two is almost entirely a matter of which Compose profiles you enable
@@ -38,7 +38,7 @@ A minimal (Slim) instance runs these core services:
 - **pgbouncer** — connection pooler in front of Postgres.
 - **redis** — Celery broker, result backend, and cache.
 
-Everything else (ClamAV, the LGTM observability stack, Flower, the Telegram bot) is optional and
+Everything else (ClamAV, the LGTM observability stack, the Telegram bot) is optional and
 gated behind Compose profiles and feature flags.
 
 ## Optional dependencies

--- a/docs/self-hosting/maintenance.md
+++ b/docs/self-hosting/maintenance.md
@@ -20,7 +20,7 @@ Restore a dump with `psql` against the running Postgres container:
 
 ```bash
 # Copy the dump into the container (or mount it), then:
-docker compose exec -T postgres psql -U <PG_USER> -d <PG_DATABASE> < backup.sql
+docker compose exec -T revel_postgres psql -U <DB_USER> -d <DB_NAME> < backup.sql
 ```
 
 Restore into an empty database. If you are recovering onto a fresh box, bring the stack up so the
@@ -36,8 +36,8 @@ schema migrations have run, then load the dump.
 ./deploy.sh update
 ```
 
-This pulls the latest application images from the registry and reloads the affected services
-(rolling them with the new images and applying any pending database migrations). Read the changelog
+This pulls the latest application images from the registry and recreates the affected services
+with them (the `web` container runs any pending database migrations on startup). Read the changelog
 before updating a production instance, and take a backup first.
 
 ## Refreshing geo data

--- a/docs/self-hosting/observability.md
+++ b/docs/self-hosting/observability.md
@@ -39,13 +39,15 @@ FEATURE_OBSERVABILITY=True
 
 ## Grafana login
 
-Grafana's admin credentials are set via environment variables in `.env`:
+Grafana's admin credentials are set via environment variables in `.env` (the wizard generates a
+random password for you):
 
-- `GF_SECURITY_ADMIN_USER` — the admin username.
-- `GF_SECURITY_ADMIN_PASSWORD` — the admin password.
+- `GRAFANA_ADMIN_USER` — the admin username (defaults to `admin`).
+- `GRAFANA_ADMIN_PASSWORD` — the admin password.
 
-Set these before first start; once Grafana initializes its database, changing the password is done
-in the Grafana UI rather than via the env var. Grafana is reachable at `https://grafana.<your-domain>`
+Compose passes these to Grafana as `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`. Set
+them before first start; once Grafana initializes its database, changing the password is done in
+the Grafana UI rather than via the env var. Grafana is reachable at `https://grafana.<your-domain>`
 once DNS and certificates are in place.
 
 ## Resource cost

--- a/docs/self-hosting/quickstart.md
+++ b/docs/self-hosting/quickstart.md
@@ -30,7 +30,7 @@ The wizard prompts you for:
 
 1. **Tier** — Slim or Full. This selects the `COMPOSE_PROFILES` and resource limits. Start with
    Slim unless you specifically want the observability stack and antivirus.
-2. **Domains** — your `FRONTEND_DOMAIN` and `API_DOMAIN` (plus `grafana`, `flower`, and `docs`
+2. **Domains** — your `FRONTEND_DOMAIN` and `API_DOMAIN` (plus `grafana` and `docs`
    subdomains if you chose Full).
 3. **Email** — SMTP host, port, credentials, and the from-address used for verification and
    ticket delivery. (You can opt into `EMAIL_DRY_RUN=True` for a test instance.)
@@ -43,10 +43,10 @@ The wizard prompts you for:
 When it finishes, the wizard:
 
 - writes a complete `.env` file (review it before going to production),
-- selects the appropriate **Caddyfile variant** (plain vs. the Cloudflare variant — see
-  [DNS & Cloudflare](dns-cloudflare.md)),
-- **fetches the geo data** (the IP2Location BIN if you supplied a token, and the cities dataset;
-  if the full cities CSV is unavailable it falls back to the bundled 50-city mini dataset), and
+- selects the appropriate **Caddyfile variant** (the generic edge variant, or the Cloudflare
+  variant if you proxy through Cloudflare — see [DNS & Cloudflare](dns-cloudflare.md)),
+- **fetches the geo data** (the cities dataset, and optionally the IP2Location BIN; if the full
+  cities CSV is unavailable it falls back to the bundled 50-city mini dataset), and
 - runs `docker compose up -d` to start the stack.
 
 !!! note "Keep this page in sync"
@@ -72,7 +72,6 @@ With DNS pointed at the box and certificates issued, your instance is reachable 
 - **Frontend** — `https://<FRONTEND_DOMAIN>`
 - **API** — `https://<API_DOMAIN>` (interactive docs at `https://<API_DOMAIN>/api/docs`)
 - **Grafana** (Full tier only) — `https://grafana.<your-domain>`
-- **Flower** (Full tier only) — `https://flower.<your-domain>`
 
 If the site does not come up, the most common cause is TLS issuance failing behind Cloudflare's
 proxy — see the [DNS & Cloudflare](dns-cloudflare.md) caveat and the

--- a/docs/self-hosting/tiers.md
+++ b/docs/self-hosting/tiers.md
@@ -11,13 +11,13 @@ limits are:
 
 | Setting | Slim (~2 vCPU / 4 GB) | Full (8 vCPU / 32 GB) |
 | --- | --- | --- |
-| `COMPOSE_PROFILES` | *(empty)* | `observability,antivirus,flower,telegram,canary` |
+| `COMPOSE_PROFILES` | *(empty)* | `observability,antivirus,telegram,canary` |
 | Postgres `shared_buffers` | `256MB` | `4GB` |
 | Gunicorn workers | `2` | `6` |
 | Celery concurrency | `2` | `4` |
 
 Slim runs only the core services (caddy, frontend, web, celery, beat, postgres, pgbouncer, redis).
-Full adds antivirus scanning, the LGTM observability stack, Flower, the Telegram bot, and the
+Full adds antivirus scanning, the LGTM observability stack, the Telegram bot, and the
 canary.
 
 ## Compose profiles
@@ -28,7 +28,6 @@ Each optional capability is gated behind a Compose profile. Add the profile name
 - **observability** — Prometheus, Loki, Tempo, Pyroscope, Alloy, and Grafana. See
   [Observability](observability.md).
 - **antivirus** — the ClamAV daemon used by `FEATURE_MALWARE_SCAN`.
-- **flower** — the Celery monitoring UI.
 - **telegram** — the Telegram bot process.
 - **canary** — the synthetic-monitoring canary.
 
@@ -50,7 +49,7 @@ just wastes RAM.
 
 - `FRONTEND_DOMAIN` — public hostname of the web app.
 - `API_DOMAIN` — public hostname of the API.
-- Additional `*_DOMAIN` vars (`grafana`, `flower`, `docs`) for the Full-tier management UIs.
+- Additional `*_DOMAIN` vars (`grafana`, `docs`) for the Full-tier management UIs.
 
 ### Feature flags
 


### PR DESCRIPTION
## Summary

Self-hosting improvements: a first-run **`bootstrap_admin`** management command, plus a sweep of doc-accuracy fixes (originally this PR, now folded together since the quickstart documents the new command).

## `bootstrap_admin` (new)

The stock `createsuperuser` prompts for `username` and `email` separately, so a self-hoster can create `username != email` — diverging from every account made through the public API (which pins username to the email). The new interactive command fixes that and bootstraps the first org in one step:

- Prompts for **admin email**, **password** (confirmed, run through Django's password validators), and **organization name**, and **proposes a slug** (editable, uniqueness-checked).
- Creates the **superuser** with `username == email`, `email_verified=True`, then the **first organization** owned by it (reusing `create_organization`; no verification email is sent because the contact email matches the verified owner).
- Prints the **admin-panel** and **frontend** URLs derived from settings (`BASE_URL` / `ADMIN_URL` / `FRONTEND_BASE_URL`) — nothing hardcoded.
- `events.create_organization()` gains an optional `slug` param (backward-compatible) so the proposed slug is honoured.
- Tests cover the happy path, slug default/uniqueness, duplicate-email and invalid-email loops, and password-mismatch retry (6 tests, all green; existing org-service tests unaffected).

The companion infra PR has the wizard call this command interactively after bring-up.

## Doc accuracy fixes

- **Drop Flower** (intentionally dropped from the self-host stack) from `index`, `tiers`, `quickstart`, `dns-cloudflare`.
- **observability**: Grafana creds are `GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD` (compose maps to `GF_SECURITY_ADMIN_*`).
- **maintenance**: restore uses `revel_postgres` + `DB_USER`/`DB_NAME`; clarified migrations run via the web entrypoint on update.
- **quickstart**: generic-vs-cloudflare Caddyfile wording; geo BIN fetched at setup; step 3 now documents `bootstrap_admin`.

## Related
Infra: letsrevel/infra#21 (slim CPU caps, host-aware wizard resources, drop Flower, gate Caddy blocks, call `bootstrap_admin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)