### PR TITLE
chore(release): v1.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.69.1] - 2026-07-10
+
+### Fixed
+- Search results no longer contain duplicates when the search term matches on a multiplying relation (e.g. tags): an event with 3 matching tags used to appear 3× in events, event-series, organization, dashboard, and questionnaire listings.
+
+### Security
+- Upgraded Django 5.2.15 → 5.2.16 to patch three known vulnerabilities (`PYSEC-2026-2090`, `PYSEC-2026-2091`, `PYSEC-2026-2092`).
+
 ## [1.69.0] - 2026-07-09
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "1.69.0"
+version = "1.69.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3618,7 +3618,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "1.69.0"
+version = "1.69.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [1.69.1] - 2026-07-10

### Fixed
- Search results no longer contain duplicates when the search term matches on a multiplying relation (e.g. tags): an event with 3 matching tags used to appear 3× in events, event-series, organization, dashboard, and questionnaire listings.

### Security
- Upgraded Django 5.2.15 → 5.2.16 to patch three known vulnerabilities (`PYSEC-2026-2090`, `PYSEC-2026-2091`, `PYSEC-2026-2092`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search results no longer display duplicate entries when queries match related data, such as tags, across multiple listing pages.

- **Security**
  - Updated Django to version 5.2.16 to address reported security vulnerabilities.

- **Release**
  - Released version 1.69.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->