### PR TITLE
feat: prod-like E2E run target with PgBouncer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ run:
 # Override concurrency with GUNICORN_WORKERS / GUNICORN_THREADS.
 .PHONY: run-e2e
 run-e2e:
-	docker compose -f compose.yaml -f docker-compose-e2e.yml up -d pgbouncer; \
-	uv run python src/manage.py generate_test_jwts; \
+	docker compose -f compose.yaml -f docker-compose-e2e.yml up -d --wait pgbouncer && \
+	uv run python src/manage.py generate_test_jwts && \
 	cd src && DB_USE_PGBOUNCER=True DB_PORT=6432 uv run gunicorn revel.wsgi:application \
 		--worker-class gthread \
 		--workers $${GUNICORN_WORKERS:-4} \

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,25 @@ run:
 	uv run python src/manage.py generate_test_jwts; \
 	uv run python src/manage.py runserver
 
+# Prod-like server for frontend E2E: gunicorn (gthread, mirrors infra's command) behind
+# PgBouncer, so parallel Playwright workers don't exhaust Postgres connections. Brings the
+# pooler up, then routes the server through it via DB_USE_PGBOUNCER/DB_PORT set inline
+# (os.environ wins over .env), leaving `make test` and `make run` on direct 5432.
+# Override concurrency with GUNICORN_WORKERS / GUNICORN_THREADS.
+.PHONY: run-e2e
+run-e2e:
+	docker compose -f compose.yaml -f docker-compose-e2e.yml up -d pgbouncer; \
+	uv run python src/manage.py generate_test_jwts; \
+	cd src && DB_USE_PGBOUNCER=True DB_PORT=6432 uv run gunicorn revel.wsgi:application \
+		--worker-class gthread \
+		--workers $${GUNICORN_WORKERS:-4} \
+		--threads $${GUNICORN_THREADS:-4} \
+		--bind 127.0.0.1:8000 \
+		--max-requests 4000 \
+		--max-requests-jitter 400 \
+		--timeout 60 \
+		--graceful-timeout 30
+
 .PHONY: jwt
 jwt:
 	@if [ -z "$(EMAIL)" ]; then \

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -1,0 +1,40 @@
+# E2E overlay: adds a PgBouncer connection pooler in front of Postgres, mirroring the
+# production topology (infra/docker-compose.yml). Heavy local load — e.g. parallel frontend
+# Playwright workers driving a gunicorn backend — otherwise exhausts Postgres connections
+# (`FATAL: sorry, too many clients already`).
+#
+# Use as an overlay so pgbouncer shares the network with the main stack's `postgres`:
+#   docker compose -f compose.yaml -f docker-compose-e2e.yml up -d pgbouncer
+# `make run-e2e` does this for you and starts the server pointed at 6432.
+#
+# Postgres stays directly reachable on 5432; nothing routes through pgbouncer unless a
+# client explicitly connects to 6432 with DB_USE_PGBOUNCER=True.
+
+services:
+  pgbouncer:
+    image: edoburu/pgbouncer
+    restart: unless-stopped
+    environment:
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_HOST: postgres
+      DB_NAME: ${DB_NAME}
+      LISTEN_PORT: 6432
+      AUTH_TYPE: scram-sha-256
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 1000
+      DEFAULT_POOL_SIZE: 25
+      RESERVE_POOL_SIZE: 5
+      ADMIN_USERS: ${DB_USER}
+    ports:
+      - "127.0.0.1:6432:6432"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 6432"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    mem_limit: 256m
+    cpus: 0.5

--- a/docs/getting-started/development-commands.md
+++ b/docs/getting-started/development-commands.md
@@ -17,10 +17,25 @@ These are the commands you will use most often during day-to-day development.
 |---------|-------------|
 | `make setup` | Complete one-time setup: installs deps, copies `.env.example`, starts Docker, bootstraps database, starts server |
 | `make run` | Start the Django development server (also generates test JWTs) |
+| `make run-e2e` | Start a prod-like gunicorn server behind PgBouncer for frontend E2E under load (see below) |
 | `make check` | Run **all** code quality checks (see below) |
 | `make test` | Run the full pytest suite in parallel (`pytest -n auto`) with coverage reporting |
 | `make test-linear` | Run the full test suite sequentially (single process, useful for debugging) |
 | `make test-failed` | Re-run only previously failed tests |
+
+!!! tip "`make run-e2e` — prod-like server for E2E under load"
+    Parallel frontend E2E runs can open enough concurrent connections to a plain `make run`
+    backend to exhaust Postgres (`FATAL: sorry, too many clients already`). `make run-e2e`
+    reproduces the production runtime instead: it starts the **PgBouncer** pooler from
+    `docker-compose-e2e.yml` and runs **gunicorn** (gthread workers, mirroring infra's
+    command) routed through it on port `6432`. This matches where the pressure actually comes
+    from — `ATOMIC_REQUESTS` pins one connection per in-flight request across every gunicorn
+    worker/thread — and multiplexes those onto a small server pool.
+
+    Only this target opts into PgBouncer (via `DB_USE_PGBOUNCER=True DB_PORT=6432` set inline);
+    `make run` and `make test` stay on a direct `5432` connection. Unlike `make run`, gunicorn
+    does not serve Django static files, so admin/Swagger pages are unstyled — irrelevant for
+    frontend E2E, which only hits `/api/*`. Tune load with `GUNICORN_WORKERS` / `GUNICORN_THREADS`.
 
 ## Code Quality and Formatting
 


### PR DESCRIPTION
## What

Adds an opt-in, prod-like way to run the backend for heavy frontend E2E load, so parallel Playwright workers no longer exhaust Postgres connections (`FATAL: sorry, too many clients already`).

- **`docker-compose-e2e.yml`** — a PgBouncer-only overlay (`edoburu/pgbouncer`, transaction pooling), mirroring the production topology in `infra/`. Used as an overlay so it shares the network with the main stack's `postgres`:
  ```
  docker compose -f compose.yaml -f docker-compose-e2e.yml up -d pgbouncer
  ```
- **`make run-e2e`** — brings up the pooler, then runs **gunicorn** (`gthread` workers, same flags as infra's `web` service) routed through PgBouncer on `6432` via `DB_USE_PGBOUNCER=True DB_PORT=6432` set inline.

## Why gunicorn (not runserver)

The connection exhaustion is `concurrency × ATOMIC_REQUESTS` — each in-flight request pins one DB connection for its whole duration. `runserver` is a single process and doesn't reproduce prod's connection pressure or its `gthread`-worker runtime. Running E2E against gunicorn + PgBouncer reproduces the actual production runtime and is exactly the topology where the pooler earns its keep (many client conns multiplexed onto a small server pool).

## Behaviour unchanged by default

- Only `make run-e2e` opts into PgBouncer (inline env vars; `os.environ` wins over `.env`). `make run` and `make test` stay on a direct `5432` connection — the parallel pytest suite creates per-worker test DBs a single-database pooler can't serve.
- The default `compose.yaml`, `.env`/`.env.example`, and CI are untouched.
- Backend already supported PgBouncer (`DB_USE_PGBOUNCER` → `CONN_MAX_AGE=0`, `DISABLE_SERVER_SIDE_CURSORS`), so no code change.

Caveat: gunicorn doesn't serve Django static files, so admin/Swagger are unstyled — irrelevant for frontend E2E, which only hits `/api/*`. Tune load with `GUNICORN_WORKERS` / `GUNICORN_THREADS`.

## Verification

Ran `make run-e2e` locally: PgBouncer came up healthy, gunicorn served `/api/healthcheck` → 200, and `SHOW POOLS` confirmed the `revel` pool active in **transaction** mode with a live server connection (client → pgbouncer → postgres). Torn back down cleanly afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end testing run mode with a production-like server configuration.
  * Added connection pooling support for E2E scenarios to improve database handling under load.

* **Documentation**
  * Documented the new E2E command, connection settings, static file behavior, and server load configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->