### PR TITLE
docs(whats-new): list editions in sidebar nav like ADR

### DIFF
--- a/.claude/skills/whats-new/SKILL.md
+++ b/.claude/skills/whats-new/SKILL.md
@@ -123,8 +123,14 @@ area sections (`##`), then the §4 changelog footer.
 - [<date> — Last <window>](<filename-without-.md>.md) — <one-line teaser of the headline items>
 ```
 
-(Dated pages are kept out of the nav via `not_in_nav: whats-new/20*.md` in `mkdocs.yml`; the index
-is their table of contents. New files are reachable by URL and from the index — no nav edit needed.)
+Also add the edition to the **left-sidebar nav** in `mkdocs.yml`, under the `What's New:` section
+right after `whats-new/index.md` (newest first, matching the ADR section's per-entry layout):
+
+```yaml
+  - What's New:
+      - whats-new/index.md
+      - whats-new/<filename>.md   # <-- prepend the new edition here, above older ones
+```
 
 **c. Print the Discord message in chat**, inside a fenced block so it's copy-pasteable — a SHORT
 teaser, not the full post: a punchy intro line, **4–6 headline bullets** (the biggest items only),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,9 @@ theme:
 
 nav:
   - Home: index.md
-  - What's New: whats-new/index.md
+  - What's New:
+      - whats-new/index.md
+      - whats-new/2026-06-22-last-month.md
   - Getting Started:
       - getting-started/index.md
       - Quick Start: getting-started/quickstart.md
@@ -124,11 +126,6 @@ nav:
 # Internal agent plans/specs live under docs/superpowers/ — kept in git but not published.
 exclude_docs: |
   superpowers/
-
-# Dated "What's New" editions are published & linked from whats-new/index.md, but kept out of
-# the nav sidebar (the index page IS their table of contents).
-not_in_nav: |
-  whats-new/20*.md
 
 plugins:
   - search


### PR DESCRIPTION
## What

Make the **What's New** docs section behave like **ADR**: each dated edition shows up as a clickable entry in the left sidebar nav, instead of being reachable only from the index page.

## Changes

- **`mkdocs.yml`** — expand the `What's New` nav into a section (`whats-new/index.md` + each edition) and remove the `not_in_nav: whats-new/20*.md` rule that previously kept editions out of the sidebar. With `navigation.indexes` already enabled, `index.md` remains the section landing page.
- **`.claude/skills/whats-new/SKILL.md`** — update step b so future `/whats-new` runs also add the new edition to the nav (newest first), keeping the sidebar consistent instead of silently drifting back to the old behavior.

## Notes

- No content change to `whats-new/index.md` — it's still a valid landing page, now also the section index.
- Reverses the earlier deliberate "index page is the only TOC" decision in favor of the ADR-style sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)