### PR TITLE
chore(deps): suppress CVE-2026-49452 (weasyprint), drop stale aiohttp suppressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,23 +74,18 @@ licensecheck:
 #       directory; if an attacker already has that level of filesystem access
 #       on our backend host, they have much larger problems. Revisit when a
 #       diskcache release ships a fix. Tracked privately: GHSA-mcv5-9q6c-vg2g.
-#   CVE-2026-34993 / CVE-2026-47265 (aiohttp): fixed in 3.14.0, but unreachable
-#       — `aiogram` pins `aiohttp<3.14` (still true on the latest aiogram
-#       3.28.2), so the resolver caps us at 3.13.x. aiohttp is transitive only
-#       (via `aiogram` → Telegram Bot API, and `instructor` → LLM APIs), used
-#       purely as an HTTP client; we run no aiohttp server. Both advisories are
-#       client-side: 34993 needs `CookieJar.load()` on an attacker-controlled
-#       file (local vector, we never call it); 47265 leaks per-request `cookies=`
-#       across a cross-origin redirect (we set no per-request cookies and only
-#       call fixed, trusted endpoints). Drop when aiogram relaxes the cap.
-#       Tracked privately: GHSA-326c-3pr9-53pf (34993), GHSA-68j9-fg24-qc3g (47265).
+#   CVE-2026-49452 (weasyprint): no fix published (68.1 still affected). CSS
+#       injection via HTML presentational hints, exploitable only with
+#       `presentational_hints=True`; we never pass it (WeasyPrint defaults to
+#       False), and all PDF HTML comes from autoescaped Django templates, so
+#       attacker markup can't reach the renderer anyway. Bump + drop when a
+#       fixed release ships. Tracked privately: GHSA-jhhc-3hcp-qhm5.
 .PHONY: audit
 audit:
 	@uv export --quiet --locked --format requirements-txt --no-emit-project --no-hashes --group dev -o .audit-reqs.txt
 	@trap 'rm -f .audit-reqs.txt' EXIT; uv run pip-audit --strict --no-deps --disable-pip -r .audit-reqs.txt \
 		--ignore-vuln CVE-2025-69872 \
-		--ignore-vuln CVE-2026-34993 \
-		--ignore-vuln CVE-2026-47265
+		--ignore-vuln CVE-2026-49452
 
 .PHONY: deps-check
 deps-check: licensecheck audit


### PR DESCRIPTION
## Summary

Triage of #639 (nightly pip-audit failure), per `docs/runbooks/dependency-audit.md`.

### Suppress CVE-2026-49452 (weasyprint 68.0)

- CSS injection via HTML presentational hints ([GHSA-jhhc-3hcp-qhm5](https://github.com/Kozea/WeasyPrint/security/advisories/GHSA-jhhc-3hcp-qhm5)), severity Moderate. **No fixed release exists** — 68.1 (latest) is still affected.
- **Not exploitable here**, for two independent reasons:
  1. The vuln only triggers with `presentational_hints=True`; both call sites (`common/service/invoice_utils.py`, `events/utils/__init__.py`) use the default (`False`), and the flag appears nowhere in the repo.
  2. All PDF HTML is rendered from autoescaped Django templates, so attacker-controlled markup can't reach the renderer.
- Suppression carries a rationale comment; bump + drop when a fixed release ships.

### Drop stale aiohttp suppressions (CVE-2026-34993 / CVE-2026-47265)

Both were fixed in aiohttp 3.14.0 but previously unreachable behind aiogram's `<3.14` pin. aiogram 3.29.0 relaxed the pin and the lock now resolves to **3.14.1**, which OSV reports clean — the suppressions were dead weight.

Also reviewed CVE-2025-69872 (diskcache): 5.6.3 is still the latest release and still affected, so that suppression stays.

## Verification

`make audit` passes: `No known vulnerabilities found, 2 ignored` — the 2 ignored exactly match the two remaining flags (diskcache, weasyprint).

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit settings to reflect the latest vulnerability exemptions.
  * Removed older exemptions and added a new one to keep audit results aligned with current risk reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->