### PR TITLE
fix: de-duplicate search results across M2M joins (#664)

### DIFF
--- a/src/common/controllers/__init__.py
+++ b/src/common/controllers/__init__.py
@@ -1,5 +1,6 @@
 from .base import UserAwareController
 from .media import MediaValidationController
+from .searching import DistinctSearching
 from .tags import TagController
 
-__all__ = ["MediaValidationController", "TagController", "UserAwareController"]
+__all__ = ["DistinctSearching", "MediaValidationController", "TagController", "UserAwareController"]

--- a/src/common/controllers/searching.py
+++ b/src/common/controllers/searching.py
@@ -1,0 +1,27 @@
+import typing as t
+
+from django.db.models import QuerySet
+from ninja_extra.searching import Searching
+
+
+class DistinctSearching(Searching):
+    """`Searching` that de-duplicates results after filtering.
+
+    The default `Searching` builds an OR across `search_fields` and applies it as a single
+    `queryset.filter(...)`. When any search field spans a multiplying relation (a many-to-many
+    or reverse foreign key, e.g. `tags__tag__name`), the join emits one row per related match,
+    so an object appears once per matching related row. Appending `.distinct()` collapses those
+    duplicates back to one row per object.
+
+    Use this instead of `Searching` whenever `search_fields` traverses an M2M/reverse relation;
+    forward FK joins cannot multiply and do not need it.
+    """
+
+    def searching_queryset(
+        self, items: t.Union[QuerySet[t.Any], t.List[t.Any]], searching_input: "Searching.Input"
+    ) -> t.Union[QuerySet[t.Any], t.List[t.Any]]:
+        """Apply the base search filter, then de-duplicate querysets with `.distinct()`."""
+        result = super().searching_queryset(items, searching_input)
+        if isinstance(result, QuerySet):
+            return result.distinct()
+        return result

--- a/src/common/controllers/searching.py
+++ b/src/common/controllers/searching.py
@@ -22,6 +22,10 @@ class DistinctSearching(Searching):
     ) -> t.Union[QuerySet[t.Any], t.List[t.Any]]:
         """Apply the base search filter, then de-duplicate querysets with `.distinct()`."""
         result = super().searching_queryset(items, searching_input)
-        if isinstance(result, QuerySet):
+        # The base class returns `items` unchanged when there is no search term, so only the
+        # search filter can introduce the multiplying join — only then is `.distinct()` needed.
+        # Applying it unconditionally would defeat the callers' "materialize IDs to avoid an
+        # expensive COUNT(*) on a DISTINCT subquery" pagination optimization on every request.
+        if result is not items and isinstance(result, QuerySet):
             return result.distinct()
         return result

--- a/src/events/controllers/dashboard.py
+++ b/src/events/controllers/dashboard.py
@@ -16,7 +16,7 @@ from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseS
 from ninja_extra.searching import Searching, searching
 
 from common.authentication import I18nJWTAuth
-from common.controllers import UserAwareController
+from common.controllers import DistinctSearching, UserAwareController
 from common.signing import get_file_url
 from common.throttling import UserDefaultThrottle
 from events import filters, models, schema
@@ -50,7 +50,7 @@ class DashboardController(UserAwareController):
         response=PaginatedResponseSchema[schema.OrganizationRetrieveSchema],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
-    @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
+    @searching(DistinctSearching, search_fields=["name", "description", "tags__tag__name"])
     def dashboard_organizations(
         self,
         params: t.Annotated[filters.DashboardOrganizationsFiltersSchema, Query(...)],
@@ -66,7 +66,7 @@ class DashboardController(UserAwareController):
     @route.get("/events", url_name="dashboard_events", response=PaginatedResponseSchema[schema.EventInListSchema])
     @paginate(PageNumberPaginationExtra, page_size=20)
     @searching(
-        Searching,
+        DistinctSearching,
         search_fields=[
             "name",
             "description",
@@ -147,7 +147,7 @@ class DashboardController(UserAwareController):
         response=PaginatedResponseSchema[schema.EventSeriesRetrieveSchema],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
-    @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
+    @searching(DistinctSearching, search_fields=["name", "description", "tags__tag__name"])
     def dashboard_event_series(
         self,
         params: t.Annotated[filters.DashboardEventSeriesFiltersSchema, Query(...)],

--- a/src/events/controllers/event_public/discovery.py
+++ b/src/events/controllers/event_public/discovery.py
@@ -10,9 +10,10 @@ from ninja_extra import (
     route,
 )
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
-from ninja_extra.searching import Searching, searching
+from ninja_extra.searching import searching
 
 from common.authentication import I18nJWTAuth, OptionalAuth
+from common.controllers import DistinctSearching
 from common.schema import ResponseMessage
 from common.throttling import WriteThrottle
 from events import filters, models, schema
@@ -33,7 +34,7 @@ class EventPublicDiscoveryController(EventPublicBaseController):
     @route.get("/", url_name="list_events", response=PaginatedResponseSchema[schema.EventInListSchema])
     @paginate(PageNumberPaginationExtra, page_size=20)
     @searching(
-        Searching,
+        DistinctSearching,
         search_fields=[
             "name",
             "description",

--- a/src/events/controllers/event_series.py
+++ b/src/events/controllers/event_series.py
@@ -11,7 +11,7 @@ from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseS
 from ninja_extra.searching import Searching, searching
 
 from common.authentication import I18nJWTAuth, OptionalAuth
-from common.controllers import UserAwareController
+from common.controllers import DistinctSearching, UserAwareController
 from common.throttling import WriteThrottle
 from events import filters, models, schema
 from events.service import follow_service
@@ -35,7 +35,7 @@ class EventSeriesController(UserAwareController):
         response=PaginatedResponseSchema[schema.EventSeriesInListSchema],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
-    @searching(Searching, search_fields=["name", "description", "organization__name", "tags__tag__name"])
+    @searching(DistinctSearching, search_fields=["name", "description", "organization__name", "tags__tag__name"])
     def list_event_series(
         self,
         params: t.Annotated[filters.EventSeriesFilterSchema, Query(...)],

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -15,7 +15,7 @@ from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseS
 from ninja_extra.searching import Searching, searching
 
 from common.authentication import I18nJWTAuth, OptionalAuth
-from common.controllers import UserAwareController
+from common.controllers import DistinctSearching, UserAwareController
 from common.schema import ResponseMessage
 from common.throttling import (
     UserRequestThrottle,
@@ -104,7 +104,7 @@ class OrganizationController(UserAwareController):
 
     @route.get("/", url_name="list_organizations", response=PaginatedResponseSchema[schema.OrganizationInListSchema])
     @paginate(PageNumberPaginationExtra, page_size=20)
-    @searching(Searching, search_fields=["name", "description", "tags__tag__name"])
+    @searching(DistinctSearching, search_fields=["name", "description", "tags__tag__name"])
     def list_organizations(
         self,
         params: t.Annotated[filters.OrganizationFilterSchema, Query(...)],

--- a/src/events/controllers/questionnaire/core.py
+++ b/src/events/controllers/questionnaire/core.py
@@ -5,9 +5,10 @@ from django.db.models import Prefetch, QuerySet
 from ninja import Query
 from ninja_extra import route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
-from ninja_extra.searching import Searching, searching
+from ninja_extra.searching import searching
 
 from common.authentication import I18nJWTAuth
+from common.controllers import DistinctSearching
 from common.schema import ValidationErrorResponse
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import filters
@@ -31,7 +32,7 @@ class QuestionnaireCoreMixin(QuestionnaireControllerBase):
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
-    @searching(Searching, search_fields=["questionnaire__name", "events__name", "event_series__name"])
+    @searching(DistinctSearching, search_fields=["questionnaire__name", "events__name", "event_series__name"])
     def list_org_questionnaires(
         self,
         params: t.Annotated[filters.QuestionnaireFilterSchema, Query(...)],

--- a/src/events/tests/test_controllers/test_event_controller/test_list_events.py
+++ b/src/events/tests/test_controllers/test_event_controller/test_list_events.py
@@ -179,3 +179,30 @@ def test_list_events_search(
     response = client.get(url, {"search": "nonexistent"})
     assert response.status_code == 200
     assert len(response.json()["results"]) == 0
+
+
+def test_list_events_search_no_duplicates_with_tags(
+    client: Client, organization: Organization, next_week: datetime
+) -> None:
+    """A tagged event must appear once when searched, not once per tag (regression for #664)."""
+    event = Event.objects.create(
+        name="Summer Sunset Music Festival",
+        slug="sunset",
+        organization=organization,
+        visibility="public",
+        event_type=Event.EventType.PUBLIC,
+        description="Open-air music.",
+        status="open",
+        start=next_week,
+        end=next_week + timedelta(days=1),
+    )
+    event.add_tags("music", "festival", "summer")
+
+    url = reverse("api:list_events")
+    response = client.get(url, {"search": "Sunset"})
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    ids = [r["id"] for r in results]
+    assert ids == [str(event.id)]
+    assert len(ids) == len(set(ids))


### PR DESCRIPTION
Fixes #664.

## Problem
`ninja_extra`'s `Searching` applies the search filter as a single `queryset.filter(Q(...) | ...)` with **no `.distinct()`**. When a `search_field` spans a *multiplying* relation (M2M / reverse FK, e.g. `tags__tag__name`), the join emits one row per related match, so each object was returned **once per matching row**.

For the events list this meant an event with 3 tags appeared 3× when `search` was used (`Summer Sunset Music Festival ×3`), which breaks id-keyed rendering on the frontend (blank list / "3 events found" with no cards) — the guest search journey was broken.

## Fix
Add a small shared `DistinctSearching(Searching)` (in `common/controllers/`) that appends `.distinct()` after the base filter, and use it on **every** search endpoint whose `search_fields` traverse an M2M / reverse relation:

- events discovery (`list_events`) — the reported endpoint
- event series (`list_event_series`)
- organizations (`list_organizations`)
- dashboard: organizations, events, series
- org questionnaires (`list_org_questionnaires` — `events__name`, `event_series__name` are both M2M)

Forward-FK search endpoints (`event__name`, `organization__name`, …) keep the base `Searching` — a many-to-one join can't multiply.

## Test
Regression test `test_list_events_search_no_duplicates_with_tags` creates a 3-tag event and asserts it appears exactly once when searched. Verified it fails on the pre-fix code and passes with the fix.

## Follow-up (frontend, separate repo)
The FE E2E spec `j01-guest/browse-events.spec.ts` has the search test marked `test.fixme` referencing #664 — flip it back on in a frontend PR once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)