### PR TITLE
fix(tooling): correct bootstrap-tests target and dedup seed blacklist entries (#591)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ seed:
 
 .PHONY: bootstrap-tests
 bootstrap-tests:
-	uv run python src/manage.py bootstrap_tests
+	uv run python src/manage.py bootstrap_test_events
 
 .PHONY: run
 run:

--- a/docs/getting-started/development-commands.md
+++ b/docs/getting-started/development-commands.md
@@ -149,7 +149,7 @@ To test with real async processing, set `CELERY_TASK_ALWAYS_EAGER=False` in your
 | `make shell` | Open the Django interactive shell |
 | `make reset-db` | Reset the database using the `reset_db` management command |
 | `make db-diagram` | Generate a database entity-relationship diagram (requires `django-extensions`) |
-| `make bootstrap-tests` | Run only the `bootstrap_tests` management command (test events for eligibility gates) |
+| `make bootstrap-tests` | Run only the `bootstrap_test_events` management command (test events for eligibility gates) |
 | `make check-version` | Check the currently deployed versions on main and dev servers |
 | `make count-lines` | Count non-blank, non-comment Python lines in `src/` |
 | `make tree` | Print the project directory tree (excludes `__pycache__`, images, htmlcov) |

--- a/src/events/management/commands/seeder/interactions.py
+++ b/src/events/management/commands/seeder/interactions.py
@@ -302,6 +302,13 @@ class InteractionSeeder(BaseSeeder):
 
         entries_to_create: list[Blacklist] = []
 
+        # Blacklist enforces unique (org, user), (org, email), and (org, phone) per org;
+        # track what we've already queued so random picks/faker collisions don't trip the
+        # constraints during bulk_create (especially at small --users counts).
+        seen_users: set[tuple[str, str]] = set()
+        seen_emails: set[tuple[str, str]] = set()
+        seen_phones: set[tuple[str, str]] = set()
+
         for org in self.state.organizations:
             # 5-15 blacklist entries per org
             num_entries = self.random_int(5, 15)
@@ -311,6 +318,9 @@ class InteractionSeeder(BaseSeeder):
 
                 if entry_type == "user":
                     user = self.random_choice(self.state.regular_users)
+                    if (str(org.id), str(user.id)) in seen_users:
+                        continue
+                    seen_users.add((str(org.id), str(user.id)))
                     entries_to_create.append(
                         Blacklist(
                             organization=org,
@@ -321,10 +331,14 @@ class InteractionSeeder(BaseSeeder):
                         )
                     )
                 elif entry_type == "email":
+                    email = self.faker.email()
+                    if (str(org.id), email) in seen_emails:
+                        continue
+                    seen_emails.add((str(org.id), email))
                     entries_to_create.append(
                         Blacklist(
                             organization=org,
-                            email=self.faker.email(),
+                            email=email,
                             reason=self.faker.sentence(),
                             created_by=org.owner,
                         )
@@ -340,10 +354,14 @@ class InteractionSeeder(BaseSeeder):
                         )
                     )
                 else:  # phone
+                    phone_number = self.faker.phone_number()[:20]
+                    if (str(org.id), phone_number) in seen_phones:
+                        continue
+                    seen_phones.add((str(org.id), phone_number))
                     entries_to_create.append(
                         Blacklist(
                             organization=org,
-                            phone_number=self.faker.phone_number()[:20],
+                            phone_number=phone_number,
                             reason=self.faker.sentence(),
                             created_by=org.owner,
                         )


### PR DESCRIPTION
## Summary

Closes #591 and fixes a latent bug surfaced while sanity-checking the test-data flows.

### 1. `make bootstrap-tests` was broken (#591)
The target invoked a non-existent management command `bootstrap_tests` → `Unknown command: 'bootstrap_tests'`. The real command is `bootstrap_test_events`. Fixed the `Makefile` target and the docs table that mirrored the same typo.

### 2. `seed` could abort on the blacklist seeder
`Blacklist` enforces unique `(org, user)`, `(org, email)`, and `(org, phone)` per org. `_create_blacklist` picked random users / faker values with **no dedup** and bulk-created with `ignore_conflicts=False`, so any repeated pick within an org raised an `IntegrityError` and aborted the whole seed.

- Improbable at the default scale (`make seed`, 1000 users), which is why it went unnoticed.
- **Reliable failure at small `--users` counts** (e.g. `--users 6`), and `--users` is an advertised flag.

Fix: track queued keys per org and skip duplicates — matching the existing dedup pattern already used by the invitation/RSVP seeders in this same module.

## Verification

- `bootstrap_test_events` and `seed` were each executed against the live schema inside a rolled-back transaction (no committed writes).
- `seed --users 6 --organizations 2 --events 2` previously aborted on the blacklist phase; now completes cleanly.
- `seed` at default scale and `bootstrap_test_events` both run clean.
- `mypy --strict` and `ruff` pass on the changed file.

> Note: tests not run per project convention (the user runs the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate blacklist entries during test event initialization. The system now properly deduplicates user, email, and phone number entries based on organization associations to ensure clean, consistent test databases.

* **Chores**
  * Updated bootstrap command naming for clarity and synchronized development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->