### PR TITLE
feat: let any org staff list members (#686)

### DIFF
--- a/src/events/controllers/organization_admin/members.py
+++ b/src/events/controllers/organization_admin/members.py
@@ -41,6 +41,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         "/members",
         url_name="list_organization_members",
         response=PaginatedResponseSchema[schema.OrganizationMemberSchema],
+        permissions=[IsOrganizationStaff()],
         throttle=UserDefaultThrottle(),
     )
     @paginate(PageNumberPaginationExtra, page_size=20)

--- a/src/events/tests/test_controllers/test_organization_admin/test_members.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_members.py
@@ -26,6 +26,24 @@ class TestManageMembersAndStaff:
         assert data["count"] == 1
         assert data["results"][0]["user"]["email"] == member_user.email
 
+    def test_list_members_by_staff_without_manage_members(
+        self, organization_staff_client: Client, organization: Organization, member_user: RevelUser
+    ) -> None:
+        """Any staff can list members even without manage_members (read relaxed to staff)."""
+        OrganizationMember.objects.create(organization=organization, user=member_user)
+        url = reverse("api:list_organization_members", kwargs={"slug": organization.slug})
+        response = organization_staff_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["user"]["email"] == member_user.email
+
+    def test_list_members_by_member_forbidden(self, member_client: Client, organization: Organization) -> None:
+        """A regular member (non-staff) cannot list members."""
+        url = reverse("api:list_organization_members", kwargs={"slug": organization.slug})
+        response = member_client.get(url)
+        assert response.status_code == 403
+
     def test_list_staff(
         self, organization_owner_client: Client, organization: Organization, staff_member: OrganizationStaff
     ) -> None:


### PR DESCRIPTION
## Summary

Unblocks the frontend "Create RSVP on behalf of a user" picker (letsrevel/revel-frontend#616 / #686) using the **member-scoped lookup** approach — no new endpoint, no raw-email get-or-create.

The blocker was a permission mismatch:
- `create_rsvp` (`POST /event-admin/{event_id}/rsvps`) is gated on **`invite_to_event`** (defaults **True** for staff).
- The only member list, `list_members` (`GET /organization-admin/{slug}/members`), was gated on **`manage_members`** (defaults **False**).

So a staff member who could create RSVPs on behalf of a user had no reachable way to resolve that user to a `user_id`.

## Change

Relax **only the `list_members` read** from `manage_members` to `IsOrganizationStaff()` (owner or any staff). This exactly matches the set of users who hold `invite_to_event` (all are owner/staff). All mutations on the members controller stay gated on `manage_members`.

This is idiomatic — `list_membership_tiers` in the same controller already uses the identical per-route `IsOrganizationStaff()` override.

`RSVPCreateSchema` / `create_rsvp` are **unchanged**: the endpoint already accepts a `user_id` and upserts the RSVP. Member scoping lives at the lookup layer, as decided.

## Tests

- `test_list_members_by_staff_without_manage_members` — staff with `manage_members=False` now gets 200 (the crux).
- `test_list_members_by_member_forbidden` — a plain member still gets 403.

ruff (format + lint) and mypy pass on the changed files.

## Notes

- OpenAPI spec is unchanged (permission-only change), so no frontend client regeneration is required.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated organization member listing access controls.
  * Organization staff can list members without the separate member-management permission.
  * Regular organization members are prevented from accessing the member list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->