### PR TITLE
fix(events): honor RecurrenceRule.timezone with DST-aware occurrences (#594)

### DIFF
--- a/USER_JOURNEYS.md
+++ b/USER_JOURNEYS.md
@@ -1073,7 +1073,7 @@ See [Journey 25: Revenue & VAT Reporting](#journey-25-revenue--vat-reporting) fo
 
 ### 18.4 Recurring Events (Organizer)
 First-class recurring series with rolling-window materialization:
-- Define a `RecurrenceRule` (frequency, interval, weekdays, monthly params, boundaries) → emits an RFC 5545 `RRULE`
+- Define a `RecurrenceRule` (frequency, interval, weekdays, monthly params, boundaries, IANA `timezone`) → emits an RFC 5545 `RRULE`; occurrences preserve their wall-clock time in the rule's `timezone` across DST transitions
 - Series config: `template_event`, `recurrence_rule`, `exdates`, `auto_publish`, `generation_window_weeks`
 - Each occurrence is a **real materialized `Event`** (independent tickets, payments, capacity) duplicated from the template; safe template edits propagate via a `PROPAGATABLE_FIELDS` whitelist
 - A daily Celery beat task drives rolling-window generation

--- a/docs/architecture/recurring-series.md
+++ b/docs/architecture/recurring-series.md
@@ -25,7 +25,7 @@ This page covers the rule model, how and when occurrences are generated, drift d
 | `dtstart` | DateTime | Anchor of the series. |
 | `until` / `count` | DateTime / int, nullable | Optional boundaries. |
 | `rrule_string` | Text, read-only | Recomputed on every save from the structured fields. |
-| `timezone` | str (default `UTC`) | Validated IANA zone. **Currently reserved metadata** — occurrences are anchored to the UTC `dtstart` and do not yet observe DST in the named tz (a `# ponytail:`-style Phase-3 ceiling noted in the model). |
+| `timezone` | str (default `UTC`) | Validated IANA zone. `to_rrule()` localizes `dtstart` into this zone, so occurrences **preserve their wall-clock time across DST** (a "Mondays 10:00 Europe/Vienna" rule stays at 10:00 Vienna before and after the switch; the underlying UTC instant shifts by the offset). Default `UTC` is a no-op. |
 
 Validation is delegated to `events/utils/recurrence_validators.py` so the Pydantic input schema and the model `clean()` enforce identical rules. `to_rrule()` builds a `dateutil.rrule`; `get_occurrences(after, before)` returns the occurrence datetimes strictly between two bounds.
 

--- a/src/events/migrations/0087_reanchor_non_utc_series_occurrences.py
+++ b/src/events/migrations/0087_reanchor_non_utc_series_occurrences.py
@@ -1,0 +1,97 @@
+"""Re-anchor future occurrences of non-UTC recurring series to DST-correct times.
+
+Before timezone-aware occurrence generation landed, ``RecurrenceRule.to_rrule()``
+anchored occurrences to the UTC ``dtstart`` and ignored the rule's ``timezone``,
+so a "Mondays 10:00 Europe/Vienna" series drifted to 11:00 Vienna after the
+spring DST switch. ``to_rrule()`` now localizes the anchor into the named zone.
+
+This data migration realigns already-materialized occurrences so they match the
+corrected cadence (and so cadence-drift detection doesn't flag them). It only
+touches **future, unmodified, non-cancelled** occurrences of series whose rule
+uses a **non-UTC** timezone — the default ``UTC`` is a no-op, and modified
+occurrences were deliberately shifted off-cadence by an organiser. Each shift is
+at most the DST offset (≤ 1 hour); ``start`` and ``end`` move together so the
+event's duration is preserved.
+"""
+
+import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from django.db import migrations
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+def reanchor_non_utc_occurrences(apps, schema_editor):  # type: ignore[no-untyped-def]
+    """Shift future non-UTC occurrences to the DST-correct wall-clock instant."""
+    Event = apps.get_model("events", "Event")
+
+    now = timezone.now()
+    qs = (
+        Event.objects.filter(
+            is_template=False,
+            is_modified=False,
+            start__gte=now,
+            event_series__recurrence_rule__isnull=False,
+        )
+        .exclude(event_series__recurrence_rule__timezone="UTC")
+        .exclude(status="cancelled")
+        .select_related("event_series__recurrence_rule")
+    )
+
+    updated = 0
+    for event in qs:
+        rule = event.event_series.recurrence_rule
+        try:
+            tz = ZoneInfo(rule.timezone)
+        except (ZoneInfoNotFoundError, ValueError):
+            # Defensive: a row with an unparseable zone shouldn't block the
+            # whole migration. Validation rejects these on save, so this is
+            # only a guard against legacy/hand-edited data.
+            continue
+
+        anchor_local = rule.dtstart.astimezone(tz)
+        old_local = event.start.astimezone(tz)
+        # ponytail: recomputes the occurrence on its *local* calendar date with
+        # the anchor's wall-clock time-of-day. A DST drift that pushed the old
+        # start across local midnight (only possible for anchors within ~1h of
+        # midnight) would land on the wrong day; such anchors aren't used in
+        # practice and are left as-is by the equality check below.
+        new_start = datetime(
+            old_local.year,
+            old_local.month,
+            old_local.day,
+            anchor_local.hour,
+            anchor_local.minute,
+            anchor_local.second,
+            anchor_local.microsecond,
+            tzinfo=tz,
+        )
+        if new_start == event.start:
+            continue
+
+        delta = new_start - event.start
+        event.start = new_start
+        event.end = event.end + delta
+        # Historical-model save() runs no signals/full_clean, so no notifications
+        # fire — organisers communicate the corrected time out-of-band if needed.
+        event.save(update_fields=["start", "end"])
+        updated += 1
+
+    logger.info("reanchor_non_utc_occurrences_complete", extra={"updated": updated})
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("events", "0086_event_is_open_ended"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            reanchor_non_utc_occurrences,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/src/events/migrations/0087_reanchor_non_utc_series_occurrences.py
+++ b/src/events/migrations/0087_reanchor_non_utc_series_occurrences.py
@@ -15,7 +15,7 @@ event's duration is preserved.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.db import migrations
@@ -24,7 +24,7 @@ from django.utils import timezone
 logger = logging.getLogger(__name__)
 
 
-def reanchor_non_utc_occurrences(apps, schema_editor):  # type: ignore[no-untyped-def]
+def reanchor_non_utc_occurrences(apps, schema_editor):
     """Shift future non-UTC occurrences to the DST-correct wall-clock instant."""
     Event = apps.get_model("events", "Event")
 
@@ -54,11 +54,11 @@ def reanchor_non_utc_occurrences(apps, schema_editor):  # type: ignore[no-untype
 
         anchor_local = rule.dtstart.astimezone(tz)
         old_local = event.start.astimezone(tz)
-        # ponytail: recomputes the occurrence on its *local* calendar date with
-        # the anchor's wall-clock time-of-day. A DST drift that pushed the old
-        # start across local midnight (only possible for anchors within ~1h of
-        # midnight) would land on the wrong day; such anchors aren't used in
-        # practice and are left as-is by the equality check below.
+        # Recompute the occurrence on its *local* calendar date with the anchor's
+        # wall-clock time-of-day. A DST drift that pushed the old start across
+        # local midnight (only possible for anchors within ~1h of midnight) would
+        # land on the wrong day, producing a delta larger than the DST offset; the
+        # >1h guard below skips those rather than rewrite them to the wrong day.
         new_start = datetime(
             old_local.year,
             old_local.month,
@@ -73,6 +73,11 @@ def reanchor_non_utc_occurrences(apps, schema_editor):  # type: ignore[no-untype
             continue
 
         delta = new_start - event.start
+        if abs(delta) > timedelta(hours=1):
+            # A correct DST re-anchor shifts by at most the DST offset (≤1h).
+            # A larger delta means the local-date recombination crossed a day
+            # boundary (near-midnight anchor edge); skip to avoid a wrong-day move.
+            continue
         event.start = new_start
         event.end = event.end + delta
         # Historical-model save() runs no signals/full_clean, so no notifications

--- a/src/events/models/recurrence_rule.py
+++ b/src/events/models/recurrence_rule.py
@@ -2,6 +2,7 @@
 
 import typing as t
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from dateutil.rrule import DAILY, MONTHLY, WEEKLY, YEARLY, rrule
 from dateutil.rrule import weekday as rrule_weekday
@@ -61,10 +62,12 @@ class RecurrenceRule(TimeStampedModel):
     # Computed RRULE string (read-only, populated on save)
     rrule_string = models.TextField(editable=False, blank=True, default="")
 
-    # Timezone for the recurrence anchor. Currently reserved metadata: occurrences
-    # are anchored to the UTC ``dtstart`` and do not observe DST in the named tz
-    # (Phase 3 will use this field to localize the anchor). Validated as a real
-    # IANA zone name so bad data is rejected on save.
+    # IANA timezone the recurrence anchor is localized to. ``to_rrule()`` presents
+    # ``dtstart`` in this zone, so occurrences preserve wall-clock time across DST
+    # transitions (a "Mondays 10:00 Europe/Vienna" rule stays at 10:00 Vienna
+    # before and after the spring/autumn switch). The default ``"UTC"`` is a no-op
+    # (UTC has no DST), so rules that don't care keep the simple UTC behavior.
+    # Validated as a real IANA zone name so bad data is rejected on save.
     timezone = models.CharField(max_length=64, default="UTC")
 
     class Meta:
@@ -99,16 +102,32 @@ class RecurrenceRule(TimeStampedModel):
             raise ValidationError(exc.message) from exc
 
     def to_rrule(self) -> rrule:
-        """Build a dateutil rrule object from the stored fields."""
+        """Build a dateutil rrule object from the stored fields.
+
+        ``dtstart`` (and ``until``) are localized into ``self.timezone`` before
+        being handed to ``dateutil.rrule``, which then preserves the *wall-clock*
+        time-of-day across DST transitions in that zone. With the default
+        ``"UTC"`` timezone this is a no-op and occurrences stay anchored to the
+        stored UTC instant.
+
+        ``dtstart`` is stored as a UTC instant (Django ``USE_TZ``), so the
+        localized wall-clock time reflects the instant the organiser originally
+        picked, expressed in the named zone.
+        """
+        tz = ZoneInfo(self.timezone)
         freq = self.FREQ_MAP[self.frequency]
         kwargs: dict[str, t.Any] = {
             "freq": freq,
             "interval": self.interval,
-            "dtstart": self.dtstart,
+            # ponytail: a wall-clock time that is skipped/repeated by a DST
+            # transition (e.g. 02:30 on spring-forward night) is resolved by
+            # zoneinfo's fold rules rather than special-cased. Acceptable for an
+            # anchor; revisit if sub-hourly anchors near a transition matter.
+            "dtstart": self.dtstart.astimezone(tz),
         }
 
         if self.until:
-            kwargs["until"] = self.until
+            kwargs["until"] = self.until.astimezone(tz)
         if self.count:
             kwargs["count"] = self.count
 

--- a/src/events/schema/recurrence_rule.py
+++ b/src/events/schema/recurrence_rule.py
@@ -25,14 +25,15 @@ class RecurrenceRuleCreateSchema(Schema):
     timezone: str = Field(
         default="UTC",
         description=(
-            "IANA timezone name for the recurrence anchor. NOTE: this field is "
-            "currently advisory metadata only — occurrences are anchored to the "
-            "UTC `dtstart` and do not observe DST in the named zone. A weekly "
-            "rule for 'Mondays at 10:00 Europe/Vienna' starting before the "
-            "spring DST transition will materialize at 11:00 Vienna time after "
-            "the transition (because it stays anchored to 09:00 UTC). Phase 3 "
-            "will localize the anchor; until then, set `dtstart` to the exact "
-            "UTC instant you want and treat `timezone` as informational."
+            "IANA timezone name the recurrence anchor is localized to. "
+            "Occurrences preserve their wall-clock time-of-day in this zone "
+            "across DST transitions: a weekly rule for 'Mondays at 10:00 "
+            "Europe/Vienna' materializes at 10:00 Vienna time both before and "
+            "after the spring/autumn switch (the underlying UTC instant shifts "
+            "by the DST offset). `dtstart` is the UTC instant of the first "
+            "occurrence; its wall-clock time in this zone defines the anchor. "
+            "The default 'UTC' has no DST, so occurrences stay fixed to the "
+            "stored UTC instant."
         ),
     )
 

--- a/src/events/tests/test_models/test_recurrence_rule.py
+++ b/src/events/tests/test_models/test_recurrence_rule.py
@@ -525,42 +525,32 @@ class TestRecurrenceRuleSave:
 
 
 class TestRecurrenceRuleDSTBehavior:
-    """Lock in the (current, pre-Phase-3) DST behavior of recurrence rules.
+    """Verify timezone-aware occurrence generation across DST transitions.
 
-    The ``timezone`` field is currently advisory metadata only — occurrences
-    are anchored to the UTC ``dtstart`` and do **not** observe DST in the
-    named zone. This is documented in the model's field comment and in the
-    ``RecurrenceRuleCreateSchema.timezone`` description. These tests pin the
-    behavior so the eventual Phase 3 fix is intentional, observable, and
-    breaks something visible (forcing an update to these tests in lockstep
-    with the fix).
+    ``to_rrule()`` localizes ``dtstart`` into the rule's ``timezone``, so
+    occurrences preserve their wall-clock time-of-day in that zone across a
+    DST switch (the underlying UTC instant shifts by the offset). The default
+    ``"UTC"`` timezone is a no-op and keeps occurrences anchored to the stored
+    UTC instant.
     """
 
-    def test_weekly_rule_anchors_to_utc_across_dst_transition(self) -> None:
-        """Weekly rule starting before DST yields the same UTC time after DST.
+    def test_weekly_rule_preserves_wall_clock_across_dst_transition(self) -> None:
+        """A named-zone weekly rule keeps the same local time across DST.
 
-        This is the bug that Phase 3 will fix. A user expecting "Mondays at
-        10:00 in their local time" gets "Mondays at the UTC instant they
-        originally picked," which drifts by 1 hour relative to wall-clock
-        time after DST.
+        A user asking for "Mondays at 10:00 Europe/Vienna" gets 10:00 Vienna
+        both before and after the spring DST switch; the UTC instant shifts by
+        one hour (09:00 → 08:00) to keep the wall-clock time stable.
 
-        Important: we pass a UTC-normalized ``dtstart`` to the model because
-        that is what production sees. Django's ``DateTimeField`` stores datetimes
-        as UTC in the database and reads them back as UTC-aware, regardless of
-        what timezone the client originally sent. Passing a ``zoneinfo``-aware
-        datetime directly to ``dateutil.rrule`` would make ``rrule`` preserve
-        the local wall-clock time across DST (its built-in behavior), which
-        would mask the current bug. Normalizing to UTC here matches the
-        round-trip that real data goes through on save.
+        We pass a UTC-normalized ``dtstart`` to the model because that is what
+        production sees: Django's ``DateTimeField`` stores datetimes as UTC and
+        reads them back UTC-aware regardless of what offset the client sent.
         """
         import zoneinfo
         from datetime import timezone as dt_timezone
 
         # Arrange — Monday 2026-03-23 10:00 Europe/Vienna (CET, UTC+1).
         # The spring DST transition happens on 2026-03-29, so the next
-        # Monday (2026-03-30) is in CEST (UTC+2). A timezone-aware system
-        # would yield 10:00 Vienna both weeks; the current behavior yields
-        # 09:00 UTC both weeks, which is 11:00 Vienna in the second week.
+        # Monday (2026-03-30) is in CEST (UTC+2).
         vienna = zoneinfo.ZoneInfo("Europe/Vienna")
         dtstart_utc = datetime(2026, 3, 23, 10, 0, tzinfo=vienna).astimezone(dt_timezone.utc)
 
@@ -576,19 +566,38 @@ class TestRecurrenceRuleDSTBehavior:
         # Act
         occurrences = list(rule.to_rrule())
 
-        # Assert — both occurrences share the same UTC instant offset from
-        # midnight, even though the second one falls after DST. A
-        # timezone-aware Phase 3 implementation would shift the second
-        # occurrence by one hour to keep the wall-clock time stable.
+        # Assert — wall-clock time in Vienna is identical both weeks…
+        assert len(occurrences) == 2
+        first_vienna = occurrences[0].astimezone(vienna)
+        second_vienna = occurrences[1].astimezone(vienna)
+        assert (first_vienna.hour, first_vienna.minute) == (10, 0)
+        assert (second_vienna.hour, second_vienna.minute) == (10, 0)
+        # …while the UTC instant shifts by one hour across the DST boundary.
+        first_utc = occurrences[0].astimezone(dt_timezone.utc)
+        second_utc = occurrences[1].astimezone(dt_timezone.utc)
+        assert first_utc.hour == 9
+        assert second_utc.hour == 8
+
+    def test_utc_timezone_keeps_occurrences_anchored_to_utc_instant(self) -> None:
+        """The default ``UTC`` timezone is a no-op: no DST shift is applied."""
+        from datetime import timezone as dt_timezone
+
+        # Same anchor as above but with the default UTC timezone: both weeks
+        # must share the same UTC wall-clock time (no DST observance).
+        dtstart_utc = datetime(2026, 3, 23, 9, 0, tzinfo=dt_timezone.utc)
+
+        rule = RecurrenceRule(
+            frequency=RecurrenceRule.Frequency.WEEKLY,
+            interval=1,
+            weekdays=[0],  # Monday
+            dtstart=dtstart_utc,
+            count=2,
+            timezone="UTC",
+        )
+
+        occurrences = list(rule.to_rrule())
+
         assert len(occurrences) == 2
         first_utc = occurrences[0].astimezone(dt_timezone.utc)
         second_utc = occurrences[1].astimezone(dt_timezone.utc)
-        assert first_utc.hour == second_utc.hour, (
-            "Phase 1/2 anchors occurrences to UTC dtstart and ignores DST. "
-            "If this assertion starts failing, Phase 3 has been implemented "
-            "and the field comment + schema description should be updated."
-        )
-        # And the wall-clock time in Vienna drifts by exactly one hour.
-        first_vienna = occurrences[0].astimezone(vienna)
-        second_vienna = occurrences[1].astimezone(vienna)
-        assert second_vienna.hour - first_vienna.hour == 1
+        assert first_utc.hour == second_utc.hour == 9

--- a/src/events/tests/test_service/test_reanchor_dst_migration.py
+++ b/src/events/tests/test_service/test_reanchor_dst_migration.py
@@ -1,0 +1,144 @@
+"""Tests for the 0087 re-anchor data migration.
+
+The migration realigns future, unmodified, non-cancelled occurrences of non-UTC
+recurring series to the DST-correct wall-clock instant. We exercise the
+migration function directly with Django's live app registry (no extra
+migration-testing dependency) and assert it corrects only the rows it should.
+"""
+
+import importlib
+import typing as t
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.apps import apps as django_apps
+from freezegun import freeze_time
+
+from events.models import Event, EventSeries, Organization, RecurrenceRule
+
+pytestmark = pytest.mark.django_db
+
+VIENNA = ZoneInfo("Europe/Vienna")
+# The migration module name starts with a digit, so it can't be a normal import.
+_migration = importlib.import_module("events.migrations.0087_reanchor_non_utc_series_occurrences")
+reanchor = _migration.reanchor_non_utc_occurrences
+
+
+def _make_series(organization: Organization, tz: str) -> EventSeries:
+    """Create an active series anchored to Mondays 10:00 in ``tz`` (pre-DST)."""
+    rule = RecurrenceRule.objects.create(
+        frequency=RecurrenceRule.Frequency.WEEKLY,
+        interval=1,
+        weekdays=[0],
+        dtstart=datetime(2026, 3, 23, 10, 0, tzinfo=ZoneInfo(tz)),
+        timezone=tz,
+    )
+    series = EventSeries.objects.create(
+        organization=organization,
+        name=f"Series {tz}",
+        slug=f"series-{tz.lower().replace('/', '-')}",
+        recurrence_rule=rule,
+    )
+    return series
+
+
+def _make_occurrence(
+    series: EventSeries,
+    organization: Organization,
+    *,
+    start: datetime,
+    slug: str,
+    is_modified: bool = False,
+    status: str = Event.EventStatus.OPEN,
+) -> Event:
+    return Event.objects.create(
+        organization=organization,
+        event_series=series,
+        name="Occurrence",
+        slug=slug,
+        start=start,
+        end=start + timedelta(hours=2),
+        status=status,
+        visibility=Event.Visibility.PUBLIC,
+        event_type=Event.EventType.PUBLIC,
+        is_template=False,
+        is_modified=is_modified,
+        requires_ticket=False,
+    )
+
+
+@freeze_time("2026-03-01 00:00:00")
+@patch("notifications.service.notification_helpers.notify_series_events_generated")
+def test_migration_reanchors_future_non_utc_occurrence(
+    mock_notify: t.Any,
+    organization: Organization,
+) -> None:
+    """A drifted post-DST occurrence is corrected to 10:00 Vienna (08:00 UTC)."""
+    series = _make_series(organization, "Europe/Vienna")
+    # Old UTC-anchored behavior put this post-DST Monday at 09:00 UTC (11:00 CEST).
+    drifted = _make_occurrence(
+        series,
+        organization,
+        start=datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc),
+        slug="drifted",
+    )
+
+    reanchor(django_apps, None)
+
+    drifted.refresh_from_db()
+    assert drifted.start == datetime(2026, 4, 6, 8, 0, tzinfo=dt_timezone.utc)
+    local = drifted.start.astimezone(VIENNA)
+    assert (local.hour, local.minute) == (10, 0)
+    # Duration preserved: end shifts by the same delta.
+    assert drifted.end == datetime(2026, 4, 6, 10, 0, tzinfo=dt_timezone.utc)
+
+
+@freeze_time("2026-03-01 00:00:00")
+@patch("notifications.service.notification_helpers.notify_series_events_generated")
+def test_migration_leaves_utc_modified_cancelled_and_past_untouched(
+    mock_notify: t.Any,
+    organization: Organization,
+) -> None:
+    """UTC, modified, cancelled, and past occurrences are not re-anchored."""
+    # UTC series — no-op zone.
+    utc_series = _make_series(organization, "UTC")
+    utc_occ = _make_occurrence(
+        utc_series,
+        organization,
+        start=datetime(2026, 4, 6, 9, 0, tzinfo=dt_timezone.utc),
+        slug="utc-occ",
+    )
+
+    vienna_series = _make_series(organization, "Europe/Vienna")
+    modified = _make_occurrence(
+        vienna_series,
+        organization,
+        start=datetime(2026, 4, 13, 9, 0, tzinfo=dt_timezone.utc),
+        slug="modified",
+        is_modified=True,
+    )
+    cancelled = _make_occurrence(
+        vienna_series,
+        organization,
+        start=datetime(2026, 4, 20, 9, 0, tzinfo=dt_timezone.utc),
+        slug="cancelled",
+        status=Event.EventStatus.CANCELLED,
+    )
+    # Past occurrence (before frozen "now") — out of scope, never reschedule history.
+    past = _make_occurrence(
+        vienna_series,
+        organization,
+        start=datetime(2026, 2, 23, 9, 0, tzinfo=dt_timezone.utc),
+        slug="past",
+    )
+
+    originals = {e.pk: e.start for e in (utc_occ, modified, cancelled, past)}
+
+    reanchor(django_apps, None)
+
+    for event in (utc_occ, modified, cancelled, past):
+        event.refresh_from_db()
+        assert event.start == originals[event.pk]

--- a/src/events/tests/test_service/test_recurrence_service_materialize.py
+++ b/src/events/tests/test_service/test_recurrence_service_materialize.py
@@ -269,13 +269,13 @@ class TestGenerateSeriesEvents:
 
         # Assert — every occurrence is 10:00 Vienna wall-clock…
         starts = sorted(e.start for e in created)
+        assert len(starts) == 4  # Mar 23 (pre-DST) + Mar 30, Apr 6, Apr 13 (post-DST)
         for start in starts:
             local = start.astimezone(vienna)
             assert (local.hour, local.minute) == (10, 0)
         # …and the UTC instant shifts from 09:00 (CET) to 08:00 (CEST) across DST.
         utc_hours = [s.astimezone(dt_timezone.utc).hour for s in starts]
-        assert utc_hours[0] == 9  # 2026-03-23 (pre-DST)
-        assert all(h == 8 for h in utc_hours[1:])  # post-DST Mondays
+        assert utc_hours == [9, 8, 8, 8]  # Mar 23 pre-DST, rest post-DST
 
     @freeze_time("2026-04-06 10:00:00")
     @patch("notifications.service.notification_helpers.notify_series_events_generated")

--- a/src/events/tests/test_service/test_recurrence_service_materialize.py
+++ b/src/events/tests/test_service/test_recurrence_service_materialize.py
@@ -236,6 +236,47 @@ class TestGenerateSeriesEvents:
             assert event.is_template is False
             assert event.event_series_id == active_series.id
 
+    @freeze_time("2026-03-23 09:00:00")
+    @patch("notifications.service.notification_helpers.notify_series_events_generated")
+    def test_non_utc_series_preserves_wall_clock_across_dst(
+        self,
+        mock_notify: t.Any,
+        active_series: EventSeries,
+    ) -> None:
+        """A non-UTC series keeps the local wall-clock time across the DST switch.
+
+        The rule anchors to Mondays 10:00 Europe/Vienna starting 2026-03-23
+        (CET, 09:00 UTC). The spring transition is 2026-03-29, so every Monday
+        from 2026-03-30 onward is CEST (08:00 UTC) while staying at 10:00 Vienna
+        wall-clock. This exercises the full materialization pipeline, not just
+        ``to_rrule()``.
+        """
+        import zoneinfo
+        from datetime import timezone as dt_timezone
+
+        vienna = zoneinfo.ZoneInfo("Europe/Vienna")
+        # Reconfigure the rule to a Vienna-anchored Monday before the DST switch.
+        rule = active_series.recurrence_rule
+        assert rule is not None
+        rule.timezone = "Europe/Vienna"
+        rule.dtstart = datetime(2026, 3, 23, 10, 0, tzinfo=vienna)
+        rule.save()
+        active_series.generation_window_weeks = 3
+        active_series.save(update_fields=["generation_window_weeks"])
+
+        # Act
+        created = recurrence_service.generate_series_events(active_series)
+
+        # Assert — every occurrence is 10:00 Vienna wall-clock…
+        starts = sorted(e.start for e in created)
+        for start in starts:
+            local = start.astimezone(vienna)
+            assert (local.hour, local.minute) == (10, 0)
+        # …and the UTC instant shifts from 09:00 (CET) to 08:00 (CEST) across DST.
+        utc_hours = [s.astimezone(dt_timezone.utc).hour for s in starts]
+        assert utc_hours[0] == 9  # 2026-03-23 (pre-DST)
+        assert all(h == 8 for h in utc_hours[1:])  # post-DST Mondays
+
     @freeze_time("2026-04-06 10:00:00")
     @patch("notifications.service.notification_helpers.notify_series_events_generated")
     def test_skips_exdates(


### PR DESCRIPTION
Closes #594.

## Problem
`RecurrenceRule.timezone` was stored and validated but never honored: `to_rrule()` fed the UTC-stored `dtstart` straight into `dateutil.rrule` and ignored `self.timezone`. Occurrences anchored to the UTC instant and drifted by the DST offset — a "Mondays 10:00 Europe/Vienna" rule materialized at **11:00 Vienna** after the spring switch (verified empirically).

## Fix
Localize `dtstart`/`until` into the rule's IANA zone before building the rrule, so `dateutil` preserves the **wall-clock** time-of-day across DST. The default `timezone="UTC"` (every existing row's default) is a verified no-op, so **only series with an explicitly non-UTC timezone change behavior**. All consumers (`generate_series_events`, `detect_cadence_drift`, `get_occurrences`) route through `to_rrule()`, so they stay consistent.

## Existing data
Migration `0087` re-anchors **future, unmodified, non-cancelled** occurrences of **non-UTC** series to the corrected instant. Shift is ≤1h; `start` and `end` move together (duration preserved). Computed purely from stored fields (migration-safe), raw historical-model saves so no signals/notifications fire.

> ⚠️ **Heads-up:** this silently shifts non-UTC *ticketed* occurrence times by up to an hour on deploy, with no attendee notification. This matches the chosen "auto data migration" approach. An organizer heads-up / notification would be a follow-up if wanted.

## Docs
Rewrote the now-stale "advisory / Phase 3" caveats (model field comment, schema field description, `docs/architecture/recurring-series.md`) and added `timezone` to `USER_JOURNEYS.md` §18.4 (it was never actually listed there).

## Tests
- Inverted `TestRecurrenceRuleDSTBehavior` → asserts wall-clock stability across DST + a UTC no-op test.
- Added a `generate_series_events` DST-boundary integration test (full materialization pipeline).
- Added `test_reanchor_dst_migration.py`: corrects a drifted occurrence; leaves UTC / modified / cancelled / past occurrences untouched.

## Verification
`ruff format`, `ruff check`, `mypy --strict` (changed modules), and `makemigrations --check` all clean. Test suite to be run by reviewer per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timezone support for recurring events; wall-clock times now remain consistent across daylight saving time transitions.

* **Bug Fixes**
  * Fixed existing non-UTC recurring event occurrences to display correct times after DST transitions.

* **Documentation**
  * Updated documentation to reflect timezone-aware recurrence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->