### PR TITLE
fix: stop swallowing membership request approval/rejection notifications (#673)

### DIFF
--- a/src/events/tests/test_controllers/test_organization_admin/test_membership_requests.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_membership_requests.py
@@ -1,11 +1,16 @@
 """Tests for organization admin membership request endpoints."""
 
+import typing as t
+from unittest.mock import patch
+
 import orjson
 import pytest
 from django.test.client import Client
 from django.urls import reverse
 
 from events.models import MembershipTier, Organization, OrganizationMember, OrganizationMembershipRequest
+from notifications.enums import NotificationType
+from notifications.models import Notification
 
 pytestmark = pytest.mark.django_db
 
@@ -63,3 +68,66 @@ class TestManageMembershipRequests:
         assert response.status_code == 204
         organization_membership_request.refresh_from_db()
         assert organization_membership_request.status == OrganizationMembershipRequest.Status.REJECTED
+
+    def test_approve_dispatches_approval_notification(
+        self,
+        organization_owner_client: Client,
+        organization_membership_request: OrganizationMembershipRequest,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Approving a request must persist the applicant's approval notification.
+
+        Regression for #673: MEMBERSHIP_REQUEST_APPROVED was validated against a schema
+        requiring role/action keys the dispatch never sends, so the notification failed
+        validation and was silently swallowed.
+        """
+        tier = MembershipTier.objects.get(
+            organization=organization_membership_request.organization, name="General membership"
+        )
+        url = reverse(
+            "api:approve_membership_request",
+            kwargs={
+                "slug": organization_membership_request.organization.slug,
+                "request_id": organization_membership_request.id,
+            },
+        )
+        payload = {"tier_id": str(tier.id)}
+        with (
+            patch("notifications.tasks.dispatch_notification.delay"),
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            response = organization_owner_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+        assert response.status_code == 204
+
+        notifications = Notification.objects.filter(
+            user=organization_membership_request.user,
+            notification_type=NotificationType.MEMBERSHIP_REQUEST_APPROVED,
+        )
+        assert notifications.count() == 1, "approval notification failed schema validation and was swallowed"
+
+    def test_reject_dispatches_rejection_notification(
+        self,
+        organization_owner_client: Client,
+        organization_membership_request: OrganizationMembershipRequest,
+        django_capture_on_commit_callbacks: t.Any,
+    ) -> None:
+        """Rejecting a request must persist the applicant's rejection notification (regression for #673)."""
+        url = reverse(
+            "api:reject_membership_request",
+            kwargs={
+                "slug": organization_membership_request.organization.slug,
+                "request_id": organization_membership_request.id,
+            },
+        )
+        with (
+            patch("notifications.tasks.dispatch_notification.delay"),
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            response = organization_owner_client.post(url)
+        assert response.status_code == 204
+
+        notifications = Notification.objects.filter(
+            user=organization_membership_request.user,
+            notification_type=NotificationType.MEMBERSHIP_REQUEST_REJECTED,
+        )
+        assert notifications.count() == 1, "rejection notification failed schema validation and was swallowed"

--- a/src/notifications/context_schemas.py
+++ b/src/notifications/context_schemas.py
@@ -330,6 +330,24 @@ class MembershipRequestCreatedContext(BaseNotificationContext):
     request_message: t.NotRequired[str]
 
 
+class MembershipRequestApprovedContext(BaseNotificationContext):
+    """Context for MEMBERSHIP_REQUEST_APPROVED notification (to the applicant).
+
+    A request decision is not a role change, so it does not carry the ``role``/``action``
+    keys of ``MembershipContext`` — only the organization the applicant was admitted to.
+    """
+
+    organization_id: str
+    organization_name: str
+
+
+class MembershipRequestRejectedContext(BaseNotificationContext):
+    """Context for MEMBERSHIP_REQUEST_REJECTED notification (to the applicant)."""
+
+    organization_id: str
+    organization_name: str
+
+
 # ===== Account Contexts =====
 
 
@@ -585,8 +603,8 @@ NOTIFICATION_CONTEXT_SCHEMAS: dict[NotificationType, type[BaseNotificationContex
     NotificationType.MEMBERSHIP_PROMOTED: MembershipContext,
     NotificationType.MEMBERSHIP_REMOVED: MembershipContext,
     NotificationType.MEMBERSHIP_REQUEST_CREATED: MembershipRequestCreatedContext,
-    NotificationType.MEMBERSHIP_REQUEST_APPROVED: MembershipContext,
-    NotificationType.MEMBERSHIP_REQUEST_REJECTED: MembershipContext,
+    NotificationType.MEMBERSHIP_REQUEST_APPROVED: MembershipRequestApprovedContext,
+    NotificationType.MEMBERSHIP_REQUEST_REJECTED: MembershipRequestRejectedContext,
     NotificationType.ACCOUNT_BANNED: AccountBannedContext,
     NotificationType.ORG_ANNOUNCEMENT: OrgAnnouncementContext,
     NotificationType.ORG_CONTACT_MESSAGE_RECEIVED: OrgContactMessageReceivedContext,


### PR DESCRIPTION
Fixes #673.

## Root cause

`MEMBERSHIP_REQUEST_APPROVED` and `MEMBERSHIP_REQUEST_REJECTED` were both mapped to `MembershipContext`, whose schema requires `role` + `action` — keys that describe a **role change** (correct for `MEMBERSHIP_GRANTED/PROMOTED/REMOVED`). A request **decision** is not a role change: both dispatch sites (`organization_service/membership.py`) send only `organization_id`, `organization_name`, `frontend_url`, and both templates read only `organization_name`.

So every approval/rejection notification failed `validate_notification_context` with `Missing required context keys {'role', 'action'}` and was silently swallowed via `notification_request_failed` — approved applicants never received their in-app/email notification. The rejection path was broken identically.

## Fix

Give the two request-decision types their own context schemas — `MembershipRequestApprovedContext` / `MembershipRequestRejectedContext` (`organization_id` + `organization_name`, `frontend_url` inherited) — mirroring the existing `WhitelistRequestApprovedContext` / `WhitelistRequestRejectedContext` precedent. No dispatch or template changes needed.

## Tests

The existing approve/reject endpoint tests never exercised the notification (dispatch happens in `transaction.on_commit`, which doesn't fire without capture — which is how this slipped through). Added two regression tests that drive the real `on_commit` → `notification_requested` → `create_notification` → `validate_notification_context` path under `django_capture_on_commit_callbacks(execute=True)` and assert the `Notification` row is persisted (not swallowed).

## Testing
- `uv run pytest src/events/tests/test_controllers/test_organization_admin/test_membership_requests.py src/notifications/tests/test_signals.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N
