### PR TITLE
fix: reset_events fails on organizations with held series passes

### DIFF
--- a/src/events/management/commands/reset_events.py
+++ b/src/events/management/commands/reset_events.py
@@ -15,7 +15,14 @@ from accounts.models import (
     ReferralPayoutStatement,
     RevelUser,
 )
-from events.models import EventSeries, MembershipSubscription, Organization, RecurrenceRule
+from events.models import (
+    EventSeries,
+    HeldSeriesPass,
+    MembershipSubscription,
+    Organization,
+    RecurrenceRule,
+    Ticket,
+)
 from questionnaires.models import Questionnaire
 
 
@@ -108,6 +115,18 @@ class Command(BaseCommand):
             # subscriptions directly.
             MembershipSubscription.objects.all().delete()
             self.stdout.write(self.style.SUCCESS("✓ Deleted membership subscriptions"))
+
+            # Break the SeriesPass ← HeldSeriesPass PROTECT and the
+            # Ticket → HeldSeriesPass RESTRICT FKs. The Organization cascade
+            # reaches EventSeries → SeriesPass, but HeldSeriesPass PROTECTs its
+            # series_pass, which aborts the whole cascade if any held pass
+            # exists. Materialized pass tickets also RESTRICT their held_pass,
+            # so delete those tickets first, then the held passes. Production
+            # teardown goes through the series-pass service; the demo-reset path
+            # can shortcut by deleting them directly.
+            Ticket.objects.filter(held_pass__isnull=False).delete()
+            HeldSeriesPass.objects.all().delete()
+            self.stdout.write(self.style.SUCCESS("✓ Deleted series-pass holders"))
 
             # Delete all organizations (cascade will handle related objects)
             Organization.objects.all().delete()

--- a/src/events/tests/test_reset_events_command.py
+++ b/src/events/tests/test_reset_events_command.py
@@ -12,13 +12,20 @@ from unittest.mock import patch
 import pytest
 from django.core.management import call_command
 from django.test import override_settings
+from django.utils import timezone
 
 from accounts.models import RevelUser
 from events.models import (
+    Event,
+    EventSeries,
+    HeldSeriesPass,
     MembershipSubscription,
     MembershipSubscriptionPlan,
     MembershipTier,
     Organization,
+    SeriesPass,
+    Ticket,
+    TicketTier,
 )
 
 pytestmark = pytest.mark.django_db
@@ -104,3 +111,57 @@ class TestResetEventsCommand:
         # The subscriber user used a non-@letsrevel.io address, so they should
         # also have been swept up by the demo-user cleanup.
         assert not RevelUser.objects.filter(pk=demo_subscriber.pk).exists()
+
+    @override_settings(DEMO_MODE=True)
+    def test_succeeds_with_held_series_pass(
+        self,
+        demo_organization: Organization,
+        demo_subscriber: RevelUser,
+    ) -> None:
+        """Regression for the ``HeldSeriesPass.series_pass`` PROTECT / ``Ticket.held_pass`` RESTRICT chain.
+
+        A purchased series pass previously aborted the Organization cascade: the
+        cascade reaches ``EventSeries → SeriesPass``, but ``HeldSeriesPass``
+        PROTECTs its ``series_pass``. Materialized pass tickets additionally
+        RESTRICT their ``held_pass``. The demo-reset path must delete those
+        tickets and the held passes before deleting organizations.
+        """
+        series = EventSeries.objects.create(organization=demo_organization, name="Weekly", slug="weekly")
+        series_pass = SeriesPass.objects.create(
+            event_series=series,
+            name="Season Ticket",
+            price=Decimal("36.00"),
+            pro_rata_discount=Decimal("6.00"),
+            currency="EUR",
+            payment_method=TicketTier.PaymentMethod.ONLINE,
+        )
+        held_pass = HeldSeriesPass.objects.create(
+            series_pass=series_pass,
+            user=demo_subscriber,
+            status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
+            price_paid=Decimal("36.00"),
+        )
+        event = Event.objects.create(
+            organization=demo_organization,
+            name="Class 1",
+            slug="class-1",
+            event_series=series,
+            start=timezone.now(),
+        )
+        tier = TicketTier.objects.create(event=event, name="Tier", price=Decimal("10.00"), currency="EUR")
+        ticket = Ticket.objects.create(
+            event=event,
+            user=demo_subscriber,
+            tier=tier,
+            guest_name="Demo Subscriber",
+            held_pass=held_pass,
+        )
+
+        with patch("events.management.commands.reset_events.call_command") as mocked_call:
+            call_command("reset_events", "--no-input")
+            mocked_call.assert_called_once_with("bootstrap_events")
+
+        assert not Organization.objects.filter(pk=demo_organization.pk).exists()
+        assert not HeldSeriesPass.objects.filter(pk=held_pass.pk).exists()
+        assert not Ticket.objects.filter(pk=ticket.pk).exists()
+        assert not SeriesPass.objects.filter(pk=series_pass.pk).exists()


### PR DESCRIPTION
## Problem

`python manage.py reset_events` (the demo-data reset, run by the `reset_demo_data` Celery task) crashed with `ProtectedError` whenever a demo user had purchased a series pass:

```
django.db.models.deletion.ProtectedError: ("Cannot delete some instances of model 'Organization'
because they are referenced through protected foreign keys: 'EventSeries.organization'.",
{<HeldSeriesPass ...>, ...})
```

The `Organization` teardown cascades `Organization → EventSeries → SeriesPass`, but `HeldSeriesPass.series_pass` is `on_delete=PROTECT`, which aborts the whole transaction if any held pass exists. Materialized pass tickets additionally reference the held pass via `Ticket.held_pass` (`on_delete=RESTRICT`), which blocks a direct held-pass delete while those tickets still exist.

## Fix

Before deleting organizations, delete the pass-materialized tickets and then the held passes — mirroring the existing PROTECT-breaker steps in the same command (recurrence template/rule, membership subscriptions). This path is demo-reset only; production teardown still goes through the series-pass service.

## Tests

Adds `test_succeeds_with_held_series_pass`, which sets up a series pass, an `ACTIVE` `HeldSeriesPass`, and a materialized ticket, then asserts `reset_events` completes and wipes them. Verified the test fails with `ProtectedError` against the un-fixed command and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)