### PR TITLE
feat: expose org name/slug/logo on public org-token preview (#675)

### DIFF
--- a/src/events/controllers/organization_admin/tokens.py
+++ b/src/events/controllers/organization_admin/tokens.py
@@ -101,7 +101,9 @@ class OrganizationAdminTokensController(OrganizationAdminBaseController):
         - Verify staff invitation tokens are properly restricted
         """
         organization = self.get_one(slug)
-        return params.filter(models.OrganizationToken.objects.filter(organization=organization)).distinct()
+        return params.filter(
+            models.OrganizationToken.objects.filter(organization=organization).select_related("organization")
+        ).distinct()
 
     @route.post(
         "/tokens",

--- a/src/events/schema/organization.py
+++ b/src/events/schema/organization.py
@@ -26,6 +26,7 @@ from .mixins import (
     SocialMediaSchemaEditMixin,
     SocialMediaSchemaRetrieveMixin,
     TaggableSchemaMixin,
+    get_image_field_url,
 )
 
 
@@ -300,6 +301,13 @@ class StaffAddSchema(Schema):
 
 
 class OrganizationTokenSchema(ModelSchema):
+    # Additive, public-safe org details so the pre-claim token preview (unauthenticated)
+    # can render which organization the invitee is joining without a second lookup.
+    # ``organization`` stays a bare UUID to keep the org-admin token list contract unchanged.
+    organization_name: str
+    organization_slug: str
+    organization_logo_url: str | None = None
+
     class Meta:
         model = models.OrganizationToken
         fields = [
@@ -315,6 +323,21 @@ class OrganizationTokenSchema(ModelSchema):
             "membership_tier",
             "created_at",
         ]
+
+    @staticmethod
+    def resolve_organization_name(obj: models.OrganizationToken) -> str:
+        """Return the token's organization name."""
+        return obj.organization.name
+
+    @staticmethod
+    def resolve_organization_slug(obj: models.OrganizationToken) -> str:
+        """Return the token's organization slug."""
+        return obj.organization.slug
+
+    @staticmethod
+    def resolve_organization_logo_url(obj: models.OrganizationToken) -> str | None:
+        """Return the token's organization logo thumbnail URL, if any (public, unsigned)."""
+        return get_image_field_url(obj.organization, "logo_thumbnail")
 
 
 class OrganizationTokenBaseSchema(Schema):

--- a/src/events/tests/test_controllers/test_token_endpoints.py
+++ b/src/events/tests/test_controllers/test_token_endpoints.py
@@ -113,6 +113,10 @@ def test_get_organization_token_returns_token_details(
     assert data["name"] == "Member Invite"
     assert data["organization"] is not None
     assert data["grants_membership"] is True
+    # Public-safe org details so the pre-claim page can render which org is inviting (#675).
+    assert data["organization_name"] == organization.name
+    assert data["organization_slug"] == organization.slug
+    assert "organization_logo_url" in data  # present (null when the org has no logo)
 
 
 def test_get_organization_token_shows_staff_status(


### PR DESCRIPTION
Backend half of frontend letsrevel/revel-frontend#601. Fixes #675.

## Problem

`GET /api/organizations/tokens/{token_id}` (the public, pre-claim token preview) returned `OrganizationTokenSchema` where `organization` is a bare UUID. The `/join/org/[token_id]` page needs to show which org is inviting (name/slug/logo) before the user claims, and there is no public org-by-id endpoint to resolve the UUID — so the page SSR-500s today.

## Change

Additive, public-safe fields on the token schema, resolved from the token's organization:

- `organization_name: str`
- `organization_slug: str`
- `organization_logo_url: str | null` (logo thumbnail, public/unsigned)

This matches the existing flat `organization_*` convention used by the membership/subscription schemas (`subscription.py`), rather than a nested object. `organization` stays a bare UUID, so the **org-admin token list/create** endpoints (which share `OrganizationTokenSchema`) keep their existing contract — non-breaking.

Only name/slug/logo are exposed (no stripe/fee/contact fields) since the endpoint is unauthenticated. Expired/used tokens already 404 at the service layer (`get_organization_token` filters them out), so no org data leaks for invalid tokens.

Also `select_related("organization")` on the admin token list queryset to avoid an N+1 introduced by the new resolvers (the public endpoint already select_related's via the service).

## Testing
- `uv run pytest src/events/tests/test_controllers/test_token_endpoints.py src/events/tests/test_controllers/test_organization_admin/test_tokens.py`

The FE client should be regenerated (`pnpm generate:api`) against the updated OpenAPI spec after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N
