### PR TITLE
refactor(accounts): extract RevelUserAdmin display logic into formatters (#576)

### DIFF
--- a/src/accounts/admin/formatters.py
+++ b/src/accounts/admin/formatters.py
@@ -1,0 +1,129 @@
+"""Display/formatting helpers for ``RevelUserAdmin``.
+
+Pure functions extracted from ``RevelUserAdmin`` so the admin class stays thin
+configuration + delegation and the HTML-rendering logic is readable and testable
+in isolation. Model imports are kept local to each function to avoid import-time
+cycles (mirrors the original methods).
+"""
+
+import typing as t
+
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+
+from common.signing import get_file_url
+
+if t.TYPE_CHECKING:
+    from accounts.models import RevelUser
+
+
+def profile_thumbnail(obj: "RevelUser") -> str:
+    """Render the profile picture thumbnail (or initial fallback) for the list view."""
+    if url := get_file_url(obj.profile_picture_thumbnail):
+        return format_html(
+            '<img src="{}" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;" />',
+            url,
+        )
+    return format_html(
+        '<span style="display: inline-block; width: 32px; height: 32px; '
+        "border-radius: 50%; background-color: #e5e7eb; text-align: center; "
+        'line-height: 32px; font-size: 14px; color: #6b7280;">{}</span>',
+        obj.username[0].upper() if obj.username else "?",
+    )
+
+
+def profile_image_preview(obj: "RevelUser") -> str:
+    """Render the profile picture preview for the detail view."""
+    if url := get_file_url(obj.profile_picture_preview):
+        return format_html(
+            '<img src="{}" style="max-width: 200px; max-height: 200px; border-radius: 8px;" />',
+            url,
+        )
+    if url := get_file_url(obj.profile_picture):
+        return format_html(
+            '<img src="{}" style="max-width: 200px; max-height: 200px; border-radius: 8px;" />',
+            url,
+        )
+    return "No profile picture"
+
+
+def event_count(obj: "RevelUser") -> int:
+    """Count the events the user has tickets for or has RSVP'd to."""
+    from events.models import EventRSVP, Ticket
+
+    ticket_events = Ticket.objects.filter(user=obj).values("event").distinct().count()
+    rsvp_events = EventRSVP.objects.filter(user=obj).values("event").distinct().count()
+    return ticket_events + rsvp_events
+
+
+def organization_count(obj: "RevelUser") -> int:
+    """Count the organizations the user owns, is staff of, or is a member of."""
+    from events.models import Organization, OrganizationMember, OrganizationStaff
+
+    owned = Organization.objects.filter(owner=obj).count()
+    member = OrganizationMember.objects.filter(user=obj).count()
+    staff = OrganizationStaff.objects.filter(user=obj).count()
+    return owned + member + staff
+
+
+def event_participation(obj: "RevelUser") -> str:
+    """Render the user's recent event participation (tickets + RSVPs) as an HTML list."""
+    from events.models import EventRSVP, Ticket
+
+    tickets = Ticket.objects.filter(user=obj).select_related("event")
+    rsvps = EventRSVP.objects.filter(user=obj).select_related("event")
+
+    html = "<h4>Event Participation:</h4><ul>"
+
+    for ticket in tickets[:10]:  # Show recent 10
+        event_url = reverse("admin:events_event_change", args=[ticket.event.id])
+        html += f'<li><a href="{event_url}">{ticket.event.name}</a> - Ticket ({ticket.status})</li>'
+
+    for rsvp in rsvps[:10]:  # Show recent 10
+        event_url = reverse("admin:events_event_change", args=[rsvp.event.id])
+        html += f'<li><a href="{event_url}">{rsvp.event.name}</a> - RSVP ({rsvp.status})</li>'
+
+    html += "</ul>"
+    return mark_safe(html)
+
+
+def organization_participation(obj: "RevelUser") -> str:
+    """Render the user's organization roles (owner/staff/member) as an HTML list."""
+    from events.models import Organization, OrganizationMember, OrganizationStaff
+
+    owned_orgs = Organization.objects.filter(owner=obj)
+    staff_orgs = OrganizationStaff.objects.filter(user=obj).select_related("organization")
+    member_orgs = OrganizationMember.objects.filter(user=obj).select_related("organization")
+
+    html = "<h4>Organization Roles:</h4><ul>"
+
+    for org in owned_orgs:
+        org_url = reverse("admin:events_organization_change", args=[org.id])
+        html += f'<li><a href="{org_url}">{org.name}</a> - Owner</li>'
+
+    for staff in staff_orgs:
+        org_url = reverse("admin:events_organization_change", args=[staff.organization.id])
+        html += f'<li><a href="{org_url}">{staff.organization.name}</a> - Staff</li>'
+
+    for member in member_orgs:
+        org_url = reverse("admin:events_organization_change", args=[member.organization.id])
+        html += f'<li><a href="{org_url}">{member.organization.name}</a> - Member</li>'
+
+    html += "</ul>"
+    return mark_safe(html)
+
+
+def impersonate_link(obj: "RevelUser") -> str:
+    """Render the impersonation link for eligible (non-staff, non-superuser) users."""
+    from django.utils.translation import gettext_lazy as _
+
+    if obj.is_superuser or obj.is_staff:
+        return format_html('<span class="text-base-400">—</span>')
+    url = reverse("admin:accounts_reveluser_impersonate", args=[obj.pk])
+    return format_html(
+        '<a href="{}" target="_blank" class="text-primary-600 hover:text-primary-700 '
+        'dark:text-primary-500 dark:hover:text-primary-400 text-sm font-medium">{}</a>',
+        url,
+        _("Impersonate"),
+    )

--- a/src/accounts/admin/user.py
+++ b/src/accounts/admin/user.py
@@ -20,6 +20,7 @@ from django.utils.translation import ngettext
 from django_google_sso.admin import GoogleSSOInlineAdmin, get_current_user_and_admin
 from unfold.admin import ModelAdmin, TabularInline
 
+from accounts.admin import formatters
 from accounts.models import (
     DietaryPreference,
     DietaryRestriction,
@@ -37,7 +38,6 @@ from accounts.service.impersonation import can_impersonate, create_impersonation
 from accounts.utils.email_normalization import normalize_email_for_matching
 from common.client_ip import get_client_ip
 from common.models import SiteSettings
-from common.signing import get_file_url
 from events.models import GeneralUserPreferences
 
 # Monkey patch the missing attribute
@@ -373,36 +373,16 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
                 messages.WARNING,
             )
 
-    # Custom displays
+    # Custom displays (rendering logic lives in accounts/admin/formatters.py)
     @admin.display(description="")
     def profile_thumbnail_display(self, obj: RevelUser) -> str:
         """Display profile picture thumbnail in list view."""
-        if url := get_file_url(obj.profile_picture_thumbnail):
-            return format_html(
-                '<img src="{}" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;" />',
-                url,
-            )
-        return format_html(
-            '<span style="display: inline-block; width: 32px; height: 32px; '
-            "border-radius: 50%; background-color: #e5e7eb; text-align: center; "
-            'line-height: 32px; font-size: 14px; color: #6b7280;">{}</span>',
-            obj.username[0].upper() if obj.username else "?",
-        )
+        return formatters.profile_thumbnail(obj)
 
     @admin.display(description="Profile Picture Preview")
     def profile_image_preview_display(self, obj: RevelUser) -> str:
         """Display profile picture preview in detail view."""
-        if url := get_file_url(obj.profile_picture_preview):
-            return format_html(
-                '<img src="{}" style="max-width: 200px; max-height: 200px; border-radius: 8px;" />',
-                url,
-            )
-        if url := get_file_url(obj.profile_picture):
-            return format_html(
-                '<img src="{}" style="max-width: 200px; max-height: 200px; border-radius: 8px;" />',
-                url,
-            )
-        return "No profile picture"
+        return formatters.profile_image_preview(obj)
 
     @admin.display(description="Display Name", ordering="preferred_name")
     def display_name_display(self, obj: RevelUser) -> str:
@@ -418,71 +398,21 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
 
     @admin.display(description="Events")
     def event_count(self, obj: RevelUser) -> int:
-        # Count events user has tickets for or RSVP'd to
-        from events.models import EventRSVP, Ticket
-
-        ticket_events = Ticket.objects.filter(user=obj).values("event").distinct().count()
-        rsvp_events = EventRSVP.objects.filter(user=obj).values("event").distinct().count()
-        return ticket_events + rsvp_events
+        return formatters.event_count(obj)
 
     @admin.display(description="Organizations")
     def organization_count(self, obj: RevelUser) -> int:
-        # Count owned + member + staff organizations
-        from events.models import Organization, OrganizationMember, OrganizationStaff
+        return formatters.organization_count(obj)
 
-        owned = Organization.objects.filter(owner=obj).count()
-        member = OrganizationMember.objects.filter(user=obj).count()
-        staff = OrganizationStaff.objects.filter(user=obj).count()
-        return owned + member + staff
-
+    @admin.display(description="Event Participation")
     def event_participation_display(self, obj: RevelUser) -> str:
         """Display user's event participation details."""
-        from events.models import EventRSVP, Ticket
+        return formatters.event_participation(obj)
 
-        tickets = Ticket.objects.filter(user=obj).select_related("event")
-        rsvps = EventRSVP.objects.filter(user=obj).select_related("event")
-
-        html = "<h4>Event Participation:</h4><ul>"
-
-        for ticket in tickets[:10]:  # Show recent 10
-            event_url = reverse("admin:events_event_change", args=[ticket.event.id])
-            html += f'<li><a href="{event_url}">{ticket.event.name}</a> - Ticket ({ticket.status})</li>'
-
-        for rsvp in rsvps[:10]:  # Show recent 10
-            event_url = reverse("admin:events_event_change", args=[rsvp.event.id])
-            html += f'<li><a href="{event_url}">{rsvp.event.name}</a> - RSVP ({rsvp.status})</li>'
-
-        html += "</ul>"
-        return mark_safe(html)
-
-    event_participation_display.short_description = "Event Participation"  # type: ignore[attr-defined]
-
+    @admin.display(description="Organization Participation")
     def organization_participation_display(self, obj: RevelUser) -> str:
         """Display user's organization participation details."""
-        from events.models import Organization, OrganizationMember, OrganizationStaff
-
-        owned_orgs = Organization.objects.filter(owner=obj)
-        staff_orgs = OrganizationStaff.objects.filter(user=obj).select_related("organization")
-        member_orgs = OrganizationMember.objects.filter(user=obj).select_related("organization")
-
-        html = "<h4>Organization Roles:</h4><ul>"
-
-        for org in owned_orgs:
-            org_url = reverse("admin:events_organization_change", args=[org.id])
-            html += f'<li><a href="{org_url}">{org.name}</a> - Owner</li>'
-
-        for staff in staff_orgs:
-            org_url = reverse("admin:events_organization_change", args=[staff.organization.id])
-            html += f'<li><a href="{org_url}">{staff.organization.name}</a> - Staff</li>'
-
-        for member in member_orgs:
-            org_url = reverse("admin:events_organization_change", args=[member.organization.id])
-            html += f'<li><a href="{org_url}">{member.organization.name}</a> - Member</li>'
-
-        html += "</ul>"
-        return mark_safe(html)
-
-    organization_participation_display.short_description = "Organization Participation"  # type: ignore[attr-defined]
+        return formatters.organization_participation(obj)
 
     def get_list_display(self, request: HttpRequest) -> list[str]:  # type: ignore[override]
         list_display = list(super().get_list_display(request))
@@ -494,16 +424,7 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
     @admin.display(description=_("Impersonate"))
     def impersonate_link(self, obj: RevelUser) -> str:
         """Display impersonation link for eligible users."""
-        # Don't show link for superusers or staff (can't impersonate them)
-        if obj.is_superuser or obj.is_staff:
-            return format_html('<span class="text-base-400">—</span>')
-        url = reverse("admin:accounts_reveluser_impersonate", args=[obj.pk])
-        return format_html(
-            '<a href="{}" target="_blank" class="text-primary-600 hover:text-primary-700 '
-            'dark:text-primary-500 dark:hover:text-primary-400 text-sm font-medium">{}</a>',
-            url,
-            _("Impersonate"),
-        )
+        return formatters.impersonate_link(obj)
 
     def get_urls(self) -> list[t.Any]:
         """Add custom URLs for impersonation."""

--- a/src/accounts/tests/test_admin_formatters.py
+++ b/src/accounts/tests/test_admin_formatters.py
@@ -1,0 +1,61 @@
+"""Tests for the RevelUserAdmin display formatters (accounts/admin/formatters.py)."""
+
+import typing as t
+
+import pytest
+
+from accounts.admin import formatters
+from accounts.models import RevelUser
+
+pytestmark = pytest.mark.django_db
+
+
+def test_profile_thumbnail_fallback_uses_username_initial(user: RevelUser) -> None:
+    html = formatters.profile_thumbnail(user)
+    # No profile picture set -> initial-letter fallback span.
+    assert "<span" in html
+    assert user.username[0].upper() in html
+
+
+def test_profile_thumbnail_fallback_question_mark_when_no_username() -> None:
+    # Defensive branch: the manager rejects empty usernames, so use an unsaved instance.
+    assert ">?</span>" in formatters.profile_thumbnail(RevelUser(username=""))
+
+
+def test_profile_image_preview_without_picture(user: RevelUser) -> None:
+    assert formatters.profile_image_preview(user) == "No profile picture"
+
+
+def test_counts_zero_for_fresh_user(user: RevelUser) -> None:
+    assert formatters.event_count(user) == 0
+    assert formatters.organization_count(user) == 0
+
+
+def test_organization_count_and_participation_for_owned_org(user: RevelUser) -> None:
+    from events.models import Organization
+
+    org = Organization.objects.create(name="Owned Org", slug="owned-org", owner=user)
+
+    assert formatters.organization_count(user) == 1
+    html = formatters.organization_participation(user)
+    assert "Organization Roles:" in html
+    assert org.name in html
+    assert "Owner" in html
+    assert str(org.id) in html
+
+
+def test_event_participation_empty(user: RevelUser) -> None:
+    html = formatters.event_participation(user)
+    assert "Event Participation:" in html
+    assert "<ul></ul>" in html
+
+
+def test_impersonate_link_dash_for_staff(revel_user_factory: t.Callable[..., RevelUser]) -> None:
+    staff = revel_user_factory(username="staff@example.com", email="staff@example.com", is_staff=True)
+    assert "—" in formatters.impersonate_link(staff)
+
+
+def test_impersonate_link_for_regular_user(user: RevelUser) -> None:
+    html = formatters.impersonate_link(user)
+    assert "Impersonate" in html
+    assert str(user.pk) in html


### PR DESCRIPTION
Closes #576.

## What

`RevelUserAdmin` (in `accounts/admin/user.py`, **986 lines** — third file at the 1000-line CI cliff) generated HTML inline inside its display methods. This extracts the display/formatting callables into a new **`accounts/admin/formatters.py`** as pure functions; the admin methods now thinly delegate while keeping their `@admin.display` config on the class.

Extracted:
- `profile_thumbnail` / `profile_image_preview`
- `event_count` / `organization_count`
- `event_participation` / `organization_participation`
- `impersonate_link`

## Why it's safe

- **Pure refactor** — HTML output is byte-for-byte preserved (`mark_safe` kept exactly where it was).
- No celery task names, migrations, or OpenAPI/frontend contract touched — admin-only, single app.
- `accounts/admin/user.py`: **986 → 907 lines**; new `formatters.py` is 129 lines.

## Validation

- `ruff format` + `ruff check` clean
- `mypy --strict` clean (`user.py`, `formatters.py`, test)
- file-length gate: no file over 1000 lines
- Django `setup()` imports the admin cleanly (no circular import); `RevelUser` still registered
- Added focused characterization tests for the extracted formatters (8 tests, all passing) — these are net-new coverage; the methods had no tests before

## Acceptance criteria (#576)

- [x] `RevelUserAdmin` substantially smaller; display HTML extracted
- [x] `accounts/admin/user.py` comfortably under 1000 lines
- [x] Admin behavior unchanged (delegation preserves identical output)
- [x] `make check` passes (format + lint + mypy + file-length)

## Follow-up (out of scope, noted not fixed)

`event_participation` / `organization_participation` interpolate user-controlled `event.name` / `org.name` unescaped via `mark_safe(f"...")` — a latent **admin-only stored-XSS**. I deliberately preserved this behavior to keep the PR a pure refactor. Switching those two functions to `format_html`/`format_html_join` would fix it as a small, isolated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)