### PR TITLE
chore(cleanup): remove dead code & redundant user() overrides (#574)

### DIFF
--- a/src/events/controllers/dashboard.py
+++ b/src/events/controllers/dashboard.py
@@ -15,7 +15,6 @@ from ninja_extra import (
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 from ninja_extra.searching import Searching, searching
 
-from accounts.models import RevelUser
 from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
 from common.signing import get_file_url
@@ -27,10 +26,6 @@ from events.service.attendee_invoice_service import ensure_pdf_exists
 
 @api_controller("/dashboard", auth=I18nJWTAuth())
 class DashboardController(UserAwareController):
-    def user(self) -> RevelUser:
-        """Get the user for this request."""
-        return t.cast(RevelUser, self.context.request.user)  # type: ignore[union-attr]
-
     def get_event_queryset(self, *, include_past: bool = False) -> QuerySet[models.Event]:
         """Get the event queryset."""
         return models.Event.objects.for_user(self.user(), include_past=include_past)

--- a/src/events/controllers/questionnaire.py
+++ b/src/events/controllers/questionnaire.py
@@ -11,7 +11,6 @@ from ninja_extra import (
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 from ninja_extra.searching import Searching, searching
 
-from accounts.models import RevelUser
 from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
 from common.schema import ValidationErrorResponse
@@ -44,10 +43,6 @@ class QuestionnaireController(UserAwareController):
     def get_organization_queryset(self) -> QuerySet[event_models.Organization]:
         """Get the queryset for the organization."""
         return event_models.Organization.objects.for_user(self.user())
-
-    def user(self) -> RevelUser:
-        """Get a user for this request."""
-        return t.cast(RevelUser, self.context.request.user)  # type: ignore[union-attr]
 
     @route.get(
         "/",

--- a/src/notifications/service/eligibility.py
+++ b/src/notifications/service/eligibility.py
@@ -6,15 +6,12 @@ and determining which users should receive specific notification types.
 
 from uuid import UUID
 
-import structlog
 from django.db.models import Q, QuerySet
 
 from accounts.models import RevelUser
 from events.models import Event, EventInvitation, EventRSVP, Organization, OrganizationMember, Ticket, TicketTier
 from notifications.enums import NotificationType
 from notifications.models import NotificationPreference
-
-logger = structlog.get_logger(__name__)
 
 
 class BatchParticipationChecker:
@@ -575,54 +572,3 @@ def get_staff_for_notification(
         return get_organization_staff_with_permission(organization_id, required_permission)
 
     return get_organization_staff_and_owners(organization_id)
-
-
-def should_notify_user_for_questionnaire(
-    user: RevelUser, organization: Organization, notification_type: NotificationType
-) -> bool:
-    """Check if a user should be notified about questionnaire events.
-
-    Args:
-        user: The user to check
-        organization: The organization context
-        notification_type: Type of questionnaire notification
-
-    Returns:
-        True if user should be notified
-    """
-    return is_user_eligible_for_notification(user, notification_type, organization=organization)
-
-
-def log_notification_attempt(
-    user: RevelUser,
-    notification_type: NotificationType,
-    event: Event | None = None,
-    success: bool = True,
-    error_message: str | None = None,
-) -> None:
-    """Log notification attempts for debugging and audit purposes.
-
-    Args:
-        user: User who was targeted for notification
-        notification_type: Type of notification
-        event: Associated event (if any)
-        success: Whether the notification was sent successfully
-        error_message: Error message if notification failed
-    """
-    log_kwargs = {
-        "notification_type": notification_type.value,
-        "user_email": user.email,
-        "success": success,
-    }
-
-    if event:
-        log_kwargs["event_name"] = event.name
-        log_kwargs["event_id"] = str(event.id)
-
-    if error_message:
-        log_kwargs["error"] = error_message
-
-    if success:
-        logger.info("notification_sent", **log_kwargs)
-    else:
-        logger.error("notification_failed", **log_kwargs)


### PR DESCRIPTION
## Summary

Low-hanging-fruit cleanup from the v1.65.0 tech-debt assessment. Removes four verified-dead symbols (plus the imports they orphaned).

- **`notifications/service/eligibility.py`** — delete `should_notify_user_for_questionnaire` and `log_notification_attempt` (both 0 references across `src/`, including tests/migrations). This orphaned `import structlog` and the module-level `logger`, removed too.
- **`events/controllers/dashboard.py`** & **`events/controllers/questionnaire.py`** — delete the redundant `user()` overrides; the base `UserAwareController` already provides an identical implementation. This orphaned the `RevelUser` import in each, removed via ruff.

Net: **64 deletions, 0 additions** across 3 files.

## Verification

- `ruff check` — clean
- `mypy --strict` — clean (`Success: no issues found in 3 source files`)
- Each symbol re-verified for zero non-definition references before deletion.

## Notes

- Sibling issue **#602** (TypedDict for `to_rrule()` kwargs) was reviewed and **closed as not-worth-it** — it would trade one `t.Any` for several without real safety gain (matches the issue's own caveat).
- The larger tech-debt refactors (#575–#581) are intentionally left as separate PRs to stay reviewable.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal controller implementation by consolidating shared functionality in base classes.
  * Cleaned up notification service code by removing helper functions and optimizing imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->