### PR TITLE
fix(payouts): isolate statement/email failures from the payout batch (#611)

### DIFF
--- a/src/accounts/tasks/__init__.py
+++ b/src/accounts/tasks/__init__.py
@@ -28,7 +28,7 @@ from accounts.tasks.gdpr import (
     generate_user_data_export,
 )
 from accounts.tasks.notifications import notify_admin_new_user_joined, notify_admin_new_user_joined_discord
-from accounts.tasks.payouts import process_referral_payouts
+from accounts.tasks.payouts import generate_and_send_payout_statement, process_referral_payouts
 from accounts.tasks.tokens import flush_expired_tokens
 from accounts.tasks.verification_reminders import (
     deactivate_unverified_accounts,
@@ -45,6 +45,7 @@ __all__ = [
     "delete_old_inactive_accounts",
     "delete_user_account",
     "flush_expired_tokens",
+    "generate_and_send_payout_statement",
     "generate_user_data_export",
     "mark_reminder_sent",
     "notify_admin_new_user_joined",

--- a/src/accounts/tasks/payouts.py
+++ b/src/accounts/tasks/payouts.py
@@ -32,6 +32,40 @@ def _reclaim_stale_payouts() -> None:
         logger.warning("stale_pending_payouts_reclaimed", count=stale_count)
 
 
+def _dispatch_statement(payout_id: str) -> None:
+    """Dispatch the retryable statement+email task, isolating broker failures.
+
+    A dispatch failure (e.g. broker outage) must never halt the caller — the
+    payout is already PAID, and the backstop sweep re-dispatches on the next run.
+    """
+    try:
+        generate_and_send_payout_statement.delay(payout_id)
+    except Exception as exc:  # broker unavailable — isolate per the function contract
+        logger.error("payout_statement_dispatch_failed", payout_id=payout_id, error=str(exc))
+
+
+def _redispatch_missing_statements() -> None:
+    """Backstop: re-dispatch statement+email for PAID payouts that never got one.
+
+    Covers the rare case where the in-loop dispatch failed (e.g. broker outage)
+    or the retryable task exhausted its retries, leaving a PAID payout without a
+    statement — which reruns never revisit (they only scan ``CALCULATED``).
+    Idempotent: ``generate_payout_statement`` returns any existing statement, and
+    only payouts with no related statement are selected.
+    """
+    missing_ids = list(
+        ReferralPayout.objects.filter(
+            status=ReferralPayout.ReferralPayoutStatus.PAID,
+            statement__isnull=True,
+        ).values_list("id", flat=True)
+    )
+    if not missing_ids:
+        return
+    for payout_id in missing_ids:
+        _dispatch_statement(str(payout_id))
+    logger.warning("payout_statements_redispatched", count=len(missing_ids))
+
+
 def _validate_payout_eligibility(payout: ReferralPayout, referrer: RevelUser) -> str | None:
     """Run pre-flight checks for a payout. Returns a skip reason or None if eligible."""
     if not referrer.stripe_account_id or not referrer.stripe_charges_enabled:
@@ -77,16 +111,16 @@ def process_referral_payouts() -> dict[str, int]:
        and has agreed to self-billing.
     3. Create a Stripe Transfer (with idempotency key ``payout.id``).
     4. On success → ``PAID``; on Stripe error → ``FAILED`` (logged, loop continues).
-    5. Generate the payout statement PDF and email it to the referrer.
+    5. Dispatch the per-payout statement+email task (retryable, idempotent) so a
+       transient statement/email failure self-heals instead of aborting the batch.
 
     Errors are handled per-payout so one failure does not block the rest.
 
     Returns:
         Dict with ``paid``, ``failed``, and ``skipped`` counts.
     """
-    from accounts.service.payout_statement_service import generate_payout_statement
-
     _reclaim_stale_payouts()
+    _redispatch_missing_statements()
 
     payout_ids = list(
         ReferralPayout.objects.filter(status=ReferralPayout.ReferralPayoutStatus.CALCULATED)
@@ -159,12 +193,45 @@ def process_referral_payouts() -> dict[str, int]:
             currency=payout.currency,
         )
 
-        # --- Generate statement + email (only after successful transfer) ---
-        statement = generate_payout_statement(payout)
-        _send_payout_statement_email(payout, statement, referrer)
+        # --- Dispatch statement + email (retryable, only after successful transfer) ---
+        # Done out-of-band so a transient statement/email failure self-heals via
+        # Celery retry instead of aborting the batch or silently dropping the
+        # statement (a financial document). The transfer is already committed; a
+        # missed dispatch is recovered by the backstop sweep on the next run.
+        _dispatch_statement(str(payout.id))
 
     logger.info("process_referral_payouts_completed", **stats)
     return stats
+
+
+@shared_task(
+    name="accounts.generate_and_send_payout_statement",
+    autoretry_for=(Exception,),
+    retry_backoff=30,
+    retry_backoff_max=600,
+    max_retries=3,
+)
+def generate_and_send_payout_statement(payout_id: str) -> None:
+    """Generate a payout statement PDF and email it to the referrer.
+
+    Dispatched per-payout after a successful Stripe transfer (see
+    :func:`process_referral_payouts`). Retryable and idempotent so a transient
+    storage/render/SMTP failure self-heals instead of silently dropping the
+    statement — which, for a self-billing arrangement, is a financial document.
+    ``generate_payout_statement`` returns the existing statement if one was
+    already created, so retries never duplicate it.
+
+    Args:
+        payout_id: UUID (as ``str``) of the PAID ``ReferralPayout``.
+    """
+    from accounts.service.payout_statement_service import generate_payout_statement
+
+    payout = ReferralPayout.objects.select_related("referral__referrer__billing_profile", "referral__referrer").get(
+        id=payout_id
+    )
+    referrer = payout.referral.referrer
+    statement = generate_payout_statement(payout)
+    _send_payout_statement_email(payout, statement, referrer)
 
 
 def _send_payout_statement_email(

--- a/src/accounts/tasks/payouts.py
+++ b/src/accounts/tasks/payouts.py
@@ -229,6 +229,13 @@ def generate_and_send_payout_statement(payout_id: str) -> None:
     payout = ReferralPayout.objects.select_related("referral__referrer__billing_profile", "referral__referrer").get(
         id=payout_id
     )
+    # Guard the financial-document invariant: this public task must never issue a
+    # statement for a payout that wasn't actually paid (e.g. a stale beat row or a
+    # manual dispatch handing it a CALCULATED/FAILED id). Callers only dispatch
+    # PAID payouts, so this is a fail-fast safety net, not an expected path.
+    if payout.status != ReferralPayout.ReferralPayoutStatus.PAID:
+        logger.warning("payout_statement_skipped_non_paid", payout_id=payout_id, status=payout.status)
+        return
     referrer = payout.referral.referrer
     statement = generate_payout_statement(payout)
     _send_payout_statement_email(payout, statement, referrer)

--- a/src/accounts/tests/test_payout_task.py
+++ b/src/accounts/tests/test_payout_task.py
@@ -802,6 +802,24 @@ class TestGenerateAndSendPayoutStatementTask:
         assert mock_gen_statement.call_args.args[0] == calculated_payout
         mock_send_email.assert_called_once_with(calculated_payout, statement_mock, referrer)
 
+    @patch("accounts.tasks.payouts._send_payout_statement_email")
+    @patch("accounts.service.payout_statement_service.generate_payout_statement")
+    def test_skips_non_paid_payout(
+        self,
+        mock_gen_statement: MagicMock,
+        mock_send_email: MagicMock,
+        calculated_payout: ReferralPayout,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """The task is a no-op for a non-PAID payout — no statement is generated, no email is sent."""
+        # calculated_payout is still CALCULATED — generating a statement here would
+        # issue a financial document for an unpaid payout.
+        generate_and_send_payout_statement(str(calculated_payout.id))
+
+        mock_gen_statement.assert_not_called()
+        mock_send_email.assert_not_called()
+
 
 class TestPayoutStatementBackstopSweep:
     """PAID payouts missing a statement are re-dispatched at the start of each run (issue #611)."""

--- a/src/accounts/tests/test_payout_task.py
+++ b/src/accounts/tests/test_payout_task.py
@@ -24,7 +24,7 @@ from accounts.models import (
     RevelUser,
     UserBillingProfile,
 )
-from accounts.tasks import process_referral_payouts
+from accounts.tasks import generate_and_send_payout_statement, process_referral_payouts
 from common.models import SiteSettings
 
 pytestmark = pytest.mark.django_db
@@ -716,3 +716,174 @@ class TestPayoutReturnStats:
         assert stats == {"paid": 0, "failed": 0, "skipped": 0}
         mock_gen_statement.assert_not_called()
         mock_transfer_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Statement/email dispatch & batch isolation (issue #611)
+# ---------------------------------------------------------------------------
+
+
+class TestPayoutStatementDispatch:
+    """Statement+email is dispatched out-of-band and never halts the batch."""
+
+    @patch("accounts.tasks.payouts.generate_and_send_payout_statement.delay")
+    @patch("accounts.tasks.payouts.stripe.Transfer.create")
+    def test_dispatches_statement_task_after_transfer(
+        self,
+        mock_transfer_create: MagicMock,
+        mock_delay: MagicMock,
+        calculated_payout: ReferralPayout,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """After a successful transfer, the retryable statement task is dispatched with the payout id."""
+        mock_transfer_create.return_value = _mock_stripe_transfer()
+
+        process_referral_payouts()
+
+        mock_delay.assert_called_once_with(str(calculated_payout.id))
+
+    @patch("accounts.tasks.payouts.generate_and_send_payout_statement.delay")
+    @patch("accounts.tasks.payouts.stripe.Transfer.create")
+    def test_dispatch_failure_does_not_halt_batch(
+        self,
+        mock_transfer_create: MagicMock,
+        mock_delay: MagicMock,
+        calculated_payout: ReferralPayout,
+        referral: Referral,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """A dispatch failure (e.g. broker down) is isolated: remaining payouts are still transferred + PAID."""
+        second_payout = ReferralPayout.objects.create(
+            referral=referral,
+            period_start=date(2026, 2, 1),
+            period_end=date(2026, 2, 28),
+            net_platform_fees=Decimal("100.00"),
+            payout_amount=Decimal("15.00"),
+            currency="EUR",
+            status=ReferralPayout.ReferralPayoutStatus.CALCULATED,
+        )
+        mock_transfer_create.return_value = _mock_stripe_transfer()
+        mock_delay.side_effect = RuntimeError("broker unavailable")
+
+        stats = process_referral_payouts()
+
+        # Both transfers happened and both rows are PAID despite every dispatch raising.
+        assert stats == {"paid": 2, "failed": 0, "skipped": 0}
+        assert mock_delay.call_count == 2
+        calculated_payout.refresh_from_db()
+        second_payout.refresh_from_db()
+        assert calculated_payout.status == ReferralPayout.ReferralPayoutStatus.PAID
+        assert second_payout.status == ReferralPayout.ReferralPayoutStatus.PAID
+
+
+class TestGenerateAndSendPayoutStatementTask:
+    """The retryable per-payout statement task delegates to generate + email."""
+
+    @patch("accounts.tasks.payouts._send_payout_statement_email")
+    @patch("accounts.service.payout_statement_service.generate_payout_statement")
+    def test_generates_statement_and_sends_email(
+        self,
+        mock_gen_statement: MagicMock,
+        mock_send_email: MagicMock,
+        calculated_payout: ReferralPayout,
+        billing_profile: UserBillingProfile,
+        referrer: RevelUser,
+        site_settings: SiteSettings,
+    ) -> None:
+        """The task loads the payout by id, generates the statement, and emails it to the referrer."""
+        statement_mock = MagicMock(spec=ReferralPayoutStatement)
+        mock_gen_statement.return_value = statement_mock
+
+        generate_and_send_payout_statement(str(calculated_payout.id))
+
+        mock_gen_statement.assert_called_once()
+        assert mock_gen_statement.call_args.args[0] == calculated_payout
+        mock_send_email.assert_called_once_with(calculated_payout, statement_mock, referrer)
+
+
+class TestPayoutStatementBackstopSweep:
+    """PAID payouts missing a statement are re-dispatched at the start of each run (issue #611)."""
+
+    @staticmethod
+    def _paid_payout(referral: Referral, month: int) -> ReferralPayout:
+        return ReferralPayout.objects.create(
+            referral=referral,
+            period_start=date(2026, month, 1),
+            period_end=date(2026, month, 28),
+            net_platform_fees=Decimal("100.00"),
+            payout_amount=Decimal("15.00"),
+            currency="EUR",
+            status=ReferralPayout.ReferralPayoutStatus.PAID,
+        )
+
+    @patch("accounts.tasks.payouts.generate_and_send_payout_statement.delay")
+    @patch("accounts.tasks.payouts.stripe.Transfer.create")
+    def test_redispatches_paid_payout_missing_statement(
+        self,
+        mock_transfer_create: MagicMock,
+        mock_delay: MagicMock,
+        referral: Referral,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """A PAID payout with no statement is re-dispatched even though reruns never re-scan PAID rows."""
+        paid_payout = self._paid_payout(referral, month=1)
+
+        process_referral_payouts()
+
+        mock_delay.assert_called_once_with(str(paid_payout.id))
+        mock_transfer_create.assert_not_called()  # no CALCULATED payouts to transfer
+
+    @patch("accounts.tasks.payouts.generate_and_send_payout_statement.delay")
+    @patch("accounts.tasks.payouts.stripe.Transfer.create")
+    def test_does_not_redispatch_when_statement_exists(
+        self,
+        mock_transfer_create: MagicMock,
+        mock_delay: MagicMock,
+        referral: Referral,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """A PAID payout that already has a statement is left alone by the sweep."""
+        paid_payout = self._paid_payout(referral, month=1)
+        ReferralPayoutStatement.objects.create(
+            payout=paid_payout,
+            document_type=ReferralPayoutStatement.DocumentType.PAYOUT_STATEMENT,
+            document_number="RVL-RP-2026-000001",
+            amount_gross=Decimal("15.00"),
+            amount_net=Decimal("15.00"),
+            amount_vat=Decimal("0.00"),
+            vat_rate=Decimal("0.00"),
+            referrer_name="Payout Referrer",
+            platform_business_name="Revel GmbH",
+            platform_business_address="Mariahilfer Str. 10, 1060 Wien, Austria",
+            platform_vat_id="ATU12345678",
+        )
+
+        process_referral_payouts()
+
+        mock_delay.assert_not_called()
+
+    @patch("accounts.tasks.payouts.generate_and_send_payout_statement.delay")
+    @patch("accounts.tasks.payouts.stripe.Transfer.create")
+    def test_sweep_dispatch_failure_does_not_halt_run(
+        self,
+        mock_transfer_create: MagicMock,
+        mock_delay: MagicMock,
+        calculated_payout: ReferralPayout,
+        referral: Referral,
+        billing_profile: UserBillingProfile,
+        site_settings: SiteSettings,
+    ) -> None:
+        """A broker outage during the sweep is isolated: the CALCULATED batch still runs and pays out."""
+        self._paid_payout(referral, month=2)  # missing-statement row to sweep
+        mock_transfer_create.return_value = _mock_stripe_transfer()
+        mock_delay.side_effect = RuntimeError("broker unavailable")
+
+        stats = process_referral_payouts()
+
+        assert stats["paid"] == 1
+        calculated_payout.refresh_from_db()
+        assert calculated_payout.status == ReferralPayout.ReferralPayoutStatus.PAID

--- a/src/accounts/tests/test_payout_task.py
+++ b/src/accounts/tests/test_payout_task.py
@@ -792,7 +792,9 @@ class TestGenerateAndSendPayoutStatementTask:
         referrer: RevelUser,
         site_settings: SiteSettings,
     ) -> None:
-        """The task loads the payout by id, generates the statement, and emails it to the referrer."""
+        """The task loads the PAID payout by id, generates the statement, and emails it to the referrer."""
+        calculated_payout.status = ReferralPayout.ReferralPayoutStatus.PAID
+        calculated_payout.save(update_fields=["status"])
         statement_mock = MagicMock(spec=ReferralPayoutStatement)
         mock_gen_statement.return_value = statement_mock
 


### PR DESCRIPTION
## Summary

Fixes #611. In `process_referral_payouts`, the post-transfer statement generation and email send were **not** wrapped in error handling, so a failure there aborted the whole monthly batch — contradicting the function's own per-payout error-handling contract — and silently dropped the already-`PAID` referrer's statement (a financial document) with no recovery path, since reruns only re-scan `CALCULATED` rows.

Money movement was already safe (the Stripe transfer is idempotent and protected); this PR makes the statement/email steps equally resilient.

## Changes

- **Retryable per-payout task** — extract steps 5 (statement PDF + email) into `accounts.generate_and_send_payout_statement` (`autoretry_for=(Exception,)`, backoff 30s→600s, 3 retries), dispatched after the `PAID` commit. Mirrors the existing `events.deliver_attendee_invoice` pattern. Transient storage/render/SMTP failures now self-heal in the worker instead of aborting the batch. Idempotent: `generate_payout_statement` returns any existing statement, so retries never duplicate.
- **Guarded dispatch** (`_dispatch_statement`) — wraps `.delay()` so a broker outage can't halt the remaining payouts.
- **Backstop sweep** (`_redispatch_missing_statements`) — runs at the start of each batch; re-dispatches PAID payouts with no statement (`status=PAID, statement__isnull=True`), closing the gap reruns never revisit (broker down at dispatch + retries exhausted).

## Recovery timeline

- Transient failure (common): self-heals within minutes via the task's retry/backoff.
- Broker down at dispatch + retries exhausted (rare): recovered by the sweep on the next batch run (monthly).

## Tests

Added to `src/accounts/tests/test_payout_task.py`:
- `TestPayoutStatementDispatch` — dispatch happens after transfer; dispatch failure doesn't halt the batch.
- `TestGenerateAndSendPayoutStatementTask` — the task loads by id, generates, emails.
- `TestPayoutStatementBackstopSweep` — re-dispatches PAID-missing-statement rows; leaves PAID-with-statement rows alone; a sweep broker outage doesn't block the `CALCULATED` batch.

Existing happy-path tests pass unchanged (eager mode runs the dispatched task inline).

## Verification

- `ruff format` + `ruff check`: clean
- `mypy --strict` (source + tests): clean
- `make task-names`: ✅ (new task `accounts.generate_and_send_payout_statement`)
- No model/migration changes.

## Notes

The backstop sweep runs at the monthly batch cadence. If faster recovery is desired for the rare catastrophic case, it could be split into its own daily beat task (would require a small data migration); kept inline here for minimal surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payout statement generation and email delivery now run in a separate, retryable step after payouts are marked paid.
  * On subsequent runs, payouts that are already paid but missing a statement are automatically re-dispatched for statement creation and email.

* **Bug Fixes**
  * Temporary statement dispatch or delivery failures no longer block the rest of the payout processing.
  * Statement emails are only generated/sent for payouts that are in the paid state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->