### PR TITLE
ci: add no-op twin for path-filtered dependency checks

### DIFF
--- a/.github/workflows/deps-noop.yaml
+++ b/.github/workflows/deps-noop.yaml
@@ -1,0 +1,38 @@
+# No-op twin of deps.yaml — GitHub's documented pattern for path-filtered
+# required checks ("Handling skipped but required checks").
+#
+# `licensecheck` and `pip-audit` are required status checks on main, but
+# deps.yaml only runs on PRs that touch the dependency graph. A required
+# check that never reports blocks the PR forever ("Expected — Waiting for
+# status"). This workflow fires on the exact complement of deps.yaml's
+# `paths:` and reports instantly-passing jobs under the same names, so the
+# required contexts always resolve.
+#
+# INVARIANT: the `paths-ignore:` list below must stay the exact complement
+# of the `paths:` list in deps.yaml, and the workflow name + job ids must
+# match deps.yaml verbatim. Drift either double-runs the real checks
+# (harmless) or leaves PRs blocked (not harmless).
+
+name: Dependency checks
+
+on:
+  pull_request:
+    paths-ignore:
+      - pyproject.toml
+      - uv.lock
+      - Makefile
+      - .github/workflows/deps.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  licensecheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "No dependency-graph changes in this PR — licensecheck not needed."
+
+  pip-audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "No dependency-graph changes in this PR — pip-audit not needed."

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -5,6 +5,11 @@ name: Dependency checks
 #   - pip-audit:    fails on known CVEs in pinned dependencies
 # The nightly workflow (nightly-audit.yml) re-runs both against main so
 # newly-disclosed advisories surface within ~24h even without a PR.
+#
+# Both jobs are REQUIRED status checks on main. PRs that don't touch the
+# `paths:` below get a passing no-op status from deps-noop.yaml instead —
+# its `paths-ignore:` must stay the exact complement of the `paths:` here,
+# and workflow name + job ids must match verbatim.
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,23 +2,15 @@ name: Test
 
 on:
   workflow_dispatch: {}
+  # No path filter: all jobs in this workflow are required status checks on
+  # main, and a path-filtered workflow that doesn't fire leaves its required
+  # contexts stuck on "Expected — Waiting for status", blocking the PR.
+  # (The old filter also had dead globs — `./**/*.yaml` never matches because
+  # GitHub matches paths without the leading `./` — and blind spots: template,
+  # locale, and fixture changes skipped the suite entirely.)
   push:
     branches: [main]
-    paths:
-      - .github/workflows/test.yaml
-      - src/**/*.py
-      - pyproject.toml
-      - uv.lock
-      - ./**/*.yml
-      - ./**/*.yaml
-  pull_request:
-    paths:
-      - .github/workflows/test.yaml
-      - src/**/*.py
-      - pyproject.toml
-      - uv.lock
-      - ./**/*.yml
-      - ./**/*.yaml
+  pull_request: {}
 
 permissions:
   id-token: write

--- a/docs/runbooks/dependency-audit.md
+++ b/docs/runbooks/dependency-audit.md
@@ -11,11 +11,20 @@ Two checks guard the `revel-backend` dependency graph:
 Both run in two contexts:
 
 - **PR / push to `main`** — `.github/workflows/deps.yaml` runs both on any change
-  that touches `pyproject.toml`, `uv.lock`, or the workflow itself.
+  that touches `pyproject.toml`, `uv.lock`, `Makefile`, or the workflow itself.
 - **Nightly, `03:17 UTC`** — `.github/workflows/nightly-audit.yml` re-runs both
   against `main` and opens-or-bumps a GitHub issue (labels: `security`,
   `dependencies`) on failure, so newly-disclosed advisories surface within ~24h
   without a PR.
+
+Both PR jobs (`licensecheck`, `pip-audit`) are **required status checks** on
+`main`. Because `deps.yaml` is path-filtered, PRs that don't touch the dep
+graph get their passing status from the no-op twin
+`.github/workflows/deps-noop.yaml` instead (same workflow name, same job ids,
+inverse `paths-ignore:` filter — GitHub's documented pattern for skipped-but-
+required checks). **Keep the two path lists exact complements** when adding or
+removing a watched file, or non-dep PRs will hang on "Expected — Waiting for
+status to be reported".
 
 ## Local reproduction
 


### PR DESCRIPTION
## Summary

Makes `licensecheck` and `pip-audit` safe to enforce as **required status checks** on `main`.

`deps.yaml` is path-filtered (`pyproject.toml`, `uv.lock`, `Makefile`, itself), so on PRs that don't touch the dep graph the checks never report — and a required check that never reports blocks the merge forever ("Expected — Waiting for status to be reported"). This PR adds GitHub's documented workaround: `deps-noop.yaml`, a twin workflow with the same workflow name and job ids, triggered on the exact complement (`paths-ignore:` of the same four files), whose jobs pass instantly.

Exactly one of the two workflows fires per PR (both fire only when a PR touches files on both sides of the split — harmless, both pass), so the required contexts always resolve.

## Changes

- **`.github/workflows/deps-noop.yaml`** (new) — no-op twin with the sync invariant documented in the header.
- **`.github/workflows/deps.yaml`** — comment pointing at the twin and the invariant.
- **`docs/runbooks/dependency-audit.md`** — documents the required-check setup and the exact-complement rule; also fixes the watched-paths list (it was missing `Makefile`).

## Note

The ruleset change adding `licensecheck` + `pip-audit` to required checks is applied separately via the repo settings (not in-repo). Open PRs based on commits older than this one will need to update from `main` before the noop statuses can report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a no-op dependency-check workflow so pull requests that don’t touch dependency-related files still receive passing status checks.
  * Broadened the test workflow to run on all relevant push and pull request changes, not just selected file paths.

* **Bug Fixes**
  * Prevented required checks from getting stuck in a waiting state when PRs miss previous path filters.

* **Documentation**
  * Updated runbook and workflow notes to explain the new check behavior and keep the two dependency-check paths aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->