### PR TITLE
fix: make IP2Location handle thread-safe under gthread workers (#637)

### DIFF
--- a/src/geo/ip2.py
+++ b/src/geo/ip2.py
@@ -1,3 +1,5 @@
+import threading
+
 import structlog
 from django.contrib.gis.geos import Point
 from IP2Location import IP2Location
@@ -6,27 +8,33 @@ from geo import conf
 
 logger = structlog.get_logger(__name__)
 
-_DB: IP2Location | None = None
-_DB_MTIME: float | None = None
+# In the default FILE_IO mode, IP2Location reads records through a single shared
+# file cursor (seek + read), which is not thread-safe. Under Gunicorn's gthread
+# workers, concurrent requests on one shared instance corrupt each other's reads.
+# We therefore keep one handle per thread. The database pages stay in the shared
+# OS page cache (loaded once), so this costs only a cheap file descriptor per
+# thread — not a copy of the ~168 MB database. See issue #637.
+_local = threading.local()
 
 
 def get_ip2location() -> IP2Location:
-    """Initializes and returns the IP2Location database object.
+    """Return a thread-local IP2Location database handle.
 
-    Uses file modification time to detect when a new database has been downloaded
-    and automatically reloads it.
+    Each thread gets its own file descriptor because FILE_IO mode is not
+    thread-safe. Uses the database file's modification time to detect when a new
+    database has been downloaded, reloading the calling thread's handle.
     """
-    global _DB, _DB_MTIME
-
     # Get current file modification time
     current_mtime = conf.IP2LOCATION_DB_PATH.stat().st_mtime
 
-    # Reload if database hasn't been loaded or file has changed
-    if _DB is None or _DB_MTIME is None or current_mtime != _DB_MTIME:
-        _DB = IP2Location(conf.IP2LOCATION_DB_PATH)
-        _DB_MTIME = current_mtime
+    # Reload if this thread hasn't loaded the database or the file has changed
+    db: IP2Location | None = getattr(_local, "db", None)
+    if db is None or _local.mtime != current_mtime:
+        db = IP2Location(conf.IP2LOCATION_DB_PATH)
+        _local.db = db
+        _local.mtime = current_mtime
 
-    return _DB
+    return db
 
 
 def resolve_ip_to_point(ip: str) -> Point | None:

--- a/src/geo/tests/test_ip2.py
+++ b/src/geo/tests/test_ip2.py
@@ -34,6 +34,10 @@ def test_get_ip2location_is_thread_local(monkeypatch: MonkeyPatch) -> None:
 
     monkeypatch.setattr("geo.ip2.IP2Location", FakeDB)
 
+    fake_path = MagicMock()
+    fake_path.stat.return_value.st_mtime = 1.0
+    monkeypatch.setattr("geo.ip2.conf.IP2LOCATION_DB_PATH", fake_path)
+
     n_threads = 5
     barrier = threading.Barrier(n_threads)
     results: dict[int, tuple[t.Any, t.Any]] = {}

--- a/src/geo/tests/test_ip2.py
+++ b/src/geo/tests/test_ip2.py
@@ -1,0 +1,100 @@
+"""Thread-safety tests for the IP2Location handle cache (issue #637).
+
+FILE_IO mode reads through a single shared file cursor, so one instance shared
+across gthread worker threads corrupts concurrent reads. ``get_ip2location`` must
+hand each thread its own handle, while still hot-reloading when the ``.BIN`` is
+replaced by the downloader.
+"""
+
+import threading
+import typing as t
+from unittest.mock import MagicMock
+
+import pytest
+from pytest import MonkeyPatch
+
+from geo.ip2 import get_ip2location
+
+
+@pytest.fixture(autouse=True)
+def mock_ip2location() -> t.Iterator[None]:
+    """Shadow conftest's autouse mock so these tests hit the real get_ip2location."""
+    yield
+
+
+def test_get_ip2location_is_thread_local(monkeypatch: MonkeyPatch) -> None:
+    """Each thread gets its own handle; a thread reuses its own across calls."""
+    calls = {"n": 0}
+    calls_lock = threading.Lock()
+
+    class FakeDB:
+        def __init__(self, path: t.Any) -> None:
+            with calls_lock:
+                calls["n"] += 1
+
+    monkeypatch.setattr("geo.ip2.IP2Location", FakeDB)
+
+    n_threads = 5
+    barrier = threading.Barrier(n_threads)
+    results: dict[int, tuple[t.Any, t.Any]] = {}
+    results_lock = threading.Lock()
+
+    def worker(i: int) -> None:
+        barrier.wait()  # release all threads together to force concurrent access
+        first = get_ip2location()
+        second = get_ip2location()
+        with results_lock:
+            results[i] = (first, second)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    # One construction per thread — no shared handle, no redundant re-loads.
+    assert calls["n"] == n_threads
+    # Within a thread the same handle is reused...
+    for first, second in results.values():
+        assert first is second
+    # ...and every thread received a distinct handle.
+    handles = [first for first, _ in results.values()]
+    assert len({id(h) for h in handles}) == n_threads
+
+
+def test_get_ip2location_reloads_on_mtime_change(monkeypatch: MonkeyPatch) -> None:
+    """A thread reloads its handle when the database file's mtime changes."""
+    calls = {"n": 0}
+
+    class FakeDB:
+        def __init__(self, path: t.Any) -> None:
+            calls["n"] += 1
+
+    monkeypatch.setattr("geo.ip2.IP2Location", FakeDB)
+
+    fake_path = MagicMock()
+    fake_path.stat.return_value.st_mtime = 1.0
+    monkeypatch.setattr("geo.ip2.conf.IP2LOCATION_DB_PATH", fake_path)
+
+    errors: list[Exception] = []
+
+    def run() -> None:
+        try:
+            db1 = get_ip2location()
+            db2 = get_ip2location()  # same mtime -> no reload
+            assert db1 is db2
+            assert calls["n"] == 1
+
+            fake_path.stat.return_value.st_mtime = 2.0  # downloader replaced the .BIN
+            db3 = get_ip2location()  # different mtime -> reload
+            assert db3 is not db1
+            assert calls["n"] == 2
+        except Exception as e:  # surface assertion failures from the worker thread
+            errors.append(e)
+
+    # Run on a fresh thread so thread-local state starts empty.
+    th = threading.Thread(target=run)
+    th.start()
+    th.join()
+
+    assert not errors, errors


### PR DESCRIPTION
## Summary

Fixes finding #1 of #637: the global `IP2Location` handle in `geo/ip2.py` is shared across all Gunicorn `gthread` worker threads, but in the library's default **FILE_IO** mode every lookup reads through a single stateful file cursor (`self._f.seek(); self._f.read()`, `IP2Location/database.py:381-399`). Concurrent `get_all()` calls from different threads interleave seek/read on the same fd and corrupt each other's reads — returning garbage or raising parser exceptions, which `resolve_ip_to_point` silently swallows as a `warning`.

This path is reachable on the hot path: `geo.middleware.GeoPointMiddleware` attaches a `LazyGeoPoint` to **every** request, consumed by `UserAwareController.user_location()` in public event-discovery and organization listing (`order_by_distance`).

## Fix

Replace the shared `_DB`/`_DB_MTIME` module globals with `threading.local()`, so each thread gets its own `IP2Location` handle (its own file descriptor). The mtime-based hot-reload (for when the downloader replaces the `.BIN`) is preserved per-thread.

**Why thread-local rather than mmap / load-in-memory:**
- `SHARED_MEMORY` / mmap mode is **not** natively thread-safe in this library version — `_reads`/`_readi`/`_readf` still use stateful `seek()/read()` on the mmap object regardless of mode. (`MEMORY_MAPPED` isn't even a valid mode.)
- Loading the ~168 MB `.BIN` into the Python heap would duplicate it across all 6 workers (~1 GB), fighting the RAM goal that motivates the gthread deployment.
- FILE_IO + thread-local keeps the DB in the shared **OS page cache** (loaded once, shared across all threads and processes), costing only a cheap fd per thread. gthread's bounded pool caps this at ≤24 fds total.

## Not addressed (by design)

Finding #2 (Sentinel model load race) is a **false positive** under the current architecture — the evaluator only runs via the Celery **prefork** pool (single-threaded processes), never in the gthread web worker. Reasoning documented [in this comment](https://github.com/letsrevel/revel-backend/issues/637#issuecomment-4890433242). No lock added.

## Tests

New `src/geo/tests/test_ip2.py` (shadows conftest's autouse IP2Location mock to exercise the real logic):
- `test_get_ip2location_is_thread_local` — 5 threads released on a barrier for max concurrency; asserts exactly one construction per thread, within-thread handle reuse, and a distinct handle per thread.
- `test_get_ip2location_reloads_on_mtime_change` — asserts no reload on stable mtime, reload when the file's mtime changes.

Verification: new tests pass; `ruff format`, `ruff check`, and `mypy --strict` clean on both changed files.

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP geolocation database loading to avoid shared-state issues in threaded environments.
  * The app now reloads the location database automatically when the file changes, helping ensure lookups stay up to date.
  * Added coverage for concurrent access and database refresh behavior to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->