### PR TITLE
fix: make bootstrap global-ban seeding idempotent (#665)

### DIFF
--- a/src/events/management/commands/bootstrap_helpers/users.py
+++ b/src/events/management/commands/bootstrap_helpers/users.py
@@ -88,7 +88,9 @@ def create_global_bans() -> None:
     """
     logger.info("Creating global bans...")
 
-    GlobalBan.objects.create(ban_type=GlobalBan.BanType.EMAIL, value="banned.user@example.com")
-    GlobalBan.objects.create(ban_type=GlobalBan.BanType.DOMAIN, value="banned.example")
+    # Idempotent so re-seeding (e.g. reset_events → bootstrap_events) doesn't collide with the
+    # (ban_type, normalized_value) uniqueness constraint and abort the reset mid-wipe (issue #665).
+    GlobalBan.objects.get_or_create(ban_type=GlobalBan.BanType.EMAIL, value="banned.user@example.com")
+    GlobalBan.objects.get_or_create(ban_type=GlobalBan.BanType.DOMAIN, value="banned.example")
 
     logger.info("Created 2 global bans (1 email, 1 domain)")

--- a/src/events/tests/test_bootstrap_helpers.py
+++ b/src/events/tests/test_bootstrap_helpers.py
@@ -1,0 +1,32 @@
+"""Tests for bootstrap seeding helpers."""
+
+import pytest
+
+from accounts.models import GlobalBan
+from events.management.commands.bootstrap_helpers.users import create_global_bans
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCreateGlobalBans:
+    """Coverage for ``create_global_bans``."""
+
+    def test_seeds_email_and_domain_bans(self) -> None:
+        create_global_bans()
+
+        assert GlobalBan.objects.filter(ban_type=GlobalBan.BanType.EMAIL, value="banned.user@example.com").exists()
+        assert GlobalBan.objects.filter(ban_type=GlobalBan.BanType.DOMAIN, value="banned.example").exists()
+
+    def test_is_idempotent(self) -> None:
+        """Regression for issue #665.
+
+        ``reset_events`` re-runs ``bootstrap_events`` without clearing GlobalBan
+        rows, so re-seeding previously collided with the ``(ban_type,
+        normalized_value)`` uniqueness constraint and raised ``ValidationError``,
+        leaving the DB half-wiped. Seeding must be idempotent.
+        """
+        create_global_bans()
+        create_global_bans()  # must not raise
+
+        assert GlobalBan.objects.filter(ban_type=GlobalBan.BanType.EMAIL).count() == 1
+        assert GlobalBan.objects.filter(ban_type=GlobalBan.BanType.DOMAIN).count() == 1


### PR DESCRIPTION
## Summary

Fixes #665.

`manage.py reset_events` (the documented E2E reset path) crashed partway through with:

```
django.core.exceptions.ValidationError: {'__all__': ['Global Ban with this Ban type and Normalized value already exists.']}
```

**Root cause:** `reset_events` re-runs `bootstrap_events` without clearing `GlobalBan` rows. `create_global_bans` used `.create()`, and because `GlobalBan.save()` runs `full_clean()` (via `TimeStampedModel`), the re-seed collided with the `(ban_type, normalized_value)` uniqueness constraint and surfaced as a `ValidationError`. That aborted the reset mid-transaction, leaving the DB half-wiped (test users deleted, orgs partially present) and requiring `reset_db --close-sessions` + full `make bootstrap` to recover.

**Fix:** switch the two seed writes in `create_global_bans` to `get_or_create`, making `bootstrap_events` idempotent. This fixes the reset path and makes `bootstrap_events` safe to re-run in general, not just via `reset_events`.

## Tests

- New `src/events/tests/test_bootstrap_helpers.py`:
  - seeds the expected email + domain bans
  - `test_is_idempotent` — regression for #665; calling `create_global_bans` twice must not raise and must not duplicate rows (fails on `main`, passes here)
- Existing `test_reset_events_command.py` and `test_global_ban.py` still green (51 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global-ban setup so repeated initialization no longer creates duplicate entries or causes conflicts.
  * Ensures both email and domain bans remain consistently available after reinitialization.

* **Tests**
  * Added coverage verifying global bans are created correctly and repeated setup is safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->