### PR TITLE
refactor(events): move standalone task modules into the events/tasks package

### DIFF
--- a/src/events/apps.py
+++ b/src/events/apps.py
@@ -8,15 +8,14 @@ class EventsConfig(AppConfig):
     def ready(self) -> None:
         """Run startup-time side effects for the events app.
 
-        Imports the signal handlers and the ``tasks_stripe`` /
-        ``announcement_tasks`` / ``revenue_tasks`` modules (so the Celery worker
-        registers their tasks) and installs the per-app exception handlers on the
-        global Ninja API.
+        Imports the signal handlers and installs the per-app exception handlers on
+        the global Ninja API. The Celery tasks live in the ``events.tasks`` package
+        and are registered via Celery autodiscovery, so they need no manual import here.
 
         Returns:
             None: Performs registration side effects only.
         """
-        from . import announcement_tasks, revenue_tasks, signals, tasks_stripe  # noqa: F401
+        from . import signals  # noqa: F401
         from .exception_handlers import register as register_exception_handlers
 
         register_exception_handlers()

--- a/src/events/service/revenue_report_service.py
+++ b/src/events/service/revenue_report_service.py
@@ -266,7 +266,7 @@ def get_or_generate_revenue_report(
         export_type=FileExport.ExportType.REVENUE_VAT_REPORT,
         parameters=parameters,
     )
-    from events.revenue_tasks import generate_revenue_report_task
+    from events.tasks import generate_revenue_report_task
 
     transaction.on_commit(lambda: generate_revenue_report_task.delay(str(export.id)))
     return export

--- a/src/events/tasks/__init__.py
+++ b/src/events/tasks/__init__.py
@@ -6,6 +6,7 @@ exports, organization). Every task is re-exported here so the historical
 ``from events.tasks import <task>`` import path keeps working.
 """
 
+from events.tasks.announcements import resend_announcements_to_new_signups, send_scheduled_announcements
 from events.tasks.attendees import (
     build_attendee_visibility_flags,
     send_guest_rsvp_confirmation,
@@ -32,6 +33,8 @@ from events.tasks.organization import (
 )
 from events.tasks.payments import cleanup_expired_payments, cleanup_ticket_file_cache
 from events.tasks.recurrence import generate_recurring_events_task, generate_single_series_events_task
+from events.tasks.revenue import generate_revenue_report_task, send_scheduled_revenue_reports_task
+from events.tasks.stripe_webhooks import prune_stripe_webhook_events
 from events.tasks.subscriptions import expire_subscriptions_past_grace
 from events.tasks.waitlist import (
     expire_waitlist_offers_task,
@@ -55,11 +58,14 @@ __all__ = [
     "generate_monthly_invoices_task",
     "generate_questionnaire_export_task",
     "generate_recurring_events_task",
+    "generate_revenue_report_task",
     "generate_single_series_events_task",
     "notify_admin_new_organization_discord",
     "notify_admin_new_organization_pushover",
     "nudge_open_waitlists_task",
     "process_waitlist_for_event_task",
+    "prune_stripe_webhook_events",
+    "resend_announcements_to_new_signups",
     "reset_demo_data",
     "revalidate_single_vat_id_task",
     "revalidate_vat_ids_task",
@@ -68,5 +74,7 @@ __all__ = [
     "send_invoice_email_task",
     "send_organization_contact_email_verification",
     "send_organization_contact_message_email",
+    "send_scheduled_announcements",
+    "send_scheduled_revenue_reports_task",
     "send_waitlist_offer_notification_task",
 ]

--- a/src/events/tasks/announcements.py
+++ b/src/events/tasks/announcements.py
@@ -1,10 +1,8 @@
 """Celery tasks for scheduled and resent organization announcements.
 
-Split out of ``events.tasks`` to keep that module under the 1000-line limit.
-The tasks keep their original registered names (``events.send_scheduled_announcements``
+The tasks carry explicit registered names (``events.send_scheduled_announcements``
 and ``events.resend_announcements_to_new_signups``), so the Celery-beat schedules
 defined in migration 0082 — which reference tasks by name string — are unaffected.
-The Celery worker registers them via ``EventsConfig.ready`` importing this module.
 """
 
 import typing as t
@@ -14,7 +12,7 @@ from celery import shared_task
 from django.db import transaction
 from django.utils import timezone
 
-from .models import Announcement
+from events.models import Announcement
 
 logger = structlog.get_logger(__name__)
 

--- a/src/events/tasks/revenue.py
+++ b/src/events/tasks/revenue.py
@@ -1,11 +1,8 @@
 """Celery tasks for revenue & VAT report generation and scheduled delivery (#551, #552).
 
-Split out of ``events.tasks`` to keep that module under the 1000-line limit.
 The tasks carry explicit registered names (``events.generate_revenue_report`` and
 ``events.send_scheduled_revenue_reports``) so the Celery-beat schedule defined in
-migration 0085 — which references the task by name string — is decoupled from this
-module's path. The Celery worker registers them via ``EventsConfig.ready`` importing
-this module.
+migration 0085 — which references the task by name string — is unaffected.
 """
 
 from uuid import UUID

--- a/src/events/tasks/stripe_webhooks.py
+++ b/src/events/tasks/stripe_webhooks.py
@@ -1,7 +1,8 @@
 """Celery tasks for Stripe webhook maintenance.
 
-Lives outside ``events/tasks.py`` (at the file-length limit); imported from
-:meth:`events.apps.EventsConfig.ready` so the worker registers the task.
+The task carries an explicit registered name (``events.prune_stripe_webhook_events``),
+so the Celery-beat schedule defined in migration 0079 — which references the task by
+name string — is unaffected.
 """
 
 from datetime import timedelta

--- a/src/events/tests/test_tasks/test_announcement_sweeps.py
+++ b/src/events/tests/test_tasks/test_announcement_sweeps.py
@@ -10,8 +10,8 @@ from django.utils import timezone
 
 from accounts.models import RevelUser
 from conftest import RevelUserFactory
-from events.announcement_tasks import resend_announcements_to_new_signups, send_scheduled_announcements
 from events.models import Announcement, Event, Organization, Ticket, TicketTier
+from events.tasks import resend_announcements_to_new_signups, send_scheduled_announcements
 
 pytestmark = pytest.mark.django_db
 

--- a/src/events/tests/test_tasks/test_prune_stripe_webhook_events.py
+++ b/src/events/tests/test_tasks/test_prune_stripe_webhook_events.py
@@ -7,7 +7,7 @@ import pytest
 from django.utils import timezone
 
 from events.models import StripeWebhookEvent
-from events.tasks_stripe import prune_stripe_webhook_events
+from events.tasks import prune_stripe_webhook_events
 
 pytestmark = pytest.mark.django_db
 


### PR DESCRIPTION
Harmonization follow-up to the task-package splits (#606/#607). Three events Celery-task modules sat *beside* the `events/tasks/` package — leftovers from when `events/tasks.py` was at the 1000-line gate and they needed manual registration via `EventsConfig.ready`. Now that `events/tasks` is a package, they belong inside it.

## What
| from | to |
|---|---|
| `events/tasks_stripe.py` | `events/tasks/stripe_webhooks.py` |
| `events/announcement_tasks.py` | `events/tasks/announcements.py` |
| `events/revenue_tasks.py` | `events/tasks/revenue.py` |

(`git mv`, so history is preserved.)

- **`EventsConfig.ready` simplified.** It imported these three modules purely so the worker would register their tasks (autodiscovery doesn't find modules not named `tasks`). Inside the package, Celery autodiscovery registers them like every other submodule, so the manual import is removed — `signals` stays. Verified at runtime: all five tasks register via autodiscovery under their original names.
- **`__init__.py` re-exports** the five tasks; the three external import sites now use the package path; the `announcements` relative import `.models` → `events.models`. Stale docstrings (referencing the old location / `ready()` wiring) updated.

## Behavior-preserving
All tasks keep their explicit registered names (`events.prune_stripe_webhook_events`, `events.send_scheduled_announcements`, `events.resend_announcements_to_new_signups`, `events.generate_revenue_report`, `events.send_scheduled_revenue_reports`), so the Celery-beat schedules in migrations **0079 / 0082 / 0085** — which reference tasks by name string — are unaffected.

## Migration safety (swept across this rename + #606 + #607)
- **No migration imports any moved/renamed/split task module by Python path**, and none use `import_string`/`importlib`/`__import__` — so nothing breaks at migration graph-load or `RunPython` execution.
- Every migration→task link is a **name string** in a `PeriodicTask` row; all such names are preserved (rename changed only file paths; #607's six default-named `accounts.tasks.*` were name-pinned).
- `make check`: **no missing migrations** (moving `.py` files doesn't alter the graph).

## Validation
- Runtime: all 5 moved tasks register via autodiscovery; full 28-name beat sweep resolves (UNRESOLVED: NONE).
- `make check` green: ruff, `mypy --strict` (859 files), migrations, i18n, file-length.
- 51 affected task/service tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)