### PR TITLE
docs: document macOS GDAL/WeasyPrint native-lib fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ Get a local development environment running in minutes. You'll need `make`, `Doc
     make setup
     ```
 
+    > **macOS note:** if startup crashes with `Could not find the GDAL library` or a
+    > `libgobject-2.0` `dlopen` error (often after a macOS update), expose Homebrew's libs on
+    > dyld's default fallback path: `ln -s "$(brew --prefix)/lib" ~/lib`. See
+    > [Troubleshooting](docs/getting-started/troubleshooting.md#macos-could-not-find-the-gdal-library-homebrew-native-libs).
+
 4.  **You're ready!**
     *   The API is running at `http://localhost:8000`
     *   Interactive API docs (Swagger UI) are at `http://localhost:8000/api/docs`

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -4,6 +4,53 @@ Common gotchas and their solutions. Most of these surface during initial setup o
 
 ---
 
+## macOS: "Could not find the GDAL library" (Homebrew native libs)
+
+**Symptom** — on macOS, `make run` / `make test` / any `manage.py` command crashes at startup with one of:
+
+```
+django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library
+    (tried "gdal", "GDAL", "gdal3.10.0", ...). Is GDAL installed?
+```
+```
+OSError: cannot load library 'libgobject-2.0-0': dlopen(libgobject-2.0-0, ...)
+    ... ctypes.util.find_library() did not manage to locate a library
+```
+
+**Cause** — the backend loads several Homebrew-installed native libraries at import time:
+GDAL and GEOS (GeoDjango / PostGIS) and glib/pango/harfbuzz/fontconfig/cairo (WeasyPrint PDF
+rendering). These live under `$(brew --prefix)/lib` (`/opt/homebrew/lib` on Apple Silicon).
+A **macOS system update** can change how `dyld` / Python's `ctypes.util.find_library` probe for
+libraries, after which that directory is no longer searched — so the libs "disappear" even though
+Homebrew still has them installed. GDAL fails first (it's imported earliest); once it's fixed the
+same failure resurfaces for WeasyPrint's `libgobject`.
+
+**Why the obvious fixes don't work** — `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` fixes it in a
+bare shell, but **not** through `make`: `/usr/bin/make` and `/bin/sh` are SIP-protected system
+binaries, and macOS **strips all `DYLD_*` variables** from the environment when a protected binary
+launches. So exporting `DYLD_*` in `~/.zshrc` or the `Makefile` is silently dropped before the
+Django process starts. Django's `GDAL_LIBRARY_PATH` setting would fix GDAL/GEOS but not WeasyPrint,
+which has no equivalent knob.
+
+**Fix (one symlink, SIP-proof, works everywhere)** — expose Homebrew's lib dir on `dyld`'s
+*built-in default fallback path* (`$HOME/lib`), which needs no environment variable and therefore
+survives SIP for `make`, subagents, and direct `uv run` alike:
+
+```bash
+ln -s "$(brew --prefix)/lib" ~/lib
+```
+
+That single symlink resolves GDAL, GEOS, and all of WeasyPrint's native dependencies at once.
+To undo it: `rm ~/lib`.
+
+!!! note "Why `$HOME/lib` specifically"
+    macOS `dyld` consults a fixed default fallback list — `$HOME/lib:/usr/local/lib:/lib:/usr/lib` —
+    when a library isn't found by its install name. These directories are searched **without** any
+    `DYLD_*` variable, so unlike the `DYLD_FALLBACK_LIBRARY_PATH` env var they are not stripped by
+    SIP. `~/lib` is user-scoped and trivially reversible; `/usr/local/lib` would work too.
+
+---
+
 ## Geo Data Files
 
 The geo app requires two data files in `src/geo/data/`:


### PR DESCRIPTION
## What

Documents the fix for a macOS startup crash where Python can't locate Homebrew-installed native libraries (GDAL, GEOS, and WeasyPrint's glib/pango/harfbuzz/fontconfig) under `$(brew --prefix)/lib`.

**Symptom** — `make run` / `make test` / any `manage.py` command crashes at `django.setup()` with:

```
django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library
```
```
OSError: cannot load library 'libgobject-2.0-0': dlopen(...) ... find_library() did not manage to locate a library
```

## Why

A macOS system update can change how `dyld` / `ctypes.util.find_library` probe for libraries, after which `/opt/homebrew/lib` is no longer searched — the libs "disappear" even though Homebrew still has them installed.

The non-obvious part: `DYLD_FALLBACK_LIBRARY_PATH` fixes it in a bare shell but **not through `make`**, because `/usr/bin/make` and `/bin/sh` are SIP-protected and macOS strips all `DYLD_*` vars when a protected binary launches. So a `~/.zshrc` or `Makefile` export is silently dropped.

## Fix (documented)

Expose Homebrew's lib dir on dyld's built-in default fallback path (`$HOME/lib`) — no env var, so SIP can't strip it, and it works for `make`, subagents, and direct `uv run` alike:

```bash
ln -s "$(brew --prefix)/lib" ~/lib
```

## Changes

- `docs/getting-started/troubleshooting.md` — new section: symptom, cause, the SIP gotcha, and the one-symlink fix.
- `README.md` — Quick Start pointer to it.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)