### PR TITLE
feat: PR-driven releases + /release command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -42,8 +42,10 @@ Bump level requested (may be empty): $ARGUMENTS
 
 9. **Push and open the PR:**
    `git push -u origin release/vX.Y.Z`
-   then `gh pr create --base main --head release/vX.Y.Z --title "chore(release): vX.Y.Z"
-   --body-file <file containing exactly the new ## [X.Y.Z] section>`.
+   then write the new `## [X.Y.Z]` CHANGELOG section to a temporary file
+   (e.g. `BODY=$(mktemp)`), pass it via
+   `gh pr create --base main --head release/vX.Y.Z --title "chore(release): vX.Y.Z" --body-file "$BODY"`,
+   then remove it (`rm -f "$BODY"`).
    The PR body is a review copy only — on merge the workflow re-extracts the section from the
    merged `CHANGELOG.md` as the canonical release notes. Print the PR URL.
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,53 @@
+---
+description: Cut a release — reconcile CHANGELOG, bump version, open a release/vX.Y.Z PR
+argument-hint: "[major|minor|patch]"
+---
+
+Drive the local half of a release. On merge of the PR you open, `.github/workflows/release.yaml`
+creates the tag and GitHub release automatically. **Never create tags or releases yourself** —
+your job ends at opening the PR.
+
+Bump level requested (may be empty): $ARGUMENTS
+
+## Steps
+
+1. **Pre-flight.** Run `git fetch origin` and ensure the working tree is clean and `main` is
+   up to date (`git status`, `git rev-parse HEAD origin/main`). If dirty or behind, stop and
+   tell the user. Stay on `main` for now.
+
+2. **Reconcile the CHANGELOG first — never trust a stale `[Unreleased]`.** Invoke the
+   `update-changelog` skill via the Skill tool to bring `## [Unreleased]` in line with the
+   merged PRs/commits since the latest tag. Do not edit `pyproject.toml` or create tags here.
+
+3. **Determine the bump level.**
+   - If `$ARGUMENTS` is `major`, `minor`, or `patch`, use it.
+   - Otherwise infer from the now-accurate `[Unreleased]` section:
+     a `Breaking`/`Removed` entry → **major**; an `Added`/`Changed` entry → **minor**;
+     only `Fixed`/`Security` → **patch**. State your reasoning, propose the level, and
+     **ask the user to confirm before bumping**.
+
+4. **Compute the next version:** `uv version --bump <part> --dry-run --short` → `X.Y.Z`.
+
+5. **Cut the branch:** `git checkout -b release/vX.Y.Z` off the up-to-date `main`.
+
+6. **Bump:** `uv version --bump <part>` (writes `pyproject.toml`, keeps `uv.lock` in sync).
+   Never hand-edit the version.
+
+7. **Promote the CHANGELOG:** rename `## [Unreleased]` to `## [X.Y.Z] - <today's date, YYYY-MM-DD>`
+   and insert a fresh empty `## [Unreleased]` above it (preserve the link/section order
+   conventions already in the file).
+
+8. **Commit** the bump + changelog together:
+   `git add pyproject.toml uv.lock CHANGELOG.md && git commit -m "chore(release): vX.Y.Z"`.
+
+9. **Push and open the PR:**
+   `git push -u origin release/vX.Y.Z`
+   then `gh pr create --base main --head release/vX.Y.Z --title "chore(release): vX.Y.Z"
+   --body-file <file containing exactly the new ## [X.Y.Z] section>`.
+   The PR body is a review copy only — on merge the workflow re-extracts the section from the
+   merged `CHANGELOG.md` as the canonical release notes. Print the PR URL.
+
+## Notes
+- Tag/release name is always `vX.Y.Z` (required by `publish.yaml`); the branch is
+  `release/vX.Y.Z`; the PR title / squash commit is `chore(release): vX.Y.Z`.
+- `make release` remains the manual fallback and is unaffected by this command.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,13 @@ on:
     types: [closed]
     branches: [main]
 
+# Releases are low-frequency and must be serialized — never run two release jobs at once.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
-  contents: write   # create tag + release
+  contents: read   # the release/tag is created with the GitHub App token below, not GITHUB_TOKEN
 
 jobs:
   release:
@@ -15,10 +20,22 @@ jobs:
       startsWith(github.head_ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main (full history for tag checks + generate-notes)
+      # A GitHub App installation token (NOT the default GITHUB_TOKEN) is required: releases
+      # created with GITHUB_TOKEN do not trigger other workflows, so publish.yaml
+      # (on: release: published) would never run and the Docker image would never build.
+      # Setup: create a GitHub App with "Contents: write", install it on this repo, then set
+      #   vars.RELEASE_APP_ID and secrets.RELEASE_APP_PRIVATE_KEY.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout the merged commit (full history for tag checks + generate-notes)
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Resolve and validate versions
@@ -41,7 +58,7 @@ jobs:
 
       - name: Ensure tag/release does not already exist
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           V="v${{ steps.ver.outputs.version }}"
@@ -49,24 +66,25 @@ jobs:
           if gh release view "$V" >/dev/null 2>&1; then echo "::error::Release $V already exists"; exit 1; fi
 
       - name: Build release notes (curated CHANGELOG section + auto footer)
-        id: notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.ver.outputs.version }}"
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
           awk -v ver="$VERSION" '
             $0 ~ "^## \\[" ver "\\]" {flag=1; next}
             flag && /^## \[/ {exit}
             flag {print}
           ' CHANGELOG.md > curated.md
-          # Trim leading/trailing blank lines
+          # Trim leading and trailing blank lines (tac reverses so one leading-trim handles the tail)
           sed -i -e '/./,$!d' curated.md
+          tac curated.md | sed -e '/./,$!d' | tac > curated.trimmed && mv curated.trimmed curated.md
           if [ ! -s curated.md ]; then
             echo "::error::No CHANGELOG section found for $VERSION"; exit 1
           fi
           FOOTER="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="v$VERSION" -f target_commitish=main --jq '.body')"
+            -f tag_name="v$VERSION" -f target_commitish="$SHA" --jq '.body')"
           {
             cat curated.md
             printf '\n\n---\n\n'
@@ -74,10 +92,11 @@ jobs:
           } > release-notes.md
           echo "---- preview ----"; cat release-notes.md
 
-      - name: Create release (creates tag v$VERSION; publish.yaml then fires)
+      - name: Create release (creates tag v$VERSION at the merged commit; publish.yaml then fires)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           V="v${{ steps.ver.outputs.version }}"
-          gh release create "$V" --target main --title "$V" --notes-file release-notes.md
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          gh release create "$V" --target "$SHA" --title "$V" --notes-file release-notes.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write   # create tag + release
+
+jobs:
+  release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (full history for tag checks + generate-notes)
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve and validate versions
+        id: ver
+        run: |
+          set -euo pipefail
+          BRANCH_VERSION="${GITHUB_HEAD_REF#release/v}"
+          PYPROJECT_VERSION="$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')"
+          CHANGELOG_VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+
+          echo "branch=$BRANCH_VERSION pyproject=$PYPROJECT_VERSION changelog=$CHANGELOG_VERSION"
+
+          if [[ ! "$BRANCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch version '$BRANCH_VERSION' is not X.Y.Z (head_ref=$GITHUB_HEAD_REF)"; exit 1
+          fi
+          if [ "$BRANCH_VERSION" != "$PYPROJECT_VERSION" ] || [ "$BRANCH_VERSION" != "$CHANGELOG_VERSION" ]; then
+            echo "::error::Version mismatch — branch=$BRANCH_VERSION pyproject=$PYPROJECT_VERSION changelog=$CHANGELOG_VERSION"; exit 1
+          fi
+          echo "version=$BRANCH_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag/release does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          V="v${{ steps.ver.outputs.version }}"
+          if git rev-parse "$V" >/dev/null 2>&1; then echo "::error::Tag $V already exists"; exit 1; fi
+          if gh release view "$V" >/dev/null 2>&1; then echo "::error::Release $V already exists"; exit 1; fi
+
+      - name: Build release notes (curated CHANGELOG section + auto footer)
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > curated.md
+          # Trim leading/trailing blank lines
+          sed -i -e '/./,$!d' curated.md
+          if [ ! -s curated.md ]; then
+            echo "::error::No CHANGELOG section found for $VERSION"; exit 1
+          fi
+          FOOTER="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="v$VERSION" -f target_commitish=main --jq '.body')"
+          {
+            cat curated.md
+            printf '\n\n---\n\n'
+            printf '%s\n' "$FOOTER"
+          } > release-notes.md
+          echo "---- preview ----"; cat release-notes.md
+
+      - name: Create release (creates tag v$VERSION; publish.yaml then fires)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          V="v${{ steps.ver.outputs.version }}"
+          gh release create "$V" --target main --title "$V" --notes-file release-notes.md


### PR DESCRIPTION
## What

Adds a PR-driven release process alongside the existing `make release` (which is kept as the manual fallback).

- **`/release [major|minor|patch]`** command — reconciles `CHANGELOG.md` (via the `update-changelog` skill) so `[Unreleased]` is accurate, decides/confirms the bump, runs `uv version --bump`, promotes `[Unreleased]` → `## [X.Y.Z] - <date>` (+ fresh empty `[Unreleased]`), commits `chore(release): vX.Y.Z`, and opens a `release/vX.Y.Z` PR whose body is the new CHANGELOG section.
- **`.github/workflows/release.yaml`** — on merge of a `release/v*` PR into `main`, validates branch version == `pyproject.toml` == top CHANGELOG header, guards against an existing tag, slices the curated CHANGELOG section, appends GitHub's auto-generated footer, and creates the tag + release. The existing `publish.yaml` then builds/pushes the GHCR image on `release: published`.

## Design decisions

- **Release notes** = curated CHANGELOG section (re-extracted from the merged code — the canonical source, *not* the PR body) + `---` + GitHub auto footer.
- **Trigger** = branch pattern `release/vX.Y.Z`; **PR title / squash commit** = `chore(release): vX.Y.Z` (conventional); **tag/release** = `vX.Y.Z` (required by `publish.yaml`).
- The release/tag is created with a **GitHub App installation token** (`actions/create-github-app-token`), not the default `GITHUB_TOKEN` — a release created by `GITHUB_TOKEN` would *not* trigger `publish.yaml` (GitHub suppresses cascade events), so the image would never build. The job also has a `concurrency` guard and pins checkout / generate-notes / release-create to the PR's `merge_commit_sha`.

## Required setup (done)

The workflow depends on a GitHub App with `Contents: write` installed on this repo, exposed as:
- repo variable `RELEASE_APP_ID`
- repo secret `RELEASE_APP_PRIVATE_KEY`

Both are configured.

## Verification

Local dry-runs only (CI glue + a command file — no unit-test harness): YAML parse, the awk/sed/`tac` CHANGELOG-section extraction against the live file, and `uv version --dry-run`. Reviewed across three rounds (per-task + whole-branch + fix re-review).

**End-to-end is verified after merge** by cutting one real `patch` release via `/release patch` and confirming the release notes shape + that `publish.yaml` pushes the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
