### PR TITLE
fix(events): allow filtering dashboard RSVPs by multiple statuses (#627)

### DIFF
--- a/src/events/filters.py
+++ b/src/events/filters.py
@@ -169,7 +169,7 @@ class OrganizationTokenFilterSchema(FilterSchema):
 class RSVPFilterSchema(FilterSchema):
     """Filter schema for event RSVPs."""
 
-    status: EventRSVP.RsvpStatus | None = None
+    status: t.Annotated[list[EventRSVP.RsvpStatus] | None, FilterLookup(q="status__in")] = None
     user_id: UUID | None = None
     include_past: bool = False
 

--- a/src/events/tests/test_controllers/test_dashboard_controller.py
+++ b/src/events/tests/test_controllers/test_dashboard_controller.py
@@ -668,6 +668,52 @@ def test_dashboard_rsvps(
     assert data["results"][0]["id"] == str(rsvp2.id)
 
 
+def test_dashboard_rsvps_multi_status_filter(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    organization: Organization,
+) -> None:
+    """Filtering by multiple statuses (e.g. ?status=yes&status=maybe) returns the union, excluding others."""
+    statuses = {
+        EventRSVP.RsvpStatus.YES: "Yes Event",
+        EventRSVP.RsvpStatus.MAYBE: "Maybe Event",
+        EventRSVP.RsvpStatus.NO: "No Event",
+    }
+    rsvps = {}
+    for i, (status, name) in enumerate(statuses.items()):
+        event = Event.objects.create(
+            organization=organization,
+            name=name,
+            slug=f"multi-status-{status}",
+            status="open",
+            start=timezone.now() + timedelta(days=i + 1),
+            end=timezone.now() + timedelta(days=i + 2),
+        )
+        rsvps[status] = EventRSVP.objects.create(event=event, user=dashboard_user, status=status)
+
+    url = reverse("api:dashboard_rsvps")
+
+    # Going + Maybe — the dashboard "upcoming RSVPs" use case — excludes No.
+    response = dashboard_client.get(url, {"status": ["yes", "maybe"]})
+    assert response.status_code == 200
+    data = response.json()
+    returned_ids = {r["id"] for r in data["results"]}
+    assert data["count"] == 2
+    assert returned_ids == {str(rsvps[EventRSVP.RsvpStatus.YES].id), str(rsvps[EventRSVP.RsvpStatus.MAYBE].id)}
+
+    # Single status still works (parses to a one-element list).
+    response = dashboard_client.get(url, {"status": ["no"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["results"][0]["id"] == str(rsvps[EventRSVP.RsvpStatus.NO].id)
+
+    # No status filter → all three statuses returned.
+    response = dashboard_client.get(url)
+    assert response.status_code == 200
+    assert response.json()["count"] == 3
+
+
 def test_dashboard_rsvps_include_past(
     dashboard_client: Client,
     dashboard_user: RevelUser,


### PR DESCRIPTION
## Summary

`RSVPFilterSchema.status` was single-valued, so a client could not request "Going **or** Maybe" RSVPs in one query. This makes `status` accept a list, filtered with `status__in`:

```python
status: t.Annotated[list[EventRSVP.RsvpStatus] | None, FilterLookup(q="status__in")] = None
```

So `GET /api/dashboard/rsvps?status=yes&status=maybe` returns the union. The change transparently upgrades **both** consumers of the schema (`/api/dashboard/rsvps` and the event-admin RSVP list) since they only delegate to `params.filter(qs)`.

## Why

The dashboard "Upcoming RSVPs" card currently only counts **Going** RSVPs, so tentative (**Maybe**) RSVPs are invisible — and an invisible maybe tends to become a no-show. The fix is to count **Going + Maybe** (excluding **No**, i.e. declined). The backend filter being single-valued blocked expressing that in one request; this unblocks it.

## Behaviour

- `?status=yes&status=maybe` → RSVPs with status `yes` **or** `maybe`, excludes `no`
- `?status=yes` (single) → still works (parses to `["yes"]`)
- no `status` param → all statuses (upcoming only by default)
- `include_past` / search / pagination unaffected

## Tests

- `test_dashboard_rsvps_multi_status_filter` — union, exclude-No, single-status, no-filter
- existing `test_dashboard_rsvps` already covers single-status (backward-compat guard)

## Checks

- `make format`, `make lint`, `make mypy --strict` all clean
- OpenAPI regenerated: `status` is now `array<RsvpStatus> | null`

## Follow-up

Frontend consumes the new list type and ships the dashboard change independently: letsrevel/revel-frontend#511.

Closes #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSVP filtering now supports selecting multiple statuses at once, returning all matching results.
  * Requests without a status filter continue to return the full set of RSVP records.

* **Tests**
  * Added coverage for multi-status RSVP filtering, including combined, single-status, and unfiltered responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->