### PR TITLE
fix(telegram): block banned users in bot & fix /unsubscribe no-op (#583, #584)

### DIFF
--- a/src/notifications/controllers/preference_controller.py
+++ b/src/notifications/controllers/preference_controller.py
@@ -73,9 +73,8 @@ class NotificationPreferenceController(UserAwareController):
         """Disable a notification channel."""
         prefs, _ = NotificationPreference.objects.get_or_create(user=self.user())
 
-        if channel in prefs.enabled_channels:
-            prefs.enabled_channels.remove(channel)
-            prefs.save(update_fields=["enabled_channels", "updated_at"])
+        if prefs.disable_channel(channel):
+            prefs.save(update_fields=["enabled_channels", "notification_type_settings", "updated_at"])
 
         return prefs
 

--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -316,3 +316,29 @@ class NotificationPreference(TimeStampedModel):
 
         # Otherwise use global enabled channels
         return list(self.enabled_channels)
+
+    def disable_channel(self, channel: str) -> bool:
+        """Remove a delivery channel from global and per-type preferences.
+
+        Removes ``channel`` from ``enabled_channels`` and from every per-type
+        override in ``notification_type_settings``. Per-type channel lists
+        OVERRIDE ``enabled_channels`` (see ``get_channels_for_notification_type``),
+        so clearing only the global list would leave types that hardcode the
+        channel (e.g. ``ORG_CONTACT_MESSAGE_RECEIVED`` → TELEGRAM) still delivering.
+
+        Args:
+            channel: Channel to remove (e.g. ``DeliveryChannel.TELEGRAM``).
+
+        Returns:
+            True if anything changed, False otherwise.
+        """
+        changed = False
+        if channel in self.enabled_channels:
+            self.enabled_channels = [c for c in self.enabled_channels if c != channel]
+            changed = True
+        for setting in self.notification_type_settings.values():
+            channels = setting.get("channels")
+            if channels and channel in channels:
+                setting["channels"] = [c for c in channels if c != channel]
+                changed = True
+        return changed

--- a/src/notifications/signals/telegram.py
+++ b/src/notifications/signals/telegram.py
@@ -33,10 +33,9 @@ def enable_telegram_channel(sender: type, user: "RevelUser", telegram_user: "Tel
 
 @receiver(telegram_account_unlinked)
 def disable_telegram_channel(sender: type, user: "RevelUser", telegram_user: "TelegramUser", **kwargs: object) -> None:
-    """Remove TELEGRAM from enabled_channels when user unlinks their Telegram account."""
+    """Remove TELEGRAM from all preferences when user unlinks their Telegram account."""
     prefs = NotificationPreference.objects.get(user=user)
 
-    if DeliveryChannel.TELEGRAM in prefs.enabled_channels:
-        prefs.enabled_channels.remove(DeliveryChannel.TELEGRAM)
-        prefs.save(update_fields=["enabled_channels", "updated_at"])
+    if prefs.disable_channel(DeliveryChannel.TELEGRAM):
+        prefs.save(update_fields=["enabled_channels", "notification_type_settings", "updated_at"])
         logger.info("telegram_channel_disabled", user_id=str(user.id))

--- a/src/notifications/tests/test_preference_model.py
+++ b/src/notifications/tests/test_preference_model.py
@@ -1,0 +1,44 @@
+"""Tests for NotificationPreference model helpers."""
+
+import pytest
+
+from accounts.models import RevelUser
+from notifications.enums import DeliveryChannel, NotificationType
+from notifications.models import NotificationPreference
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDisableChannel:
+    def test_removes_from_enabled_channels(self, user: RevelUser) -> None:
+        prefs = NotificationPreference.objects.get(user=user)
+        prefs.enabled_channels = [DeliveryChannel.EMAIL, DeliveryChannel.TELEGRAM]
+
+        changed = prefs.disable_channel(DeliveryChannel.TELEGRAM)
+
+        assert changed is True
+        assert prefs.enabled_channels == [DeliveryChannel.EMAIL]
+
+    def test_removes_from_per_type_overrides(self, user: RevelUser) -> None:
+        """Per-type overrides bypass enabled_channels, so they must be cleared too."""
+        prefs = NotificationPreference.objects.get(user=user)
+        # Default settings seed ORG_CONTACT_MESSAGE_RECEIVED with IN_APP + TELEGRAM.
+        assert DeliveryChannel.TELEGRAM in prefs.get_channels_for_notification_type(
+            NotificationType.ORG_CONTACT_MESSAGE_RECEIVED
+        )
+
+        changed = prefs.disable_channel(DeliveryChannel.TELEGRAM)
+
+        assert changed is True
+        assert DeliveryChannel.TELEGRAM not in prefs.get_channels_for_notification_type(
+            NotificationType.ORG_CONTACT_MESSAGE_RECEIVED
+        )
+
+    def test_returns_false_when_absent(self, user: RevelUser) -> None:
+        prefs = NotificationPreference.objects.get(user=user)
+        # Strip any telegram presence (global + per-type defaults) first.
+        prefs.disable_channel(DeliveryChannel.TELEGRAM)
+
+        changed = prefs.disable_channel(DeliveryChannel.TELEGRAM)
+
+        assert changed is False

--- a/src/telegram/middleware.py
+++ b/src/telegram/middleware.py
@@ -143,6 +143,14 @@ class AuthorizationMiddleware(BaseMiddleware):
 
         user: RevelUser = t.cast(RevelUser, tg_user.user)
 
+        if not user.is_active:
+            await self._send_error(
+                event,
+                "⚠️ Your account has been deactivated.",
+                "Account deactivated",
+            )
+            return None
+
         if requires_superuser and not user.is_superuser:
             await self._send_error(event, "⚠️ This command is for administrators only.", "Administrators only")
             return None

--- a/src/telegram/routers/common.py
+++ b/src/telegram/routers/common.py
@@ -149,12 +149,10 @@ async def handle_unsubscribe(message: Message, tg_user: TelegramUser, user: Reve
     from notifications.enums import DeliveryChannel
     from notifications.models import NotificationPreference
 
-    prefs, created = await NotificationPreference.objects.aget_or_create(user=user)
+    prefs, _ = await NotificationPreference.objects.aget_or_create(user=user)
 
-    # Remove telegram from enabled channels if present
-    if DeliveryChannel.TELEGRAM in prefs.enabled_channels:
-        prefs.enabled_channels.remove(DeliveryChannel.TELEGRAM)
-    await prefs.asave(update_fields=["enabled_channels", "updated_at"])
+    if prefs.disable_channel(DeliveryChannel.TELEGRAM):
+        await prefs.asave(update_fields=["enabled_channels", "notification_type_settings", "updated_at"])
     logger.info("telegram_user_disabled_notifications", telegram_id=tg_user.telegram_id)
     await message.answer(
         "✅ You have been unsubscribed from all Telegram notifications.\n\n"

--- a/src/telegram/routers/common.py
+++ b/src/telegram/routers/common.py
@@ -146,11 +146,14 @@ async def handle_unsubscribe(message: Message, tg_user: TelegramUser, user: Reve
     logger.info("telegram_user_requested_unsubscribe", telegram_id=tg_user.telegram_id)
 
     # Get or create notification preferences and disable telegram channel
+    from notifications.enums import DeliveryChannel
     from notifications.models import NotificationPreference
 
     prefs, created = await NotificationPreference.objects.aget_or_create(user=user)
 
     # Remove telegram from enabled channels if present
+    if DeliveryChannel.TELEGRAM in prefs.enabled_channels:
+        prefs.enabled_channels.remove(DeliveryChannel.TELEGRAM)
     await prefs.asave(update_fields=["enabled_channels", "updated_at"])
     logger.info("telegram_user_disabled_notifications", telegram_id=tg_user.telegram_id)
     await message.answer(

--- a/src/telegram/tests/test_authorization_middleware.py
+++ b/src/telegram/tests/test_authorization_middleware.py
@@ -179,6 +179,28 @@ class TestRequiresLinkedUser:
         event.answer.assert_awaited_once()
         assert "deactivated" in event.answer.call_args.args[0].lower()
 
+    @pytest.mark.asyncio
+    async def test_inactive_user_blocked_callback(
+        self,
+        middleware: AuthorizationMiddleware,
+        django_inactive_user: RevelUser,
+    ) -> None:
+        """Callback queries from a banned user show an alert instead of running (issue #583)."""
+        handler = AsyncMock()
+        tg_user = await _get_tg_user(django_inactive_user)
+        event = _make_cb_event(data="some:action")
+        data: dict[str, t.Any] = {"tg_user": tg_user}
+
+        flags = {"requires_linked_user": True}
+        with patch("aiogram.dispatcher.flags.get_flag", side_effect=_make_flags_getter(flags)):
+            result = await middleware(handler, event, data)
+
+        assert result is None
+        handler.assert_not_awaited()
+        assert "user" not in data
+        event.answer.assert_awaited_once()
+        assert event.answer.call_args.kwargs["show_alert"] is True
+
 
 # ── requires_superuser ───────────────────────────────────────────────
 

--- a/src/telegram/tests/test_authorization_middleware.py
+++ b/src/telegram/tests/test_authorization_middleware.py
@@ -157,6 +157,28 @@ class TestRequiresLinkedUser:
         event.answer.assert_awaited_once()
         assert event.answer.call_args.kwargs["show_alert"] is True
 
+    @pytest.mark.asyncio
+    async def test_inactive_user_blocked(
+        self,
+        middleware: AuthorizationMiddleware,
+        django_inactive_user: RevelUser,
+    ) -> None:
+        """A globally-banned (is_active=False) linked user is rejected (issue #583)."""
+        handler = AsyncMock()
+        tg_user = await _get_tg_user(django_inactive_user)
+        event = _make_msg_event()
+        data: dict[str, t.Any] = {"tg_user": tg_user}
+
+        flags = {"requires_linked_user": True}
+        with patch("aiogram.dispatcher.flags.get_flag", side_effect=_make_flags_getter(flags)):
+            result = await middleware(handler, event, data)
+
+        assert result is None
+        handler.assert_not_awaited()
+        assert "user" not in data
+        event.answer.assert_awaited_once()
+        assert "deactivated" in event.answer.call_args.args[0].lower()
+
 
 # ── requires_superuser ───────────────────────────────────────────────
 

--- a/src/telegram/tests/test_handlers_common.py
+++ b/src/telegram/tests/test_handlers_common.py
@@ -306,16 +306,40 @@ class TestHandleUnsubscribe:
         from notifications.models import NotificationPreference
 
         tg_user = await _get_tg_user(django_user)
-        prefs = await NotificationPreference.objects.acreate(
-            user=django_user,
-            enabled_channels=[DeliveryChannel.EMAIL, DeliveryChannel.TELEGRAM],
-        )
+        prefs = await NotificationPreference.objects.aget(user=django_user)
+        prefs.enabled_channels = [DeliveryChannel.EMAIL, DeliveryChannel.TELEGRAM]
+        await prefs.asave(update_fields=["enabled_channels"])
 
         await handle_unsubscribe(mock_message, tg_user=tg_user, user=django_user)
 
         await prefs.arefresh_from_db()
         assert DeliveryChannel.TELEGRAM not in prefs.enabled_channels
         assert DeliveryChannel.EMAIL in prefs.enabled_channels
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_clears_per_type_telegram_override(
+        self,
+        mock_message: AsyncMock,
+        django_user: RevelUser,
+    ) -> None:
+        """/unsubscribe must also clear TELEGRAM from per-type overrides that bypass
+        enabled_channels (e.g. ORG_CONTACT_MESSAGE_RECEIVED defaults to IN_APP+TELEGRAM)."""
+        from notifications.enums import DeliveryChannel, NotificationType
+        from notifications.models import NotificationPreference
+
+        tg_user = await _get_tg_user(django_user)
+        # Default notification_type_settings seeds ORG_CONTACT_MESSAGE_RECEIVED with TELEGRAM.
+        prefs = await NotificationPreference.objects.aget(user=django_user)
+        assert DeliveryChannel.TELEGRAM in prefs.get_channels_for_notification_type(
+            NotificationType.ORG_CONTACT_MESSAGE_RECEIVED
+        )
+
+        await handle_unsubscribe(mock_message, tg_user=tg_user, user=django_user)
+
+        await prefs.arefresh_from_db()
+        assert DeliveryChannel.TELEGRAM not in prefs.get_channels_for_notification_type(
+            NotificationType.ORG_CONTACT_MESSAGE_RECEIVED
+        )
 
 
 # ── sanitize_text (pure function) ────────────────────────────────────

--- a/src/telegram/tests/test_handlers_common.py
+++ b/src/telegram/tests/test_handlers_common.py
@@ -295,6 +295,28 @@ class TestHandleUnsubscribe:
         text = mock_message.answer.call_args.args[0]
         assert "unsubscribed" in text.lower()
 
+    @pytest.mark.asyncio
+    async def test_unsubscribe_removes_telegram_channel(
+        self,
+        mock_message: AsyncMock,
+        django_user: RevelUser,
+    ) -> None:
+        """/unsubscribe must actually drop TELEGRAM from enabled_channels (issue #584)."""
+        from notifications.enums import DeliveryChannel
+        from notifications.models import NotificationPreference
+
+        tg_user = await _get_tg_user(django_user)
+        prefs = await NotificationPreference.objects.acreate(
+            user=django_user,
+            enabled_channels=[DeliveryChannel.EMAIL, DeliveryChannel.TELEGRAM],
+        )
+
+        await handle_unsubscribe(mock_message, tg_user=tg_user, user=django_user)
+
+        await prefs.arefresh_from_db()
+        assert DeliveryChannel.TELEGRAM not in prefs.enabled_channels
+        assert DeliveryChannel.EMAIL in prefs.enabled_channels
+
 
 # ── sanitize_text (pure function) ────────────────────────────────────
 


### PR DESCRIPTION
Bundles two related Telegram bot fixes found via `/vuln-scan`.

## #583 — Telegram ban evasion (Medium, security)
`AuthorizationMiddleware.__call__` only checked `tg_user.user_id` (and `is_superuser` for superuser routes), never `user.is_active`. Globally-banned (`is_active=False`) users were locked out of the HTTP API but retained **full access to the bot's authenticated commands** (rsvp, join_waitlist, become_member, unsubscribe, etc.).

**Fix:** add an `is_active` gate right after resolving the linked user — before the superuser check and `data["user"]` injection — mirroring what ninja_jwt's `get_user` enforces implicitly on the HTTP side. A deactivated account now gets a "⚠️ Your account has been deactivated." response and the handler never runs.

## #584 — `/unsubscribe` no-op (Low, functional/privacy)
`handle_unsubscribe` saved `NotificationPreference` with `update_fields=["enabled_channels", ...]` but never modified `enabled_channels` — a guaranteed no-op, while still telling the user they were unsubscribed. Telegram notifications kept flowing.

**Fix:** remove `DeliveryChannel.TELEGRAM` from `enabled_channels` before saving, matching the mirror logic in `notifications/signals/telegram.py`.

## Tests
- `test_authorization_middleware.py::test_inactive_user_blocked` — banned linked user is rejected; `data["user"]` never set.
- `test_handlers_common.py::test_unsubscribe_removes_telegram_channel` — `TELEGRAM` dropped from `enabled_channels`, `EMAIL` preserved.

`make check` passes (format, lint, mypy --strict, migrations, i18n, file-length).

Closes #583
Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification channel management to properly disable delivery methods across all notification types.

* **Bug Fixes**
  * Fixed Telegram account unlinking to fully remove Telegram notifications from all notification settings.
  * Added support for blocking deactivated accounts from accessing Telegram features.

* **Tests**
  * Added comprehensive test coverage for notification channel disabling and inactive account authorization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->