### PR TITLE
fix: bootstrap seeding gaps blocking E2E journeys (#659–#662)

### DIFF
--- a/src/events/management/commands/bootstrap_events.py
+++ b/src/events/management/commands/bootstrap_events.py
@@ -19,6 +19,7 @@ from .bootstrap_helpers import (
     create_event_series,
     create_events,
     create_follows,
+    create_global_bans,
     create_organizations,
     create_payments_and_invoice,
     create_potluck_items,
@@ -58,6 +59,9 @@ class Command(BaseCommand):
 
         # Create users
         create_users(state)
+
+        # Seed global bans (banned email + domain) for the registration-blocked E2E journey
+        create_global_bans()
 
         # Create organizations
         create_organizations(state)

--- a/src/events/management/commands/bootstrap_helpers/__init__.py
+++ b/src/events/management/commands/bootstrap_helpers/__init__.py
@@ -16,7 +16,7 @@ from .questionnaires import create_questionnaires
 from .relationships import create_follows, create_user_relationships
 from .tags import create_tags
 from .tickets import create_ticket_tiers
-from .users import create_users
+from .users import create_global_bans, create_users
 from .venues import create_venues
 
 __all__ = [
@@ -27,6 +27,7 @@ __all__ = [
     "create_event_series",
     "create_events",
     "create_follows",
+    "create_global_bans",
     "create_organizations",
     "create_payments_and_invoice",
     "create_referral_payouts",

--- a/src/events/management/commands/bootstrap_helpers/organizations.py
+++ b/src/events/management/commands/bootstrap_helpers/organizations.py
@@ -16,6 +16,14 @@ def create_organizations(state: BootstrapState) -> None:
     logger.info("Creating organizations...")
 
     # Organization Alpha - Public organization with Stripe Connect
+    connected_stripe_id = config("CONNECTED_TEST_STRIPE_ID", default=None)
+    if not connected_stripe_id:
+        logger.warning(
+            "!!! Org Alpha (revel-events-collective) seeded WITHOUT a Stripe account "
+            "(CONNECTED_TEST_STRIPE_ID is unset) — it will LOOK Stripe-connected but every "
+            "online-tier checkout will fail at session creation. Set CONNECTED_TEST_STRIPE_ID "
+            "and re-bootstrap before running online-checkout / E2E flows."
+        )
     org_alpha = events_models.Organization.objects.create(
         name="Revel Events Collective",
         slug="revel-events-collective",
@@ -38,7 +46,7 @@ that bring communities together.
 - Private gatherings
 """,
         city=state.cities["vienna"],
-        stripe_account_id=config("CONNECTED_TEST_STRIPE_ID", default=None),
+        stripe_account_id=connected_stripe_id,
         stripe_charges_enabled=True,
         stripe_details_submitted=True,
     )

--- a/src/events/management/commands/bootstrap_helpers/relationships.py
+++ b/src/events/management/commands/bootstrap_helpers/relationships.py
@@ -362,22 +362,22 @@ def create_follows(state: BootstrapState) -> None:
     )
 
     # Event series follows
-    # attendee_1 follows the tech talk series (member of beta org but explicitly following series)
-    if "tech_talk_series" in state.event_series:
-        EventSeriesFollow.objects.create(
-            user=state.users["attendee_1"],
-            event_series=state.event_series["tech_talk_series"],
-            notify_new_events=True,
-            is_public=False,
-        )
+    # attendee_1 follows the tech talk series (member of beta org but explicitly following series).
+    # Access the series directly (no `if ... in` guard) so a future key mismatch raises loudly
+    # instead of silently seeding zero follows.
+    EventSeriesFollow.objects.create(
+        user=state.users["attendee_1"],
+        event_series=state.event_series["tech_talks"],
+        notify_new_events=True,
+        is_public=False,
+    )
 
     # attendee_2 follows a series they're interested in
-    if "tech_talk_series" in state.event_series:
-        EventSeriesFollow.objects.create(
-            user=state.users["attendee_2"],
-            event_series=state.event_series["tech_talk_series"],
-            notify_new_events=True,
-            is_public=True,  # Public follow
-        )
+    EventSeriesFollow.objects.create(
+        user=state.users["attendee_2"],
+        event_series=state.event_series["tech_talks"],
+        notify_new_events=True,
+        is_public=True,  # Public follow
+    )
 
     logger.info("Created follow relationships")

--- a/src/events/management/commands/bootstrap_helpers/users.py
+++ b/src/events/management/commands/bootstrap_helpers/users.py
@@ -5,7 +5,7 @@ import random
 
 import structlog
 
-from accounts.models import RevelUser
+from accounts.models import GlobalBan, RevelUser
 
 from .base import BootstrapState
 
@@ -77,3 +77,18 @@ def create_users(state: BootstrapState) -> None:
         state.users[key] = user
 
     logger.info(f"Created {len(state.users)} users")
+
+
+def create_global_bans() -> None:
+    """Seed a banned email and a banned domain so the registration-blocked journey is E2E-reachable.
+
+    Neither value matches any seeded user, so the deactivation signal is a no-op — the rows exist
+    purely so a fresh registration with ``banned.user@example.com`` (or any ``@banned.example``
+    address) is rejected by the global-ban check.
+    """
+    logger.info("Creating global bans...")
+
+    GlobalBan.objects.create(ban_type=GlobalBan.BanType.EMAIL, value="banned.user@example.com")
+    GlobalBan.objects.create(ban_type=GlobalBan.BanType.DOMAIN, value="banned.example")
+
+    logger.info("Created 2 global bans (1 email, 1 domain)")

--- a/src/events/management/commands/bootstrap_test_events.py
+++ b/src/events/management/commands/bootstrap_test_events.py
@@ -72,6 +72,7 @@ class Command(BaseCommand):
             email="test.random@example.com",
             first_name="Random",
             last_name="Tester",
+            email_verified=True,
         )
 
         # Organization-specific users
@@ -81,6 +82,7 @@ class Command(BaseCommand):
             email="test.admin@example.com",
             first_name="Test",
             last_name="Admin",
+            email_verified=True,
         )
 
         self.staff_user = RevelUser.objects.create_user(
@@ -89,6 +91,7 @@ class Command(BaseCommand):
             email="test.staff@example.com",
             first_name="Test",
             last_name="Staff",
+            email_verified=True,
         )
 
         self.member_user = RevelUser.objects.create_user(
@@ -97,6 +100,7 @@ class Command(BaseCommand):
             email="test.member@example.com",
             first_name="Test",
             last_name="Member",
+            email_verified=True,
         )
 
         logger.info("Created 4 test users")


### PR DESCRIPTION
Fixes four bootstrap/seeding gaps surfaced while designing the frontend E2E suite. All are in the management-command seeders — no schema, model, or runtime-code changes.

## Changes

- **Closes #659** — `create_follows` looked up `state.event_series["tech_talk_series"]`, but the series is stored under `"tech_talks"`. Behind an `if ... in` guard the lookup missed silently, so **no `EventSeriesFollow` rows were ever seeded**. Fixed the key and dropped the guards so a future key mismatch raises a `KeyError` instead of silently seeding nothing.
- **Closes #660** — Org Alpha seeds `stripe_charges_enabled=True` while `stripe_account_id` comes from `CONNECTED_TEST_STRIPE_ID` (default `None`). When unset, the org *looks* connected but every online-tier checkout fails at session creation. `create_organizations` now emits a prominent `logger.warning` when the env var is unset.
- **Closes #661** — the four `test.*@example.com` eligibility-matrix users in `bootstrap_test_events` are now created with `email_verified=True`, so verified-email-gated flows (e.g. the public org contact form) accept them.
- **Closes #662** — new `create_global_bans()` helper seeds a banned email (`banned.user@example.com`) and a banned domain (`banned.example`), wired into `bootstrap_events` after `create_users`. Gives journey J2.5 (registration blocked by global ban) an E2E-reachable arrange path. The domain value is stored **without** the `@` to match `is_email_globally_banned`, which compares against `extract_domain()` (domain part only). Neither value matches any seeded user, so the deactivation signal is a no-op.

## Verification

- `make format`, `make lint`, `make mypy` all pass clean.
- `make bootstrap` was **not** run (destructive to the dev DB) — reviewer/author to run per project convention. Watch for the new Stripe warning when `CONNECTED_TEST_STRIPE_ID` is unset, and confirm `EventSeriesFollow` / `GlobalBan` row counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the sample event data with a blocked email address and domain for registration testing.
  * Test users created during event setup are now automatically marked as email verified.
  * Added a warning when Stripe test configuration is missing, helping identify checkout setup issues.

* **Bug Fixes**
  * Improved event-series follow setup by consistently linking seeded users to the expected series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->