### PR TITLE
refactor(accounts): consolidate 8 email-send wrappers into one template-driven task (#608)

### DIFF
--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -42,7 +42,7 @@ def _send_activation_email_for_guest(user: RevelUser) -> None:
     # transaction back. The target guest already exists (committed), so there
     # is no read-after-commit race and the email must be sent despite the
     # rollback. See register_user.
-    tasks.send_account_activation_link.delay(user.email, token)
+    tasks.send_account_email.delay(tasks.AccountEmail.ACTIVATION, user.email, token=token)
     logger.info("account_activation_email_sent", user_id=str(user.id), email=user.email)
 
 
@@ -183,9 +183,11 @@ def send_verification_email_for_user(user: RevelUser, *, defer: bool = True) -> 
     logger.info("verification_email_requested", user_id=str(user.id), email=user.email)
     token = create_verification_token(user)
     if defer:
-        transaction.on_commit(lambda: tasks.send_verification_email.delay(user.email, token))
+        transaction.on_commit(
+            lambda: tasks.send_account_email.delay(tasks.AccountEmail.VERIFICATION, user.email, token=token)
+        )
     else:
-        tasks.send_verification_email.delay(user.email, token)
+        tasks.send_account_email.delay(tasks.AccountEmail.VERIFICATION, user.email, token=token)
     return user, token
 
 
@@ -285,7 +287,9 @@ def request_password_reset(email: str) -> str | None:
         logger.info("password_reset_blocked_google_sso", user_id=str(user.id), email=email)
         return None
     token = create_password_reset_token(user)
-    transaction.on_commit(lambda: tasks.send_password_reset_link.delay(user.email, token))
+    transaction.on_commit(
+        lambda: tasks.send_account_email.delay(tasks.AccountEmail.PASSWORD_RESET, user.email, token=token)
+    )
     logger.info("password_reset_email_sent", user_id=str(user.id), email=email)
     return token
 
@@ -301,7 +305,7 @@ def request_account_deletion(user: RevelUser) -> str:
     """
     logger.info("account_deletion_requested", user_id=str(user.id), email=user.email)
     token = create_deletion_token(user)
-    transaction.on_commit(lambda: tasks.send_account_deletion_link.delay(user.email, token))
+    transaction.on_commit(lambda: tasks.send_account_email.delay(tasks.AccountEmail.DELETION, user.email, token=token))
     return token
 
 
@@ -409,8 +413,14 @@ def request_email_change(user: RevelUser, new_email: str, password: str) -> str:
         raise HttpError(400, str(_("This email is already in use.")))
 
     token = create_email_change_token(user, new_email)
-    transaction.on_commit(lambda: tasks.send_email_change_confirmation.delay(new_email, token))
-    transaction.on_commit(lambda: tasks.send_email_change_notice.delay(user.email, _mask_email(new_email)))
+    transaction.on_commit(
+        lambda: tasks.send_account_email.delay(tasks.AccountEmail.CHANGE_CONFIRMATION, new_email, token=token)
+    )
+    transaction.on_commit(
+        lambda: tasks.send_account_email.delay(
+            tasks.AccountEmail.CHANGE_NOTICE, user.email, context={"masked_new_email": _mask_email(new_email)}
+        )
+    )
     logger.info("email_change_email_sent", user_id=str(user.id), new_email=new_email)
     return token
 
@@ -469,8 +479,17 @@ def confirm_email_change(token: str) -> RevelUser:
         logger.warning("email_change_confirm_race_loss", user_id=str(user.id), new_email=new_email)
         raise HttpError(400, str(_("This email is already in use.")))
 
-    transaction.on_commit(lambda: tasks.send_email_change_completed_old.delay(old_email, new_email))
-    transaction.on_commit(lambda: tasks.send_email_change_completed_new.delay(new_email, old_email))
+    _change_completed_context = {"old_email": old_email, "new_email": new_email}
+    transaction.on_commit(
+        lambda: tasks.send_account_email.delay(
+            tasks.AccountEmail.CHANGE_COMPLETED_OLD, old_email, context=_change_completed_context
+        )
+    )
+    transaction.on_commit(
+        lambda: tasks.send_account_email.delay(
+            tasks.AccountEmail.CHANGE_COMPLETED_NEW, new_email, context=_change_completed_context
+        )
+    )
     logger.info(
         "email_change_confirmed",
         user_id=str(user.id),

--- a/src/accounts/tasks/__init__.py
+++ b/src/accounts/tasks/__init__.py
@@ -1,9 +1,12 @@
 """Tasks for the authentication app.
 
 This package groups the accounts app's asynchronous tasks by domain (email,
-tokens, gdpr, verification_reminders, notifications, bans, payouts). Every task
-is re-exported here so the historical ``from accounts.tasks import <task>``
-import path keeps working.
+tokens, gdpr, verification_reminders, notifications, bans, payouts). Tasks are
+re-exported here so the ``from accounts.tasks import <task>`` import path works.
+
+The eight per-message email-send tasks were consolidated into the single
+``send_account_email`` task (issue #608); their old names are intentionally no
+longer exported. See ``accounts/tasks/email.py``.
 
 ``mark_reminder_sent`` is re-exported because ``common.tasks._execute_email_callback``
 resolves it via ``getattr(import_module("accounts.tasks"), "mark_reminder_sent")``

--- a/src/accounts/tasks/__init__.py
+++ b/src/accounts/tasks/__init__.py
@@ -11,16 +11,7 @@ against its allowlist — it must stay importable from this package.
 """
 
 from accounts.tasks.bans import process_domain_ban_task
-from accounts.tasks.email import (
-    send_account_activation_link,
-    send_account_deletion_link,
-    send_email_change_completed_new,
-    send_email_change_completed_old,
-    send_email_change_confirmation,
-    send_email_change_notice,
-    send_password_reset_link,
-    send_verification_email,
-)
+from accounts.tasks.email import AccountEmail, send_account_email
 from accounts.tasks.gdpr import (
     DATA_EXPORT_URL_EXPIRES_IN,
     cleanup_expired_data_exports,
@@ -40,6 +31,7 @@ from accounts.tasks.verification_reminders import (
 
 __all__ = [
     "DATA_EXPORT_URL_EXPIRES_IN",
+    "AccountEmail",
     "cleanup_expired_data_exports",
     "deactivate_unverified_accounts",
     "delete_old_inactive_accounts",
@@ -52,14 +44,7 @@ __all__ = [
     "notify_admin_new_user_joined_discord",
     "process_domain_ban_task",
     "process_referral_payouts",
-    "send_account_activation_link",
-    "send_account_deletion_link",
+    "send_account_email",
     "send_early_verification_reminders",
-    "send_email_change_completed_new",
-    "send_email_change_completed_old",
-    "send_email_change_confirmation",
-    "send_email_change_notice",
     "send_final_verification_warnings",
-    "send_password_reset_link",
-    "send_verification_email",
 ]

--- a/src/accounts/tasks/email.py
+++ b/src/accounts/tasks/email.py
@@ -48,6 +48,8 @@ class _Config:
             ``frontend_base_url`` to build the action link. ``None`` for the informational
             emails that carry no link.
         link_context_key: Context key the body templates use for the built link.
+        required_context_keys: Caller-supplied context keys the templates require — validated
+            up front so a bad dispatch fails fast instead of rendering a partial email.
         include_frontend_base_url: Whether the body templates reference ``frontend_base_url``.
         subject_includes_site_name: Whether the subject template references ``site_name``
             (taken from the current ``Site``).
@@ -56,6 +58,7 @@ class _Config:
     template_base: str
     link_path: str | None = None
     link_context_key: str | None = None
+    required_context_keys: tuple[str, ...] = ()
     include_frontend_base_url: bool = False
     subject_includes_site_name: bool = False
 
@@ -84,14 +87,17 @@ _CONFIGS: dict[AccountEmail, _Config] = {
     ),
     AccountEmail.CHANGE_NOTICE: _Config(
         template_base="email_change_notice",
+        required_context_keys=("masked_new_email",),
         include_frontend_base_url=True,
     ),
     AccountEmail.CHANGE_COMPLETED_OLD: _Config(
         template_base="email_change_completed_old",
+        required_context_keys=("old_email", "new_email"),
         include_frontend_base_url=True,
     ),
     AccountEmail.CHANGE_COMPLETED_NEW: _Config(
         template_base="email_change_completed_new",
+        required_context_keys=("old_email", "new_email"),
         include_frontend_base_url=True,
     ),
     AccountEmail.DELETION: _Config(
@@ -125,13 +131,17 @@ def send_account_email(
             ``{"old_email": ..., "new_email": ...}`` for the change-completed emails.
 
     Raises:
-        ValueError: If a link-bearing email type is dispatched without a token.
+        ValueError: If a link-bearing email type is dispatched without a token, or a message
+            type is dispatched without its required context keys.
     """
     config = _CONFIGS[AccountEmail(email_type)]
     logger.info("account_email_sending", email_type=email_type, to=to)
 
     site_settings = SiteSettings.get_solo()
     body_context: dict[str, str] = dict(context or {})
+    missing_keys = [key for key in config.required_context_keys if key not in body_context]
+    if missing_keys:
+        raise ValueError(f"{email_type} email requires context keys: {', '.join(missing_keys)}")
     if config.link_path is not None:
         if token is None:
             raise ValueError(f"{email_type} email requires a token")

--- a/src/accounts/tasks/email.py
+++ b/src/accounts/tasks/email.py
@@ -1,4 +1,17 @@
-"""Transactional account email-send tasks (verification, activation, password reset, email change, deletion)."""
+"""Transactional account email-send task (verification, activation, password reset, email change, deletion).
+
+A single template-driven Celery task — :func:`send_account_email` — renders and sends every
+transactional account email. Each message type is described by an :data:`_CONFIGS` entry
+(template base, frontend link path, and which extra context the templates expect), so adding a
+new message is a one-line config addition rather than another near-identical wrapper task.
+
+Consolidated from eight per-message wrapper tasks (issue #608). The old task names
+(``accounts.tasks.send_verification_email`` etc.) are **gone** — deploys must drain Celery
+(``safe_reboot``) so no in-flight message references a removed name.
+"""
+
+import dataclasses
+import enum
 
 import structlog
 from celery import shared_task
@@ -11,138 +24,126 @@ from common.tasks import send_email
 logger = structlog.get_logger(__name__)
 
 
-@shared_task(name="accounts.tasks.send_verification_email")
-def send_verification_email(email: str, token: str) -> None:
-    """Send a verification email."""
-    logger.info("verification_email_sending", email=email)
-    subject = str(render_to_string("accounts/emails/email_verification_subject.txt"))
-    verification_link = SiteSettings.get_solo().frontend_base_url + f"/login/confirm-email?token={token}"
-    body = render_to_string("accounts/emails/email_verification_body.txt", {"verification_link": verification_link})
-    html_body = render_to_string(
-        "accounts/emails/email_verification_body.html", {"verification_link": verification_link}
-    )
-    send_email(to=email, subject=subject, body=body, html_body=html_body)
-    logger.info("verification_email_sent", email=email)
+class AccountEmail(enum.StrEnum):
+    """The transactional account email types dispatched via :func:`send_account_email`."""
+
+    VERIFICATION = "verification"
+    ACTIVATION = "activation"
+    PASSWORD_RESET = "password_reset"
+    CHANGE_CONFIRMATION = "change_confirmation"
+    CHANGE_NOTICE = "change_notice"
+    CHANGE_COMPLETED_OLD = "change_completed_old"
+    CHANGE_COMPLETED_NEW = "change_completed_new"
+    DELETION = "deletion"
 
 
-@shared_task(name="accounts.tasks.send_account_activation_link")
-def send_account_activation_link(email: str, token: str) -> None:
-    """Send an account activation email to a guest user registering for a full account."""
-    logger.info("account_activation_email_sending", email=email)
-    subject = str(render_to_string("accounts/emails/account_activation_subject.txt"))
-    activation_link = SiteSettings.get_solo().frontend_base_url + f"/login/reset-password?token={token}"
-    body = render_to_string("accounts/emails/account_activation_body.txt", {"activation_link": activation_link})
-    html_body = render_to_string("accounts/emails/account_activation_body.html", {"activation_link": activation_link})
-    send_email(to=email, subject=subject, body=body, html_body=html_body)
-    logger.info("account_activation_email_sent", email=email)
+@dataclasses.dataclass(frozen=True)
+class _Config:
+    """Static description of one transactional account email.
+
+    Attributes:
+        template_base: Stem under ``accounts/emails/`` — renders ``{base}_subject.txt``,
+            ``{base}_body.txt`` and ``{base}_body.html``.
+        link_path: Frontend path (a ``{token}`` format string) appended to
+            ``frontend_base_url`` to build the action link. ``None`` for the informational
+            emails that carry no link.
+        link_context_key: Context key the body templates use for the built link.
+        include_frontend_base_url: Whether the body templates reference ``frontend_base_url``.
+        subject_includes_site_name: Whether the subject template references ``site_name``
+            (taken from the current ``Site``).
+    """
+
+    template_base: str
+    link_path: str | None = None
+    link_context_key: str | None = None
+    include_frontend_base_url: bool = False
+    subject_includes_site_name: bool = False
 
 
-@shared_task(name="accounts.tasks.send_password_reset_link")
-def send_password_reset_link(email: str, token: str) -> None:
-    """Send a password reset email."""
-    logger.info("password_reset_email_sending", email=email)
-    subject = str(render_to_string("accounts/emails/password_reset_subject.txt"))
-    password_reset_link = SiteSettings.get_solo().frontend_base_url + f"/login/reset-password?token={token}"
-    body = render_to_string("accounts/emails/password_reset_body.txt", {"password_reset_link": password_reset_link})
-    html_body = render_to_string(
-        "accounts/emails/password_reset_body.html", {"password_reset_link": password_reset_link}
-    )
-    send_email(to=email, subject=subject, body=body, html_body=html_body)
-    logger.info("password_reset_email_sent", email=email)
+_CONFIGS: dict[AccountEmail, _Config] = {
+    AccountEmail.VERIFICATION: _Config(
+        template_base="email_verification",
+        link_path="/login/confirm-email?token={token}",
+        link_context_key="verification_link",
+    ),
+    AccountEmail.ACTIVATION: _Config(
+        template_base="account_activation",
+        link_path="/login/reset-password?token={token}",
+        link_context_key="activation_link",
+    ),
+    AccountEmail.PASSWORD_RESET: _Config(
+        template_base="password_reset",
+        link_path="/login/reset-password?token={token}",
+        link_context_key="password_reset_link",
+    ),
+    AccountEmail.CHANGE_CONFIRMATION: _Config(
+        template_base="email_change_confirmation",
+        link_path="/account/confirm-email-change?token={token}",
+        link_context_key="confirmation_link",
+        include_frontend_base_url=True,
+    ),
+    AccountEmail.CHANGE_NOTICE: _Config(
+        template_base="email_change_notice",
+        include_frontend_base_url=True,
+    ),
+    AccountEmail.CHANGE_COMPLETED_OLD: _Config(
+        template_base="email_change_completed_old",
+        include_frontend_base_url=True,
+    ),
+    AccountEmail.CHANGE_COMPLETED_NEW: _Config(
+        template_base="email_change_completed_new",
+        include_frontend_base_url=True,
+    ),
+    AccountEmail.DELETION: _Config(
+        template_base="account_delete",
+        link_path="/account/confirm-deletion?token={token}",
+        link_context_key="account_deletion_link",
+        include_frontend_base_url=True,
+        subject_includes_site_name=True,
+    ),
+}
 
 
-@shared_task(name="accounts.tasks.send_email_change_confirmation")
-def send_email_change_confirmation(new_email: str, token: str) -> None:
-    """Send the confirmation link to the **new** email address.
-
-    Clicking the link proves the user controls the new mailbox.
+@shared_task(name="accounts.tasks.send_account_email")
+def send_account_email(
+    email_type: str,
+    to: str,
+    *,
+    token: str | None = None,
+    context: dict[str, str] | None = None,
+) -> None:
+    """Render and send a transactional account email.
 
     Args:
-        new_email: The new email address requested by the user.
-        token: The single-use email-change JWT to embed in the confirmation link.
+        email_type: An :class:`AccountEmail` value selecting the message and its template set.
+        to: Recipient email address.
+        token: Single-use token for the link-bearing emails (verification, activation,
+            password reset, email-change confirmation, deletion). ``None`` for the
+            informational email-change emails.
+        context: Extra template context required by some message types — e.g.
+            ``{"masked_new_email": ...}`` for the change notice, or
+            ``{"old_email": ..., "new_email": ...}`` for the change-completed emails.
+
+    Raises:
+        ValueError: If a link-bearing email type is dispatched without a token.
     """
-    logger.info("email_change_confirmation_sending", new_email=new_email)
-    subject = str(render_to_string("accounts/emails/email_change_confirmation_subject.txt"))
+    config = _CONFIGS[AccountEmail(email_type)]
+    logger.info("account_email_sending", email_type=email_type, to=to)
+
     site_settings = SiteSettings.get_solo()
-    confirmation_link = site_settings.frontend_base_url + f"/account/confirm-email-change?token={token}"
-    context = {"confirmation_link": confirmation_link, "frontend_base_url": site_settings.frontend_base_url}
-    body = render_to_string("accounts/emails/email_change_confirmation_body.txt", context)
-    html_body = render_to_string("accounts/emails/email_change_confirmation_body.html", context)
-    send_email(to=new_email, subject=subject, body=body, html_body=html_body)
-    logger.info("email_change_confirmation_sent", new_email=new_email)
+    body_context: dict[str, str] = dict(context or {})
+    if config.link_path is not None:
+        if token is None:
+            raise ValueError(f"{email_type} email requires a token")
+        assert config.link_context_key is not None
+        body_context[config.link_context_key] = site_settings.frontend_base_url + config.link_path.format(token=token)
+    if config.include_frontend_base_url:
+        body_context["frontend_base_url"] = site_settings.frontend_base_url
 
+    subject_context = {"site_name": Site.objects.get_current().name} if config.subject_includes_site_name else {}
+    subject = str(render_to_string(f"accounts/emails/{config.template_base}_subject.txt", subject_context))
+    body = render_to_string(f"accounts/emails/{config.template_base}_body.txt", body_context)
+    html_body = render_to_string(f"accounts/emails/{config.template_base}_body.html", body_context)
+    send_email(to=to, subject=subject, body=body, html_body=html_body)
 
-@shared_task(name="accounts.tasks.send_email_change_notice")
-def send_email_change_notice(current_email: str, masked_new_email: str) -> None:
-    """Notify the **current** email address that a change was requested.
-
-    Informational only — there is no cancel link in v1.
-
-    Args:
-        current_email: The user's current email address.
-        masked_new_email: The new address in masked form (e.g. ``a***@example.com``).
-    """
-    logger.info("email_change_notice_sending", current_email=current_email)
-    subject = str(render_to_string("accounts/emails/email_change_notice_subject.txt"))
-    site_settings = SiteSettings.get_solo()
-    context = {"masked_new_email": masked_new_email, "frontend_base_url": site_settings.frontend_base_url}
-    body = render_to_string("accounts/emails/email_change_notice_body.txt", context)
-    html_body = render_to_string("accounts/emails/email_change_notice_body.html", context)
-    send_email(to=current_email, subject=subject, body=body, html_body=html_body)
-    logger.info("email_change_notice_sent", current_email=current_email)
-
-
-@shared_task(name="accounts.tasks.send_email_change_completed_old")
-def send_email_change_completed_old(old_email: str, new_email: str) -> None:
-    """Notify the **old** address that the email change has completed.
-
-    Args:
-        old_email: The address being decommissioned.
-        new_email: The address that is now primary on the account.
-    """
-    logger.info("email_change_completed_old_sending", old_email=old_email)
-    subject = str(render_to_string("accounts/emails/email_change_completed_old_subject.txt"))
-    site_settings = SiteSettings.get_solo()
-    context = {"old_email": old_email, "new_email": new_email, "frontend_base_url": site_settings.frontend_base_url}
-    body = render_to_string("accounts/emails/email_change_completed_old_body.txt", context)
-    html_body = render_to_string("accounts/emails/email_change_completed_old_body.html", context)
-    send_email(to=old_email, subject=subject, body=body, html_body=html_body)
-    logger.info("email_change_completed_old_sent", old_email=old_email)
-
-
-@shared_task(name="accounts.tasks.send_email_change_completed_new")
-def send_email_change_completed_new(new_email: str, old_email: str) -> None:
-    """Welcome message to the **new** address confirming the change is live.
-
-    Args:
-        new_email: The address that is now primary on the account.
-        old_email: The previous address (referenced in the body for clarity).
-    """
-    logger.info("email_change_completed_new_sending", new_email=new_email)
-    subject = str(render_to_string("accounts/emails/email_change_completed_new_subject.txt"))
-    site_settings = SiteSettings.get_solo()
-    context = {"old_email": old_email, "new_email": new_email, "frontend_base_url": site_settings.frontend_base_url}
-    body = render_to_string("accounts/emails/email_change_completed_new_body.txt", context)
-    html_body = render_to_string("accounts/emails/email_change_completed_new_body.html", context)
-    send_email(to=new_email, subject=subject, body=body, html_body=html_body)
-    logger.info("email_change_completed_new_sent", new_email=new_email)
-
-
-@shared_task(name="accounts.tasks.send_account_deletion_link")
-def send_account_deletion_link(email: str, token: str) -> None:
-    """Send an account deletion confirmation email."""
-    logger.info("account_deletion_email_sending", email=email)
-    site = Site.objects.get_current()
-    subject = str(render_to_string("accounts/emails/account_delete_subject.txt", {"site_name": site.name}))
-    site_settings = SiteSettings.get_solo()
-    account_deletion_link = site_settings.frontend_base_url + f"/account/confirm-deletion?token={token}"
-    body = render_to_string(
-        "accounts/emails/account_delete_body.txt",
-        {"account_deletion_link": account_deletion_link, "frontend_base_url": site_settings.frontend_base_url},
-    )
-    html_body = render_to_string(
-        "accounts/emails/account_delete_body.html",
-        {"account_deletion_link": account_deletion_link, "frontend_base_url": site_settings.frontend_base_url},
-    )
-    send_email(to=email, subject=subject, body=body, html_body=html_body)
-    logger.info("account_deletion_email_sent", email=email)
+    logger.info("account_email_sent", email_type=email_type, to=to)

--- a/src/accounts/tasks/email.py
+++ b/src/accounts/tasks/email.py
@@ -2,8 +2,12 @@
 
 A single template-driven Celery task — :func:`send_account_email` — renders and sends every
 transactional account email. Each message type is described by an :data:`_CONFIGS` entry
-(template base, frontend link path, and which extra context the templates expect), so adding a
-new message is a one-line config addition rather than another near-identical wrapper task.
+(template base, frontend link path, and any required extra context), so adding a new message is a
+one-line config addition rather than another near-identical wrapper task.
+
+Every body is rendered with ``frontend_base_url`` in context and every link-bearing template uses
+the same ``action_link`` key, so the config carries only what actually differs per message —
+no per-template "does this one use the base URL / a link" flags.
 
 Consolidated from eight per-message wrapper tasks (issue #608). The old task names
 (``accounts.tasks.send_verification_email`` etc.) are **gone** — deploys must drain Celery
@@ -15,7 +19,6 @@ import enum
 
 import structlog
 from celery import shared_task
-from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 
 from common.models import SiteSettings
@@ -43,69 +46,51 @@ class _Config:
 
     Attributes:
         template_base: Stem under ``accounts/emails/`` — renders ``{base}_subject.txt``,
-            ``{base}_body.txt`` and ``{base}_body.html``.
-        link_path: Frontend path (a ``{token}`` format string) appended to
-            ``frontend_base_url`` to build the action link. ``None`` for the informational
-            emails that carry no link.
-        link_context_key: Context key the body templates use for the built link.
+            ``{base}_body.txt`` and ``{base}_body.html``. The body templates receive
+            ``frontend_base_url`` and, for link-bearing messages, ``action_link``.
+        link_path: Frontend path (a ``{token}`` format string) appended to ``frontend_base_url``
+            to build ``action_link``. ``None`` for the informational emails that carry no link.
         required_context_keys: Caller-supplied context keys the templates require — validated
             up front so a bad dispatch fails fast instead of rendering a partial email.
-        include_frontend_base_url: Whether the body templates reference ``frontend_base_url``.
-        subject_includes_site_name: Whether the subject template references ``site_name``
-            (taken from the current ``Site``).
     """
 
     template_base: str
     link_path: str | None = None
-    link_context_key: str | None = None
     required_context_keys: tuple[str, ...] = ()
-    include_frontend_base_url: bool = False
-    subject_includes_site_name: bool = False
 
 
 _CONFIGS: dict[AccountEmail, _Config] = {
     AccountEmail.VERIFICATION: _Config(
         template_base="email_verification",
         link_path="/login/confirm-email?token={token}",
-        link_context_key="verification_link",
     ),
     AccountEmail.ACTIVATION: _Config(
         template_base="account_activation",
         link_path="/login/reset-password?token={token}",
-        link_context_key="activation_link",
     ),
     AccountEmail.PASSWORD_RESET: _Config(
         template_base="password_reset",
         link_path="/login/reset-password?token={token}",
-        link_context_key="password_reset_link",
     ),
     AccountEmail.CHANGE_CONFIRMATION: _Config(
         template_base="email_change_confirmation",
         link_path="/account/confirm-email-change?token={token}",
-        link_context_key="confirmation_link",
-        include_frontend_base_url=True,
     ),
     AccountEmail.CHANGE_NOTICE: _Config(
         template_base="email_change_notice",
         required_context_keys=("masked_new_email",),
-        include_frontend_base_url=True,
     ),
     AccountEmail.CHANGE_COMPLETED_OLD: _Config(
         template_base="email_change_completed_old",
         required_context_keys=("old_email", "new_email"),
-        include_frontend_base_url=True,
     ),
     AccountEmail.CHANGE_COMPLETED_NEW: _Config(
         template_base="email_change_completed_new",
         required_context_keys=("old_email", "new_email"),
-        include_frontend_base_url=True,
     ),
     AccountEmail.DELETION: _Config(
         template_base="account_delete",
         link_path="/account/confirm-deletion?token={token}",
-        link_context_key="account_deletion_link",
-        include_frontend_base_url=True,
-        subject_includes_site_name=True,
     ),
 }
 
@@ -137,21 +122,19 @@ def send_account_email(
     config = _CONFIGS[AccountEmail(email_type)]
     logger.info("account_email_sending", email_type=email_type, to=to)
 
-    site_settings = SiteSettings.get_solo()
-    body_context: dict[str, str] = dict(context or {})
-    missing_keys = [key for key in config.required_context_keys if key not in body_context]
+    caller_context = context or {}
+    missing_keys = [key for key in config.required_context_keys if key not in caller_context]
     if missing_keys:
         raise ValueError(f"{email_type} email requires context keys: {', '.join(missing_keys)}")
+
+    site_settings = SiteSettings.get_solo()
+    body_context: dict[str, str] = {"frontend_base_url": site_settings.frontend_base_url, **caller_context}
     if config.link_path is not None:
         if token is None:
             raise ValueError(f"{email_type} email requires a token")
-        assert config.link_context_key is not None
-        body_context[config.link_context_key] = site_settings.frontend_base_url + config.link_path.format(token=token)
-    if config.include_frontend_base_url:
-        body_context["frontend_base_url"] = site_settings.frontend_base_url
+        body_context["action_link"] = site_settings.frontend_base_url + config.link_path.format(token=token)
 
-    subject_context = {"site_name": Site.objects.get_current().name} if config.subject_includes_site_name else {}
-    subject = str(render_to_string(f"accounts/emails/{config.template_base}_subject.txt", subject_context))
+    subject = str(render_to_string(f"accounts/emails/{config.template_base}_subject.txt"))
     body = render_to_string(f"accounts/emails/{config.template_base}_body.txt", body_context)
     html_body = render_to_string(f"accounts/emails/{config.template_base}_body.html", body_context)
     send_email(to=to, subject=subject, body=body, html_body=html_body)

--- a/src/accounts/templates/accounts/emails/account_activation_body.html
+++ b/src/accounts/templates/accounts/emails/account_activation_body.html
@@ -9,7 +9,7 @@
     <p>{% blocktrans %}To complete setting up your Revel account, please click the link below to set your password:{% endblocktrans %}</p>
 
     <p>
-        <a href="{{ activation_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
+        <a href="{{ action_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
             {% trans "Set Password" %}
         </a>
     </p>

--- a/src/accounts/templates/accounts/emails/account_activation_body.txt
+++ b/src/accounts/templates/accounts/emails/account_activation_body.txt
@@ -2,7 +2,7 @@
 
 {% blocktrans %}To complete setting up your Revel account, please click the link below to set your password:{% endblocktrans %}
 
-{{ activation_link }}
+{{ action_link }}
 
 {% blocktrans %}If you didn't request this, you can safely ignore this email.{% endblocktrans %}
 

--- a/src/accounts/templates/accounts/emails/account_delete_body.html
+++ b/src/accounts/templates/accounts/emails/account_delete_body.html
@@ -15,7 +15,7 @@
     <p>{% blocktrans %}To confirm the deletion of your account, click the link below:{% endblocktrans %}</p>
 
     <p>
-        <a href="{{ account_deletion_link }}" style="display: inline-block; padding: 10px 20px; background-color: #dc3545; color: #ffffff; text-decoration: none; border-radius: 5px;">
+        <a href="{{ action_link }}" style="display: inline-block; padding: 10px 20px; background-color: #dc3545; color: #ffffff; text-decoration: none; border-radius: 5px;">
             {% trans "Confirm Account Deletion" %}
         </a>
     </p>

--- a/src/accounts/templates/accounts/emails/account_delete_body.txt
+++ b/src/accounts/templates/accounts/emails/account_delete_body.txt
@@ -6,7 +6,7 @@
 
 {% blocktrans %}To confirm the deletion of your account, click the link below:{% endblocktrans %}
 
-{{ account_deletion_link }}
+{{ action_link }}
 
 {% blocktrans %}Thank you,
 The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/email_change_confirmation_body.html
+++ b/src/accounts/templates/accounts/emails/email_change_confirmation_body.html
@@ -9,7 +9,7 @@
     <p>{% blocktrans %}You (or someone using your account) asked to change the email address on your Revel account to this one. To confirm the change, click the button below:{% endblocktrans %}</p>
 
     <p>
-        <a href="{{ confirmation_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
+        <a href="{{ action_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
             {% trans "Confirm new email" %}
         </a>
     </p>

--- a/src/accounts/templates/accounts/emails/email_change_confirmation_body.txt
+++ b/src/accounts/templates/accounts/emails/email_change_confirmation_body.txt
@@ -2,7 +2,7 @@
 
 {% blocktrans %}You (or someone using your account) asked to change the email address on your Revel account to this one. To confirm the change, click the link below:{% endblocktrans %}
 
-{{ confirmation_link }}
+{{ action_link }}
 
 {% blocktrans %}Important: after you confirm, you will be signed out of every other device and you will need to sign in again using this new email address.{% endblocktrans %}
 

--- a/src/accounts/templates/accounts/emails/email_verification_body.html
+++ b/src/accounts/templates/accounts/emails/email_verification_body.html
@@ -8,7 +8,7 @@
     <h2>{% trans "Verify your email" %}</h2>
     <p>{% blocktrans %}Please verify your email and finish setting up your account.{% endblocktrans %}</p>
     <p>
-        <a href="{{ verification_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
+        <a href="{{ action_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
             {% trans "Verify Email" %}
         </a>
     </p>

--- a/src/accounts/templates/accounts/emails/email_verification_body.txt
+++ b/src/accounts/templates/accounts/emails/email_verification_body.txt
@@ -2,7 +2,7 @@
 
 {% blocktrans %}Please verify your email and finish setting up your account.{% endblocktrans %}
 
-{{ verification_link }}
+{{ action_link }}
 
 {% blocktrans %}Thank you,
 The Revel Team{% endblocktrans %}

--- a/src/accounts/templates/accounts/emails/password_reset_body.html
+++ b/src/accounts/templates/accounts/emails/password_reset_body.html
@@ -9,7 +9,7 @@
     <p>{% blocktrans %}Please click the link below to set up a new password:{% endblocktrans %}</p>
 
     <p>
-        <a href="{{ password_reset_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
+        <a href="{{ action_link }}" style="display: inline-block; padding: 10px 20px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 5px;">
             {% trans "Reset Password" %}
         </a>
     </p>

--- a/src/accounts/templates/accounts/emails/password_reset_body.txt
+++ b/src/accounts/templates/accounts/emails/password_reset_body.txt
@@ -2,7 +2,7 @@
 
 {% blocktrans %}Please click the link below to set up a new password:{% endblocktrans %}
 
-{{ password_reset_link }}
+{{ action_link }}
 
 {% blocktrans %}If you didn't request this, you can safely ignore this email.{% endblocktrans %}
 

--- a/src/accounts/tests/test_account_email_task.py
+++ b/src/accounts/tests/test_account_email_task.py
@@ -1,8 +1,8 @@
-"""Byte-for-byte render coverage for the consolidated ``send_account_email`` task (issue #608).
+"""Render coverage for the consolidated ``send_account_email`` task (issue #608).
 
-Each case independently reconstructs the subject/body/html the old per-message wrapper produced
-and asserts the consolidated task renders exactly the same — locking the link paths and template
-context so the consolidation is behaviour-preserving.
+Each case independently re-renders the message's templates with the context the task is expected
+to build, then asserts the task produced exactly that subject/body/html — locking the link paths,
+the ``action_link`` key, and the per-type context so the task and its templates can't drift apart.
 """
 
 from unittest.mock import MagicMock, patch

--- a/src/accounts/tests/test_account_email_task.py
+++ b/src/accounts/tests/test_account_email_task.py
@@ -1,0 +1,168 @@
+"""Byte-for-byte render coverage for the consolidated ``send_account_email`` task (issue #608).
+
+Each case independently reconstructs the subject/body/html the old per-message wrapper produced
+and asserts the consolidated task renders exactly the same — locking the link paths and template
+context so the consolidation is behaviour-preserving.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.sites.models import Site
+from django.template.loader import render_to_string
+
+from accounts.tasks import AccountEmail, send_account_email
+from common.models import SiteSettings
+
+pytestmark = pytest.mark.django_db
+
+_TOKEN = "test-token-123"  # noqa: S105 — not a real secret
+
+
+def _render(
+    base: str, context: dict[str, str], *, subject_context: dict[str, str] | None = None
+) -> tuple[str, str, str]:
+    """Render the (subject, body, html_body) triad for an ``accounts/emails`` template base."""
+    subject = str(render_to_string(f"accounts/emails/{base}_subject.txt", subject_context or {}))
+    body = render_to_string(f"accounts/emails/{base}_body.txt", context)
+    html_body = render_to_string(f"accounts/emails/{base}_body.html", context)
+    return subject, body, html_body
+
+
+# (email_type, recipient, template_base, link_path, link_context_key, include_frontend_base_url, subject_site_name)
+_LINK_CASES = [
+    (
+        AccountEmail.VERIFICATION,
+        "u@example.com",
+        "email_verification",
+        "/login/confirm-email?token={token}",
+        "verification_link",
+        False,
+        False,
+    ),
+    (
+        AccountEmail.ACTIVATION,
+        "u@example.com",
+        "account_activation",
+        "/login/reset-password?token={token}",
+        "activation_link",
+        False,
+        False,
+    ),
+    (
+        AccountEmail.PASSWORD_RESET,
+        "u@example.com",
+        "password_reset",
+        "/login/reset-password?token={token}",
+        "password_reset_link",
+        False,
+        False,
+    ),
+    (
+        AccountEmail.CHANGE_CONFIRMATION,
+        "new@example.com",
+        "email_change_confirmation",
+        "/account/confirm-email-change?token={token}",
+        "confirmation_link",
+        True,
+        False,
+    ),
+    (
+        AccountEmail.DELETION,
+        "u@example.com",
+        "account_delete",
+        "/account/confirm-deletion?token={token}",
+        "account_deletion_link",
+        True,
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "email_type, to, base, link_path, link_key, include_fbu, subject_site_name",
+    _LINK_CASES,
+)
+@patch("accounts.tasks.email.send_email")
+def test_link_email_renders_byte_for_byte(
+    mock_send: MagicMock,
+    email_type: AccountEmail,
+    to: str,
+    base: str,
+    link_path: str,
+    link_key: str,
+    include_fbu: bool,
+    subject_site_name: bool,
+) -> None:
+    site_settings = SiteSettings.get_solo()
+    full_link = site_settings.frontend_base_url + link_path.format(token=_TOKEN)
+    expected_context = {link_key: full_link}
+    if include_fbu:
+        expected_context["frontend_base_url"] = site_settings.frontend_base_url
+    subject_context = {"site_name": Site.objects.get_current().name} if subject_site_name else {}
+    exp_subject, exp_body, exp_html = _render(base, expected_context, subject_context=subject_context)
+
+    send_account_email(email_type, to, token=_TOKEN)
+
+    mock_send.assert_called_once()
+    kwargs = mock_send.call_args.kwargs
+    assert kwargs["to"] == to
+    assert kwargs["subject"] == exp_subject
+    assert kwargs["body"] == exp_body
+    assert kwargs["html_body"] == exp_html
+    # Lock the link path: the built action link must actually appear in the rendered email.
+    assert full_link in (exp_body + exp_html)
+
+
+# (email_type, recipient, template_base, extra_context) — informational emails, no token.
+_CONTEXT_CASES = [
+    (AccountEmail.CHANGE_NOTICE, "cur@example.com", "email_change_notice", {"masked_new_email": "n***@example.com"}),
+    (
+        AccountEmail.CHANGE_COMPLETED_OLD,
+        "old@example.com",
+        "email_change_completed_old",
+        {"old_email": "old@example.com", "new_email": "new@example.com"},
+    ),
+    (
+        AccountEmail.CHANGE_COMPLETED_NEW,
+        "new@example.com",
+        "email_change_completed_new",
+        {"old_email": "old@example.com", "new_email": "new@example.com"},
+    ),
+]
+
+
+@pytest.mark.parametrize("email_type, to, base, context", _CONTEXT_CASES)
+@patch("accounts.tasks.email.send_email")
+def test_context_email_renders_byte_for_byte(
+    mock_send: MagicMock,
+    email_type: AccountEmail,
+    to: str,
+    base: str,
+    context: dict[str, str],
+) -> None:
+    site_settings = SiteSettings.get_solo()
+    expected_context = {**context, "frontend_base_url": site_settings.frontend_base_url}
+    exp_subject, exp_body, exp_html = _render(base, expected_context)
+
+    send_account_email(email_type, to, context=context)
+
+    mock_send.assert_called_once()
+    kwargs = mock_send.call_args.kwargs
+    assert kwargs["to"] == to
+    assert kwargs["subject"] == exp_subject
+    assert kwargs["body"] == exp_body
+    assert kwargs["html_body"] == exp_html
+
+
+@patch("accounts.tasks.email.send_email")
+def test_link_email_without_token_raises(mock_send: MagicMock) -> None:
+    """A link-bearing email dispatched without a token is a programming error, not a silent no-op."""
+    with pytest.raises(ValueError, match="requires a token"):
+        send_account_email(AccountEmail.VERIFICATION, "u@example.com")
+    mock_send.assert_not_called()
+
+
+def test_email_type_accepts_raw_string_value() -> None:
+    """Celery serialises the StrEnum to its value; the task must accept the round-tripped string."""
+    assert AccountEmail("verification") is AccountEmail.VERIFICATION

--- a/src/accounts/tests/test_account_email_task.py
+++ b/src/accounts/tests/test_account_email_task.py
@@ -163,6 +163,14 @@ def test_link_email_without_token_raises(mock_send: MagicMock) -> None:
     mock_send.assert_not_called()
 
 
+@patch("accounts.tasks.email.send_email")
+def test_missing_required_context_raises(mock_send: MagicMock) -> None:
+    """A message dispatched without its required context keys fails fast, not with a partial render."""
+    with pytest.raises(ValueError, match="requires context keys: old_email, new_email"):
+        send_account_email(AccountEmail.CHANGE_COMPLETED_OLD, "old@example.com")
+    mock_send.assert_not_called()
+
+
 def test_email_type_accepts_raw_string_value() -> None:
     """Celery serialises the StrEnum to its value; the task must accept the round-tripped string."""
     assert AccountEmail("verification") is AccountEmail.VERIFICATION

--- a/src/accounts/tests/test_account_email_task.py
+++ b/src/accounts/tests/test_account_email_task.py
@@ -8,7 +8,6 @@ context so the consolidation is behaviour-preserving.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 
 from accounts.tasks import AccountEmail, send_account_email
@@ -19,70 +18,30 @@ pytestmark = pytest.mark.django_db
 _TOKEN = "test-token-123"  # noqa: S105 — not a real secret
 
 
-def _render(
-    base: str, context: dict[str, str], *, subject_context: dict[str, str] | None = None
-) -> tuple[str, str, str]:
+def _render(base: str, context: dict[str, str]) -> tuple[str, str, str]:
     """Render the (subject, body, html_body) triad for an ``accounts/emails`` template base."""
-    subject = str(render_to_string(f"accounts/emails/{base}_subject.txt", subject_context or {}))
+    subject = str(render_to_string(f"accounts/emails/{base}_subject.txt"))
     body = render_to_string(f"accounts/emails/{base}_body.txt", context)
     html_body = render_to_string(f"accounts/emails/{base}_body.html", context)
     return subject, body, html_body
 
 
-# (email_type, recipient, template_base, link_path, link_context_key, include_frontend_base_url, subject_site_name)
+# (email_type, recipient, template_base, link_path)
 _LINK_CASES = [
-    (
-        AccountEmail.VERIFICATION,
-        "u@example.com",
-        "email_verification",
-        "/login/confirm-email?token={token}",
-        "verification_link",
-        False,
-        False,
-    ),
-    (
-        AccountEmail.ACTIVATION,
-        "u@example.com",
-        "account_activation",
-        "/login/reset-password?token={token}",
-        "activation_link",
-        False,
-        False,
-    ),
-    (
-        AccountEmail.PASSWORD_RESET,
-        "u@example.com",
-        "password_reset",
-        "/login/reset-password?token={token}",
-        "password_reset_link",
-        False,
-        False,
-    ),
+    (AccountEmail.VERIFICATION, "u@example.com", "email_verification", "/login/confirm-email?token={token}"),
+    (AccountEmail.ACTIVATION, "u@example.com", "account_activation", "/login/reset-password?token={token}"),
+    (AccountEmail.PASSWORD_RESET, "u@example.com", "password_reset", "/login/reset-password?token={token}"),
     (
         AccountEmail.CHANGE_CONFIRMATION,
         "new@example.com",
         "email_change_confirmation",
         "/account/confirm-email-change?token={token}",
-        "confirmation_link",
-        True,
-        False,
     ),
-    (
-        AccountEmail.DELETION,
-        "u@example.com",
-        "account_delete",
-        "/account/confirm-deletion?token={token}",
-        "account_deletion_link",
-        True,
-        True,
-    ),
+    (AccountEmail.DELETION, "u@example.com", "account_delete", "/account/confirm-deletion?token={token}"),
 ]
 
 
-@pytest.mark.parametrize(
-    "email_type, to, base, link_path, link_key, include_fbu, subject_site_name",
-    _LINK_CASES,
-)
+@pytest.mark.parametrize("email_type, to, base, link_path", _LINK_CASES)
 @patch("accounts.tasks.email.send_email")
 def test_link_email_renders_byte_for_byte(
     mock_send: MagicMock,
@@ -90,17 +49,12 @@ def test_link_email_renders_byte_for_byte(
     to: str,
     base: str,
     link_path: str,
-    link_key: str,
-    include_fbu: bool,
-    subject_site_name: bool,
 ) -> None:
     site_settings = SiteSettings.get_solo()
     full_link = site_settings.frontend_base_url + link_path.format(token=_TOKEN)
-    expected_context = {link_key: full_link}
-    if include_fbu:
-        expected_context["frontend_base_url"] = site_settings.frontend_base_url
-    subject_context = {"site_name": Site.objects.get_current().name} if subject_site_name else {}
-    exp_subject, exp_body, exp_html = _render(base, expected_context, subject_context=subject_context)
+    # Every body gets frontend_base_url; every link-bearing template reads the same action_link key.
+    expected_context = {"frontend_base_url": site_settings.frontend_base_url, "action_link": full_link}
+    exp_subject, exp_body, exp_html = _render(base, expected_context)
 
     send_account_email(email_type, to, token=_TOKEN)
 

--- a/src/accounts/tests/test_account_service.py
+++ b/src/accounts/tests/test_account_service.py
@@ -12,6 +12,7 @@ from accounts import schema
 from accounts.jwt import create_token
 from accounts.models import Referral, ReferralCode, RevelUser
 from accounts.service import account as account_service
+from accounts.tasks import AccountEmail
 
 pytestmark = pytest.mark.django_db
 
@@ -49,7 +50,7 @@ class TestRegisterUserSchemaEmailNormalization:
         )
         assert payload.email == "user@example.com"
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_registration_saves_lowercase_email(self, mock_send_email: MagicMock) -> None:
         """Test that user registration saves email as lowercase in database."""
         payload = schema.RegisterUserSchema(
@@ -64,11 +65,11 @@ class TestRegisterUserSchemaEmailNormalization:
         assert user.username == "mixedcase@example.com"
 
 
-# transaction=True: register_user dispatches send_verification_email via transaction.on_commit.
+# transaction=True: register_user dispatches send_account_email via transaction.on_commit.
 # In default pytest-django mode the wrapping transaction is rolled back and the callback never
 # fires, breaking the delay_mock assertion.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_user_success(mock_send_email: MagicMock, valid_register_payload: schema.RegisterUserSchema) -> None:
     """Test successful user registration creates a user and sends an email."""
     assert RevelUser.objects.count() == 0
@@ -79,10 +80,10 @@ def test_register_user_success(mock_send_email: MagicMock, valid_register_payloa
     assert user.username == valid_register_payload.email
     assert not user.email_verified
     assert user.is_active  # Active by default to allow email verification
-    mock_send_email.assert_called_once_with(user.email, token)
+    mock_send_email.assert_called_once_with(AccountEmail.VERIFICATION, user.email, token=token)
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_user_already_exists(
     mock_send_email: MagicMock, user: RevelUser, valid_register_payload: schema.RegisterUserSchema
 ) -> None:
@@ -98,7 +99,7 @@ def test_register_user_already_exists(
     mock_send_email.assert_not_called()
 
 
-@patch("accounts.tasks.send_account_activation_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_user_sends_activation_for_guest(mock_activation: MagicMock, guest_user: RevelUser) -> None:
     """Test that registering with a guest email sends activation email and raises 400."""
     original_password = guest_user.password
@@ -123,7 +124,7 @@ def test_register_user_sends_activation_for_guest(mock_activation: MagicMock, gu
     assert guest_user.password == original_password
 
 
-@patch("accounts.tasks.send_account_activation_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_user_sends_activation_for_verified_guest(mock_activation: MagicMock, guest_user: RevelUser) -> None:
     """Test that registration sends activation for a guest even with anomalous email_verified=True."""
     guest_user.email_verified = True
@@ -146,7 +147,7 @@ def test_register_user_sends_activation_for_verified_guest(mock_activation: Magi
     assert guest_user.guest is True
 
 
-@patch("accounts.tasks.send_account_activation_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_guest_activation_uses_password_reset_token(mock_activation: MagicMock, guest_user: RevelUser) -> None:
     """Test that the activation email uses a password-reset token so reset_password() handles conversion."""
     payload = schema.RegisterUserSchema(
@@ -160,7 +161,7 @@ def test_register_guest_activation_uses_password_reset_token(mock_activation: Ma
         account_service.register_user(payload)
 
     mock_activation.assert_called_once()
-    token = mock_activation.call_args[0][1]
+    token = mock_activation.call_args.kwargs["token"]
     # The token must be decodable as a PasswordResetJWTPayloadSchema
     decoded = account_service.token_to_payload(token, schema.PasswordResetJWTPayloadSchema)
     assert decoded.user_id == guest_user.id
@@ -253,7 +254,7 @@ def test_resend_verification_email_blocks_guest_user(mock_send: MagicMock, guest
     assert guest_user.email_verified is False
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_register_user_existing_unverified_non_guest(
     mock_send_email: MagicMock, user: RevelUser, valid_register_payload: schema.RegisterUserSchema
 ) -> None:
@@ -269,18 +270,18 @@ def test_register_user_existing_unverified_non_guest(
     mock_send_email.assert_called_once()
 
 
-# transaction=True: request_password_reset dispatches send_password_reset_link via transaction.on_commit.
+# transaction=True: request_password_reset dispatches send_account_email via transaction.on_commit.
 # Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_password_reset_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_request_password_reset_success(mock_send_email: MagicMock, user: RevelUser) -> None:
     """Test requesting a password reset sends an email for an existing user."""
     token = account_service.request_password_reset(user.email)
     assert token is not None
-    mock_send_email.assert_called_once_with(user.email, token)
+    mock_send_email.assert_called_once_with(AccountEmail.PASSWORD_RESET, user.email, token=token)
 
 
-@patch("accounts.tasks.send_password_reset_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_request_password_reset_nonexistent_user(mock_send_email: MagicMock) -> None:
     """Test that no email is sent for a nonexistent user (to prevent enumeration)."""
     token = account_service.request_password_reset("nobody@example.com")
@@ -288,7 +289,7 @@ def test_request_password_reset_nonexistent_user(mock_send_email: MagicMock) -> 
     mock_send_email.assert_not_called()
 
 
-@patch("accounts.tasks.send_password_reset_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_request_password_reset_for_google_user(mock_send_email: MagicMock, google_user: RevelUser) -> None:
     """Test that password reset is disabled for Google SSO users."""
     token = account_service.request_password_reset(google_user.email)
@@ -296,15 +297,15 @@ def test_request_password_reset_for_google_user(mock_send_email: MagicMock, goog
     mock_send_email.assert_not_called()
 
 
-# transaction=True: request_password_reset dispatches send_password_reset_link via transaction.on_commit.
+# transaction=True: request_password_reset dispatches send_account_email via transaction.on_commit.
 # Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_password_reset_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_request_password_reset_for_guest_user(mock_send_email: MagicMock, guest_user: RevelUser) -> None:
     """Test that guest users can request a password reset (converts them on reset)."""
     token = account_service.request_password_reset(guest_user.email)
     assert token is not None
-    mock_send_email.assert_called_once_with(guest_user.email, token)
+    mock_send_email.assert_called_once_with(AccountEmail.PASSWORD_RESET, guest_user.email, token=token)
 
 
 def test_reset_password_converts_guest_user(guest_user: RevelUser) -> None:
@@ -351,15 +352,15 @@ def test_reset_password_for_google_user_fails(google_user: RevelUser) -> None:
         account_service.reset_password(token, "any-password")
 
 
-# transaction=True: request_account_deletion dispatches send_account_deletion_link via transaction.on_commit.
+# transaction=True: request_account_deletion dispatches send_account_email via transaction.on_commit.
 # Default pytest-django mode rolls back the wrapping transaction so the callback never fires.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_account_deletion_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_request_account_deletion(mock_send_email: MagicMock, user: RevelUser) -> None:
     """Test that requesting account deletion sends the correct email task."""
     token = account_service.request_account_deletion(user)
     assert token is not None
-    mock_send_email.assert_called_once_with(user.email, token)
+    mock_send_email.assert_called_once_with(AccountEmail.DELETION, user.email, token=token)
 
 
 # transaction=True: confirm_account_deletion dispatches delete_user_account via transaction.on_commit.
@@ -380,7 +381,7 @@ def test_confirm_account_deletion_success(user: RevelUser) -> None:
     assert not RevelUser.objects.filter(id=user_id).exists()
 
 
-@patch("accounts.tasks.send_account_activation_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_full_guest_to_full_user_lifecycle(mock_activation: MagicMock, guest_user: RevelUser) -> None:
     """Test the complete guest activation lifecycle.
 
@@ -404,7 +405,7 @@ def test_full_guest_to_full_user_lifecycle(mock_activation: MagicMock, guest_use
         account_service.register_user(payload)
 
     mock_activation.assert_called_once()
-    activation_token = mock_activation.call_args[0][1]
+    activation_token = mock_activation.call_args.kwargs["token"]
 
     # Guest is still a guest
     guest_user.refresh_from_db()
@@ -437,7 +438,7 @@ class TestRegisterWithReferralCode:
     def active_code(self, referrer: RevelUser) -> ReferralCode:
         return ReferralCode.objects.create(user=referrer, code="TESTCODE")
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_register_with_valid_referral_code(self, mock_send_email: MagicMock, active_code: ReferralCode) -> None:
         """Test that a valid referral code creates a Referral record."""
         payload = schema.RegisterUserSchema(
@@ -455,7 +456,7 @@ class TestRegisterWithReferralCode:
         assert referral.referrer == active_code.user
         assert referral.revenue_share_percent == settings.DEFAULT_REFERRAL_SHARE_PERCENT
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_register_with_case_insensitive_referral_code(
         self, mock_send_email: MagicMock, active_code: ReferralCode
     ) -> None:
@@ -505,7 +506,7 @@ class TestRegisterWithReferralCode:
 
         assert RevelUser.objects.filter(email="referred@example.com").count() == 0
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_register_without_referral_code(self, mock_send_email: MagicMock) -> None:
         """Test that registration without a referral code creates no Referral."""
         payload = schema.RegisterUserSchema(

--- a/src/accounts/tests/test_controllers/test_account_controller.py
+++ b/src/accounts/tests/test_controllers/test_account_controller.py
@@ -69,11 +69,11 @@ def test_verify_email_success(
     assert data["token"]["access"] == "access_token"
 
 
-# transaction=True: resend_verification_email dispatches send_verification_email via
+# transaction=True: resend_verification_email dispatches send_account_email via
 # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
 # and the callback never fires, breaking the delay_mock assertion.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_resend_verification_email_success(
     mock_send_email: MagicMock, client: Client, unverified_user: RevelUser
 ) -> None:
@@ -87,7 +87,7 @@ def test_resend_verification_email_success(
     mock_send_email.assert_called_once()
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_resend_verification_email_for_verified_user(
     mock_send_email: MagicMock, client: Client, user: RevelUser
 ) -> None:
@@ -104,7 +104,7 @@ def test_resend_verification_email_for_verified_user(
     mock_send_email.assert_not_called()
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_resend_verification_email_nonexistent_user(mock_send_email: MagicMock, client: Client) -> None:
     """Test resending verification for a non-existent user returns 200 (security by obscurity)."""
     url = reverse("api:resend-verification-email")
@@ -117,11 +117,11 @@ def test_resend_verification_email_nonexistent_user(mock_send_email: MagicMock, 
     mock_send_email.assert_not_called()
 
 
-# transaction=True: request_account_deletion dispatches send_account_deletion_link via
+# transaction=True: request_account_deletion dispatches send_account_email via
 # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
 # and the callback never fires, breaking the delay_mock assertion.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_account_deletion_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_delete_account_request(mock_send_email: MagicMock, auth_client: Client) -> None:
     """Test that requesting account deletion returns 200."""
     url = reverse("api:delete-account-request")
@@ -144,11 +144,11 @@ def test_delete_account_confirm(mock_confirm_delete: MagicMock, client: Client) 
     mock_confirm_delete.assert_called_once_with("valid.deletion.token")
 
 
-# transaction=True: request_password_reset dispatches send_password_reset_link via
+# transaction=True: request_password_reset dispatches send_account_email via
 # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
 # and the callback never fires, breaking the delay_mock assertion.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_password_reset_link.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_password_reset_request(mock_send_email: MagicMock, client: Client, user: RevelUser) -> None:
     """Test password reset request returns 200, preventing user enumeration."""
     url = reverse("api:reset-password-request")

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -20,6 +20,14 @@ from accounts import schema
 from accounts.jwt import create_token
 from accounts.models import GlobalBan, RevelUser
 from accounts.service import account as account_service
+from accounts.tasks import AccountEmail
+
+
+def _call_for(mock: MagicMock, email_type: AccountEmail) -> t.Any:
+    """Return the single send_account_email.delay call matching ``email_type``."""
+    calls = [c for c in mock.call_args_list if c.args[0] == email_type]
+    assert len(calls) == 1, f"expected exactly one {email_type} call, got {len(calls)}"
+    return calls[0]
 
 
 def _jti(token: str) -> str:
@@ -52,41 +60,41 @@ class TestRequestEmailChange:
     # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled
     # back and the callbacks never fire, breaking the delay_mock assertions.
     @pytest.mark.django_db(transaction=True)
-    @patch("accounts.tasks.send_email_change_notice.delay")
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_success(
         self,
-        mock_send_conf: MagicMock,
-        mock_send_notice: MagicMock,
+        mock_send: MagicMock,
         user: RevelUser,
     ) -> None:
         token = account_service.request_email_change(
             user=user, new_email="new@example.com", password="strong-password-123!"
         )
         assert token
-        mock_send_conf.assert_called_once_with("new@example.com", token)
-        mock_send_notice.assert_called_once()
-        notice_args = mock_send_notice.call_args
-        assert notice_args.args[0] == user.email
+        conf_call = _call_for(mock_send, AccountEmail.CHANGE_CONFIRMATION)
+        assert conf_call.args == (AccountEmail.CHANGE_CONFIRMATION, "new@example.com")
+        assert conf_call.kwargs == {"token": token}
+        notice_call = _call_for(mock_send, AccountEmail.CHANGE_NOTICE)
+        assert notice_call.args[1] == user.email
+        masked = notice_call.kwargs["context"]["masked_new_email"]
         # Masking: a****@example.com style
-        assert notice_args.args[1].endswith("@example.com")
-        assert "*" in notice_args.args[1]
+        assert masked.endswith("@example.com")
+        assert "*" in masked
 
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_wrong_password(self, mock_send: MagicMock, user: RevelUser) -> None:
         with pytest.raises(HttpError) as exc:
             account_service.request_email_change(user=user, new_email="new@example.com", password="WRONG")
         assert exc.value.status_code == 400
         mock_send.assert_not_called()
 
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_same_email(self, mock_send: MagicMock, user: RevelUser) -> None:
         with pytest.raises(HttpError) as exc:
             account_service.request_email_change(user=user, new_email=user.email, password="strong-password-123!")
         assert exc.value.status_code == 400
         mock_send.assert_not_called()
 
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_duplicate_email(self, mock_send: MagicMock, user: RevelUser, django_user_model: t.Type[RevelUser]) -> None:
         django_user_model.objects.create_user(username="taken@example.com", email="taken@example.com", password="x")
         with pytest.raises(HttpError) as exc:
@@ -96,7 +104,7 @@ class TestRequestEmailChange:
         assert exc.value.status_code == 400
         mock_send.assert_not_called()
 
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_duplicate_email_case_insensitive(
         self, mock_send: MagicMock, user: RevelUser, django_user_model: t.Type[RevelUser]
     ) -> None:
@@ -108,7 +116,7 @@ class TestRequestEmailChange:
             )
         mock_send.assert_not_called()
 
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_google_sso_user_rejected(self, mock_send: MagicMock, google_user: RevelUser) -> None:
         # Real SSO accounts have only the sentinel password — do not override it. The
         # SSO branch must fire before the password check, otherwise these users get the
@@ -119,12 +127,10 @@ class TestRequestEmailChange:
         assert "SSO" in str(exc.value.message)
         mock_send.assert_not_called()
 
-    @patch("accounts.tasks.send_email_change_notice.delay")
-    @patch("accounts.tasks.send_email_change_confirmation.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_globally_banned_target_no_op(
         self,
-        mock_send_conf: MagicMock,
-        mock_send_notice: MagicMock,
+        mock_send: MagicMock,
         user: RevelUser,
     ) -> None:
         GlobalBan.objects.create(
@@ -136,8 +142,7 @@ class TestRequestEmailChange:
             user=user, new_email="banned@example.com", password="strong-password-123!"
         )
         assert token == ""
-        mock_send_conf.assert_not_called()
-        mock_send_notice.assert_not_called()
+        mock_send.assert_not_called()
 
 
 # ===== Service: confirm_email_change =====
@@ -159,12 +164,10 @@ class TestConfirmEmailChange:
     # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled
     # back and the callbacks never fire, breaking the delay_mock assertions.
     @pytest.mark.django_db(transaction=True)
-    @patch("accounts.tasks.send_email_change_completed_new.delay")
-    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_success(
         self,
-        mock_send_old: MagicMock,
-        mock_send_new: MagicMock,
+        mock_send: MagicMock,
         user: RevelUser,
     ) -> None:
         old_email = user.email
@@ -176,15 +179,18 @@ class TestConfirmEmailChange:
         assert result.email == "new@example.com"
         assert result.username == "new@example.com"
         assert result.email_verified is True
-        mock_send_old.assert_called_once_with(old_email, "new@example.com")
-        mock_send_new.assert_called_once_with("new@example.com", old_email)
+        expected_context = {"old_email": old_email, "new_email": "new@example.com"}
+        old_call = _call_for(mock_send, AccountEmail.CHANGE_COMPLETED_OLD)
+        assert old_call.args == (AccountEmail.CHANGE_COMPLETED_OLD, old_email)
+        assert old_call.kwargs == {"context": expected_context}
+        new_call = _call_for(mock_send, AccountEmail.CHANGE_COMPLETED_NEW)
+        assert new_call.args == (AccountEmail.CHANGE_COMPLETED_NEW, "new@example.com")
+        assert new_call.kwargs == {"context": expected_context}
 
-    @patch("accounts.tasks.send_email_change_completed_new.delay")
-    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_blacklists_all_user_tokens(
         self,
-        mock_old: MagicMock,
-        mock_new: MagicMock,
+        mock_send: MagicMock,
         user: RevelUser,
     ) -> None:
         # Issue a couple of refresh tokens for the user — they should all be blacklisted.
@@ -205,9 +211,8 @@ class TestConfirmEmailChange:
             account_service.confirm_email_change(token)
         assert exc.value.status_code == 400
 
-    @patch("accounts.tasks.send_email_change_completed_new.delay")
-    @patch("accounts.tasks.send_email_change_completed_old.delay")
-    def test_blacklisted_token_rejected(self, mock_old: MagicMock, mock_new: MagicMock, user: RevelUser) -> None:
+    @patch("accounts.tasks.send_account_email.delay")
+    def test_blacklisted_token_rejected(self, mock_send: MagicMock, user: RevelUser) -> None:
         token = _make_change_token(user, "new@example.com")
         account_service.confirm_email_change(token)
         # The specific JTI is blacklisted.
@@ -216,12 +221,10 @@ class TestConfirmEmailChange:
         with pytest.raises(HttpError):
             account_service.confirm_email_change(token)
 
-    @patch("accounts.tasks.send_email_change_completed_new.delay")
-    @patch("accounts.tasks.send_email_change_completed_old.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_race_email_taken(
         self,
-        mock_old: MagicMock,
-        mock_new: MagicMock,
+        mock_send: MagicMock,
         user: RevelUser,
         django_user_model: t.Type[RevelUser],
     ) -> None:
@@ -259,11 +262,8 @@ class TestConfirmEmailChange:
 # transaction.on_commit. In default pytest-django mode the wrapping transaction is rolled back
 # and the callbacks never fire, breaking the delay_mock assertions.
 @pytest.mark.django_db(transaction=True)
-@patch("accounts.tasks.send_email_change_notice.delay")
-@patch("accounts.tasks.send_email_change_confirmation.delay")
-def test_email_change_request_endpoint(
-    mock_conf: MagicMock, mock_notice: MagicMock, auth_client: Client, user: RevelUser
-) -> None:
+@patch("accounts.tasks.send_account_email.delay")
+def test_email_change_request_endpoint(mock_send: MagicMock, auth_client: Client, user: RevelUser) -> None:
     url = reverse("api:email-change-request")
     response = auth_client.post(
         url,
@@ -272,8 +272,8 @@ def test_email_change_request_endpoint(
     )
     assert response.status_code == 200, response.content
     assert "confirmation link" in response.json()["message"].lower()
-    mock_conf.assert_called_once()
-    mock_notice.assert_called_once()
+    _call_for(mock_send, AccountEmail.CHANGE_CONFIRMATION)
+    _call_for(mock_send, AccountEmail.CHANGE_NOTICE)
 
 
 def test_email_change_request_requires_auth(client: Client) -> None:
@@ -286,11 +286,9 @@ def test_email_change_request_requires_auth(client: Client) -> None:
     assert response.status_code == 401
 
 
-@patch("accounts.tasks.send_email_change_completed_new.delay")
-@patch("accounts.tasks.send_email_change_completed_old.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_email_change_confirm_endpoint(
-    mock_old: MagicMock,
-    mock_new: MagicMock,
+    mock_send: MagicMock,
     client: Client,
     user: RevelUser,
 ) -> None:
@@ -308,11 +306,9 @@ def test_email_change_confirm_endpoint(
     assert "refresh" in data["token"]
 
 
-@patch("accounts.tasks.send_email_change_completed_new.delay")
-@patch("accounts.tasks.send_email_change_completed_old.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_full_flow_old_refresh_tokens_invalidated(
-    mock_old: MagicMock,
-    mock_new: MagicMock,
+    mock_send: MagicMock,
     client: Client,
     user: RevelUser,
 ) -> None:

--- a/src/accounts/tests/test_email_change.py
+++ b/src/accounts/tests/test_email_change.py
@@ -70,6 +70,8 @@ class TestRequestEmailChange:
             user=user, new_email="new@example.com", password="strong-password-123!"
         )
         assert token
+        # Exactly the confirmation + notice emails — no extra/unrelated dispatch.
+        assert mock_send.call_count == 2
         conf_call = _call_for(mock_send, AccountEmail.CHANGE_CONFIRMATION)
         assert conf_call.args == (AccountEmail.CHANGE_CONFIRMATION, "new@example.com")
         assert conf_call.kwargs == {"token": token}
@@ -179,6 +181,8 @@ class TestConfirmEmailChange:
         assert result.email == "new@example.com"
         assert result.username == "new@example.com"
         assert result.email_verified is True
+        # Exactly the completed-old + completed-new emails — no extra/unrelated dispatch.
+        assert mock_send.call_count == 2
         expected_context = {"old_email": old_email, "new_email": "new@example.com"}
         old_call = _call_for(mock_send, AccountEmail.CHANGE_COMPLETED_OLD)
         assert old_call.args == (AccountEmail.CHANGE_COMPLETED_OLD, old_email)

--- a/src/accounts/tests/test_email_mailpit_integration.py
+++ b/src/accounts/tests/test_email_mailpit_integration.py
@@ -1,0 +1,157 @@
+"""Integration tests for the consolidated ``send_account_email`` task against a live Mailpit.
+
+These send each account email type through the **real SMTP path** (Django's SMTP backend →
+Mailpit on ``localhost:1025``) and assert via Mailpit's REST API (``localhost:8025``) that the
+message actually arrived with the right subject, recipient, and rendered ``action_link`` /
+context. This is the end-to-end complement to ``test_account_email_task.py`` (which asserts the
+in-process render): here a real mailbox receives a real MIME message.
+
+Excluded from normal runs and CI (``addopts = -m 'not integration'``). Run manually with Mailpit
+up (``docker compose up -d mailpit``):
+
+    pytest -m integration src/accounts/tests/test_email_mailpit_integration.py -v
+
+Override the Mailpit API base with ``MAILPIT_API_URL`` if not on the default port.
+"""
+
+import os
+import time
+import typing as t
+import uuid
+
+import httpx
+import pytest
+from django.test import override_settings
+
+from accounts.tasks import AccountEmail, send_account_email
+from common.models import SiteSettings
+
+MAILPIT_API = os.environ.get("MAILPIT_API_URL", "http://localhost:8025/api/v1")
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def _require_mailpit() -> None:
+    """Skip cleanly when Mailpit isn't running.
+
+    Done as an autouse fixture (not an import-time ``skipif``) so the reachability probe only
+    fires when these integration tests actually run — never during normal ``make test`` collection.
+    """
+    try:
+        reachable = httpx.get(f"{MAILPIT_API}/info", timeout=2.0).status_code == 200
+    except httpx.HTTPError:
+        reachable = False
+    if not reachable:
+        pytest.skip(f"Mailpit not reachable at {MAILPIT_API}")
+
+
+# Route Django's mailer at the live Mailpit SMTP listener for the duration of these tests,
+# regardless of the ambient .env (EMAIL_DRY_RUN, console backend, etc.).
+_smtp_to_mailpit = override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+    EMAIL_HOST="localhost",
+    EMAIL_PORT=1025,
+    EMAIL_USE_TLS=False,
+    EMAIL_USE_SSL=False,
+)
+
+
+def _wait_for_message(to_address: str, *, attempts: int = 20, delay: float = 0.25) -> dict[str, t.Any]:
+    """Poll Mailpit until exactly one message addressed to ``to_address`` shows up; return its detail."""
+    for _ in range(attempts):
+        resp = httpx.get(f"{MAILPIT_API}/search", params={"query": f"to:{to_address}"}, timeout=5.0)
+        resp.raise_for_status()
+        messages = resp.json()["messages"]
+        if messages:
+            detail = httpx.get(f"{MAILPIT_API}/message/{messages[0]['ID']}", timeout=5.0)
+            detail.raise_for_status()
+            return t.cast(dict[str, t.Any], detail.json())
+        time.sleep(delay)
+    raise AssertionError(f"no Mailpit message delivered to {to_address} within {attempts * delay:.1f}s")
+
+
+def _enable_live_emails() -> str:
+    """Set the solo SiteSettings so recipients aren't catch-all-rewritten; return frontend_base_url."""
+    site = SiteSettings.get_solo()
+    site.live_emails = True
+    site.save(update_fields=["live_emails"])
+    return t.cast(str, site.frontend_base_url)
+
+
+def _unique_recipient() -> str:
+    return f"acct-email-it-{uuid.uuid4().hex}@example.com"
+
+
+_TOKEN = "mailpit-it-token-abc123"  # noqa: S105 — not a real secret
+
+
+def _link_cases() -> list[t.Any]:
+    """Link-bearing emails: (email_type, path that must appear as action_link)."""
+    return [
+        pytest.param(AccountEmail.VERIFICATION, "/login/confirm-email?token=", id="verification"),
+        pytest.param(AccountEmail.ACTIVATION, "/login/reset-password?token=", id="activation"),
+        pytest.param(AccountEmail.PASSWORD_RESET, "/login/reset-password?token=", id="password_reset"),
+        pytest.param(
+            AccountEmail.CHANGE_CONFIRMATION, "/account/confirm-email-change?token=", id="change_confirmation"
+        ),
+        pytest.param(AccountEmail.DELETION, "/account/confirm-deletion?token=", id="deletion"),
+    ]
+
+
+@_smtp_to_mailpit
+@pytest.mark.parametrize("email_type, link_path", _link_cases())
+def test_link_email_delivered_to_mailpit(email_type: AccountEmail, link_path: str) -> None:
+    base_url = _enable_live_emails()
+    to = _unique_recipient()
+    expected_link = f"{base_url}{link_path}{_TOKEN}"
+
+    send_account_email(email_type, to, token=_TOKEN)
+
+    msg = _wait_for_message(to)
+    assert msg["To"][0]["Address"] == to
+    assert msg["Subject"].strip()  # a real, rendered subject line
+    # The action link must appear in both the text and HTML parts.
+    assert expected_link in msg["Text"]
+    assert expected_link in msg["HTML"]
+
+
+@_smtp_to_mailpit
+def test_change_notice_delivered_to_mailpit() -> None:
+    base_url = _enable_live_emails()
+    to = _unique_recipient()
+    masked = "n***@example.com"
+
+    send_account_email(AccountEmail.CHANGE_NOTICE, to, context={"masked_new_email": masked})
+
+    msg = _wait_for_message(to)
+    assert msg["To"][0]["Address"] == to
+    assert msg["Subject"].strip()
+    assert masked in msg["Text"]
+    assert masked in msg["HTML"]
+    # frontend_base_url is injected into every body; this template renders it.
+    assert base_url in msg["Text"]
+
+
+@_smtp_to_mailpit
+@pytest.mark.parametrize(
+    "email_type",
+    [
+        pytest.param(AccountEmail.CHANGE_COMPLETED_OLD, id="completed_old"),
+        pytest.param(AccountEmail.CHANGE_COMPLETED_NEW, id="completed_new"),
+    ],
+)
+def test_change_completed_delivered_to_mailpit(email_type: AccountEmail) -> None:
+    _enable_live_emails()
+    to = _unique_recipient()
+    old_email, new_email = "old-addr@example.com", "new-addr@example.com"
+
+    send_account_email(email_type, to, context={"old_email": old_email, "new_email": new_email})
+
+    msg = _wait_for_message(to)
+    assert msg["To"][0]["Address"] == to
+    assert msg["Subject"].strip()
+    # Both addresses are referenced in the completion bodies.
+    assert old_email in msg["Text"]
+    assert new_email in msg["Text"]

--- a/src/accounts/tests/test_email_mailpit_integration.py
+++ b/src/accounts/tests/test_email_mailpit_integration.py
@@ -77,7 +77,7 @@ def _enable_live_emails() -> str:
     site = SiteSettings.get_solo()
     site.live_emails = True
     site.save(update_fields=["live_emails"])
-    return t.cast(str, site.frontend_base_url)
+    return site.frontend_base_url
 
 
 def _unique_recipient() -> str:

--- a/src/accounts/tests/test_global_ban.py
+++ b/src/accounts/tests/test_global_ban.py
@@ -628,7 +628,7 @@ class TestProcessDomainBanTask:
 class TestRegistrationBanGuard:
     """Tests for ban check in register_user."""
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_registration_blocked_for_banned_email(self, mock_email: MagicMock, admin_user: RevelUser) -> None:
         GlobalBan.objects.create(
             ban_type=GlobalBan.BanType.EMAIL,
@@ -648,7 +648,7 @@ class TestRegistrationBanGuard:
         assert exc_info.value.status_code == 403
         assert "not available" in str(exc_info.value)
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_registration_blocked_for_banned_domain(self, mock_email: MagicMock, admin_user: RevelUser) -> None:
         GlobalBan.objects.create(
             ban_type=GlobalBan.BanType.DOMAIN,
@@ -667,7 +667,7 @@ class TestRegistrationBanGuard:
             account_service.register_user(payload)
         assert exc_info.value.status_code == 403
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_registration_allowed_for_clean_email(self, mock_email: MagicMock) -> None:
         payload = schema.RegisterUserSchema(
             email="clean@example.com",
@@ -684,7 +684,7 @@ class TestRegistrationBanGuard:
 class TestVerifyEmailBanGuard:
     """Tests for ban check in verify_email."""
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_verify_email_blocked_for_banned_user(
         self,
         mock_email: MagicMock,
@@ -710,7 +710,7 @@ class TestVerifyEmailBanGuard:
             account_service.verify_email(token)
         assert exc_info.value.status_code == 403
 
-    @patch("accounts.tasks.send_verification_email.delay")
+    @patch("accounts.tasks.send_account_email.delay")
     def test_verify_email_allowed_for_clean_user(
         self,
         mock_email: MagicMock,

--- a/src/accounts/tests/test_i18n.py
+++ b/src/accounts/tests/test_i18n.py
@@ -23,7 +23,7 @@ def test_user_language_field_choices(user: RevelUser) -> None:
     assert user.language in valid_languages
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_error_message_translation_german(mock_send_email: object, user: RevelUser) -> None:
     """Test that error messages are translated to German."""
     with translation.override("de"):
@@ -40,7 +40,7 @@ def test_error_message_translation_german(mock_send_email: object, user: RevelUs
             )
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_error_message_translation_italian(mock_send_email: object, user: RevelUser) -> None:
     """Test that error messages are translated to Italian."""
     with translation.override("it"):
@@ -57,7 +57,7 @@ def test_error_message_translation_italian(mock_send_email: object, user: RevelU
             )
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_error_message_translation_french(mock_send_email: object, user: RevelUser) -> None:
     """Test that error messages are translated to French."""
     with translation.override("fr"):
@@ -74,7 +74,7 @@ def test_error_message_translation_french(mock_send_email: object, user: RevelUs
             )
 
 
-@patch("accounts.tasks.send_verification_email.delay")
+@patch("accounts.tasks.send_account_email.delay")
 def test_error_message_default_english(mock_send_email: object, user: RevelUser) -> None:
     """Test that error messages default to English when no translation is active."""
     with translation.override("en"):


### PR DESCRIPTION
Closes #608.

Consolidates the 8 near-identical transactional account email wrappers in `accounts/tasks/email.py` into a single template-driven Celery task.

## What changed

- **One task replaces eight.** `send_account_email(email_type, to, *, token=None, context=None)` (pinned name `accounts.tasks.send_account_email`) renders + sends every account email. An `AccountEmail` `StrEnum` names the message types; a frozen-dataclass `_CONFIGS` table captures each type's `template_base`, frontend `link_path`, context key, and whether it needs `frontend_base_url` / `site_name`. The task rebuilds the exact context each old wrapper built.
- **Dispatchers migrated** — all 8 `.delay()` sites in `service/account.py` now call `send_account_email.delay(AccountEmail.X, to, token=…/context=…)`.
- **Tests migrated** — ~40 patch points moved to `accounts.tasks.send_account_email.delay`. The email-change tests that previously patched two distinct task names now patch the single task and filter `call_args_list` by `email_type` (via a `_call_for` helper).
- **New coverage** — `test_account_email_task.py` asserts **byte-for-byte** equivalence per message type (independently reconstructs the expected subject/body/html and compares), locks each frontend link path, and covers the missing-token error path.

## Task-name strategy (clean cut)

The 8 old registered Celery names are **removed**, not shimmed. Decided in favor of a clean cut because:

- None of the 8 are beat-scheduled → no `PeriodicTask` rows / migration impact.
- Deploys run `safe_reboot`, which drains Celery to empty before workers restart → no in-flight message references a removed name at cutover; low traffic makes the version-skew window negligible.

> ⚠️ **Deploy note:** this PR removes the old task names — deploy **must** go through `safe_reboot` (Celery drained) so no queued old-name message is left unresolvable.

## Verification

- `ruff format` + `ruff check`: clean
- `mypy --strict`: clean on all changed files
- `make task-names`: ✅ every task declares an explicit `name=`
- Targeted tests: **143 passed** (consolidated-task, email-change, account-service, controller, i18n, global-ban, tasks suites)

## Out of scope

The #607 watch item (`questionnaires/service/questionnaire_service.py` nearing the 1000-line gate) is tracked separately in #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGTfpamTNcHS9UfB9HhKip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account lifecycle transactional emails (verification, activation, password reset, deletion, and email changes) are now sent via a single consistent background email sender.
  * Email-change notifications now deliver updates to both the old and new addresses with the required masked-context details.
* **Bug Fixes**
  * Deferred email sending is still only triggered after a successful transaction commit.
  * The consolidated sending flow validates required token/context before dispatching.
  * Updated email templates now use a shared `action_link` for all primary call-to-action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->