### PR TITLE
fix: bump django to 5.2.16 (PYSEC-2026-2090/2091/2092)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -762,16 +762,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.15"
+version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pip-audit` flagged **Django 5.2.15** with 3 known vulnerabilities (`PYSEC-2026-2090`, `PYSEC-2026-2091`, `PYSEC-2026-2092`), all fixed in **5.2.16**. This upgrades the lockfile pin to 5.2.16 — staying on the 5.2 LTS line (existing `django>=5.2.14,<6.0` constraint already permitted it, only `uv.lock` needed the bump).

`make audit` now reports **"No known vulnerabilities found."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N
