### PR TITLE
fix: guard org-admin routes on real PermissionMap keys (#683)

### DIFF
--- a/src/events/controllers/organization_admin/discount_codes.py
+++ b/src/events/controllers/organization_admin/discount_codes.py
@@ -22,7 +22,7 @@ from .base import OrganizationAdminBaseController
     auth=I18nJWTAuth(),
     tags=["Organization Admin"],
     throttle=WriteThrottle(),
-    permissions=[OrganizationPermission("manage_events")],
+    permissions=[OrganizationPermission("manage_tickets")],
 )
 class OrganizationAdminDiscountCodesController(OrganizationAdminBaseController):
     """Organization discount code management endpoints."""

--- a/src/events/controllers/organization_admin/resources.py
+++ b/src/events/controllers/organization_admin/resources.py
@@ -95,7 +95,7 @@ class OrganizationAdminResourcesController(OrganizationAdminBaseController):
         "/resources/{resource_id}",
         url_name="delete_organization_resource",
         response={204: None},
-        permissions=[OrganizationPermission("manage_organization")],
+        permissions=[OrganizationPermission("edit_organization")],
     )
     def delete_resource(self, slug: str, resource_id: UUID) -> tuple[int, None]:
         """Delete a resource from the organization."""

--- a/src/events/controllers/organization_admin/revenue.py
+++ b/src/events/controllers/organization_admin/revenue.py
@@ -12,7 +12,7 @@ from common.authentication import I18nJWTAuth
 from common.models import FileExport
 from common.throttling import ExportThrottle, UserDefaultThrottle
 from events import schema
-from events.controllers.permissions import OrganizationPermission
+from events.controllers.permissions import IsOrganizationOwner
 from events.exceptions import InvalidPeriodError
 from events.schema.export import FileExportSchema
 from events.schema.financials import OrganizationFinancialsSchema
@@ -25,7 +25,7 @@ from .base import OrganizationAdminBaseController
     "/organization-admin/{slug}",
     auth=I18nJWTAuth(),
     tags=["Organization Admin"],
-    permissions=[OrganizationPermission("manage_organization")],
+    permissions=[IsOrganizationOwner()],
 )
 class OrganizationAdminRevenueController(OrganizationAdminBaseController):
     """Generate and poll downloadable revenue & VAT report bundles."""

--- a/src/events/controllers/permissions.py
+++ b/src/events/controllers/permissions.py
@@ -30,7 +30,20 @@ class RootPermission(BasePermission):
         return True
 
 
-class EventSeriesPermission(RootPermission):
+class PermissionMapPermission(RootPermission):
+    """Base for permissions whose ``action`` is resolved against ``PermissionMap``.
+
+    Constraining ``action`` to :data:`~events.models.PermissionKey` makes mypy (and the
+    IDE) reject any key that is not a real ``PermissionMap`` field — a bogus key can never
+    be granted, so it would silently deny all non-owner staff (see #683).
+    """
+
+    def __init__(self, action: models.PermissionKey) -> None:
+        """Store the map-backed action."""
+        super().__init__(action=action)
+
+
+class EventSeriesPermission(PermissionMapPermission):
     def has_object_permission(
         self,
         request: HttpRequest,
@@ -41,7 +54,7 @@ class EventSeriesPermission(RootPermission):
         return obj.organization.has_org_permission(t.cast(UUID, request.user.id), self.action)
 
 
-class EventPermission(RootPermission):
+class EventPermission(PermissionMapPermission):
     def has_object_permission(
         self,
         request: HttpRequest,
@@ -52,7 +65,7 @@ class EventPermission(RootPermission):
         return obj.organization.has_org_permission(t.cast(UUID, request.user.id), self.action)
 
 
-class OrganizationPermission(RootPermission):
+class OrganizationPermission(PermissionMapPermission):
     def has_object_permission(
         self,
         request: HttpRequest,
@@ -63,7 +76,7 @@ class OrganizationPermission(RootPermission):
         return obj.has_org_permission(t.cast(UUID, request.user.id), self.action)
 
 
-class QuestionnairePermission(RootPermission):
+class QuestionnairePermission(PermissionMapPermission):
     def has_object_permission(
         self,
         request: HttpRequest,
@@ -71,7 +84,9 @@ class QuestionnairePermission(RootPermission):
         obj: models.OrganizationQuestionnaire,
     ) -> bool:
         """Can edit organization."""
-        return OrganizationPermission(self.action).has_object_permission(request, controller, obj.organization)
+        # self.action is a PermissionKey by construction, but stored as str on the base.
+        action = t.cast(models.PermissionKey, self.action)
+        return OrganizationPermission(action).has_object_permission(request, controller, obj.organization)
 
 
 class IsOrganizationOwner(RootPermission):

--- a/src/events/models/__init__.py
+++ b/src/events/models/__init__.py
@@ -30,6 +30,7 @@ from .organization import (
     OrganizationStaff,
     OrganizationToken,
     OrgTractionRow,
+    PermissionKey,
     PermissionMap,
     PermissionsSchema,
 )
@@ -86,6 +87,7 @@ __all__ = [
     "OrganizationStaff",
     "OrganizationToken",
     "OrgTractionRow",
+    "PermissionKey",
     "PermissionMap",
     "PermissionsSchema",
     # Event Series

--- a/src/events/models/organization.py
+++ b/src/events/models/organization.py
@@ -459,6 +459,37 @@ class Organization(
         return False
 
 
+# Canonical set of staff-permission keys. Every ``PermissionMap`` field below must appear
+# here (and vice versa) so that ``OrganizationPermission("...")`` and the other map-resolving
+# permission classes only accept real keys — a bogus key can never be granted, so it would
+# silently deny all non-owner staff (see #683). The two are kept in sync by a unit test.
+PermissionKey = t.Literal[
+    "view_organization_details",
+    "create_event",
+    "create_event_series",
+    "edit_event_series",
+    "delete_event_series",
+    "edit_event",
+    "delete_event",
+    "open_event",
+    "manage_tickets",
+    "close_event",
+    "manage_event",
+    "check_in_attendees",
+    "invite_to_event",
+    "edit_organization",
+    "manage_members",
+    "manage_potluck",
+    "create_questionnaire",
+    "edit_questionnaire",
+    "delete_questionnaire",
+    "evaluate_questionnaire",
+    "send_announcements",
+    "manage_subscriptions",
+    "manage_polls",
+]
+
+
 class PermissionMap(BaseModel):
     view_organization_details: bool = True
     create_event: bool = False

--- a/src/events/tests/test_controllers/test_organization_admin/test_discount_codes.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_discount_codes.py
@@ -6,7 +6,7 @@ Tests cover:
 - Getting discount code detail (exists, not found, wrong organization)
 - Updating discount codes (partial update, M2M update)
 - Deleting discount codes (hard-delete when unused, otherwise deactivate)
-- Permission checks (owner, staff with manage_events, staff without, non-staff)
+- Permission checks (owner, staff with manage_tickets, staff without, non-staff)
 """
 
 import uuid
@@ -36,20 +36,41 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def manage_events_staff(
+def manage_tickets_staff(
     organization: Organization, organization_staff_user: RevelUser, staff_member: OrganizationStaff
 ) -> OrganizationStaff:
-    """Staff member with manage_events permission (required by discount codes controller)."""
+    """Staff member with manage_tickets permission (required by discount codes controller)."""
     perms = staff_member.permissions
-    perms["default"]["manage_events"] = True
+    perms["default"]["manage_tickets"] = True
     staff_member.permissions = perms
     staff_member.save()
     return staff_member
 
 
 @pytest.fixture
-def manage_events_staff_client(organization_staff_user: RevelUser, manage_events_staff: OrganizationStaff) -> Client:
-    """API client for a staff member with manage_events permission."""
+def manage_tickets_staff_client(organization_staff_user: RevelUser, manage_tickets_staff: OrganizationStaff) -> Client:
+    """API client for a staff member with manage_tickets permission."""
+    from ninja_jwt.tokens import RefreshToken
+
+    refresh = RefreshToken.for_user(organization_staff_user)
+    return Client(HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}")  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def no_tickets_staff(
+    organization: Organization, organization_staff_user: RevelUser, staff_member: OrganizationStaff
+) -> OrganizationStaff:
+    """Staff member without manage_tickets permission (manage_tickets defaults to True)."""
+    perms = staff_member.permissions
+    perms["default"]["manage_tickets"] = False
+    staff_member.permissions = perms
+    staff_member.save()
+    return staff_member
+
+
+@pytest.fixture
+def no_tickets_staff_client(organization_staff_user: RevelUser, no_tickets_staff: OrganizationStaff) -> Client:
+    """API client for a staff member without manage_tickets permission."""
     from ninja_jwt.tokens import RefreshToken
 
     refresh = RefreshToken.for_user(organization_staff_user)
@@ -208,29 +229,27 @@ class TestListDiscountCodes:
         assert data["count"] == 1
         assert data["results"][0]["code"] == "SAVE20"
 
-    def test_list_by_staff_with_manage_events(
+    def test_list_by_staff_with_manage_tickets(
         self,
-        manage_events_staff_client: Client,
+        manage_tickets_staff_client: Client,
         organization: Organization,
         dc_percentage: DiscountCode,
     ) -> None:
-        """Staff with manage_events permission should access the list."""
+        """Staff with manage_tickets permission should access the list."""
         url = reverse("api:list_discount_codes", kwargs={"slug": organization.slug})
-        response = manage_events_staff_client.get(url)
+        response = manage_tickets_staff_client.get(url)
 
         assert response.status_code == 200
         assert response.json()["count"] == 1
 
     def test_list_by_staff_without_permission_forbidden(
         self,
-        organization_staff_client: Client,
+        no_tickets_staff_client: Client,
         organization: Organization,
-        staff_member: OrganizationStaff,
     ) -> None:
-        """Staff without manage_events permission should get 403."""
-        # staff_member has edit_organization=True but not manage_events
+        """Staff without manage_tickets permission should get 403."""
         url = reverse("api:list_discount_codes", kwargs={"slug": organization.slug})
-        response = organization_staff_client.get(url)
+        response = no_tickets_staff_client.get(url)
 
         assert response.status_code == 403
 
@@ -323,12 +342,12 @@ class TestCreateDiscountCode:
         assert data["event_ids"] == [str(event.id)]
         assert data["tier_ids"] == [str(event_ticket_tier.id)]
 
-    def test_create_by_staff_with_manage_events(
+    def test_create_by_staff_with_manage_tickets(
         self,
-        manage_events_staff_client: Client,
+        manage_tickets_staff_client: Client,
         organization: Organization,
     ) -> None:
-        """Staff with manage_events permission should be able to create codes."""
+        """Staff with manage_tickets permission should be able to create codes."""
         url = reverse("api:create_discount_code", kwargs={"slug": organization.slug})
         payload = {
             "code": "STAFFCODE",
@@ -336,7 +355,7 @@ class TestCreateDiscountCode:
             "discount_value": "5.00",
         }
 
-        response = manage_events_staff_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+        response = manage_tickets_staff_client.post(url, data=orjson.dumps(payload), content_type="application/json")
 
         assert response.status_code == 201
 
@@ -419,18 +438,18 @@ class TestGetDiscountCode:
 
         assert response.status_code == 404
 
-    def test_get_by_staff_with_manage_events(
+    def test_get_by_staff_with_manage_tickets(
         self,
-        manage_events_staff_client: Client,
+        manage_tickets_staff_client: Client,
         organization: Organization,
         dc_percentage: DiscountCode,
     ) -> None:
-        """Staff with manage_events should see discount code details."""
+        """Staff with manage_tickets should see discount code details."""
         url = reverse(
             "api:get_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_percentage.id},
         )
-        response = manage_events_staff_client.get(url)
+        response = manage_tickets_staff_client.get(url)
 
         assert response.status_code == 200
 
@@ -521,20 +540,20 @@ class TestUpdateDiscountCode:
 
         assert response.status_code == 404
 
-    def test_update_by_staff_with_manage_events(
+    def test_update_by_staff_with_manage_tickets(
         self,
-        manage_events_staff_client: Client,
+        manage_tickets_staff_client: Client,
         organization: Organization,
         dc_percentage: DiscountCode,
     ) -> None:
-        """Staff with manage_events should be able to update codes."""
+        """Staff with manage_tickets should be able to update codes."""
         url = reverse(
             "api:update_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_percentage.id},
         )
         payload = {"max_uses": 50}
 
-        response = manage_events_staff_client.patch(url, data=orjson.dumps(payload), content_type="application/json")
+        response = manage_tickets_staff_client.patch(url, data=orjson.dumps(payload), content_type="application/json")
 
         assert response.status_code == 200
         assert response.json()["max_uses"] == 50
@@ -596,18 +615,18 @@ class TestDeleteDiscountCode:
 
         assert response.status_code == 404
 
-    def test_delete_by_staff_with_manage_events(
+    def test_delete_by_staff_with_manage_tickets(
         self,
-        manage_events_staff_client: Client,
+        manage_tickets_staff_client: Client,
         organization: Organization,
         dc_fixed: DiscountCode,
     ) -> None:
-        """Staff with manage_events should be able to delete codes."""
+        """Staff with manage_tickets should be able to delete codes."""
         url = reverse(
             "api:delete_discount_code",
             kwargs={"slug": organization.slug, "code_id": dc_fixed.id},
         )
-        response = manage_events_staff_client.delete(url)
+        response = manage_tickets_staff_client.delete(url)
 
         assert response.status_code == 200
         assert response.json() == {"action": "deleted"}

--- a/src/events/tests/test_controllers/test_organization_admin/test_financials.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_financials.py
@@ -74,9 +74,18 @@ def test_financials_currency_filter(
     assert [t["currency"] for t in body["totals"]] == ["USD"]
 
 
-def test_financials_requires_manage_organization(
+def test_financials_forbidden_for_member(
     member_client: Client,
     organization: Organization,
 ) -> None:
     response = member_client.get(_url(organization))
+    assert response.status_code == 403
+
+
+def test_financials_forbidden_for_staff(
+    organization_staff_client: Client,
+    organization: Organization,
+) -> None:
+    """Financials are owner-only; even a staff member is denied."""
+    response = organization_staff_client.get(_url(organization))
     assert response.status_code == 403

--- a/src/events/tests/test_controllers/test_resources_endpoints.py
+++ b/src/events/tests/test_controllers/test_resources_endpoints.py
@@ -466,6 +466,21 @@ class TestAdminResourceEndpoints:
         assert response.status_code == 204
         assert not models.AdditionalResource.objects.filter(id=public_resource.id).exists()
 
+    def test_delete_resource_by_staff_with_edit_organization(
+        self,
+        organization_staff_client: Client,
+        staff_member: models.OrganizationStaff,
+        organization: models.Organization,
+        public_resource: models.AdditionalResource,
+    ) -> None:
+        """A staff member granted edit_organization can delete a resource (regression for #683)."""
+        url = reverse(
+            "api:delete_organization_resource", kwargs={"slug": organization.slug, "resource_id": public_resource.id}
+        )
+        response = organization_staff_client.delete(url)
+        assert response.status_code == 204
+        assert not models.AdditionalResource.objects.filter(id=public_resource.id).exists()
+
     def test_non_admin_cannot_create_resource(
         self, member_client: Client, organization: models.Organization, create_payload: dict[str, t.Any]
     ) -> None:

--- a/src/events/tests/test_models/test_permission_key_sync.py
+++ b/src/events/tests/test_models/test_permission_key_sync.py
@@ -1,0 +1,23 @@
+"""Keep the ``PermissionKey`` literal in sync with ``PermissionMap`` (see #683).
+
+mypy checks every ``OrganizationPermission("...")`` (and sibling) call site against
+:data:`~events.models.PermissionKey`, but it cannot verify that the literal itself lists
+exactly the ``PermissionMap`` fields. This test closes that gap: if a permission is added
+to (or renamed on) ``PermissionMap`` without updating the literal, CI fails here — before
+a bogus key can silently deny every non-owner staff member.
+"""
+
+import typing as t
+
+from events.models import PermissionKey, PermissionMap
+
+
+def test_permission_key_matches_permission_map_fields() -> None:
+    """The PermissionKey literal must list exactly the PermissionMap fields."""
+    literal_keys = set(t.get_args(PermissionKey))
+    model_fields = set(PermissionMap.model_fields)
+    assert literal_keys == model_fields, (
+        "PermissionKey and PermissionMap have drifted. "
+        f"Only in PermissionKey: {literal_keys - model_fields}. "
+        f"Only in PermissionMap: {model_fields - literal_keys}."
+    )

--- a/src/polls/permissions.py
+++ b/src/polls/permissions.py
@@ -14,15 +14,16 @@ from django.http import HttpRequest
 from ninja_extra import ControllerBase
 from ninja_extra.exceptions import PermissionDenied
 
-from events.controllers.permissions import RootPermission
+from events.controllers.permissions import PermissionMapPermission, RootPermission
 from polls.models import Poll
 
 
-class PollPermission(RootPermission):
+class PollPermission(PermissionMapPermission):
     """Generic poll-action permission.
 
     Delegates to ``Poll.organization.has_org_permission(user_id, action)``
     using the action passed at construction time (e.g. ``"manage_polls"``).
+    The ``action`` is constrained to a real ``PermissionMap`` key (see #683).
     """
 
     def has_object_permission(


### PR DESCRIPTION
Fixes #683.

## Problem

Three `OrganizationPermission("<key>")` route guards referenced permission keys **not present in `PermissionMap`** (`events/models/organization.py`). `PermissionMap` is the canonical, enumerated set of staff-permission keys — both the Django admin staff form (`admin/base.py`) and the frontend editor (generated from this schema) render checkboxes *only* for keys in the map. Because no legitimate path can grant a key that isn't in the map, `OrganizationStaff.has_permission(...)` always returned `False`, so these routes **silently denied every non-owner staff member regardless of the permissions they were granted** — effectively making them owner-only, but via a guard that reads like a bug.

| Route | Before | After |
|---|---|---|
| `resources.py` DELETE resource | `manage_organization` ❌ | `edit_organization` (matches create/update in the same controller) |
| `discount_codes.py` (whole controller) | `manage_events` ❌ | `manage_tickets` (discount codes are ticket pricing) |
| `revenue.py` financials/VAT reports (whole controller) | `manage_organization` ❌ | `IsOrganizationOwner()` (owner-only, made explicit) |

### Why these choices

- **Resources DELETE → `edit_organization`**: create/update in the same controller already use `edit_organization`; deleting is the same tier of operation.
- **Discount codes → `manage_tickets`**: semantically closest existing key. Note this widens access: `manage_tickets` defaults to `True`, so staff who were (incorrectly) locked out can now manage codes as intended.
- **Financials → owner-only**: financial/VAT reports are owner territory; `IsOrganizationOwner()` states that explicitly instead of relying on a key that silently never matches.

## Prevention: compile-time guard against bogus permission keys

To stop this class of bug from recurring, the permission-guard constructors are now **type-constrained to real `PermissionMap` keys**, so mypy (and any mypy/pyright-backed IDE) rejects a non-existent key at the call site.

- Added `PermissionKey = t.Literal[...]` next to `PermissionMap` (exported from `events.models`).
- Added a `PermissionMapPermission` base whose `__init__(action: PermissionKey)` narrows the type; reparented the map-resolving permission classes onto it: `OrganizationPermission`, `EventPermission`, `EventSeriesPermission`, `QuestionnairePermission` (events) and `PollPermission` (polls). The fixed/special-action classes (`IsOrganizationOwner`, `PotluckItemPermission`, `CanPurchaseTicket`, …) — whose actions are deliberately *not* map keys (`is_owner`, `create_potluck_item`, …) — stay on `RootPermission` untouched.
- Added a drift-guard test asserting `PermissionKey` lists exactly the `PermissionMap` fields, since mypy can't verify the literal against the model itself.

This is a type-only change with no runtime behavior difference. Verified that `OrganizationPermission("manage_tickets_typo")` now produces a mypy error listing every valid key.

## Tests

- Discount-code suite now grants/denies the real `manage_tickets` key (added a `no_tickets_staff` fixture for the deny case, since `manage_tickets` defaults to `True`).
- Financials: renamed the member-deny test and added a **staff-deny** test proving owner-only.
- Resources: added a regression test that a staff member granted `edit_organization` **can** delete a resource — the exact scenario the bug broke.
- New `test_permission_key_sync.py` guards `PermissionKey` ≡ `PermissionMap`.

The pre-existing tests passed only because they injected the bogus key straight into the JSON blob (`perms["default"]["manage_events"] = True`), which no real UI/API does — so they never caught the bug.

`make format lint mypy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Discount-code management now requires the **Manage tickets** permission.
  * Organization staff with **Edit organization** permission can delete additional resources.
  * Financial information is restricted to **organization owners**; members and staff are denied.

* **Bug Fixes**
  * Improved and standardized authorization behavior across organization-admin endpoints, with updated automated coverage to verify the correct permission requirements and forbidden access responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->