### PR TITLE
fix(events): shift waitlist_cutoff_date in duplicate_event (#645)

### DIFF
--- a/src/events/service/duplication.py
+++ b/src/events/service/duplication.py
@@ -41,6 +41,7 @@ _EXCLUDED_FROM_COPY: frozenset[str] = frozenset(
         "apply_before",
         "check_in_starts_at",
         "check_in_ends_at",
+        "waitlist_cutoff_date",
     }
 )
 
@@ -49,6 +50,7 @@ _SHIFTED_DATE_FIELDS: tuple[str, ...] = (
     "apply_before",
     "check_in_starts_at",
     "check_in_ends_at",
+    "waitlist_cutoff_date",
 )
 
 # Tier fields that are NOT copied from the template tier:

--- a/src/events/tests/test_service/test_event_service.py
+++ b/src/events/tests/test_service/test_event_service.py
@@ -459,6 +459,31 @@ class TestDuplicateEvent:
         assert new_event.check_in_starts_at == original_checkin_start + timedelta(days=7)
         assert new_event.check_in_ends_at == original_checkin_end + timedelta(days=7)
 
+    def test_duplicate_event_shifts_waitlist_cutoff_date(self, organization: Organization) -> None:
+        """waitlist_cutoff_date must shift with the start date, not be copied verbatim (#645)."""
+        original_start = timezone.now() + timedelta(days=1)
+        original_cutoff = original_start - timedelta(hours=12)
+
+        template = Event.objects.create(
+            organization=organization,
+            name="Waitlist Template",
+            start=original_start,
+            end=original_start + timedelta(hours=3),
+            waitlist_open=True,
+            waitlist_time_window=timedelta(hours=24),
+            waitlist_cutoff_date=original_cutoff,
+            requires_ticket=False,
+        )
+
+        new_start = original_start + timedelta(days=30)
+        new_event = event_service.duplicate_event(
+            template_event=template,
+            new_name="Shifted Waitlist Event",
+            new_start=new_start,
+        )
+
+        assert new_event.waitlist_cutoff_date == original_cutoff + timedelta(days=30)
+
     def test_duplicate_event_copies_ticket_tiers(self, public_event: Event) -> None:
         """Test that ticket tiers are duplicated with shifted dates."""
         # Create a tier with dates

--- a/src/events/tests/test_service/test_recurrence_service_materialize.py
+++ b/src/events/tests/test_service/test_recurrence_service_materialize.py
@@ -131,6 +131,26 @@ class TestMaterializeOccurrence:
         ga_tier = next(t for t in tiers if t.name == "General Admission")
         assert ga_tier.quantity_sold == 0  # Reset
 
+    @patch("notifications.service.notification_helpers.notify_series_events_generated")
+    def test_waitlist_cutoff_date_shifted_from_template(
+        self,
+        mock_notify: t.Any,
+        active_series: EventSeries,
+    ) -> None:
+        """Occurrences shift the template's waitlist_cutoff_date by the start delta (#645)."""
+        template = active_series.template_event
+        assert template is not None
+        template.waitlist_open = True
+        template.waitlist_time_window = timedelta(hours=24)
+        template.waitlist_cutoff_date = template.start - timedelta(days=2)
+        template.save(update_fields=["waitlist_open", "waitlist_time_window", "waitlist_cutoff_date"])
+
+        dt = timezone.make_aware(datetime(2026, 4, 13, 10, 0))
+
+        event = recurrence_service.materialize_occurrence(active_series, dt, index=0)
+
+        assert event.waitlist_cutoff_date == template.waitlist_cutoff_date + (dt - template.start)
+
     def test_raises_value_error_when_no_template(
         self,
         event_series: EventSeries,


### PR DESCRIPTION
## Summary

`waitlist_cutoff_date` was missing from `_SHIFTED_DATE_FIELDS` in `events/service/duplication.py`, so it flowed through `_collect_copyable_field_values()` and was copied **verbatim** (the template's absolute timestamp) instead of being shifted by `new_start - template_event.start`.

Consequences (per #645):
- **Duplicate to a later date**: the copy inherits a cutoff in the past → waitlist effectively closed from creation.
- **Duplicate to an earlier date**: the copied cutoff can be `>= start`, violating the `Event.clean()` invariant ("Cutoff date must be before event start").
- **Recurring series**: every occurrence materialized via `duplicate_event()` inherits the template's absolute cutoff.

## Fix

Add `waitlist_cutoff_date` to `_SHIFTED_DATE_FIELDS` and to the shifted-fields group of `_EXCLUDED_FROM_COPY`, matching the other shifted date windows.

## Tests

- `test_duplicate_event_shifts_waitlist_cutoff_date` — duplicates an event with a cutoff and asserts the cutoff shifts by the same delta as `start` (fails on `main`, passes here).
- `test_waitlist_cutoff_date_shifted_from_template` — covers the recurrence path via `materialize_occurrence`.

Ran the affected test files (149 tests passing) plus `make check` (format, lint, mypy, migrations, i18n, file-length, task-names) — all green.

## Follow-up

The frontend `DuplicateEventModal` carries a code comment documenting this bug ("`waitlist_cutoff_date` is copied verbatim (unshifted)…") — it can be removed once this lands (frontend #543 / PR #555).

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCmCKEjL7ftq8UGwiGt6UY