### PR TITLE
feat: enrich public org/event token previews (#677, #679)

### DIFF
--- a/src/events/controllers/event_admin/tokens.py
+++ b/src/events/controllers/event_admin/tokens.py
@@ -181,7 +181,11 @@ class EventAdminTokensController(EventAdminBaseController):
         - Audit who created which tokens and when
         """
         self.get_one(event_id)
-        qs = models.EventToken.objects.filter(event_id=event_id).prefetch_related("ticket_tiers")
+        qs = (
+            models.EventToken.objects.filter(event_id=event_id)
+            .select_related("event", "event__organization")
+            .prefetch_related("ticket_tiers")
+        )
         return params.filter(qs).distinct()
 
     @route.post(

--- a/src/events/controllers/organization_admin/tokens.py
+++ b/src/events/controllers/organization_admin/tokens.py
@@ -102,7 +102,9 @@ class OrganizationAdminTokensController(OrganizationAdminBaseController):
         """
         organization = self.get_one(slug)
         return params.filter(
-            models.OrganizationToken.objects.filter(organization=organization).select_related("organization")
+            models.OrganizationToken.objects.filter(organization=organization).select_related(
+                "organization", "membership_tier"
+            )
         ).distinct()
 
     @route.post(

--- a/src/events/schema/invitation.py
+++ b/src/events/schema/invitation.py
@@ -10,6 +10,7 @@ from common.schema import OneToOneFiftyString, StrippedString
 from events import models
 
 from .event import EventInListSchema
+from .mixins import get_image_field_url
 from .ticket import TicketTierSchema
 
 
@@ -137,6 +138,14 @@ class EventInvitationRequestInternalSchema(EventInvitationRequestSchema):
 
 class EventTokenSchema(ModelSchema):
     ticket_tiers: list[TicketTierSchema] = Field(default_factory=list)
+    # Additive, public-safe event details so the pre-claim token preview (unauthenticated)
+    # can render which event the invitee is joining without a second lookup.
+    # ``event`` stays a bare UUID to keep the event-admin token list contract unchanged.
+    event_name: str
+    event_slug: str
+    organization_slug: str
+    event_start: AwareDatetime
+    event_cover_url: str | None = None
 
     class Meta:
         model = models.EventToken
@@ -152,6 +161,31 @@ class EventTokenSchema(ModelSchema):
             "invitation_payload",
             "created_at",
         ]
+
+    @staticmethod
+    def resolve_event_name(obj: models.EventToken) -> str:
+        """Return the token's event name."""
+        return obj.event.name
+
+    @staticmethod
+    def resolve_event_slug(obj: models.EventToken) -> str:
+        """Return the token's event slug."""
+        return obj.event.slug
+
+    @staticmethod
+    def resolve_organization_slug(obj: models.EventToken) -> str:
+        """Return the slug of the event's organization (for FE navigation)."""
+        return obj.event.organization.slug
+
+    @staticmethod
+    def resolve_event_start(obj: models.EventToken) -> AwareDatetime:
+        """Return the event start time."""
+        return obj.event.start
+
+    @staticmethod
+    def resolve_event_cover_url(obj: models.EventToken) -> str | None:
+        """Return the event's social cover-art URL, if any (public, unsigned)."""
+        return get_image_field_url(obj.event, "cover_art_social")
 
 
 class EventTokenBaseSchema(Schema):

--- a/src/events/schema/organization.py
+++ b/src/events/schema/organization.py
@@ -307,6 +307,7 @@ class OrganizationTokenSchema(ModelSchema):
     organization_name: str
     organization_slug: str
     organization_logo_url: str | None = None
+    membership_tier_name: str | None = None
 
     class Meta:
         model = models.OrganizationToken
@@ -338,6 +339,11 @@ class OrganizationTokenSchema(ModelSchema):
     def resolve_organization_logo_url(obj: models.OrganizationToken) -> str | None:
         """Return the token's organization logo thumbnail URL, if any (public, unsigned)."""
         return get_image_field_url(obj.organization, "logo_thumbnail")
+
+    @staticmethod
+    def resolve_membership_tier_name(obj: models.OrganizationToken) -> str | None:
+        """Return the granted membership tier's name, if the token targets a specific tier."""
+        return obj.membership_tier.name if obj.membership_tier else None
 
 
 class OrganizationTokenBaseSchema(Schema):

--- a/src/events/service/organization_service/tokens.py
+++ b/src/events/service/organization_service/tokens.py
@@ -226,7 +226,7 @@ def get_organization_token(token: str) -> OrganizationToken | None:
     exhausted (``uses < max_uses``, or ``max_uses == 0`` for unlimited).
     """
     return (
-        OrganizationToken.objects.select_related("organization")
+        OrganizationToken.objects.select_related("organization", "membership_tier")
         .filter(
             Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()),
             Q(max_uses=0) | Q(uses__lt=F("max_uses")),

--- a/src/events/service/tokens.py
+++ b/src/events/service/tokens.py
@@ -142,7 +142,7 @@ def get_event_token(token: str) -> EventToken | None:
         The EventToken if found and still valid, None otherwise.
     """
     return (
-        EventToken.objects.select_related("event")
+        EventToken.objects.select_related("event", "event__organization")
         .prefetch_related("ticket_tiers")
         .filter(
             Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()),

--- a/src/events/tests/test_controllers/test_token_endpoints.py
+++ b/src/events/tests/test_controllers/test_token_endpoints.py
@@ -117,6 +117,8 @@ def test_get_organization_token_returns_token_details(
     assert data["organization_name"] == organization.name
     assert data["organization_slug"] == organization.slug
     assert "organization_logo_url" in data  # present (null when the org has no logo)
+    # Target membership tier name for the pre-claim page (#677).
+    assert data["membership_tier_name"] == default_tier.name
 
 
 def test_get_organization_token_shows_staff_status(

--- a/src/events/tests/test_controllers/test_token_endpoints.py
+++ b/src/events/tests/test_controllers/test_token_endpoints.py
@@ -38,6 +38,12 @@ def test_get_event_token_returns_token_details(
     assert data["name"] == "Test Token"
     assert data["event"] is not None
     assert data["grants_invitation"] is True
+    # Public-safe event details so the pre-claim page can render the event (#679).
+    assert data["event_name"] == event.name
+    assert data["event_slug"] == event.slug
+    assert data["organization_slug"] == event.organization.slug
+    assert data["event_start"] is not None
+    assert "event_cover_url" in data  # present (null when the event has no cover art)
 
 
 def test_get_event_token_shows_ticket_tier_when_present(


### PR DESCRIPTION
Bundles two sibling token-preview enrichments (they touch the same public pre-claim flow). Fixes #677 and #679.

## #677 — org-token preview: `membership_tier_name`
Follow-on to #675/#676. Tokens granting a specific membership tier exposed `membership_tier` only as a bare UUID, so the `/join/org` page couldn't name the target tier. Adds additive, public-safe `membership_tier_name: str | null` (resolved from `obj.membership_tier`) + `select_related("membership_tier")` on the public preview service and admin token list.

## #679 — event-token preview: event details
The unauthenticated event-token preview (`GET /events/tokens/{token_id}`) returned `event` as a bare UUID, so `/join/event` rendered **"Join undefined"**. Adds additive, public-safe:
- `event_name`, `event_slug` (identity)
- `organization_slug` (FE navigation)
- `event_start`, `event_cover_url` (context)

resolved from the token's event, plus `select_related("event__organization")` on the public preview service and admin event-token list to avoid N+1.

## Non-breaking
`membership_tier` / `event` stay bare UUIDs; all fields are purely additive. The org-admin and event-admin token list/create schemas keep their existing contracts.

## Out of scope (flagged for a separate decision)
#679 also raises changing expired/used-up token previews from **404** to **410-with-reason** ("expired" vs "used up"). That's a distinct FE-contract behavior change and is intentionally not included here.

## Testing
- `uv run pytest src/events/tests/test_controllers/test_token_endpoints.py src/events/tests/test_controllers/test_organization_admin/test_tokens.py`

FE client should be regenerated (`pnpm generate:api`) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N
