### PR TITLE
test(#670) attempt-burn regression guard + docs(#671) silk E2E deadlock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ STRIPE_WEBHOOK_EVENT_RETENTION_DAYS=90
 # Warning: SET TO FALSE IN PRODUCTION
 DEMO_MODE=True
 
+# Django Silk profiling UI (dev-only). Its middleware writes a request row to Postgres per
+# request, which deadlocks under parallel load — set to False for frontend E2E / parallel-load
+# runs to avoid sporadic 500s (see docs/getting-started/troubleshooting.md, issue #671).
+SILK_PROFILER=False
+
 # Feature Flags (self-hosting). All default to True (full SaaS behaviour);
 # set to False to drop the corresponding optional dependency.
 # Skip the ClamAV scan and mark uploads clean immediately (run without antivirus).

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -244,3 +244,12 @@ Flags that affect development behavior:
 
 !!! danger "Production safety"
     `DEMO_MODE` and `SYSTEM_TESTING` must be `False` in production. `DEMO_MODE` defaults to `True` when `DEBUG=True`, so it's safe in development, but always verify production `.env` files.
+
+!!! warning "Silk deadlocks under parallel E2E runs"
+    Django Silk's middleware writes a request row to Postgres on every request. When the frontend
+    E2E suite drives a local `make run` backend with several parallel Playwright workers, those
+    concurrent inserts can deadlock in Postgres and surface as sporadic 500s on unrelated
+    endpoints (e.g. `POST /api/account/verify`). Run the backend with **`SILK_PROFILER=False`**
+    for E2E / parallel-load runs — the profiler is a dev-only convenience and is fully gated off
+    by this flag (middleware, app, and URLs). The durable fix belongs in the E2E harness that
+    launches the backend (see `letsrevel/revel-frontend#596`); this is tracked in #671.

--- a/src/events/tests/test_controllers/test_event_controller/test_questionnaire.py
+++ b/src/events/tests/test_controllers/test_event_controller/test_questionnaire.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from events.models import (
     Event,
+    EventQuestionnaireSubmission,
     OrganizationQuestionnaire,
 )
 from questionnaires.models import (
@@ -153,6 +154,27 @@ def test_submit_questionnaire_missing_mandatory_fails(
     response = nonmember_client.post(url, data=orjson.dumps(payload), content_type="application/json")
     assert response.status_code == 400
     assert "You are missing mandatory answers" in response.json()["detail"]
+
+
+def test_submit_missing_mandatory_does_not_burn_attempt(
+    nonmember_client: Client, public_event: Event, event_questionnaire: Questionnaire
+) -> None:
+    """A rejected (missing-mandatory) READY submission must not persist anything.
+
+    An admission "attempt" is the existence of an EventQuestionnaireSubmission row, so the
+    submit endpoint rolling back before creating one is what protects the limited
+    ``max_attempts``. Regression guard for #670.
+    """
+    url = reverse(
+        "api:submit_questionnaire",
+        kwargs={"event_id": public_event.pk, "questionnaire_id": event_questionnaire.pk},
+    )
+    payload = {"questionnaire_id": str(event_questionnaire.pk), "status": "ready"}
+    response = nonmember_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+    assert response.status_code == 400
+    # Neither the submission nor the attempt-tracking row may be written.
+    assert QuestionnaireSubmission.objects.count() == 0
+    assert EventQuestionnaireSubmission.objects.count() == 0
 
 
 def test_submit_questionnaire_anonymous_fails(


### PR DESCRIPTION
Addresses #670 and #671.

## #670 — questionnaire submit burning an attempt on empty/partial submissions

Verified **already fixed on `main`**: `SubmissionService._validate_submission` enforces that every *applicable* mandatory question (respecting conditional-branching visibility) is answered for `status: "ready"` submissions, raising `MissingMandatoryAnswerError` → **400** inside the atomic block, **before** the `EventQuestionnaireSubmission` attempt-tracking row is created. So a rejected submission does **not** consume one of the limited `max_attempts`. `test_submit_questionnaire_missing_mandatory_fails` already covers the 400.

This PR adds `test_submit_missing_mandatory_does_not_burn_attempt`, which additionally asserts that **neither** a `QuestionnaireSubmission` **nor** an `EventQuestionnaireSubmission` row is persisted on a rejected READY submission — locking in the "no attempt burned" invariant so it can't silently regress.

No runtime change; #670 can be closed as already-fixed with this coverage in place.

## #671 — django-silk deadlocks in Postgres under parallel E2E load

Root cause is configuration, not a backend bug: silk's middleware writes a request row per request, and several parallel Playwright workers hitting a local `make run` backend deadlock on those concurrent inserts (sporadic 500s on unrelated endpoints). `SILK_PROFILER=False` already fully gates silk off (middleware, app, urls).

Documented the guidance in `troubleshooting.md` and surfaced `SILK_PROFILER=False` in `.env.example`. The durable fix belongs in the FE E2E harness that launches the backend — see `revel-frontend#596`. No backend code change.

## Testing
- `uv run pytest src/events/tests/test_controllers/test_event_controller/test_questionnaire.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed questionnaire submissions that omit mandatory answers now return a validation error without consuming an attempt or creating a submission record.

* **Documentation**
  * Added troubleshooting guidance for sporadic errors during parallel end-to-end runs caused by the development profiling tool.

* **Configuration**
  * Added the `SILK_PROFILER` setting to the environment template, allowing profiling to be disabled when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->