### PR TITLE
chore(release): v1.67.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.67.1] - 2026-07-07
+
+### Fixed
+- IP-based geolocation no longer returns garbage results or logs parser warnings under concurrent requests: each worker thread now gets its own IP2Location database handle instead of sharing one non-thread-safe file cursor.
+- Admins are no longer pinged on Discord when a guest account is created — the new-user notification now fires only for real user signups.
+
 ## [1.67.0] - 2026-07-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.67.0"
+version = "1.67.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3951,7 +3951,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.67.0"
+version = "1.67.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [1.67.1] - 2026-07-07

### Fixed
- IP-based geolocation no longer returns garbage results or logs parser warnings under concurrent requests: each worker thread now gets its own IP2Location database handle instead of sharing one non-thread-safe file cursor.
- Admins are no longer pinged on Discord when a guest account is created — the new-user notification now fires only for real user signups.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
