### PR TITLE
refactor(controllers): hoist repeated endpoint permissions to class level (#595)

### DIFF
--- a/src/events/controllers/event_admin/invitations.py
+++ b/src/events/controllers/event_admin/invitations.py
@@ -32,7 +32,6 @@ class EventAdminInvitationsController(EventAdminBaseController):
         "/invitations",
         url_name="create_direct_invitations",
         response={200: schema.DirectInvitationResponseSchema, 400: ValidationErrorResponse},
-        permissions=[EventPermission("invite_to_event")],
     )
     def create_invitations(self, event_id: UUID, payload: schema.DirectInvitationCreateSchema) -> dict[str, int]:
         """Create direct invitations for users by email addresses."""
@@ -43,7 +42,6 @@ class EventAdminInvitationsController(EventAdminBaseController):
         "/invitations",
         url_name="list_event_invitations",
         response=PaginatedResponseSchema[schema.EventInvitationListSchema],
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -57,7 +55,6 @@ class EventAdminInvitationsController(EventAdminBaseController):
         "/pending-invitations",
         url_name="list_pending_invitations",
         response=PaginatedResponseSchema[schema.PendingEventInvitationListSchema],
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -74,7 +71,6 @@ class EventAdminInvitationsController(EventAdminBaseController):
         "/invitations/{invitation_type}/{invitation_id}",
         url_name="delete_invitation",
         response={204: None, 404: ValidationErrorResponse},
-        permissions=[EventPermission("invite_to_event")],
     )
     def delete_invitation_endpoint(
         self, event_id: UUID, invitation_type: t.Literal["registered", "pending"], invitation_id: UUID

--- a/src/events/controllers/event_admin/rsvps.py
+++ b/src/events/controllers/event_admin/rsvps.py
@@ -33,7 +33,6 @@ class EventAdminRSVPsController(EventAdminBaseController):
         "/rsvps",
         url_name="list_rsvps",
         response=PaginatedResponseSchema[schema.RSVPDetailSchema],
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -62,7 +61,6 @@ class EventAdminRSVPsController(EventAdminBaseController):
         "/rsvps/{rsvp_id}",
         url_name="get_rsvp",
         response=schema.RSVPDetailSchema,
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     def get_rsvp(self, event_id: UUID, rsvp_id: UUID) -> models.EventRSVP:
@@ -74,7 +72,6 @@ class EventAdminRSVPsController(EventAdminBaseController):
         "/rsvps",
         url_name="create_rsvp",
         response=schema.RSVPDetailSchema,
-        permissions=[EventPermission("invite_to_event")],
     )
     def create_rsvp(self, event_id: UUID, payload: schema.RSVPCreateSchema) -> models.EventRSVP:
         """Create an RSVP on behalf of a user.
@@ -105,7 +102,6 @@ class EventAdminRSVPsController(EventAdminBaseController):
         "/rsvps/{rsvp_id}",
         url_name="update_rsvp",
         response=schema.RSVPDetailSchema,
-        permissions=[EventPermission("invite_to_event")],
     )
     def update_rsvp(self, event_id: UUID, rsvp_id: UUID, payload: schema.RSVPUpdateSchema) -> models.EventRSVP:
         """Update an existing RSVP.
@@ -124,7 +120,6 @@ class EventAdminRSVPsController(EventAdminBaseController):
         "/rsvps/{rsvp_id}",
         url_name="delete_rsvp",
         response={204: None},
-        permissions=[EventPermission("invite_to_event")],
     )
     def delete_rsvp(self, event_id: UUID, rsvp_id: UUID) -> tuple[int, None]:
         """Delete an RSVP.

--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -65,7 +65,7 @@ TICKET_ORDER_FIELDS: dict[TicketOrdering, str] = {
 @api_controller(
     "/event-admin/{event_id}",
     auth=I18nJWTAuth(),
-    permissions=[EventPermission("invite_to_event")],
+    permissions=[EventPermission("manage_tickets")],
     tags=["Event Admin"],
     throttle=WriteThrottle(),
 )
@@ -78,6 +78,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tiers",
         url_name="list_ticket_tiers",
         response=PaginatedResponseSchema[schema.TicketTierDetailSchema],
+        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -95,7 +96,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tier",
         url_name="create_ticket_tier",
         response=schema.TicketTierDetailSchema,
-        permissions=[EventPermission("manage_tickets")],
     )
     def create_ticket_tier(self, event_id: UUID, payload: schema.TicketTierCreateSchema) -> models.TicketTier:
         """Create a new ticket tier for an event."""
@@ -106,7 +106,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tier/{tier_id}",
         url_name="update_ticket_tier",
         response=schema.TicketTierDetailSchema,
-        permissions=[EventPermission("manage_tickets")],
     )
     def update_ticket_tier(
         self, event_id: UUID, tier_id: UUID, payload: schema.TicketTierUpdateSchema
@@ -120,7 +119,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tier/{tier_id}",
         url_name="delete_ticket_tier",
         response={204: None},
-        permissions=[EventPermission("manage_tickets")],
     )
     def delete_ticket_tier(self, event_id: UUID, tier_id: UUID) -> tuple[int, None]:
         """Delete a ticket tier.
@@ -136,7 +134,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tiers/reorder",
         url_name="reorder_ticket_tiers",
         response={204: None},
-        permissions=[EventPermission("manage_tickets")],
     )
     def reorder_ticket_tiers(self, event_id: UUID, payload: schema.ReorderSchema) -> tuple[int, None]:
         """Reorder ticket tiers for an event."""
@@ -150,7 +147,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets",
         url_name="list_tickets",
         response=PaginatedResponseSchema[schema.AdminTicketSchema],
-        permissions=[EventPermission("manage_tickets")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -190,7 +186,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets/{ticket_id}",
         url_name="get_ticket",
         response={200: schema.AdminTicketSchema},
-        permissions=[EventPermission("manage_tickets")],
         throttle=UserDefaultThrottle(),
     )
     def get_ticket(self, event_id: UUID, ticket_id: UUID) -> models.Ticket:
@@ -202,7 +197,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets/{ticket_id}/confirm-payment",
         url_name="confirm_ticket_payment",
         response={200: schema.UserTicketSchema},
-        permissions=[EventPermission("manage_tickets")],
     )
     def confirm_ticket_payment(
         self,
@@ -228,7 +222,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets/{ticket_id}/unconfirm-payment",
         url_name="unconfirm_ticket_payment",
         response={200: schema.UserTicketSchema},
-        permissions=[EventPermission("manage_tickets")],
     )
     def unconfirm_ticket_payment(self, event_id: UUID, ticket_id: UUID) -> models.Ticket:
         """Revert a confirmed ticket back to pending status.
@@ -250,7 +243,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets/{ticket_id}/mark-refunded",
         url_name="mark_ticket_refunded",
         response={200: schema.UserTicketSchema},
-        permissions=[EventPermission("manage_tickets")],
     )
     def mark_ticket_refunded(
         self,
@@ -284,7 +276,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/tickets/{ticket_id}/cancel",
         url_name="cancel_ticket",
         response={200: schema.UserTicketSchema},
-        permissions=[EventPermission("manage_tickets")],
     )
     def cancel_ticket(
         self,
@@ -335,7 +326,6 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/revenue",
         url_name="event_revenue",
         response=EventFinancialsSchema,
-        permissions=[EventPermission("manage_tickets")],
         throttle=UserDefaultThrottle(),
     )
     def get_event_revenue(

--- a/src/events/controllers/event_admin/waitlist.py
+++ b/src/events/controllers/event_admin/waitlist.py
@@ -28,7 +28,6 @@ class EventAdminWaitlistController(EventAdminBaseController):
         "/waitlist",
         url_name="list_waitlist",
         response=PaginatedResponseSchema[schema.WaitlistEntrySchema],
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -49,7 +48,6 @@ class EventAdminWaitlistController(EventAdminBaseController):
         "/waitlist/{waitlist_id}",
         url_name="delete_waitlist_entry",
         response={204: None},
-        permissions=[EventPermission("invite_to_event")],
     )
     def delete_waitlist_entry(self, event_id: UUID, waitlist_id: UUID) -> tuple[int, None]:
         """Remove a user from the event waitlist.

--- a/src/events/controllers/event_admin/waitlist_offers.py
+++ b/src/events/controllers/event_admin/waitlist_offers.py
@@ -73,7 +73,6 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
         "/waitlist-offers",
         url_name="list_waitlist_offers",
         response=PaginatedResponseSchema[schema.WaitlistOfferSchema],
-        permissions=[EventPermission("invite_to_event")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)

--- a/src/events/controllers/organization_admin/members.py
+++ b/src/events/controllers/organization_admin/members.py
@@ -22,7 +22,13 @@ from events.service import organization_service, update_db_instance
 from .base import OrganizationAdminBaseController
 
 
-@api_controller("/organization-admin/{slug}", auth=I18nJWTAuth(), tags=["Organization Admin"], throttle=WriteThrottle())
+@api_controller(
+    "/organization-admin/{slug}",
+    auth=I18nJWTAuth(),
+    tags=["Organization Admin"],
+    throttle=WriteThrottle(),
+    permissions=[OrganizationPermission("manage_members")],
+)
 class OrganizationAdminMembersController(OrganizationAdminBaseController):
     """Organization membership management endpoints.
 
@@ -35,7 +41,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/members",
         url_name="list_organization_members",
         response=PaginatedResponseSchema[schema.OrganizationMemberSchema],
-        permissions=[OrganizationPermission("manage_members")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -57,7 +62,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/members/{user_id}",
         url_name="update_organization_member",
         response=schema.OrganizationMemberSchema,
-        permissions=[OrganizationPermission("manage_members")],
     )
     def update_member(
         self, slug: str, user_id: UUID, payload: schema.OrganizationMemberUpdateSchema
@@ -100,7 +104,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/members/{user_id}",
         url_name="remove_organization_member",
         response={204: None},
-        permissions=[OrganizationPermission("manage_members")],
     )
     def remove_member(self, slug: str, user_id: UUID) -> tuple[int, None]:
         """Remove a member from an organization."""
@@ -113,7 +116,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/members/{user_id}",
         url_name="create_organization_member",
         response={201: schema.OrganizationMemberSchema},
-        permissions=[OrganizationPermission("manage_members")],
     )
     def add_member(
         self, slug: str, user_id: UUID, payload: schema.MemberAddSchema
@@ -142,7 +144,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/membership-tiers",
         url_name="create_membership_tier",
         response={201: schema.MembershipTierSchema},
-        permissions=[OrganizationPermission("manage_members")],
     )
     def create_membership_tier(
         self, slug: str, payload: schema.MembershipTierCreateSchema
@@ -156,7 +157,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/membership-tiers/{tier_id}",
         url_name="update_membership_tier",
         response=schema.MembershipTierSchema,
-        permissions=[OrganizationPermission("manage_members")],
     )
     def update_membership_tier(
         self, slug: str, tier_id: UUID, payload: schema.MembershipTierUpdateSchema
@@ -170,7 +170,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/membership-tiers/{tier_id}",
         url_name="delete_membership_tier",
         response={204: None},
-        permissions=[OrganizationPermission("manage_members")],
     )
     def delete_membership_tier(self, slug: str, tier_id: UUID) -> tuple[int, None]:
         """Delete a membership tier.
@@ -188,7 +187,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/staff",
         url_name="list_organization_staff",
         response=PaginatedResponseSchema[schema.OrganizationStaffSchema],
-        permissions=[OrganizationPermission("manage_members")],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
@@ -215,7 +213,6 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/staff/{user_id}",
         url_name="create_organization_staff",
         response={201: schema.OrganizationStaffSchema},
-        permissions=[OrganizationPermission("manage_members")],
     )
     def add_staff(
         self, slug: str, user_id: UUID, payload: models.PermissionsSchema | None = None

--- a/src/events/controllers/organization_admin/recurring_events.py
+++ b/src/events/controllers/organization_admin/recurring_events.py
@@ -19,7 +19,13 @@ from events.service.recurrence_service import PropagateScope
 from .base import OrganizationAdminBaseController
 
 
-@api_controller("/organization-admin/{slug}", auth=I18nJWTAuth(), tags=["Organization Admin"], throttle=WriteThrottle())
+@api_controller(
+    "/organization-admin/{slug}",
+    auth=I18nJWTAuth(),
+    tags=["Organization Admin"],
+    throttle=WriteThrottle(),
+    permissions=[OrganizationPermission("edit_event_series")],
+)
 class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController):
     """Recurring event management endpoints.
 
@@ -67,7 +73,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/template",
         url_name="update_series_template",
         response={200: schema.EventSeriesRecurrenceDetailSchema, 400: ValidationErrorResponse},
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def update_template(
         self,
@@ -98,7 +103,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/recurrence",
         url_name="update_series_recurrence",
         response={200: schema.EventSeriesRecurrenceDetailSchema, 400: ValidationErrorResponse},
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def update_recurrence(
         self, slug: str, series_id: UUID, payload: schema.EventSeriesRecurrenceUpdateSchema
@@ -117,7 +121,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/cancel-occurrence",
         url_name="cancel_series_occurrence",
         response={200: schema.EventSeriesRecurrenceDetailSchema},
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def cancel_occurrence(
         self, slug: str, series_id: UUID, payload: schema.CancelOccurrenceSchema
@@ -132,7 +135,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/generate",
         url_name="generate_series_events",
         response=list[schema.EventDetailSchema],
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def generate_events(
         self,
@@ -149,7 +151,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}",
         url_name="get_series_detail",
         response=schema.EventSeriesRecurrenceDetailSchema,
-        permissions=[OrganizationPermission("edit_event_series")],
         throttle=UserDefaultThrottle(),
     )
     def get_series_detail(self, slug: str, series_id: UUID) -> models.EventSeries:
@@ -166,7 +167,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/drift",
         url_name="get_series_drift",
         response=schema.EventSeriesDriftSchema,
-        permissions=[OrganizationPermission("edit_event_series")],
         throttle=UserDefaultThrottle(),
     )
     def get_series_drift(self, slug: str, series_id: UUID) -> schema.EventSeriesDriftSchema:
@@ -185,7 +185,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/template-event",
         url_name="get_series_template_event",
         response=schema.EventDetailSchema,
-        permissions=[OrganizationPermission("edit_event_series")],
         throttle=UserDefaultThrottle(),
     )
     def get_series_template_event(self, slug: str, series_id: UUID) -> models.Event:
@@ -206,7 +205,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/pause",
         url_name="pause_series",
         response=schema.EventSeriesRecurrenceDetailSchema,
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def pause_series(self, slug: str, series_id: UUID) -> models.EventSeries:
         """Pause generation without cancelling existing events."""
@@ -219,7 +217,6 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         "/event-series/{series_id}/resume",
         url_name="resume_series",
         response=schema.EventSeriesRecurrenceDetailSchema,
-        permissions=[OrganizationPermission("edit_event_series")],
     )
     def resume_series(self, slug: str, series_id: UUID) -> models.EventSeries:
         """Resume generation for a paused series."""

--- a/src/events/controllers/organization_admin/revenue.py
+++ b/src/events/controllers/organization_admin/revenue.py
@@ -21,7 +21,12 @@ from events.service import revenue_aggregation, revenue_report_service
 from .base import OrganizationAdminBaseController
 
 
-@api_controller("/organization-admin/{slug}", auth=I18nJWTAuth(), tags=["Organization Admin"])
+@api_controller(
+    "/organization-admin/{slug}",
+    auth=I18nJWTAuth(),
+    tags=["Organization Admin"],
+    permissions=[OrganizationPermission("manage_organization")],
+)
 class OrganizationAdminRevenueController(OrganizationAdminBaseController):
     """Generate and poll downloadable revenue & VAT report bundles."""
 
@@ -29,7 +34,6 @@ class OrganizationAdminRevenueController(OrganizationAdminBaseController):
         "/revenue-report",
         url_name="create_revenue_report",
         response=FileExportSchema,
-        permissions=[OrganizationPermission("manage_organization")],
         throttle=ExportThrottle(),
     )
     def create_revenue_report(
@@ -57,7 +61,6 @@ class OrganizationAdminRevenueController(OrganizationAdminBaseController):
         "/revenue",
         url_name="organization_financials",
         response=OrganizationFinancialsSchema,
-        permissions=[OrganizationPermission("manage_organization")],
         throttle=UserDefaultThrottle(),
     )
     def get_organization_financials(
@@ -81,7 +84,6 @@ class OrganizationAdminRevenueController(OrganizationAdminBaseController):
         "/revenue-reports/{export_id}",
         url_name="get_revenue_report",
         response=FileExportSchema,
-        permissions=[OrganizationPermission("manage_organization")],
         throttle=UserDefaultThrottle(),
     )
     def get_revenue_report(self, slug: str, export_id: UUID) -> FileExport:

--- a/src/events/controllers/organization_admin/vat.py
+++ b/src/events/controllers/organization_admin/vat.py
@@ -25,6 +25,7 @@ from .base import OrganizationAdminBaseController
     auth=I18nJWTAuth(),
     tags=["Organization Admin - VAT"],
     throttle=UserDefaultThrottle(),
+    permissions=[IsOrganizationOwner()],
 )
 class OrganizationAdminVATController(OrganizationAdminBaseController):
     """VAT settings and platform fee invoice management."""
@@ -35,7 +36,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/billing-info",
         url_name="get_billing_info",
         response=schema.OrganizationBillingInfoSchema,
-        permissions=[IsOrganizationOwner()],
     )
     def get_billing_info(self, slug: str) -> models.Organization:
         """Get organization billing info and VAT settings."""
@@ -45,7 +45,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/billing-info",
         url_name="update_billing_info",
         response=schema.OrganizationBillingInfoSchema,
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def update_billing_info(
@@ -63,7 +62,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/vat-id",
         url_name="set_vat_id",
         response=schema.OrganizationBillingInfoSchema,
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def set_vat_id(self, slug: str, payload: schema.VATIdUpdateSchema) -> models.Organization:
@@ -76,7 +74,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/vat-id",
         url_name="delete_vat_id",
         response={204: None},
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def delete_vat_id(self, slug: str) -> tuple[int, None]:
@@ -90,7 +87,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/invoices",
         url_name="list_invoices",
         response=PaginatedResponseSchema[schema.PlatformFeeInvoiceSchema],
-        permissions=[IsOrganizationOwner()],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
     def list_invoices(self, slug: str) -> QuerySet[models.PlatformFeeInvoice]:
@@ -102,7 +98,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/invoices/{invoice_id}",
         url_name="get_invoice",
         response=schema.PlatformFeeInvoiceSchema,
-        permissions=[IsOrganizationOwner()],
     )
     def get_invoice(self, slug: str, invoice_id: UUID) -> models.PlatformFeeInvoice:
         """Get a specific platform fee invoice."""
@@ -113,7 +108,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/invoices/{invoice_id}/download",
         url_name="download_invoice",
         response=schema.InvoiceDownloadURLSchema,
-        permissions=[IsOrganizationOwner()],
     )
     def download_invoice(self, slug: str, invoice_id: UUID) -> schema.InvoiceDownloadURLSchema:
         """Get a signed download URL for an invoice PDF."""
@@ -130,7 +124,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/credit-notes",
         url_name="list_credit_notes",
         response=PaginatedResponseSchema[schema.PlatformFeeCreditNoteSchema],
-        permissions=[IsOrganizationOwner()],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
     def list_credit_notes(self, slug: str) -> QuerySet[models.PlatformFeeCreditNote]:
@@ -144,7 +137,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/invoicing",
         url_name="set_invoicing_mode",
         response=schema.OrganizationBillingInfoSchema,
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def set_invoicing_mode(self, slug: str, payload: schema.InvoicingModeUpdateSchema) -> models.Organization:
@@ -166,7 +158,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices",
         url_name="list_attendee_invoices",
         response=PaginatedResponseSchema[schema.AttendeeInvoiceDetailSchema],
-        permissions=[IsOrganizationOwner()],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
     @searching(Searching, search_fields=["invoice_number", "buyer_name", "buyer_email", "event__name"])
@@ -179,7 +170,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices/{invoice_id}",
         url_name="get_attendee_invoice",
         response=schema.AttendeeInvoiceDetailSchema,
-        permissions=[IsOrganizationOwner()],
     )
     def get_attendee_invoice(self, slug: str, invoice_id: UUID) -> models.AttendeeInvoice:
         """Get a specific attendee invoice."""
@@ -190,7 +180,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices/{invoice_id}/download",
         url_name="download_attendee_invoice",
         response=schema.InvoiceDownloadURLSchema,
-        permissions=[IsOrganizationOwner()],
     )
     def download_attendee_invoice(self, slug: str, invoice_id: UUID) -> schema.InvoiceDownloadURLSchema:
         """Get a signed download URL for an attendee invoice PDF.
@@ -211,7 +200,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices/{invoice_id}",
         url_name="update_attendee_invoice",
         response=schema.AttendeeInvoiceDetailSchema,
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def update_attendee_invoice(
@@ -229,7 +217,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices/{invoice_id}/issue",
         url_name="issue_attendee_invoice",
         response=schema.AttendeeInvoiceDetailSchema,
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def issue_attendee_invoice(self, slug: str, invoice_id: UUID) -> models.AttendeeInvoice:
@@ -244,7 +231,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-invoices/{invoice_id}",
         url_name="delete_attendee_invoice",
         response={204: None},
-        permissions=[IsOrganizationOwner()],
         throttle=WriteThrottle(),
     )
     def delete_attendee_invoice(self, slug: str, invoice_id: UUID) -> tuple[int, None]:
@@ -262,7 +248,6 @@ class OrganizationAdminVATController(OrganizationAdminBaseController):
         "/attendee-credit-notes",
         url_name="list_attendee_credit_notes",
         response=PaginatedResponseSchema[schema.AttendeeInvoiceCreditNoteSchema],
-        permissions=[IsOrganizationOwner()],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
     @searching(

--- a/src/events/controllers/organization_admin/venues.py
+++ b/src/events/controllers/organization_admin/venues.py
@@ -15,7 +15,13 @@ from events.service import venue_service
 from .base import OrganizationAdminBaseController
 
 
-@api_controller("/organization-admin/{slug}", auth=I18nJWTAuth(), tags=["Organization Admin"], throttle=WriteThrottle())
+@api_controller(
+    "/organization-admin/{slug}",
+    auth=I18nJWTAuth(),
+    tags=["Organization Admin"],
+    throttle=WriteThrottle(),
+    permissions=[OrganizationPermission("edit_organization")],
+)
 class OrganizationAdminVenuesController(OrganizationAdminBaseController):
     """Organization venue management endpoints.
 
@@ -46,7 +52,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues",
         url_name="create_organization_venue",
         response={201: schema.VenueDetailSchema},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def create_venue(self, slug: str, payload: schema.VenueCreateSchema) -> tuple[int, models.Venue]:
         """Create a new venue for the organization.
@@ -83,7 +88,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}",
         url_name="update_organization_venue",
         response=schema.VenueDetailSchema,
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def update_venue(self, slug: str, venue_id: UUID, payload: schema.VenueUpdateSchema) -> models.Venue:
         """Update venue details.
@@ -101,7 +105,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}",
         url_name="delete_organization_venue",
         response={204: None},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def delete_venue(self, slug: str, venue_id: UUID) -> tuple[int, None]:
         """Delete a venue and all its sectors and seats.
@@ -142,7 +145,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors",
         url_name="create_venue_sector",
         response={201: schema.VenueSectorWithSeatsSchema},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def create_sector(
         self, slug: str, venue_id: UUID, payload: schema.VenueSectorCreateSchema
@@ -180,7 +182,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}",
         url_name="update_venue_sector",
         response=schema.VenueSectorWithSeatsSchema,
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def update_sector(
         self, slug: str, venue_id: UUID, sector_id: UUID, payload: schema.VenueSectorUpdateSchema
@@ -199,7 +200,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}",
         url_name="delete_venue_sector",
         response={204: None},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def delete_sector(self, slug: str, venue_id: UUID, sector_id: UUID) -> tuple[int, None]:
         """Delete a sector and all its seats.
@@ -219,7 +219,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}/seats",
         url_name="bulk_create_venue_seats",
         response={201: list[schema.VenueSeatSchema]},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def bulk_create_seats(
         self, slug: str, venue_id: UUID, sector_id: UUID, payload: schema.VenueSeatBulkCreateSchema
@@ -239,7 +238,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}/seats/bulk-delete",
         url_name="bulk_delete_venue_seats",
         response={200: dict[str, int]},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def bulk_delete_seats(
         self, slug: str, venue_id: UUID, sector_id: UUID, payload: schema.VenueSeatBulkDeleteSchema
@@ -259,7 +257,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}/seats/bulk-update",
         url_name="bulk_update_venue_seats",
         response=list[schema.VenueSeatSchema],
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def bulk_update_seats(
         self, slug: str, venue_id: UUID, sector_id: UUID, payload: schema.VenueSeatBulkUpdateSchema
@@ -281,7 +278,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}/seats/by-label/{label}",
         url_name="update_venue_seat",
         response=schema.VenueSeatSchema,
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def update_seat(
         self, slug: str, venue_id: UUID, sector_id: UUID, label: str, payload: schema.VenueSeatUpdateSchema
@@ -304,7 +300,6 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         "/venues/{venue_id}/sectors/{sector_id}/seats/by-label/{label}",
         url_name="delete_venue_seat",
         response={204: None},
-        permissions=[OrganizationPermission("edit_organization")],
     )
     def delete_seat(self, slug: str, venue_id: UUID, sector_id: UUID, label: str) -> tuple[int, None]:
         """Delete a specific seat by its label.

--- a/src/polls/controllers/question_controller.py
+++ b/src/polls/controllers/question_controller.py
@@ -50,6 +50,7 @@ from questionnaires.service import QuestionnaireService
     tags=["Polls"],
     auth=I18nJWTAuth(),
     throttle=WriteThrottle(),
+    permissions=[PollPermission("manage_polls")],
 )
 class PollQuestionController(UserAwareController):
     """Poll-scoped question/option/section CRUD.
@@ -72,7 +73,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/sections",
         url_name="poll_create_section",
         response=questionnaire_schema.SectionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def create_section(
         self, poll_id: UUID, payload: questionnaire_schema.SectionCreateSchema
@@ -86,7 +86,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/sections/{section_id}",
         url_name="poll_update_section",
         response=questionnaire_schema.SectionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def update_section(
         self, poll_id: UUID, section_id: UUID, payload: questionnaire_schema.SectionUpdateSchema
@@ -105,7 +104,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/sections/{section_id}",
         url_name="poll_delete_section",
         response={204: None},
-        permissions=[PollPermission("manage_polls")],
     )
     def delete_section(self, poll_id: UUID, section_id: UUID) -> tuple[int, None]:
         """Delete a section (and its nested questions) from a DRAFT poll."""
@@ -124,7 +122,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-questions",
         url_name="poll_create_mc_question",
         response=questionnaire_schema.MultipleChoiceQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def create_mc_question(
         self, poll_id: UUID, payload: questionnaire_schema.MultipleChoiceQuestionCreateSchema
@@ -138,7 +135,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-questions/{question_id}",
         url_name="poll_update_mc_question",
         response=questionnaire_schema.MultipleChoiceQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def update_mc_question(
         self,
@@ -160,7 +156,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-questions/{question_id}",
         url_name="poll_delete_mc_question",
         response={204: None},
-        permissions=[PollPermission("manage_polls")],
     )
     def delete_mc_question(self, poll_id: UUID, question_id: UUID) -> tuple[int, None]:
         """Delete a multiple-choice question (and its options) from a DRAFT poll."""
@@ -179,7 +174,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-questions/{question_id}/options",
         url_name="poll_create_mc_option",
         response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def create_mc_option(
         self,
@@ -201,7 +195,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-options/{option_id}",
         url_name="poll_update_mc_option",
         response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def update_mc_option(
         self,
@@ -223,7 +216,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/multiple-choice-options/{option_id}",
         url_name="poll_delete_mc_option",
         response={204: None},
-        permissions=[PollPermission("manage_polls")],
     )
     def delete_mc_option(self, poll_id: UUID, option_id: UUID) -> tuple[int, None]:
         """Delete an MC option from a DRAFT poll."""
@@ -242,7 +234,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/free-text-questions",
         url_name="poll_create_ft_question",
         response=questionnaire_schema.FreeTextQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def create_ft_question(
         self, poll_id: UUID, payload: questionnaire_schema.FreeTextQuestionCreateSchema
@@ -256,7 +247,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/free-text-questions/{question_id}",
         url_name="poll_update_ft_question",
         response=questionnaire_schema.FreeTextQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def update_ft_question(
         self,
@@ -278,7 +268,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/free-text-questions/{question_id}",
         url_name="poll_delete_ft_question",
         response={204: None},
-        permissions=[PollPermission("manage_polls")],
     )
     def delete_ft_question(self, poll_id: UUID, question_id: UUID) -> tuple[int, None]:
         """Delete a free-text question from a DRAFT poll."""
@@ -297,7 +286,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/file-upload-questions",
         url_name="poll_create_fu_question",
         response=questionnaire_schema.FileUploadQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def create_fu_question(
         self, poll_id: UUID, payload: questionnaire_schema.FileUploadQuestionCreateSchema
@@ -311,7 +299,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/file-upload-questions/{question_id}",
         url_name="poll_update_fu_question",
         response=questionnaire_schema.FileUploadQuestionResponseSchema,
-        permissions=[PollPermission("manage_polls")],
     )
     def update_fu_question(
         self,
@@ -333,7 +320,6 @@ class PollQuestionController(UserAwareController):
         "/{poll_id}/file-upload-questions/{question_id}",
         url_name="poll_delete_fu_question",
         response={204: None},
-        permissions=[PollPermission("manage_polls")],
     )
     def delete_fu_question(self, poll_id: UUID, question_id: UUID) -> tuple[int, None]:
         """Delete a file-upload question from a DRAFT poll."""


### PR DESCRIPTION
Closes #595.

Moves the prevailing permission to the `@api_controller(..., permissions=[...])` class decorator and drops redundant per-endpoint declarations. **No behavior change** — the resolved permission for every endpoint stays identical (with one deliberate drift fix, below).

Net: **+31 / −91** across 11 controllers.

## Pure HOIST (same permission on every endpoint)
| File | Permission | Endpoints |
|---|---|---|
| `organization_admin/vat.py` | `IsOrganizationOwner()` | 16 |
| `organization_admin/revenue.py` | `manage_organization` | 3 |
| `polls/.../question_controller.py` | `manage_polls` | 15 |

## Redundant repeats dropped (class default already correct)
`event_admin/invitations.py` (4), `rsvps.py` (5), `waitlist.py` (2) — all `invite_to_event`.

## HOIST + OVERRIDE (prevailing default + minority overrides kept)
- **`venues.py`** → class `edit_organization`; 4 read GETs keep `IsOrganizationStaff()`
- **`members.py`** → class `manage_members`; kept 4× `edit_organization`, 1× `IsOrganizationStaff()`, 1× `IsOrganizationOwner()`
- **`recurring_events.py`** → class `edit_event_series`; kept `create_event` on `create_recurring_event`
- **`tickets.py`** → class default changed `invite_to_event` → `manage_tickets`; kept `check_in_attendees` and `manage_event` overrides

## Drift fix
- **`waitlist_offers.py`** → removed the `invite_to_event` override on `list_waitlist_offers` so it inherits `manage_event` like its siblings. This is the issue's one *intentional* behavior change.

## Two judgment calls (verified)
1. **`tickets.py` → `list_ticket_tiers`** had no explicit permission, inheriting the old class default `invite_to_event`. To avoid silently tightening it to `manage_tickets`, it's now pinned explicitly to `invite_to_event` — exact behavior preserved. The existing `test_list_ticket_tiers_by_staff_with_permission` test (asserting `invite_to_event` access) confirms this gate.
2. **`waitlist_offers.py` drift** tightens `list_waitlist_offers` from `invite_to_event` → `manage_event`. Its tests use the owner client, so they still pass.

## Verification
- `ruff check` + `ruff format --check`: clean
- `mypy --strict` on controllers: no issues
- **433 targeted tests** across all 11 affected controllers: all pass

No model/migration/OpenAPI changes (permissions don't appear in the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated authorization configuration across multiple controllers by moving permission requirements from individual endpoints to controller level. This improves code maintainability and consistency while preserving all existing access control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->