### PR TITLE
docs: refresh docs/ against recent changes (1.53.0 → 1.66.0)

### DIFF
--- a/docs/architecture/billing-and-vat.md
+++ b/docs/architecture/billing-and-vat.md
@@ -197,6 +197,8 @@ The `Organization` model stores:
 | `billing_name` | CharField | Legal entity name for invoices (auto-filled from VIES if empty; falls back to org name) |
 | `billing_address` | TextField | Billing address (auto-filled from VIES if empty) |
 | `billing_email` | EmailField | Billing contact (falls back to contact_email for invoices) |
+| `revenue_report_cadence` | CharField | Scheduled revenue-report cadence (`NONE`/`QUARTERLY`/`MONTHLY`, default `NONE`). **Owner-only to write** (as of 1.65.0); requires `billing_email` when not `NONE` |
+| `last_revenue_report_sent_period` | CharField | Internal scheduling bookkeeping — the last period emailed (e.g. `2026-Q1` or `2026-03`); prevents double-sends |
 
 !!! note "Online tier prerequisite"
     Creating an online (Stripe) ticket tier requires `billing_name`, `vat_country_code`, and `billing_address` to be set on the organization (when platform fees are configured). This ensures invoices can be generated correctly from the first sale.
@@ -218,9 +220,88 @@ Each `TicketTier` has an optional `vat_rate` field. If set, it overrides the org
 | `platform_vat_rate` | Platform's domestic VAT rate |
 | `platform_invoice_bcc_email` | BCC address for all outgoing invoices |
 
+## Revenue & VAT Reporting
+
+Organizers get a financial-reporting suite for their own tax filing, all driven by **one
+tax-precise aggregation engine** (`events.service.revenue_aggregation`) so every view
+reconciles: the downloadable report rolls it up across events, the org `/revenue` endpoint
+groups it by event, and the per-event endpoint filters it to a single event.
+
+### Aggregation Engine
+
+`build_revenue_report_data()` (and its live-endpoint projections) performs a single per-row
+pass over both revenue sources and folds them into buckets keyed by **currency** and then by
+**VAT rate**:
+
+| Source | Selected rows |
+|---|---|
+| Online (Stripe) | `Payment` records on `ONLINE` tiers with status `SUCCEEDED` or `REFUNDED` |
+| Offline / at-the-door | Paid `Ticket` records on `OFFLINE` / `AT_THE_DOOR` tiers, plus cancelled tickets carrying an `offline_refund_amount` |
+
+Key behaviors:
+
+- **Per currency, per VAT rate** — each currency section carries one `RateBucket` per VAT
+  rate; reverse-charge and 0%-rate rows collapse into a single `0% / reverse-charge` bucket.
+- **Refunds attributed to the period they occurred** — a sale and its refund are counted in
+  whichever report period each one falls into (by local date), not lumped onto the sale date.
+  Rate-bucket money is net-of-refunds; refunds are also surfaced separately
+  (`refunds_total` / `refunded_count`).
+- **Net taxable turnover** — per currency, the sum of net (sale minus refund) across rate
+  buckets.
+- **VAT snapshot first** — online payments use the persisted `net_amount`/`vat_amount`/`vat_rate`
+  snapshot when present, falling back to `calculate_vat_inclusive()` at the org rate; offline
+  tickets are always extracted at the org rate.
+- **Org timezone** — sale/refund dates are converted to the org's city timezone before the
+  period window is applied.
+
+!!! info "One engine, three views"
+    The report ZIP, the org `/revenue` dashboard endpoint, and the per-event `/revenue`
+    endpoint all call into the same aggregator. The only differences are scope (org-wide vs.
+    one event) and shape (the live endpoints skip the per-transaction detail rows).
+
+### Report Bundle (ZIP)
+
+`POST /organization-admin/{slug}/revenue-report` produces a **multi-file ZIP** built by
+`events.service.revenue_report_service`:
+
+- **`*.xlsx`** — two sheets: **Summary** (per currency: one row per VAT rate, a Refunds row, a
+  bold Net-taxable-turnover total) and **Transactions** (one row per sale/refund line).
+- **`*.pdf`** — rendered via WeasyPrint: per-VAT-rate table, refunds, and net taxable turnover.
+
+Generation is asynchronous (a `FileExport` row + Celery task — see
+[Exports](exports.md#revenue-vat-export) for the artifact mechanics). The result is **cached**:
+a matching READY export (same org, event, date range, and a content hash over the in-scope
+rows) is reused unless `?refresh=true` is passed.
+
+### Scheduled Delivery
+
+Orgs can opt into emailed reports via `Organization.revenue_report_cadence`
+(`NONE` / `QUARTERLY` / `MONTHLY`, default `NONE`). A monthly Beat sweep
+(`deliver_scheduled_revenue_reports`) computes the **just-closed period in the org's own
+timezone**, generates the ZIP, and emails it to the org's `billing_email` (plus the owner if
+different). Empty periods are skipped (no email, marker not advanced), and a
+`last_revenue_report_sent_period` marker prevents double-sends. QUARTERLY orgs only actually
+send in Jan/Apr/Jul/Oct; other months no-op.
+
+### Per-Event Schema Change
+
+!!! warning "Breaking change (1.64.0)"
+    The per-event revenue endpoint now returns `EventFinancialsSchema`, which differs from the
+    previous shape:
+
+    - `refunded` → **`refunds`**.
+    - **`paid_ticket_count` removed** — derive it as `sold_count - refunded_count`.
+    - `sold_count` semantics changed: it now also counts sales that were later
+      refunded/cancelled (the gross count ever sold), not just currently-paid tickets.
+    - VAT detail **added**: `net_taxable`, `vat`, and `rate_buckets` (per-VAT-rate breakdown).
+
+    A coordinated frontend update is required.
+
 ## API Endpoints
 
-All endpoints require organization **owner** permissions.
+Billing-info, VAT-ID, invoice, and credit-note endpoints require organization **owner**
+permissions. The **revenue & VAT** endpoints instead require the `manage_organization`
+permission (owner or staff with that grant) — see [Revenue Endpoints](#revenue-endpoints).
 
 ### Billing Info
 
@@ -247,6 +328,23 @@ All endpoints require organization **owner** permissions.
 | `GET` | `/organization-admin/{slug}/invoices/{id}` | Get invoice detail |
 | `GET` | `/organization-admin/{slug}/invoices/{id}/download` | Get signed PDF download URL |
 | `GET` | `/organization-admin/{slug}/credit-notes` | List credit notes (paginated) |
+
+### Revenue Endpoints
+
+These require `manage_organization` (not owner), and return the data described under
+[Revenue & VAT Reporting](#revenue-vat-reporting).
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/organization-admin/{slug}/revenue-report` | Create (or reuse a cached) report ZIP for a period; `?refresh=true` forces regeneration. Returns a `FileExport` (poll for the signed URL) |
+| `GET` | `/organization-admin/{slug}/revenue-reports/{export_id}` | Poll a report; the response carries a signed download URL once `status=READY` |
+| `GET` | `/organization-admin/{slug}/revenue` | Live org financials by event: `year` + optional `month`/`quarter`, `currency` switching (`available_currencies`), `sort=revenue\|event_start`, `order=asc\|desc` |
+
+!!! note "Per-event financials"
+    A per-event view lives on the event-admin controller:
+    `GET /event-admin/{event_id}/revenue` (permission `manage_tickets`) returns
+    `EventFinancialsSchema` — the same engine scoped to one event, all-time by default with an
+    optional `year`/`month`/`quarter` filter.
 
 ## Attendee Invoicing
 
@@ -488,5 +586,13 @@ Both are configured via environment variables and fall back to `DEFAULT_FROM_EMA
 | `events.calculate_referral_payouts` | 1st of month, 06:00 UTC | Calculate referral payout amounts |
 | `accounts.process_referral_payouts` | 1st of month, 06:30 UTC | Stripe transfers + statement PDFs + emails |
 | `events.revalidate_vat_ids` | 15th of month, 03:00 UTC | Re-validate all org VAT IDs via VIES |
+| `events.send_scheduled_revenue_reports` | 5th of month, 06:00 UTC | Email the just-closed period's report ZIP to `billing_email` + owner for opted-in orgs (period computed in org timezone; skips empty periods) |
 
 Tasks are registered via data migrations.
+
+!!! note "On-demand vs. scheduled"
+    `events.generate_revenue_report` is **not** a Beat job — it is the worker task that builds a
+    single report ZIP, dispatched on demand by the `POST .../revenue-report` endpoint (via
+    `transaction.on_commit`) and reused by the scheduled sweep above. Only
+    `events.send_scheduled_revenue_reports` runs on a schedule. The sweep fires on the 5th
+    (not the 1st) to leave a short settle window for late refunds before the snapshot is taken.

--- a/docs/architecture/exports.md
+++ b/docs/architecture/exports.md
@@ -1,6 +1,19 @@
-# XLSX Exports
+# Exports
 
-Revel supports asynchronous Excel exports for attendee lists and questionnaire submissions. Exports are generated as background Celery tasks and delivered via email with a time-limited download link.
+Revel supports asynchronous data exports for attendee lists, questionnaire submissions, and
+revenue & VAT reports. Exports are generated as background Celery tasks, tracked through a
+`FileExport` row, and delivered via a time-limited signed download link (and, for some types,
+email).
+
+Not every export is a single `.xlsx`: the attendee and questionnaire exports produce one XLSX
+workbook, while the **revenue & VAT report** is a multi-file **ZIP** (XLSX Summary +
+Transactions, plus a per-VAT-rate PDF). See [Revenue & VAT Export](#revenue-vat-export).
+
+!!! info "Mechanics vs. narrative"
+    This page covers the **artifact mechanics** (the `FileExport` lifecycle, builders, and
+    download security). The financial meaning of revenue reports — the aggregation engine, VAT
+    bucketing, refund attribution, and scheduled delivery — lives in
+    [Billing & VAT → Revenue & VAT Reporting](billing-and-vat.md#revenue-vat-reporting).
 
 ## Architecture
 
@@ -19,9 +32,9 @@ The `FileExport` model (`common/models.py`) tracks the lifecycle of every export
 | Field | Description |
 |---|---|
 | `requested_by` | User who requested the export |
-| `export_type` | `questionnaire_submissions` or `attendee_list` |
+| `export_type` | `questionnaire_submissions`, `attendee_list`, or `revenue_vat_report` |
 | `status` | `PENDING` → `PROCESSING` → `READY` or `FAILED` |
-| `file` | `ProtectedFileField` — the generated `.xlsx` file (HMAC-signed URLs) |
+| `file` | `ProtectedFileField` — the generated artifact (a `.xlsx` workbook or a `.zip` bundle), served via HMAC-signed URLs |
 | `parameters` | JSON dict with export-specific inputs (event ID, questionnaire ID, etc.) |
 | `error_message` | Populated on failure |
 | `completed_at` | Timestamp when the export finished |
@@ -52,6 +65,31 @@ Generates a workbook with two sheets:
 - **Summary** — submission statistics (total, unique users, approved/rejected/pending), score distribution (avg/min/max), pronoun distribution
 - **Submissions** — one row per submission: user info, evaluation status/score/comments, and one column per question (MC options joined with `;`, free-text answers, file upload filenames)
 
+### Revenue & VAT Export
+
+**Location:** `events/service/revenue_report_service.py`
+
+Unlike the attendee and questionnaire exports, this one bundles **multiple files into a ZIP**
+(`build_zip` → `build_xlsx` + `build_pdf`):
+
+- **XLSX** — two sheets: **Summary** (per currency, one row per VAT rate, a Refunds row, and a
+  bold Net-taxable-turnover total) and **Transactions** (one row per sale/refund line).
+- **PDF** — rendered with WeasyPrint (`reports/revenue_vat_report.html`): per-VAT-rate table,
+  refunds, and net taxable turnover.
+
+**Caching:** `get_or_generate_revenue_report()` reuses an existing READY `FileExport` whose
+parameters (org, optional event, date range) and a content hash over the in-scope rows match,
+unless the request passes `?refresh=true` — in which case a fresh export is always enqueued.
+The actual build runs in the `events.generate_revenue_report` Celery task (dispatched on
+`transaction.on_commit`); a failure marks the export `FAILED` before re-raising.
+
+**Scheduled delivery:** the `events.send_scheduled_revenue_reports` Beat task generates and
+emails the just-closed period's ZIP to opted-in orgs (the financial details live in
+[Billing & VAT → Scheduled Delivery](billing-and-vat.md#scheduled-delivery)).
+
+The aggregation logic that feeds these builders is documented in
+[Billing & VAT → Revenue & VAT Reporting](billing-and-vat.md#revenue-vat-reporting).
+
 ### Shared Formatting
 
 **Location:** `events/service/export/formatting.py`
@@ -60,4 +98,8 @@ Reusable styling utilities applied to all exports: header row styling (white-on-
 
 ## Download Security
 
-Export files are stored as `ProtectedFileField` entries, using the same HMAC-signed URL mechanism described in [Protected Files](protected-files.md). Download links are generated with a 7-day expiry and delivered via email.
+All export files — workbooks and ZIP bundles alike — are stored as `ProtectedFileField` entries,
+using the same HMAC-signed URL mechanism described in [Protected Files](protected-files.md).
+For every `FileExport` type, the signed download URL is generated with a **7-day expiry**
+(`EXPORT_URL_EXPIRES_IN`) once the export reaches `READY` — exposed on the export's API response
+(`download_url`) and, for the attendee/questionnaire exports, delivered via email.

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -1,0 +1,146 @@
+# Content Moderation (Name Blocklist)
+
+Revel ships a small, self-contained **moderation** app that screens user-supplied **names**
+against a curated multi-language blocklist before they are persisted. It exists to stop slurs and
+abusive terms from entering shared, user-visible vocabularies — today, the free-text **food item**
+names that feed dietary-restriction autocomplete.
+
+!!! info "Scope"
+    This is a **deterministic, exact-match** name screen — not a general content-moderation or
+    LLM-based toxicity classifier. It is intentionally narrow and auditable. Prompt-injection
+    defenses for free-text questionnaire answers are a separate system; see
+    [Questionnaires → Prompt Injection Protection](questionnaires.md#prompt-injection-protection).
+
+## Where it lives
+
+The app is registered in `INSTALLED_APPS` (`src/revel/settings/base.py`) and has no models or
+migrations of its own — the wordlists are flat files on disk.
+
+```
+src/moderation/
+├── blocklist/
+│   ├── normalize.py   # canonicalization (defeat evasion)
+│   ├── loader.py      # load + memoize wordlists
+│   └── screen.py      # is_blocked() / assert_name_allowed() / NameNotAllowed
+└── data/blocklist/
+    ├── en.txt
+    ├── de.txt
+    ├── it.txt
+    └── fr.txt
+```
+
+## Screening Pipeline
+
+```mermaid
+flowchart TD
+    Name["User-supplied name"] --> Normalize["normalize_text()<br/>lowercase · strip accents · de-leet<br/>collapse repeats · drop non-alnum"]
+    Normalize --> Tokens["tokens()<br/>whitespace split"]
+    Tokens --> Candidates["candidates =<br/>tokens + adjacent bigrams"]
+    Candidates --> Match{"Any candidate<br/>in blocklist set?"}
+    Match -->|"Yes"| Block["NameNotAllowed → HTTP 422"]
+    Match -->|"No"| Allow["Allowed → persist"]
+
+    style Block fill:#c62828,color:#fff
+    style Allow fill:#2e7d32,color:#fff
+```
+
+### 1. Normalization (`normalize.py`)
+
+Before matching, both the input name and every blocklist term are pushed through
+`normalize_text()`, which canonicalizes text to defeat common evasion tricks:
+
+| Step | Purpose | Example |
+|---|---|---|
+| Lowercase | Case-insensitive matching | `Foo` → `foo` |
+| Unicode NFKD + strip combining marks | Defeat accent/diacritic evasion | `fóò` → `foo` |
+| Leet translation | Map common substitutions back to letters | `f00` → `foo` (`3→e 0→o 1→i 4→a 5→s 7→t $→s @→a`) |
+| Collapse 3+ repeats | Defeat character padding | `fooooo` → `fo` |
+| Drop non-alphanumeric | Remove separator/punctuation evasion | `f-o-o` → `foo` |
+| Collapse whitespace | Stable tokenization | `foo   bar` → `foo bar` |
+
+`tokens()` then splits the normalized string on whitespace into a list of tokens.
+
+### 2. Matching (`screen.py`)
+
+`is_blocked()` builds a candidate set and tests it for **exact** membership in the normalized
+blocklist:
+
+```python
+def is_blocked(text: str, *, wordlist: frozenset[str] | None = None) -> bool:
+    words = wordlist if wordlist is not None else load_blocklist()
+    if not words:
+        return False
+    toks = tokens(text)
+    candidates = toks + ["".join(pair) for pair in zip(toks, toks[1:])]
+    return any(c in words for c in candidates)
+```
+
+Candidates are:
+
+1. **Each normalized token**, and
+2. **Each adjacent bigram** — neighbouring tokens joined with no separator. This catches a term
+   that gets split across two tokens once separators are stripped (e.g. `bad word` → `badword`).
+
+!!! warning "Exact match only — no fuzzy matching"
+    Matching is **exact set membership** against the normalized wordlist. There is **no** edit
+    distance, substring, or fuzzy matching. A term must normalize to exactly a blocklist entry
+    (as a single token or an adjacent bigram) to be blocked. This keeps the screen fast,
+    deterministic, and free of false positives — at the cost of not catching every creative
+    misspelling. The normalization layer is what absorbs the common evasions.
+
+### 3. Loading (`loader.py`)
+
+`load_blocklist()` reads all four language files (`en`, `de`, `it`, `fr`), skips blank lines and
+`#` comments, normalizes each term the same way as input, and returns a single
+`frozenset[str]`. The result is memoized with `functools.lru_cache(maxsize=1)`, so the files are
+read once per process.
+
+!!! note "Wordlists are reviewed like code"
+    The `data/blocklist/*.txt` files are curated and audited; terms are added out-of-band by
+    maintainers. Each file is kept minimal and intentionally small.
+
+## The Guard: `assert_name_allowed` / `NameNotAllowed`
+
+The public entry point is `assert_name_allowed(name)`. It raises `NameNotAllowed` — a subclass of
+ninja's `HttpError` that renders as **HTTP 422** with a translated message — when the name is
+blocked:
+
+```python
+class NameNotAllowed(HttpError):
+    def __init__(self) -> None:
+        super().__init__(422, str(_("This name is not allowed.")))
+
+def assert_name_allowed(name: str) -> None:
+    if is_blocked(name):
+        raise NameNotAllowed
+```
+
+Because `NameNotAllowed` subclasses `HttpError`, it renders directly through ninja's standard
+error handling — no per-app exception handler is needed.
+
+## Integration Point
+
+!!! info "Single integration point today"
+    The guard is currently wired into **one** place: free-text **food item / dietary restriction
+    name creation** in `accounts/controllers/dietary.py`. These are the only endpoints where a user
+    types a name into a shared, autocompleted vocabulary, so they are the relevant attack surface.
+
+`assert_name_allowed()` is called at the top of both write paths, **before** any `FoodItem` row is
+created:
+
+| Endpoint | Guarded field |
+|---|---|
+| `POST /api/dietary/food-items` | `payload.name` |
+| `POST /api/dietary/restrictions` | `payload.food_item_name` (the food item is auto-created if missing) |
+
+A blocked name returns `422` and **no** `FoodItem` (or `DietaryRestriction`) row is created.
+Benign names proceed through the normal `get_or_create_with_race_protection` flow.
+
+## Staff Remediation
+
+The screen is preventative, but the wordlist is deliberately minimal and matching is exact, so
+some offensive items can still slip through. When that happens, staff can remove them through the
+Django admin: `FoodItem` is registered (`FoodItemAdmin` in `accounts/admin/user.py`) with name
+search, and offending rows can be deleted there. (Food items cannot be **added** through the
+admin — `has_add_permission` is superuser-only — they are only ever created through the dietary
+flow, which is exactly the path the guard protects.)

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -64,13 +64,33 @@ The following notification types are supported across all channels:
 |---|---|
 | `ticket_created` | Ticket was successfully created |
 | `ticket_cancelled` | Ticket was cancelled |
-| `ticket_checked_in` | User was checked in at an event |
 | `ticket_refunded` | Ticket payment was refunded |
 | `ticket_updated` | Ticket details were updated |
 | `payment_confirmation` | Payment was processed successfully |
 | `rsvp_confirmation` | RSVP was confirmed |
 | `rsvp_updated` | RSVP details were updated |
 | `rsvp_cancelled` | RSVP was cancelled |
+
+!!! note "`ticket_checked_in` is no longer dispatched (1.64.0)"
+    The `ticket_checked_in` enum value (and its template/context scaffolding) still
+    exists, but no notification is sent on check-in — the holder is already at the
+    event, so the message was pure noise.
+
+### Transactional types (bypass the digest)
+
+Four notification types are flagged **transactional** in
+`notifications/service/dispatcher.py` (`TRANSACTIONAL_TYPES`):
+
+- `payment_confirmation`
+- `ticket_created`
+- `ticket_cancelled`
+- `ticket_refunded`
+
+These are time- and money-sensitive, so they **always deliver immediately on the
+user's enabled channels and bypass the digest cadence** — even for users on a
+daily/weekly digest, they are never bundled and held back. Every other type honours
+the user's digest setting (digest users get the in-app notification now and the email
+in the next digest sweep).
 
 ### Waitlist & Availability
 
@@ -117,6 +137,12 @@ The following notification types are supported across all channels:
 | `org_announcement` | Organization-wide announcement |
 | `system_announcement` | Platform-wide announcement (e.g., privacy policy or ToC updates) |
 
+!!! note "Announcements can be sent now or scheduled"
+    Org announcements can be **sent immediately**, **scheduled** for a future absolute
+    or event-relative time, and optionally **re-sent** to attendees who sign up after the
+    first send — all delivered as `org_announcement` notifications through this dispatcher.
+    See [Scheduled Announcements](scheduled-announcements.md).
+
 ### Following
 
 | Type | Description |
@@ -160,7 +186,7 @@ Users configure their notification preferences per channel and per type. The pre
 
 - **Per-channel toggles**: Enable/disable each channel independently
 - **Per-type toggles**: Fine-grained control over which notifications to receive
-- **Digest mode**: Batch notifications into periodic summaries instead of sending individually
+- **Digest mode**: Batch notifications into periodic summaries instead of sending individually (does not apply to the [transactional types](#transactional-types-bypass-the-digest), which always deliver immediately)
 
 !!! info "Defaults"
     New users receive most notification types on all available channels by default. Exceptions: **potluck notifications** are restricted to in-app only (no email or Telegram) and **guest users** have potluck notifications disabled entirely. Telegram notifications always require the user to have linked their Telegram account.
@@ -176,6 +202,23 @@ The notification system is implemented in `notifications/service/`, which includ
 - **Unsubscribe handling**: Manages per-type and per-channel opt-outs
 
 Notifications are triggered from the service layer via Django signals and direct dispatcher calls. Delivery for email and Telegram channels is always asynchronous via Celery tasks.
+
+!!! info "Digest email (overhauled in 1.64.0)"
+    The digest groups its notifications by **human-readable type label** (e.g. "Event
+    Reminder"). Each item carries its body, a timestamp, and a **"View details"** link
+    derived from the notification's context, and the whole email is restyled to match
+    the transactional email templates. See `NotificationDigest._build_notification_groups`
+    in `notifications/service/digest.py`.
+
+!!! info "Event times render in the event's timezone (1.64.0)"
+    Event times in notifications and emails are always rendered in the **event's own
+    timezone** (via `format_event_datetime`), not the recipient's or the server's.
+
+!!! warning "`FEATURE_TELEGRAM` strips the Telegram channel platform-wide"
+    When `FEATURE_TELEGRAM` is off (self-host without a bot), the dispatcher strips the
+    Telegram channel from every notification's delivery list — no Telegram delivery is
+    ever enqueued, regardless of a user's per-channel preference. See
+    [Telegram Bot → Configuration](../guides/telegram-bot.md).
 
 ## Admin Pings (Pushover & Discord)
 

--- a/docs/architecture/permissions.md
+++ b/docs/architecture/permissions.md
@@ -162,6 +162,8 @@ A flat set of boolean flags representing individual actions:
 | `delete_questionnaire` | `False` | Delete questionnaires |
 | `evaluate_questionnaire` | `True` | Review and score questionnaire submissions |
 | `send_announcements` | `False` | Send announcements to members |
+| `manage_subscriptions` | `True` | Manage membership subscriptions |
+| `manage_polls` | `False` | Manage organization polls |
 
 ### `PermissionsSchema` (with per-event overrides)
 
@@ -314,6 +316,19 @@ class OrganizationAdminCoreController(OrganizationAdminBaseController):
     def stripe_connect(self, slug: str, payload: EmailSchema):
         ...
 ```
+
+!!! warning "Owner-only fields inside `edit_organization`-gated endpoints"
+    A few financially sensitive organization fields are **owner-only even when the
+    endpoint itself is gated by `edit_organization`** (which is staff-grantable). The
+    update flows past the permission class, but the service layer re-checks ownership
+    and rejects the change for non-owners.
+
+    The current example is `revenue_report_cadence` (it controls scheduled financial-report
+    delivery, consistent with the owner-only org revenue endpoints). A non-owner staff
+    member with `edit_organization` can update other org fields, but attempting to change
+    `revenue_report_cadence` raises `RevenueReportCadenceOwnerOnlyError`. The check lives in
+    `update_organization` (`events/service/organization_service.py`), not in the permission
+    class (carve-out introduced in v1.65.0).
 
 ### How `get_object_or_exception` Triggers Permission Checks
 

--- a/docs/architecture/polls.md
+++ b/docs/architecture/polls.md
@@ -1,0 +1,176 @@
+# Polls
+
+Polls are **organization-managed votes** layered on top of the [questionnaire](questionnaires.md) engine. A `Poll` does not store votes itself — it is a thin wrapper around a `Questionnaire`, and every vote is an ordinary `QuestionnaireSubmission`. This lets polls reuse the question/option/answer model, the per-viewer shuffle, and the file-upload machinery for free, while adding poll-specific concerns: lifecycle (draft/open/closed), audience & result visibility, anonymity, and vote-change policy.
+
+The feature is gated by the `manage_polls` organization permission (owner ✓, staff ✓ by default, member ✗).
+
+---
+
+## Overview
+
+A poll wraps exactly one questionnaire (`OneToOneField`, `on_delete=CASCADE` from poll → questionnaire). The wrapped questionnaire is always forced to `evaluation_mode=MANUAL` so the poll never triggers the LLM/automatic evaluation pipeline — a poll collects answers, it does not grade them.
+
+Casting a vote is the same operation as finalizing a questionnaire submission: a `QuestionnaireSubmission` in `READY` status, with the MC/free-text/file-upload answer rows hanging off it. Because the questionnaire's unique constraint already enforces **one submission per `(user, questionnaire)`**, a user can hold at most one vote per poll. Changing a vote replaces the answers in place.
+
+```mermaid
+erDiagram
+    Poll ||--|| Questionnaire : "wraps (1:1)"
+    Poll }o--|| Organization : "belongs to"
+    Poll }o--o| Event : "optionally scoped to"
+    Poll }o--o{ MembershipTier : "vote_membership_tiers"
+    Poll }o--o{ MembershipTier : "result_membership_tiers"
+    Questionnaire ||--o{ QuestionnaireSubmission : "votes"
+    QuestionnaireSubmission ||--o{ MultipleChoiceAnswer : "contains"
+    QuestionnaireSubmission ||--o{ FreeTextAnswer : "contains"
+
+    Poll {
+        uuid id
+        uuid questionnaire FK
+        uuid organization FK
+        uuid event FK
+        string status
+        datetime opened_at
+        datetime closes_at
+        datetime closed_at
+        boolean allow_vote_changes
+        string vote_visibility
+        string result_visibility
+        string result_timing
+        boolean staff_anonymous
+        boolean public_anonymous
+    }
+```
+
+---
+
+## Data model (`Poll`)
+
+`src/polls/models.py`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `questionnaire` | OneToOne → `Questionnaire` | The vote container. Cascade deletes votes when the poll is torn down. |
+| `organization` | FK → `Organization` | Owner of the poll; drives `manage_polls` checks. |
+| `event` | FK → `Event`, nullable | Optional event scoping. **Required** when any visibility is `PRIVATE` or `ATTENDEES_ONLY` (enforced by a `CheckConstraint`). |
+| `status` | `PollStatus` | `DRAFT` / `OPEN` / `CLOSED`. |
+| `opened_at` / `closes_at` / `closed_at` | DateTime, nullable | `closes_at` is the optional auto-close deadline; `opened_at` / `closed_at` are stamped on transition. |
+| `allow_vote_changes` | bool | When `False`, a second vote raises `PollVoteAlreadyCastError` (409) and withdrawing is forbidden. |
+| `vote_visibility` | `ResourceVisibility` | Who may **cast** a vote (and, combined with results, who may see the poll exists). |
+| `result_visibility` | `ResourceVisibility` | Who may **see results** (default `STAFF_ONLY`). |
+| `result_timing` | `PollResultTiming` | `NEVER` (default) / `AFTER_VOTE` / `AFTER_CLOSE`. |
+| `vote_membership_tiers` / `result_membership_tiers` | M2M → `MembershipTier` | Optional tier restriction applied on top of `MEMBERS_ONLY` visibility. |
+| `staff_anonymous` / `public_anonymous` | bool, default `True` | Whether voter identity is hidden from staff / non-staff viewers in results. |
+
+### Constraints & invariants
+
+- **`poll_public_results_must_be_anonymous`** — if `result_visibility` is `PUBLIC` or `UNLISTED`, `public_anonymous` must be `True`. You cannot expose voter identities on a publicly-readable result set.
+- **`poll_restricted_visibility_requires_event`** — `PRIVATE` / `ATTENDEES_ONLY` visibility (vote or result) requires an attached `event`, since those audiences are defined by event relationships (ticket / RSVP / invitation).
+- **Anonymity is immutable after creation.** `Poll.save()` re-reads the old row and raises `PollAnonymityImmutableError` if `staff_anonymous` or `public_anonymous` changed. The only way to get a poll with different anonymity is to [duplicate](#duplicating-a-poll) it (where overrides are allowed because the copy is a fresh row).
+
+---
+
+## Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT : create_poll
+    DRAFT --> OPEN : open_poll
+    OPEN --> CLOSED : close_poll / close_polls_due
+    CLOSED --> OPEN : reopen_poll (future closes_at)
+```
+
+All lifecycle transitions live in `src/polls/service/poll_service.py` and take a `SELECT FOR UPDATE` lock on the poll row inside `transaction.atomic()`, so a close racing with an in-flight vote resolves deterministically.
+
+- **`open_poll`** — only a `DRAFT` poll can be opened directly; stamps `opened_at`.
+- **`close_poll`** — only an `OPEN` poll can be closed; stamps `closed_at`.
+- **`reopen_poll`** — only a `CLOSED` poll can be reopened, and only with a meaningful future deadline: the caller must supply a future `closes_at`, set `clear_closes_at=True`, or have an existing future `closes_at`. Reopening with a past deadline would close again on the next sweep.
+- **Auto-close** — the `polls.tasks.close_polls_due` Celery task sweeps `OPEN` polls whose `closes_at` has elapsed, re-checking each under a row lock before flipping it to `CLOSED`. It snapshots candidate IDs first and processes each in its own transaction (no server-side cursor — PgBouncer-safe, see [engineering notes](../engineering-notes.md)).
+
+!!! note "DRAFT polls are invisible to non-staff"
+    A DRAFT poll's detail endpoint never leaks its questions/options to non-staff even if the caller knows the UUID and the poll's `vote_visibility` is `PUBLIC` — `can_see_poll` short-circuits to `False` for DRAFT unless the viewer is staff/owner.
+
+---
+
+## Visibility & eligibility
+
+Pure-logic helpers live in `src/polls/service/eligibility.py` (no DB writes; they take a resolved `Poll` + user). The same `ResourceVisibility` enum used for events/resources drives the audience checks.
+
+| Visibility | Who passes |
+|---|---|
+| `PUBLIC` / `UNLISTED` | Everyone (anonymous included). |
+| `MEMBERS_ONLY` | Active org members; if tiers are set, the member's tier must be in the list. |
+| `ATTENDEES_ONLY` | Users with a non-cancelled ticket or YES RSVP for the linked event. |
+| `PRIVATE` | Attendees **or** invited users for the linked event. |
+| `STAFF_ONLY` | Org staff / owner only. |
+
+Staff/owner (and Django superusers/staff) always pass every check. Banned / hard-blacklisted users see no polls from that organization, mirroring `EventQuerySet.for_user`.
+
+Three derived predicates govern access:
+
+- **`can_see_poll`** — viewer is in the vote audience **or** the result audience **or** has already voted. Used by list + detail.
+- **`can_vote`** — viewer passes `vote_visibility` (and is authenticated). The `OPEN` status check is applied separately by the caller.
+- **`can_see_results`** — viewer passes `result_visibility` **and** the `result_timing` gate (`NEVER` → never; `AFTER_CLOSE` → only when `CLOSED`; `AFTER_VOTE` → only after the viewer voted). Staff/owner bypass timing.
+
+### Listing performance
+
+The list endpoint annotates each row via `PollQuerySet.with_user_annotations` (a set of `Exists()` subqueries for ownership/staff/membership/ticket/RSVP/invitation/voted flags) so per-row schema resolvers compute eligibility with a **flat** query count regardless of page size. `Poll.objects.for_user` applies the visibility filter at the SQL level. Tier-restricted `MEMBERS_ONLY` polls are intentionally not refined in the listing (a benign false-positive that the fine-grained per-poll check then resolves), matching the listings-vs-access split used for events.
+
+---
+
+## Voting
+
+`poll_service.vote` and `poll_service.withdraw_vote`, both under a poll-row `SELECT FOR UPDATE`:
+
+1. The poll must be `OPEN` → else `PollNotOpenError` (**423 Locked**).
+2. The user must pass `can_vote` → else `PollNotEligibleError` (**403**).
+3. If a submission already exists and `allow_vote_changes=False` → `PollVoteAlreadyCastError` (**409**).
+4. Otherwise create/reuse the `QuestionnaireSubmission` (`READY`, `submitted_at=now`), clear any prior answers, and re-write the MC/free-text/file-upload answers. Each answer is validated against the poll's own questionnaire (questions must belong to it, options to their question, files to the uploader) — bogus IDs raise `PollValidationError` (**422**) and roll back.
+
+Withdrawing requires `OPEN` **and** `allow_vote_changes=True` (`PollVoteChangesNotAllowedError` → **403**), and simply deletes the submission.
+
+---
+
+## Results & anonymity
+
+`compute_poll_results` (`src/polls/service/aggregation.py`) aggregates the `READY` submissions for the poll's questionnaire:
+
+- **MC distributions** reuse `aggregate_mc_distributions` from the events questionnaire service (shared code path).
+- **`total_voters`** is the distinct count of submitting users.
+- **Free-text responses** are returned verbatim, ordered by submission time.
+
+Whether **voter identity** is attached is decided by `_viewer_sees_identity`: a staff/owner viewer sees identity only when `staff_anonymous=False`; a non-staff viewer only when `public_anonymous=False`. When identity is hidden, free-text `user_*` fields are `None` and each MC option's `voters` is `None` (not `[]`, so the frontend can distinguish "anonymous poll" from "nobody picked this").
+
+---
+
+## Duplicating a poll
+
+`poll_service.duplicate_poll` deep-copies the wrapped questionnaire (`duplicate_questionnaire_content` — sections, questions, options, intra-questionnaire dependency remapping) and creates a fresh poll in `DRAFT` with a reset lifecycle (`opened_at` / `closed_at` / `closes_at` cleared). It copies visibility, result timing, vote-change policy, and both membership-tier M2Ms. Because the copy is a new row, `staff_anonymous` / `public_anonymous` may be overridden in the payload (otherwise the template's values are copied verbatim); overriding `public_anonymous=False` while the result visibility is public raises `PollResultsMustBeAnonymousError`. **Votes, submissions, answers, evaluations, and uploaded files are never copied.**
+
+---
+
+## API
+
+`PollController` (`src/polls/controllers/poll_controller.py`), mounted at `/api/polls`, `OptionalAuth` (anonymous reads allowed). Reads return `404` when a poll doesn't exist vs `403` when it exists but the caller can't see it, so frontends can branch without inspecting bodies.
+
+| Method | Path | Permission | Purpose |
+|---|---|---|---|
+| `GET` | `/polls/` | visibility filter | Paginated list (filter by `organization_id`, `event_id`, `status`). |
+| `GET` | `/polls/{id}/` | `can_see_poll` | Detail incl. per-user flags and (when allowed) results. |
+| `GET` | `/polls/{id}/results` | `can_see_results` | Aggregated results, honoring visibility + timing + anonymity. |
+| `POST` | `/polls/organizations/{org_id}` | `manage_polls` | Create a poll (+ its questionnaire) in `DRAFT`. |
+| `PATCH` | `/polls/{id}/` | `manage_polls` | Partial update (poll fields + wrapped `name`/`description`). |
+| `POST` | `/polls/{id}/open` · `/close` · `/reopen` | `manage_polls` | Lifecycle transitions. |
+| `POST` | `/polls/{id}/duplicate` | `manage_polls` | Deep-copy into a new DRAFT poll. |
+| `DELETE` | `/polls/{id}/` | **org owner only** (`IsPollOrganizationOwner`) | Hard-delete the poll, its questionnaire, and all votes. |
+| `POST` | `/polls/{id}/vote` | authenticated + `can_vote` | Cast or replace a vote. |
+| `DELETE` | `/polls/{id}/vote` | authenticated | Withdraw a vote (OPEN + `allow_vote_changes`). |
+
+Service-layer exceptions are translated to HTTP statuses by the per-app handlers in `src/polls/exception_handlers.py` (`PollNotOpenError` → 423, `PollNotEligibleError` → 403, `PollVoteAlreadyCastError` → 409, `PollValidationError` → 422).
+
+---
+
+## Related reading
+
+- [Questionnaires](questionnaires.md) — the underlying question/submission engine polls reuse.
+- [Permissions](permissions.md) — `manage_polls` and the organization role model.
+- [Service Layer](service-layer.md) — poll lifecycle follows the function-based service pattern with row-locked transitions.

--- a/docs/architecture/questionnaires.md
+++ b/docs/architecture/questionnaires.md
@@ -458,6 +458,53 @@ The `QuestionnaireService` class provides CRUD operations for questionnaires and
 - **`create_section()` / `create_mc_question()` / `create_ft_question()` / `create_fu_question()`**: Individual creation methods supporting nested conditional content
 - **`evaluate_submission()`**: Creates or updates a manual evaluation for a submission
 
+## Security
+
+Beyond [prompt-injection protection](#prompt-injection-protection), two access-control
+invariants guard the questionnaire system.
+
+### Admin reads are org-admin gated
+
+The **admin** questionnaire schema exposes the answer key — `is_correct` on each option,
+per-question `positive_weight` / `negative_weight`, the questionnaire's `min_score`,
+`reviewer_notes`, and `llm_guidelines`. None of this may reach a candidate who is about to
+take the questionnaire.
+
+Accordingly, the admin **detail** (`GET /{org_questionnaire_id}`) and **list**
+(`GET /`) endpoints are restricted to organization administrators:
+
+- The detail endpoint requires `QuestionnairePermission("evaluate_questionnaire")` (owner or
+  staff with that flag).
+- The list endpoint is scoped to `OrganizationQuestionnaire.objects.for_admin(self.user())`,
+  so only organizations the user owns or staffs are returned.
+
+!!! danger "Why this matters"
+    Before this was tightened, the admin detail read could leak the full answer key
+    (`is_correct`, weights, `min_score`, `reviewer_notes`, `llm_guidelines`) to any
+    authenticated user. Candidates take questionnaires through the separate user-facing
+    `build()` flow, which never serializes those fields.
+
+### Submission invariants enforced in the service layer
+
+Answers are persisted with `bulk_create`, which **skips** Django's `Model.clean()`. So model-level
+checks (`MultipleChoiceAnswer.clean()`) are **not** a sufficient guard on the write path. The
+`QuestionnaireService` re-enforces the invariants explicitly at submission time:
+
+- **Single-answer questions** (`allow_multiple_answers=False`) may receive at most one selected
+  option. Options are aggregated per question **across all answer entries** (de-duplicated), so a
+  client cannot split selections into several entries to slip past a per-entry length check. A
+  violation raises `DisallowedMultipleAnswersError`.
+- **Options must belong to their question.** Each `(question_id, option_id)` pair is checked
+  against the options actually owned by that question (queried fresh, since the prefetched cache
+  can be stale). A foreign option id raises `CrossQuestionnaireSubmissionError`.
+
+!!! warning "Why service-layer enforcement is required"
+    Without these checks, a submitter could pair a single-answer question with *every* option
+    (guaranteeing the correct one is selected) or borrow a correct option from another question —
+    the evaluator would credit the paired question's weight and, in `AUTOMATIC` mode,
+    auto-approve an admission gate. The model `clean()` alone does not catch this because answers
+    are bulk-created.
+
 ## Information-Gathering Mode (`requires_evaluation`)
 
 The `OrganizationQuestionnaire` wrapper has a `requires_evaluation` boolean field (default `True`). When set to `False`, the questionnaire gates access based on submission existence alone — no LLM evaluation, no manual review, no scoring.
@@ -474,6 +521,15 @@ This is useful for **admission questionnaires that collect information without j
 
 !!! warning "Interaction with evaluation_mode"
     The `requires_evaluation` flag takes precedence over the underlying `Questionnaire.evaluation_mode`. Even if the questionnaire is configured with `AUTOMATIC` evaluation mode, setting `requires_evaluation=False` on the `OrganizationQuestionnaire` wrapper will skip evaluation entirely.
+
+!!! info "Submission responses expose `requires_evaluation`"
+    Submission response schemas (`QuestionnaireSubmissionResponseSchema` and the staff-side
+    `SubmissionListItemSchema`) now include the `requires_evaluation` boolean (resolved from the
+    wrapping `OrganizationQuestionnaire`). Clients can branch on it — for example, to avoid
+    showing an information-gathering submission as "pending review" when no evaluation will ever
+    run. The resolver is idempotent: when ninja re-validates the pre-built schema instance on the
+    submit endpoint (it has no `.questionnaire` relation), the already-computed value is reused
+    rather than re-walking the ORM, defaulting to `True` when no organization wrapper exists.
 
 ## Integration with Eligibility
 

--- a/docs/architecture/recurring-series.md
+++ b/docs/architecture/recurring-series.md
@@ -1,0 +1,190 @@
+# Recurring Event Series
+
+Revel models recurring events as **first-class series with rolling-window materialization**. A recurring series is defined by a `RecurrenceRule` and a **template event**; a daily Celery beat task walks the rule forward and materializes each occurrence as a **real, independent `Event`** — its own tickets, payments, capacity, RSVPs, and check-in window. Occurrences are not virtual: once generated, they behave exactly like a one-off event.
+
+This page covers the rule model, how and when occurrences are generated, drift detection after a cadence change, how template edits propagate, and the single `SERIES_EVENTS_GENERATED` digest sent per generated batch.
+
+!!! note "A series is recurring iff it has a rule"
+    `EventSeries` is also used as a plain grouping container (a series of unrelated events). A series is "recurring" precisely when it has an attached `RecurrenceRule`; that's what the `is_recurring` annotation (`EventSeriesQuerySet.with_is_recurring`) exposes on list/detail.
+
+---
+
+## Data model
+
+### `RecurrenceRule`
+
+`src/events/models/recurrence_rule.py`. Stores the recurrence parameters and computes an RFC 5545 `RRULE` string on save (via `python-dateutil`).
+
+| Field | Type | Notes |
+|---|---|---|
+| `frequency` | `Frequency` | `DAILY` / `WEEKLY` / `MONTHLY` / `YEARLY`. |
+| `interval` | PositiveInt (default 1) | Every N units of the frequency. |
+| `weekdays` | JSON list of ints | Weekly recurrence: `0=Mon … 6=Sun`. |
+| `monthly_type` | `MonthlyType`, nullable | `DAY_OF_MONTH` or `NTH_WEEKDAY`. |
+| `day_of_month` / `nth_weekday` / `weekday` | int, nullable | Monthly parameters (e.g. "3rd Tuesday" or "the 15th"). |
+| `dtstart` | DateTime | Anchor of the series. |
+| `until` / `count` | DateTime / int, nullable | Optional boundaries. |
+| `rrule_string` | Text, read-only | Recomputed on every save from the structured fields. |
+| `timezone` | str (default `UTC`) | Validated IANA zone. **Currently reserved metadata** — occurrences are anchored to the UTC `dtstart` and do not yet observe DST in the named tz (a `# ponytail:`-style Phase-3 ceiling noted in the model). |
+
+Validation is delegated to `events/utils/recurrence_validators.py` so the Pydantic input schema and the model `clean()` enforce identical rules. `to_rrule()` builds a `dateutil.rrule`; `get_occurrences(after, before)` returns the occurrence datetimes strictly between two bounds.
+
+### `EventSeries` (recurrence fields)
+
+`src/events/models/event_series.py`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `template_event` | OneToOne → `Event`, `PROTECT` | The DRAFT blueprint every occurrence is cloned from. |
+| `recurrence_rule` | OneToOne → `RecurrenceRule`, `PROTECT` | The cadence. |
+| `exdates` | JSON list | UTC-normalized ISO strings of cancelled/excluded occurrence instants. |
+| `is_active` | bool | Master switch — `False` pauses generation (existing occurrences untouched). |
+| `auto_publish` | bool | When `True`, materialized occurrences are created `OPEN` instead of `DRAFT`. |
+| `generation_window_weeks` | PositiveInt (default 8, max 52) | Rolling horizon ahead of "now" to keep materialized. |
+| `last_generated_until` | DateTime, nullable | Cursor: how far ahead occurrences have been generated. |
+
+!!! danger "Both recurrence FKs are `PROTECT`"
+    `template_event` and `recurrence_rule` use `on_delete=PROTECT` so an admin can't delete the Event or RecurrenceRule out from under a (possibly paid-ticket-bearing) series. Series teardown goes through `EventSeries.delete()`, which nulls both PROTECTing FKs in one UPDATE before cascading to the template and occurrences. The orphaned `RecurrenceRule` row is left behind by design (cleanup belongs in a future service-level teardown helper).
+
+---
+
+## Rolling-window materialization
+
+The single entrypoint is `generate_series_events(series, until_override=None)` in `src/events/service/recurrence_service.py`.
+
+```mermaid
+flowchart TD
+    Start([generate_series_events]) --> Pre{"is_active?<br/>has rule + template?"}
+    Pre -->|No| Empty([return []])
+    Pre -->|Yes| Lock[SELECT FOR UPDATE series row<br/>of=self]
+    Lock --> Recheck{"still active?<br/>still has rule + template?"}
+    Recheck -->|No| Empty
+    Recheck -->|Yes| Window["start_from = last_generated_until<br/>or dtstart − 1s<br/>horizon = now + window_weeks"]
+    Window --> Cap{"start_from > horizon?"}
+    Cap -->|Yes| Clamp[clamp start_from = horizon]
+    Cap -->|No| Occ
+    Clamp --> Occ[rule.between start_from, horizon]
+    Occ --> Loop["for each occurrence dt:<br/>skip if in exdates or existing_starts<br/>else materialize_occurrence"]
+    Loop --> Cursor[last_generated_until = horizon]
+    Cursor --> Commit[(commit)]
+    Commit --> Digest{"any created?"}
+    Digest -->|Yes| Notify[notify_series_events_generated<br/>SERIES_EVENTS_GENERATED]
+    Digest -->|No| Done([return created])
+    Notify --> Done
+```
+
+### How it works
+
+- **Cheap pre-check, then a locked re-check.** The function first short-circuits inactive / rule-less series without opening a transaction, then re-fetches inside the lock — the locked state is the source of truth.
+- **Series-row lock.** The whole computation runs in one `transaction.atomic()` that begins with `select_for_update(of=("self",))` on the `EventSeries` row. This serializes concurrent callers (e.g. the daily beat fan-out overlapping a manual "Generate now" click); without it, both would compute the same gap, call `duplicate_event` with the same deterministic slug, and race on the `(organization, slug)` unique constraint. (`of=("self",)` is required: a plain `FOR UPDATE` with `select_related` on the nullable rule/template FKs would produce a LEFT JOIN that PostgreSQL rejects for `FOR UPDATE`.)
+- **The window.** `start_from` is `last_generated_until` (or `dtstart − 1s` on the first run, so `dtstart` itself is included). `horizon` is `now + generation_window_weeks` (or an explicit `until_override` from manual generation). If `start_from > horizon` (e.g. the window was shrunk), it's clamped so generation can't silently stall.
+- **Idempotency.** `existing_starts` (occurrences already in the window) and `exdates` are both skipped, so re-running is safe and produces no duplicates. The `occurrence_index` continues monotonically from the max existing index.
+- **Cloning.** `materialize_occurrence` calls `duplicate_event` (deep clone of the template) with the occurrence start, index, and a status override (`OPEN` if `auto_publish`, else the template's DRAFT). The event `schedule`/timeline is copied verbatim from the template.
+- **Atomicity of cursor + occurrences.** The materialization loop and the `last_generated_until` bump commit together — a failure on any occurrence rolls back the whole batch and the cursor. The notification dispatch is deliberately **outside** the atomic block so a notification glitch can't roll back successfully-materialized events.
+
+### When it runs
+
+| Trigger | Path |
+|---|---|
+| Daily beat | `events.generate_recurring_events` (Celery beat, **daily at 04:00 UTC**, migration `0067`) fans out one `events.generate_single_series_events` subtask per active recurring series, so one series failing doesn't block the rest. |
+| Series creation | `create_recurring_event_series` runs an initial generation pass immediately. |
+| Cadence/window change | `update_series_recurrence` resets `last_generated_until` (see below) so the next pass backfills the new cadence. |
+| Manual | `POST .../event-series/{id}/generate` (optional `until` override). |
+
+The per-series subtask retries with exponential backoff **only** on transient DB errors (deadlocks, dropped connections); programming errors (missing template, invalid rule) fail loudly on the first run.
+
+---
+
+## Cursor invalidation on cadence change
+
+`update_series_recurrence` (same module) applies partial updates to the series and/or its rule. When a change would shift the schedule, it resets `last_generated_until = None` so the next generation pass regenerates from `dtstart` rather than waiting for real time to catch up. The cursor is invalidated when:
+
+- `generation_window_weeks` changes (decreases can stall; increases should backfill the new horizon).
+- Any of the rule's schedule-defining fields change: `frequency`, `interval`, `weekdays`, `monthly_type`, `day_of_month`, `nth_weekday`, `weekday`, `dtstart`, `until`, `count`, `timezone` (`_RULE_CURSOR_INVALIDATING_FIELDS`).
+
+`pause_series` / `resume_series` flip `is_active` without touching the cursor or existing occurrences.
+
+---
+
+## Drift detection
+
+Changing the cadence does **not** retroactively move occurrences that were already materialized — they keep their old dates. `detect_cadence_drift(series)` returns the IDs of future occurrences that no longer match the current `RRULE`, so the admin UI can highlight stale rows and offer a bulk "cancel stale dates" action.
+
+An occurrence is reported as drifted when it is **all** of:
+
+- `is_template=False` — the template is never an occurrence.
+- `start >= now()` — past occurrences are out of scope.
+- `status != CANCELLED` — already-cancelled rows don't need another pass.
+- `is_modified=False` — manually-edited occurrences were deliberately shifted off-cadence by an organizer (the standard event-edit endpoint sets `is_modified=True`); flagging them would be misleading.
+
+Comparison is **by UTC instant** (both the RRULE output and stored `start` are normalized to UTC before the set-membership check), so a DST shift in a stored timezone doesn't cause a spurious classification. Exdates are subtracted from the expected set so an occurrence sitting on an exdate is correctly reported as drift rather than masked. Exposed via `GET .../event-series/{id}/drift`.
+
+---
+
+## Cancelling a single occurrence
+
+`cancel_occurrence(series, occurrence_date)` (under a series-row lock):
+
+1. Adds the occurrence's UTC-normalized instant to `exdates` (deduplicated, so equivalent instants in different tz representations don't accumulate) — this prevents the date from being re-materialized.
+2. If the occurrence was already materialized, flips that `Event` to `CANCELLED` (matching by instant, not wall-clock).
+
+The lock makes concurrent cancellations of different occurrences safe (otherwise a last-writer-wins overwrite would silently drop an exclusion).
+
+---
+
+## Template-change propagation
+
+Editing the template (`update_template`) optionally pushes changes onto future occurrences, controlled by a `propagate` scope query parameter:
+
+| Scope | Effect |
+|---|---|
+| `NONE` (default) | Only the template is updated; the next generation pass picks up changes for *new* occurrences. |
+| `FUTURE_UNMODIFIED` | Apply to future occurrences that haven't been manually edited (`is_modified=False`). |
+| `ALL_FUTURE` | Apply to all future occurrences, including manually-edited ones. |
+
+Only fields in the **`PROPAGATABLE_FIELDS`** whitelist are propagated — content/config like `name`, `description`, `visibility`, `event_type`, capacity, toggles, `address`/`location`, `is_open_ended`. Per-occurrence state (`start`/`end`, `status`, slugs, FKs, computed fields) is **never** overwritten.
+
+!!! note "Coupled fields move together"
+    `address` and `location` (human-readable text + PostGIS `Point`) are a coupled pair: if either is propagated, the other is pulled from the template too, so an occurrence never ends up with an address that disagrees with its coordinates.
+
+Propagation writes via per-instance `save()` (so `full_clean()` and coupled-field invariants run), suppresses per-event notifications during the batch, and runs inside one atomic block (`update_template` updates the template and propagates atomically, avoiding a half-applied state).
+
+---
+
+## The `SERIES_EVENTS_GENERATED` digest
+
+Per-occurrence `EVENT_OPEN` notifications are **suppressed** during materialization (`suppress_event_notifications()`). Instead, after a successful generation batch with at least one new occurrence, `notify_series_events_generated` sends a **single digest** (`NotificationType.SERIES_EVENTS_GENERATED`) — one per batch, not one per occurrence.
+
+The audience mirrors who would have received `EVENT_OPEN`, **gated by the template's visibility**:
+
+- `STAFF_ONLY` / `PRIVATE` / `UNLISTED` → staff + owners only (the digest deliberately doesn't broadcast non-public occurrences to members/followers).
+- `MEMBERS_ONLY` → staff, owners, and active/paused members.
+- `PUBLIC` → staff, owners, members, plus org/series followers who opted into new-event notifications.
+
+Each candidate is then filtered through their `NotificationPreference` (users who silenced everything or disabled `SERIES_EVENTS_GENERATED` are dropped). The notification links to the public series route `/events/{org_slug}/series/{series_slug}`. See [Notifications](notifications.md) for the multi-channel dispatch.
+
+---
+
+## Admin API
+
+`OrganizationAdminRecurringEventsController` (`src/events/controllers/organization_admin/recurring_events.py`), mounted under `/organization-admin/{slug}`. Creation requires `create_event`; all other endpoints require `edit_event_series`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/create-recurring-event` | Create rule + series + template, run initial generation. Returns `EventSeriesRecurrenceDetailSchema`. |
+| `PATCH` | `/event-series/{id}/template` | Edit the template; `?propagate=none\|future_unmodified\|all_future`. |
+| `PATCH` | `/event-series/{id}/recurrence` | Update rule / `auto_publish` / `generation_window_weeks` (resets the cursor when the schedule shifts). |
+| `POST` | `/event-series/{id}/cancel-occurrence` | Exclude (and cancel, if materialized) one occurrence. |
+| `POST` | `/event-series/{id}/generate` | Manual rolling-window generation (optional `until`). |
+| `POST` | `/event-series/{id}/pause` · `/resume` | Toggle `is_active`. |
+| `GET` | `/event-series/{id}` | Full admin detail (`EventSeriesRecurrenceDetailSchema`). |
+| `GET` | `/event-series/{id}/drift` | Off-cadence future occurrence IDs. |
+| `GET` | `/event-series/{id}/template-event` | The template's `EventDetailSchema` (the public detail route filters templates out). |
+
+---
+
+## Related reading
+
+- [Notifications](notifications.md) — the `SERIES_EVENTS_GENERATED` digest channel architecture.
+- [Service Layer](service-layer.md) — `recurrence_service.py` follows the function-based pattern with row-locked, atomic generation.
+- [Engineering Notes](../engineering-notes.md) — Celery `on_commit` and PgBouncer `.iterator()` gotchas relevant to the generation task.

--- a/docs/architecture/scheduled-announcements.md
+++ b/docs/architecture/scheduled-announcements.md
@@ -1,0 +1,215 @@
+# Scheduled Announcements
+
+Organization announcements are no longer send-now-only. As of **1.64.0** a draft can be
+**scheduled** to fire at a future time — either an **absolute** timestamp or a time
+**relative to the event's start or end** — and event announcements can be **re-delivered to
+attendees who sign up after the first send**. Two Celery-beat sweeps do the work; the
+announcement model and the existing notification dispatcher do the rest.
+
+This page documents the scheduling and resend mechanics. For the announcement
+notification itself (`org_announcement`) and the multi-channel delivery path, see
+[Notifications](notifications.md).
+
+!!! note "Immediate send is unchanged"
+    Sending an announcement **now** (`POST /announcements/{id}/send`) works exactly as
+    before. Scheduling is an opt-in layer on top: a scheduled announcement is just a
+    `DRAFT` that has been parked in `SCHEDULED` until a sweep decides it is due.
+
+---
+
+## Status model
+
+An `Announcement` (`src/events/models/announcement.py`) moves through three statuses:
+
+| Status | Meaning |
+|---|---|
+| `DRAFT` | Editable, never delivered. The default on create. |
+| `SCHEDULED` | Has a resolved future send time; waiting for the beat sweep. Still editable. |
+| `SENT` | Delivered (immutable except for the resend bookkeeping). |
+
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT: create_announcement
+    DRAFT --> SCHEDULED: schedule_announcement<br/>(/schedule)
+    SCHEDULED --> DRAFT: unschedule_announcement<br/>(/unschedule)
+    DRAFT --> SENT: send_announcement<br/>(/send, manual)
+    SCHEDULED --> SENT: send_scheduled_announcements<br/>(beat sweep, when due)
+    SENT --> SENT: resend_to_new_recipients<br/>(beat sweep, delta only)
+    SENT --> [*]
+```
+
+Only `DRAFT` and `SCHEDULED` announcements can be **updated** or **deleted**; `SENT` is
+preserved for audit.
+
+---
+
+## Scheduling: absolute vs relative
+
+`schedule_announcement` (`announcement_service.py`) accepts **exactly one** of two modes.
+The choice is enforced both at the schema level (`AnnouncementScheduleSchema`) and in the
+model's `clean()`.
+
+| Mode | Fields | Resolves to |
+|---|---|---|
+| **Absolute** | `scheduled_at` (an `AwareDatetime`) | `scheduled_at` verbatim |
+| **Relative** | `schedule_anchor` (`event_start` / `event_end`) + `schedule_offset_minutes` (signed) | `anchor_time + offset` |
+
+`schedule_offset_minutes` is signed: `-1440` means 24 hours **before** the anchor,
+`+1440` means 24 hours **after**. The resolved time must be **in the future** at schedule
+time, or `/schedule` returns **422**.
+
+### Invariants (enforced in `Announcement.clean()` and the service)
+
+- Absolute and relative scheduling are **mutually exclusive** — provide one, not both.
+- Relative scheduling requires **both** an anchor and an offset.
+- Relative scheduling requires an **event-targeted** announcement (there is no anchor
+  without an event).
+
+### Relative schedules auto-shift with the event
+
+The live send time is **not** frozen at schedule time. It is recomputed on every sweep
+from the model's `effective_send_at` property:
+
+```python
+@property
+def effective_send_at(self) -> dt.datetime | None:
+    if self.schedule_anchor is None:
+        return self.scheduled_at          # absolute: fixed
+    if self.event is None:
+        return None
+    anchor_time = (
+        self.event.start
+        if self.schedule_anchor == self.ScheduleAnchor.EVENT_START
+        else self.event.end
+    )
+    return anchor_time + dt.timedelta(minutes=self.schedule_offset_minutes or 0)
+```
+
+!!! tip "Move the event, and the announcement follows"
+    An announcement scheduled for "1 hour before the doors open" stays correct if the
+    organizer reschedules the event. Because the sweep reads `effective_send_at` fresh on
+    every run, a relative schedule **auto-shifts** with `event.start` / `event.end`.
+    Absolute schedules (`scheduled_at`) are fixed and never move.
+
+---
+
+## Endpoints
+
+Mounted on `OrganizationAdminAnnouncementsController`
+(`src/events/controllers/organization_admin/announcements.py`), under
+`/organization-admin/{slug}/...` with the `send_announcements` org permission.
+
+| Method | Path | From → To | Purpose |
+|---|---|---|---|
+| `POST` | `/announcements/{id}/schedule` | `DRAFT` → `SCHEDULED` | Park a draft with an absolute or relative schedule. Body is `AnnouncementScheduleSchema`. |
+| `POST` | `/announcements/{id}/unschedule` | `SCHEDULED` → `DRAFT` | Cancel a schedule and clear all schedule fields. |
+| `POST` | `/announcements/{id}/send` | `DRAFT` → `SENT` | Manual immediate send (unchanged). |
+
+Both schedule endpoints map service `ValueError`s (wrong status, unresolvable or past
+time, missing event for relative mode) to **HTTP 422**.
+
+---
+
+## Delivery: background sweeps
+
+Both sweeps live in `src/events/announcement_tasks.py` (split out of `events.tasks` to
+keep that module under the 1000-line limit; the registered task **names** are preserved so
+the beat schedule in migration `0082` keeps working). The worker registers them via
+`EventsConfig.ready` importing the module.
+
+| Task | Cadence | Purpose |
+|---|---|---|
+| `events.send_scheduled_announcements` | Every **5 min** (migration `0082`) | Send `SCHEDULED` announcements whose `effective_send_at` is now due. |
+| `events.resend_announcements_to_new_signups` | Every **15 min** (migration `0082`, offset to reduce lock contention) | Re-deliver `SENT` event announcements with `resend_to_new_signups=True` to attendees who joined since the last delivery. |
+
+### Scheduled-send sweep
+
+`send_scheduled_announcements` snapshots candidate IDs, then re-fetches each under
+`select_for_update` (per the PgBouncer / server-side-cursor rule, #458), **recomputes
+`effective_send_at` live** (so relative schedules pick up any event move), and sends the
+due ones via `announcement_service.send_announcement`.
+
+!!! note "Overlapping runs are safe"
+    `send_announcement` re-checks the status inside its own row-locked transaction, so a
+    double-send caused by two overlapping beat runs is harmless — the second run sees the
+    announcement is already `SENT` and skips it.
+
+---
+
+## Resend to new sign-ups
+
+An **event** announcement can opt into `resend_to_new_signups=True`. After the first send,
+the 15-minute sweep keeps re-delivering it to attendees who join later — until the event
+ends.
+
+```mermaid
+flowchart TD
+    Start([resend sweep, every 15 min]) --> Q["Query: status=SENT<br/>AND resend_to_new_signups=True<br/>AND event.end > now"]
+    Q --> Loop[For each candidate, SELECT FOR UPDATE]
+    Loop --> Current["current = get_recipients(announcement)"]
+    Current --> Notified["notified = users with an existing<br/>org_announcement notification<br/>for this announcement_id"]
+    Notified --> Delta{"new = current − notified<br/>non-empty?"}
+    Delta -->|"No"| Skip([no-op])
+    Delta -->|"Yes"| Deliver["_deliver_to_recipients(new)<br/>+ recipient_count += N"]
+    Deliver --> Done([resent])
+```
+
+Key properties of `resend_to_new_recipients` (`announcement_service.py`):
+
+- **No double-notify.** The set of already-notified users is derived from the existing
+  `org_announcement` notifications keyed on `context__announcement_id` — that notification
+  ledger **is** the dedup mechanism. Only `current − notified` get a new notification.
+- **Stop condition is the query.** The sweep only considers announcements whose
+  `event.end > now`; once the event ends, the announcement simply drops out of the
+  candidate set. `resend_to_new_recipients` also re-checks `event.end <= now` under the
+  lock as a guard.
+- **Event-only.** `resend_to_new_signups` requires an event-targeted announcement
+  (validated in both `clean()` and the service) — "new sign-ups" only has meaning for an
+  event's attendee set.
+- **Row-locked + idempotent.** Each candidate is processed under `select_for_update`, and
+  `recipient_count` is bumped with an `F()` update for the delta actually delivered.
+
+!!! info "Recipients = event attendees"
+    For an event announcement, recipients are users with an **active or checked-in ticket**
+    or a **YES RSVP** (`_get_event_recipients`). As more people buy tickets or RSVP yes,
+    the recipient set grows — which is exactly what the resend sweep picks up.
+
+---
+
+## Lifecycle examples
+
+### Example 1: Relative schedule that survives a reschedule
+
+1. Organizer drafts "Doors update" targeting event *E* (`start = Sat 20:00`).
+2. `POST /schedule` with `schedule_anchor=event_start`, `schedule_offset_minutes=-60`.
+   - `effective_send_at` resolves to `Sat 19:00`; it's in the future → status `SCHEDULED`.
+3. The next day the organizer moves *E* to `Sat 21:00`.
+4. The 5-minute sweep recomputes `effective_send_at = Sat 20:00`. It does **not** fire at
+   19:00 (that time no longer resolves) — it fires at the new 20:00.
+
+### Example 2: Resend to late RSVPs
+
+1. Organizer sends "Bring your ID" for event *E* with `resend_to_new_signups=True`.
+   - 40 current attendees are notified; status `SENT`, `recipient_count=40`.
+2. Over the next two days, 12 more people RSVP yes.
+3. The 15-minute sweep computes `current=52`, `notified=40`, `new=12`, delivers to the 12,
+   and bumps `recipient_count` to 52. The original 40 are never re-notified.
+4. Event *E* ends. The announcement drops out of the sweep's query; no further resends.
+
+### Example 3: Unschedule before it fires
+
+1. A `SCHEDULED` announcement is parked for next week.
+2. The organizer changes their mind and calls `POST /unschedule`.
+   - Status → `DRAFT`; `scheduled_at`, `schedule_anchor`, `schedule_offset_minutes` are
+     all cleared. The sweep no longer considers it.
+
+---
+
+## Related reading
+
+- [Notifications](notifications.md) — announcements deliver as `org_announcement`
+  notifications through the standard multi-channel dispatcher.
+- [Service Layer](service-layer.md) — `announcement_service.py` follows the function-based
+  service pattern.
+- [Permissions](permissions.md) — the `send_announcements` org permission gates all of
+  these endpoints.

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -18,7 +18,7 @@ The `make check` command runs six checks in sequence:
 | **Lint** | ruff | Catches code quality issues and anti-patterns |
 | **Type check** | mypy (strict) | Validates type annotations across the entire codebase |
 | **Migration check** | Django | Verifies no migrations are missing (`makemigrations --check`) |
-| **i18n check** | custom | Ensures compiled `.mo` files are up-to-date with `.po` sources |
+| **i18n check** | custom | Ensures every `_()` string is extracted and every `.po` entry is translated (no empty `msgstr` / fuzzy) — no `.mo` involved |
 | **File length** | custom | Ensures no source file exceeds 1,000 lines |
 
 !!! tip "Run Locally First"

--- a/docs/getting-started/project-structure.md
+++ b/docs/getting-started/project-structure.md
@@ -12,9 +12,11 @@ revel-backend/
 │   ├── events/             # Core event management app
 │   ├── questionnaires/     # Dynamic questionnaires app
 │   ├── notifications/      # Multi-channel notifications app
+│   ├── polls/              # Organization-managed polls (1.58.0)
 │   ├── wallet/             # Apple Wallet pass generation
 │   ├── geo/                # Geolocation app
 │   ├── telegram/           # Telegram bot app
+│   ├── moderation/         # Content moderation / blocklists (1.64.0)
 │   ├── api/                # Global API configuration
 │   └── common/             # Shared utilities
 ├── docs/                   # MkDocs documentation
@@ -55,7 +57,10 @@ The largest and most central app. Manages the full lifecycle of events, from org
 Key responsibilities:
 
 - **Organizations**: creation, membership, roles (Owner, Staff, Member)
-- **Events**: creation, configuration, publishing
+- **Memberships**: paid membership subscriptions
+- **Events**: creation, configuration, publishing; recurring event series; open-ended events
+  (`is_open_ended`, 1.65.0)
+- **Schedule**: per-event schedule / timeline of sessions (1.64.0)
 - **Ticket tiers**: pricing, capacity, payment methods (free, online, PWYC)
 - **Tickets**: checkout, payment confirmation, check-in
 - **Venues**: location management
@@ -64,6 +69,7 @@ Key responsibilities:
 - **Blacklists**: organization-level email blocking
 - **Discount codes**: organization-scoped percentage/fixed-amount discounts for ticket purchases
 - **Followers**: user-to-organization following
+- **Billing**: attendee invoicing and revenue / VAT reporting
 - **Exports**: async XLSX exports for attendee lists and questionnaire submissions
 
 ---
@@ -89,6 +95,19 @@ Key responsibilities:
 - Notification creation and delivery
 - Channel routing (in-app, email, Telegram)
 - User notification preferences
+
+---
+
+### `polls/`: Organization-Managed Polls
+
+Lets organizations run polls for their members. Each `Poll` wraps a `Questionnaire` 1:1, reusing
+the questionnaire engine for the questions and recording votes as questionnaire submissions.
+
+Key responsibilities:
+
+- Poll modeling (1:1 with a `Questionnaire`)
+- Vote casting and tallying (votes are questionnaire submissions)
+- Access gated by the `manage_polls` organization permission
 
 ---
 
@@ -120,6 +139,18 @@ Key responsibilities:
 - Minimal FSM-based conversation management (preferences, broadcast)
 - Account linking (Telegram user to Revel user via OTP)
 - Notification delivery via Telegram
+
+---
+
+### `moderation/`: Content Moderation
+
+Guards user-supplied content against offensive input. Its primary use is blocking offensive
+food-item names (potluck) across multiple languages via a maintained blocklist.
+
+Key responsibilities:
+
+- Multi-language blocklist matching for user-supplied names
+- Staff deletion of offending content
 
 ---
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -167,7 +167,11 @@ Most external services have safe defaults for local development. Here's what act
 | Env Var | Default | Description |
 |---------|---------|-------------|
 | `FEATURE_LLM_EVALUATION` | `True` | Enable LLM-powered evaluation for questionnaires with free-text questions |
-| `FEATURE_GOOGLE_SSO` | `True` | Enable Google SSO login endpoint |
+| `FEATURE_GOOGLE_SSO` | `False` | Enable Google SSO login endpoint (opt-in; needs OAuth creds) |
+| `FEATURE_MALWARE_SCAN` | `True` | Scan uploads with ClamAV; when `False`, uploads are marked clean (ClamAV optional) |
+| `FEATURE_TELEGRAM` | `True` | Enable Telegram delivery and linking endpoints |
+| `FEATURE_ORGANIZATION_CREATION` | `True` | Allow regular users to create organizations |
+| `FEATURE_OBSERVABILITY` | `True` | Enable metrics/traces/logs exporters (renamed from `ENABLE_OBSERVABILITY`, whose deprecated alias still works for one release) |
 
 !!! info "Telegram token"
     The default `TELEGRAM_BOT_TOKEN` is a non-functional placeholder. The app starts fine with it, but Telegram features won't work. To develop with a real bot, create one via [@BotFather](https://t.me/BotFather) and set the token in your `.env`.

--- a/docs/guides/internationalization.md
+++ b/docs/guides/internationalization.md
@@ -9,6 +9,7 @@ Revel supports multiple languages with full translation coverage across API resp
 | `en` | English | Default |
 | `de` | German | Informal ("du") |
 | `it` | Italian | Informal ("tu") |
+| `fr` | French | Informal ("tu") |
 
 ---
 
@@ -74,9 +75,12 @@ src/locale/
 ├── de/
 │   └── LC_MESSAGES/
 │       └── django.po    # German translations (source; .mo built, not committed)
-└── it/
+├── it/
+│   └── LC_MESSAGES/
+│       └── django.po    # Italian translations (source; .mo built, not committed)
+└── fr/
     └── LC_MESSAGES/
-        └── django.po    # Italian translations (source; .mo built, not committed)
+        └── django.po    # French translations (source; .mo built, not committed)
 ```
 
 !!! note "No English locale directory"

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -220,25 +220,58 @@ FEATURE_OBSERVABILITY=True
 
 ---
 
+## Reading Production Logs
+
+For day-to-day operations, prefer the operator CLI over hand-writing LogQL:
+
+```bash
+# last hour of web errors
+.venv/bin/python scripts/loki_logs.py web --level error
+
+# everything for one request, across services, last 6h
+.venv/bin/python scripts/loki_logs.py --request-id 9f3c... --since 6h --forward
+
+# 500s in the API, last 2h
+.venv/bin/python scripts/loki_logs.py web --status-code 500 --since 2h
+```
+
+`scripts/loki_logs.py` talks to Loki through the Grafana datasource proxy (Loki
+itself is not exposed publicly) using a Grafana service-account token read from
+`GRAFANA_TOKEN`. It filters by service, level, status code, user id, request/trace
+id, path, IP, and free-text grep, and has a `-q/--query` raw-LogQL escape hatch.
+
+!!! tip "`loki-logs` skill"
+
+    The `loki-logs` Claude skill wraps this CLI for log investigations (a prod
+    error, a stuck Celery task, tracing one request/trace_id/user across services).
+
+---
+
 ## Example Queries
 
 === "Loki (LogQL)"
 
+    Since 1.62.4 each event is a single JSON render, and the request-metadata fields
+    (`status_code`, `user_id`, `method`, `path`, `request_id`, `trace_id`,
+    `ip_address`, `user_agent`) are promoted to **structured metadata** (1.62.5) —
+    filter them with `| field="value"`, no `| json` parse needed. Stream **labels**
+    are `service_name`, `level`, and `environment`.
+
     ```logql
-    # All errors in the last hour
-    {app="revel"} |= "error" | json
+    # All web errors in the last hour
+    {service_name="web", level="error"}
 
-    # Errors for a specific user
-    {app="revel"} | json | user_id="<uuid>"
+    # Errors for a specific user (structured-metadata label filter)
+    {service_name="web", level="error"} | user_id="<uuid>"
 
-    # Slow requests (>1s)
-    {app="revel"} | json | duration > 1000
+    # 500s in the API (status_code is a structured-metadata label)
+    {service_name="web"} | status_code="500"
 
     # Celery task failures
-    {app="revel", component="celery"} |= "task_failure"
+    {service_name="celery_default"} |= "task_failure"
 
     # Payment-related logs
-    {app="revel"} | json | logql_filter="payment"
+    {service_name="web"} |= "stripe"
     ```
 
 === "Prometheus (PromQL)"

--- a/docs/guides/telegram-bot.md
+++ b/docs/guides/telegram-bot.md
@@ -80,7 +80,7 @@ Superusers can broadcast messages to all bot users via a dedicated FSM flow.
 |---|---|
 | `/start` | Welcome message, shows linked status |
 | `/connect` | Link Telegram account to Revel via OTP |
-| `/preferences` | Manage notification preferences *(stub — not yet implemented)* |
+| `/preferences` | Manage notification preferences *(not yet implemented — the command, router, and FSM scaffolding are registered but the handler is empty, so the command currently no-ops)* |
 | `/cancel` | Cancel current FSM conversation |
 | `/toc` | Terms and conditions |
 | `/privacy` | Privacy policy |
@@ -90,6 +90,7 @@ Superusers can broadcast messages to all bot users via a dedicated FSM flow.
 
 | Setting | Default | Description |
 |---|---|---|
+| `FEATURE_TELEGRAM` | `True` (on) | Master switch for the integration. When off, the OTP-linking endpoints (`/telegram/connect`, `/disconnect`, `/status`, `/botname`) return **404** and the notification dispatcher strips the Telegram channel platform-wide, so **no Telegram notifications are sent**. Key self-hosting toggle for instances running without a bot. |
 | `TELEGRAM_BOT_TOKEN` | `0000000000:AABBCCDD` (placeholder) | Bot token from [@BotFather](https://t.me/BotFather) |
 | `TELEGRAM_SUPERUSER_IDS` | `""` | Comma-separated Telegram user IDs with superuser access |
 | `TELEGRAM_STAFF_IDS` | `""` | Comma-separated Telegram user IDs with staff access |

--- a/docs/guides/user-journey.md
+++ b/docs/guides/user-journey.md
@@ -2,8 +2,8 @@
 
 This guide documents the primary user flows through the Revel platform, covering both attendee and organizer perspectives.
 
-!!! tip "Comprehensive user journeys"
-    For the full persona-based user journey map (used to drive E2E test cases), see [`USER_JOURNEYS.md`](https://github.com/letsrevel/revel-backend/blob/main/USER_JOURNEYS.md) in the repository root.
+!!! tip "This guide is a curated overview"
+    This page covers the primary flows at a glance. It is **not exhaustive** — for the full, canonical, persona-based user journey map (used to drive E2E test cases), see [`USER_JOURNEYS.md`](https://github.com/letsrevel/revel-backend/blob/main/USER_JOURNEYS.md) in the repository root. Where a subsystem has a dedicated architecture page, the relevant section links to it.
 
 ---
 
@@ -324,6 +324,9 @@ Organizers can create discount codes to offer reduced pricing on ticket purchase
 3. Buyer enters code during checkout → validated and applied to price
 4. Usage tracked per code and per user
 
+!!! note "Duplicate codes & delete-vs-deactivate"
+    Creating a code whose string already exists returns a clear **409 Conflict** (it used to surface as an opaque 500). Deleting a code that has **never been used** hard-deletes it; deleting a code that **has been used** deactivates it instead, preserving usage history.
+
 ### Billing Profile Management
 
 Users participating in the referral program can set up a billing profile:
@@ -339,6 +342,90 @@ Users participating in the referral program can set up a billing profile:
 
 !!! note "Referral payouts"
     A complete billing profile with self-billing agreement and connected Stripe account is required before referral payouts can be processed.
+
+### Bookmarks
+
+Users can privately bookmark events for later. Bookmarks do not sign you up and do not affect eligibility.
+
+- `POST /api/events/{event_id}/bookmark` → `201` for a new bookmark, `200` if it already existed
+- `DELETE /api/events/{event_id}/bookmark` is idempotent and works even for events you can no longer see
+- `is_bookmarked` is reflected on event list/detail responses; find them via the `bookmarked` facet on `/dashboard/events` (bookmarked **unlisted** events surface there even though they stay hidden from discovery)
+
+### Self-Service Ticket Cancellation & Refunds
+
+Opt-in per ticket tier via `allow_user_cancellation`, `cancellation_deadline_hours`, and `refund_policy` (tiered % by hours-before-event + flat fee). Buyers see the cancellation terms **before purchase** on `TicketTierSchema`, and the active policy is **snapshotted onto the ticket at purchase** (`refund_policy_snapshot`) so later policy changes never affect issued tickets.
+
+- `GET /events/tickets/{id}/cancellation-preview` — policy windows + a live refund quote for this ticket
+- `POST /events/tickets/{id}/cancel` — works for free, offline, at-the-door, and online (Stripe) tickets; online tickets trigger a per-`Payment`, partial-amount-aware Stripe refund
+- Blocked cases (already cancelled, checked-in, event started, past deadline) return `409 CancellationBlockedErrorSchema` with a stable `code`; cancelling an already-cancelled ticket returns 409
+- Triggers a `TICKET_CANCELLED` / `TICKET_REFUNDED` notification (immediate transactional email) reporting the actual `refund_amount`
+
+### Recurring Events & Series
+
+Organizers can run first-class recurring series: a `RecurrenceRule` + a template event drive rolling-window materialization, where each occurrence is a real, independent `Event`. A daily Celery beat task keeps the window populated; template edits propagate to future occurrences via a field whitelist, and a drift endpoint surfaces occurrences that no longer match the rule after a cadence change. A single `SERIES_EVENTS_GENERATED` digest is sent per generated batch.
+
+- Admin: `POST /organization-admin/{slug}/create-recurring-event`, plus `PATCH .../event-series/{id}/template` (with `?propagate=`), `.../recurrence`, `POST .../generate` / `.../pause` / `.../resume` / `.../cancel-occurrence`, and `GET .../event-series/{id}/drift`
+
+!!! info "See Also"
+    Full architecture: [Recurring Event Series](../architecture/recurring-series.md).
+
+### Open-Ended Events
+
+An event can be marked `is_open_ended` for ongoing/no-fixed-end events. `end` is still set (defaults to start + 24h) and used internally for ICS/Wallet/upcoming gates; the flag is a display signal so the frontend can render "Ongoing" and hide the end time.
+
+### Membership Subscriptions
+
+> **Phase 1 — OFFLINE only.** Subscriptions are staff-managed (recorded payments), not self-served Stripe billing.
+
+Organizers configure recurring membership plans per membership tier (`MembershipSubscriptionPlan`), gated by the `manage_subscriptions` permission (owner ✓, staff ✓ by default, member ✗). Staff create/list/get subscriptions, drive the lifecycle (cancel / pause / resume), and record payments (`MembershipPayment`, with `occurred_at` to backfill the real payment date). A `post_save` signal syncs `OrganizationMember.status + tier` from the subscription (never creating members, never touching a `BANNED` member), and a daily beat task expires subscriptions past the org's grace period.
+
+- Member view: `GET /me/membership-subscriptions`, `GET /me/organizations/{org_id}/subscription`, and `GET /me/memberships` (unified memberships list, inlining the most recent non-terminal subscription per org)
+- Org policy: `membership_grace_period_days` (default 7), `membership_refund_policy`
+
+### Polls
+
+Organization-managed polls built on the questionnaire pipeline — a `Poll` is 1:1 with a `Questionnaire` and votes are stored as `QuestionnaireSubmission` rows. Creation and management require the `manage_polls` permission. Polls have a draft/open/closed lifecycle, configurable audience/result visibility, anonymity, and a vote-change policy.
+
+- `/api/polls/` group: list, detail, `GET /{id}/results`, create (`POST /polls/organizations/{org_id}`), patch, `open` / `close` / `reopen`, `duplicate`, delete (owner-only), `POST /{id}/vote`, `DELETE /{id}/vote`
+
+!!! info "See Also"
+    Full architecture: [Polls](../architecture/polls.md).
+
+### Content Moderation
+
+Offensive **food-item names** are blocked at creation across all supported languages (the `moderation` app), and staff can delete offensive food items via the admin. Quarantined (malware-flagged) uploads are stored behind a protected, signed-URL media path — never publicly downloadable; staff retrieve them via a signed admin link.
+
+!!! info "See Also"
+    Full architecture: [Content Moderation](../architecture/moderation.md).
+
+### Event Schedule / Timeline
+
+Organizers author an ordered list of display-only sessions via `PUT /event-admin/{event_id}/schedule`. Each session has a title, Markdown description, relative start offset, optional duration/location, and an `is_required` badge. The schedule is exposed on the public event detail and copied verbatim on event duplication and recurring-series materialization.
+
+### Revenue & VAT Reporting
+
+A VAT-precise financial-reporting suite for organizers, driven by one tax engine so every view reconciles (online Stripe + offline/at-the-door payments, per currency and per VAT rate; refunds attributed to the period they occurred).
+
+- Live org financials: `GET /organization-admin/{slug}/revenue` (sortable, period- and currency-filtered)
+- Downloadable report: `POST /organization-admin/{slug}/revenue-report` → poll `GET .../revenue-reports/{id}`; output is a ZIP bundling an XLSX (Summary + Transactions) and a PDF (per-VAT-rate table)
+- Scheduled delivery: org-level `revenue_report_cadence` (`NONE` / `QUARTERLY` / `MONTHLY`, **owner-only** to change) emails the just-closed period's report to the org billing email and owner
+- Per-event: `GET /event-admin/{event_id}/tickets/revenue` → `EventFinancialsSchema`
+
+!!! info "See Also"
+    Full architecture: [Billing & VAT](../architecture/billing-and-vat.md).
+
+### Guest Checkout & Guest-to-User Upgrade
+
+When an event has `can_attend_without_login=True`, anonymous visitors can attend without an account: a guest RSVP or guest ticket checkout creates a guest `RevelUser` (`guest=True`) from just a name and email. If the guest later registers with the same email, an activation link upgrades the guest account to a full user and all previous guest tickets/RSVPs are preserved.
+
+### Self-Served Email Change
+
+Users can change their own email address:
+
+- `POST /account/email-change-request` — requires the current password; sends a single-use confirmation link to the **new** address (proof of control)
+- `POST /account/email-change-confirm` — swaps `email` + `username`, **blacklists every outstanding JWT** for the user, and returns a fresh token pair so the confirming device stays signed in
+
+Both addresses receive completion emails; the old address also gets an in-flight notice with a masked rendering of the new address. The flow rejects Google-SSO accounts and same-email / already-taken targets with clear `400`s, and silently no-ops for globally-banned targets.
 
 ---
 

--- a/docs/runbooks/rate-limit-429s.md
+++ b/docs/runbooks/rate-limit-429s.md
@@ -13,15 +13,25 @@ Throttles live in `common/throttling.py` (subclasses of `ninja_extra`'s
 | `UserRateThrottle`, **authenticated** request | `user.pk` | No — per user |
 | `AnonRateThrottle`, or any throttle on an **anonymous** request | client IP via `get_ident()` | **Yes** |
 
-`get_ident()` with `NUM_PROXIES=1` returns the **last** `X-Forwarded-For` entry,
-which in production is the **Cloudflare edge IP**, not the visitor (the real IP is
-only in `CF-Connecting-IP`, which nothing reads yet). So anonymous users behind the
-same Cloudflare egress IP **share a throttle bucket** — the most likely cause of
+Throttling uses the **stock** `get_ident()` — the throttle classes in
+`common/throttling.py` do **not** override it. With `NUM_PROXIES=1`, `get_ident()`
+returns the **last** `X-Forwarded-For` entry, which in production is the
+**Cloudflare edge IP**, not the visitor. So anonymous users behind the same
+Cloudflare egress IP **share a throttle bucket** — the most likely cause of
 *false-positive* 429s for legitimate users.
 
-See backend issue #479 and infra#3 for the proper fix (lock origin to Cloudflare,
-then key throttles on the real visitor IP). This is **not** a bypass — the current
-key is unspoofable; the risk is collateral throttling, not evasion.
+!!! note "Throttling keys on the proxy IP, not `X-Real-IP`"
+
+    Since 1.62.4, `common/client_ip.py` resolves the real visitor IP from
+    `X-Real-IP` (which Caddy sets from Cloudflare's `CF-Connecting-IP`), and request
+    logging, the geo middleware, and impersonation audit all read it. **Throttling
+    does not** — it still keys on the proxy IP via stock `get_ident()`
+    (`X-Forwarded-For` + `NUM_PROXIES`), so the shared-bucket collision above is
+    unchanged until throttles are migrated onto `get_client_ip()`.
+
+See backend issue #479 and infra#3 for the remaining fix (key throttles on the real
+visitor IP too). This is **not** a bypass — the current key is unspoofable; the risk
+is collateral throttling, not evasion.
 
 The lowest, most collision-prone limit is anonymous **registration**
 (`UserRegistrationThrottle`, 100/day).

--- a/docs/runbooks/stripe-hardening-rollout.md
+++ b/docs/runbooks/stripe-hardening-rollout.md
@@ -130,6 +130,11 @@ provisioning command) deployed. Run the WHOLE procedure on demo first.
    ```
    **Immediately copy both printed `whsec_*` secrets** — Stripe never shows them again.
    (If lost: delete the endpoint in the dashboard and re-run.)
+
+   For scripted self-hosted setup, `provision_stripe_webhooks` supports
+   `--format json` (1.64.0+): it prints **only** a machine-readable object
+   (`{"platform": {"id", "secret"}, "connect": {"id", "secret"}}`) instead of the
+   human-readable block. It cannot be combined with `--dry-run`.
 3. Update the env — new secrets first, **old secret kept last** (the overlap window):
    ```
    STRIPE_WEBHOOK_SECRETS=<new_platform_whsec>,<new_connect_whsec>,<old_whsec>

--- a/docs/runbooks/stripe-webhook-endpoints.md
+++ b/docs/runbooks/stripe-webhook-endpoints.md
@@ -58,6 +58,13 @@ Rotation = provision a new pair with `--force`, add the new secrets to the CSV
 endpoints in the dashboard and drop their secrets. The event-log dedup
 (`StripeWebhookEvent.event_id` unique) makes the overlap window harmless.
 
+!!! tip "Machine-readable output (1.64.0+)"
+
+    Pass `--format json` to print **only** a JSON object
+    (`{"platform": {"id", "secret"}, "connect": {"id", "secret"}}`) instead of the
+    human-readable secrets block — for scripted self-hosted setup (e.g. `setup.sh`).
+    It cannot be combined with `--dry-run`.
+
 ## Host-as-org binding
 
 Exactly one organization may use the platform's own Stripe account:

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -53,6 +53,7 @@ each dependency does, whether you can omit it, and the lever you use to do so:
 | LLM / OpenAI | Yes | Manual questionnaire eval still works | `FEATURE_LLM_EVALUATION=False` |
 | Geo / IP2Location | Yes | Lookups return `None` | BIN optional; mini cities fallback |
 | Telegram | Yes | Per-user delivery skipped | `FEATURE_TELEGRAM=False`; profile off |
+| Google SSO | Yes (opt-in) | Login button hidden; password auth only | `FEATURE_GOOGLE_SSO=True` + OAuth creds |
 | Apple Wallet | Yes | `/wallet/apple` → 503; PDF tickets fine | leave certs unset |
 | Email / SMTP | Required* | Needed for verification | real SMTP or `EMAIL_DRY_RUN=True` |
 

--- a/docs/self-hosting/quickstart.md
+++ b/docs/self-hosting/quickstart.md
@@ -79,6 +79,10 @@ With DNS pointed at the box and certificates issued, your instance is reachable 
 - **API** — `https://<API_DOMAIN>` (interactive docs at `https://<API_DOMAIN>/api/docs`)
 - **Grafana** (Full tier only) — `https://grafana.<your-domain>`
 
+A quick sanity check on your configuration: `GET https://<API_DOMAIN>/version` returns the
+active feature flags (`organization_creation`, `telegram`, `google_sso`, `llm_evaluation`), so you
+can confirm the deployment picked up the flags you set.
+
 If the site does not come up, the most common cause is TLS issuance failing behind Cloudflare's
 proxy — see the [DNS & Cloudflare](dns-cloudflare.md) caveat and the
 [Troubleshooting](troubleshooting.md) page.

--- a/docs/self-hosting/tiers.md
+++ b/docs/self-hosting/tiers.md
@@ -53,8 +53,9 @@ just wastes RAM.
 
 ### Feature flags
 
-These default to `True` (production behaviour). Set them to `False` to drop the corresponding
-dependency:
+Most default to `True` (production behaviour); set them to `False` to drop the corresponding
+dependency. `FEATURE_GOOGLE_SSO` is the exception — it is opt-in and defaults to `False`
+(see [ADR-0008](../adr/0008-environment-feature-flags.md)).
 
 - `FEATURE_MALWARE_SCAN` — when `False`, uploads skip the ClamAV scan and are marked clean
   immediately. Lets you run without the `antivirus` profile.
@@ -64,6 +65,8 @@ dependency:
   evaluation still works. Lets you run without an OpenAI key.
 - `FEATURE_ORGANIZATION_CREATION` — when `False`, regular users cannot create organizations; staff
   and superusers still can. See below.
+- `FEATURE_GOOGLE_SSO` — opt-in (defaults to `False`). Leave it off for password-only auth (the
+  login button stays hidden); set `True` and provide OAuth credentials to enable Google login.
 - `FEATURE_OBSERVABILITY` — master toggle for the metrics/traces/logs exporters and the async log
   queue. Set `False` (and drop the `observability` profile) on Slim. Legacy alias:
   `ENABLE_OBSERVABILITY` (deprecated). See [Observability](observability.md).

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -27,6 +27,18 @@ FEATURE_MALWARE_SCAN=False
 Either run the `antivirus` profile **or** set this flag — don't do neither. (The setup wizard keeps
 these aligned; this only bites if you edit `.env` by hand.)
 
+## Telegram linking returns 404 / no Telegram notifications
+
+**Cause:** the `telegram` Compose profile and `FEATURE_TELEGRAM` are out of sync. With
+`FEATURE_TELEGRAM=False` the linking endpoints return 404 and Telegram is dropped from
+notification delivery; with the profile off there is no bot process to poll updates or send
+messages.
+
+**Fix:** pair the two. To use Telegram, run the `telegram` profile **and** leave
+`FEATURE_TELEGRAM=True` (the default). To run without it, set `FEATURE_TELEGRAM=False` and leave
+the profile off. (As with ClamAV, the setup wizard keeps these aligned; mismatches only happen when
+you edit `.env` by hand.)
+
 ## Cloudflare 5xx / certificate errors
 
 **Cause:** the Cloudflare proxy ("orange cloud") was enabled before Caddy obtained its certificate,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,12 +69,16 @@ nav:
       - Permissions & Roles: architecture/permissions.md
       - Eligibility Pipeline: architecture/eligibility-pipeline.md
       - Advanced Waitlist: architecture/waitlist.md
+      - Recurring Series: architecture/recurring-series.md
       - Protected Files (HMAC): architecture/protected-files.md
       - File Security: architecture/security.md
       - Notifications: architecture/notifications.md
+      - Scheduled Announcements: architecture/scheduled-announcements.md
       - Questionnaires: architecture/questionnaires.md
+      - Polls: architecture/polls.md
+      - Content Moderation: architecture/moderation.md
       - Billing & VAT: architecture/billing-and-vat.md
-      - XLSX Exports: architecture/exports.md
+      - Exports: architecture/exports.md
       - Engineering Notes (deep gotchas): engineering-notes.md
   - Guides:
       - guides/index.md


### PR DESCRIPTION
## Summary

Cross-referenced the docs site against the CHANGELOG (1.53.0 → 1.66.0) and the code to close gaps from recent feature work. Investigation and writing were fanned out across parallel agents per docs area; every fact was verified against source, not just the changelog.

`mkdocs build --strict` is clean (no link/anchor warnings).

## New architecture pages
- **moderation** — blocklist screening (normalize → token + adjacent-bigram exact match, no fuzzy), per-language wordlists, `NameNotAllowed`→422, single integration point (food-item names)
- **polls** — questionnaire-backed polls (1:1 with a Questionnaire, votes as submissions), `manage_polls`, row-locked lifecycle, anonymity
- **recurring-series** — `RecurrenceRule`/`EventSeries`, rolling-window materialization, drift detection, field propagation, `SERIES_EVENTS_GENERATED` digest
- **scheduled-announcements** — `SCHEDULED` status, absolute/relative-with-auto-shift timing, `/schedule`+`/unschedule`, sweeps, resend-to-new-signups

## Refreshed (19 files)
- **billing-and-vat / exports** — Revenue & VAT reporting suite; corrected "owner-only" claim (revenue endpoints use `manage_organization`); breaking `EventFinancialsSchema` change; `revenue_vat_report` export type + ZIP mechanics
- **notifications / telegram** — transactional digest-bypass types, digest overhaul, `FEATURE_TELEGRAM` channel drop, event-timezone rendering, removed `ticket_checked_in`, `/preferences` no-op clarification
- **permissions / questionnaires** — `manage_subscriptions`/`manage_polls`, owner-only `revenue_report_cadence` carve-out, `requires_evaluation` exposure, answer-key security note
- **self-hosting / getting-started / i18n** — `FEATURE_GOOGLE_SSO` (corrected a wrong existing default), `GET /version` features, Telegram troubleshooting, polls/moderation in project structure, feature-flag table, French
- **observability / runbooks / ci-pipeline** — `loki_logs.py` CLI + corrected LogQL examples, fixed i18n-check description (`.po` not `.mo`, per ADR-0011), corrected the `X-Real-IP` vs throttling story, `--format json` for Stripe webhooks
- **user-journey** — expanded with subscriptions, polls, revenue, recurring, moderation, schedule, open-ended, cancellation/refund, bookmarks, guest checkout, email change + discount-code 409/delete-vs-deactivate

## Follow-ups (filed separately, code not touched here)
Surfaced during the audit; tracked as issues:
- `make bootstrap-tests` invokes a non-existent `bootstrap_tests` command
- CHANGELOG 1.64.0 cites the wrong per-event revenue path
- polls auto-close beat runs every 1 minute (violates the no-per-minute-beat rule)
- `RecurrenceRule.timezone` is reserved/non-functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture guides for polls, recurring event series, scheduled announcements, and content moderation features.
  * Enhanced existing documentation for revenue & VAT reporting, notification dispatch, exports, permissions, and questionnaires.
  * Updated deployment documentation, observability guides, user journey flows, and expanded internationalization support with French language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->