### PR TITLE
fix: allow RSVP no/maybe on full events (#691)

### DIFF
--- a/src/events/service/event_manager/manager.py
+++ b/src/events/service/event_manager/manager.py
@@ -69,11 +69,18 @@ class EventManager:
         if has_yes_rsvp:
             bypass_eligibility_checks = True
 
-        eligibility = self.check_eligibility(bypass=bypass_eligibility_checks)
+        # Capacity/availability only gates seat-claiming writes (a brand-new YES).
+        # NO/MAYBE never consume a seat, and downgrades (YES -> NO/MAYBE) free one, so
+        # they must go through even on a full event — otherwise attendees can't free
+        # their seat exactly when a waitlist is waiting for it (#691). Every other
+        # eligibility gate still applies to NO/MAYBE.
+        claims_seat = answer == EventRSVP.RsvpStatus.YES and not has_yes_rsvp
+        eligibility = self.check_eligibility(bypass=bypass_eligibility_checks, skip_availability=not claims_seat)
         if not eligibility.allowed:
             raise UserIsIneligibleError("The user is not eligible for this event.", eligibility=eligibility)
 
-        self._assert_capacity(use_tickets=False, tier=None)
+        if claims_seat:
+            self._assert_capacity(use_tickets=False, tier=None)
 
         rsvp, _created = EventRSVP.objects.update_or_create(
             user=self.user,
@@ -119,15 +126,23 @@ class EventManager:
         # when there's no work, so this is cheap when idempotent.
         enqueue_waitlist_processing(self.event.id)
 
-    def check_eligibility(self, bypass: bool = False, raise_on_false: bool = False) -> EventUserEligibility:
+    def check_eligibility(
+        self, bypass: bool = False, raise_on_false: bool = False, skip_availability: bool = False
+    ) -> EventUserEligibility:
         """Call the eligibility check.
+
+        Args:
+            bypass: When True, skip all eligibility gates.
+            raise_on_false: When True, raise ``UserIsIneligibleError`` if not eligible.
+            skip_availability: When True, skip the capacity/availability gate (for RSVP
+                writes that don't claim a seat).
 
         Returns:
             EventUserEligibility
         Raises:
             UserIsIneligibleError if the user is not eligible for this event and raise_on_false is True
         """
-        eligibility = self.eligibility_service.check_eligibility(bypass=bypass)
+        eligibility = self.eligibility_service.check_eligibility(bypass=bypass, skip_availability=skip_availability)
         if not eligibility.allowed and raise_on_false:
             raise UserIsIneligibleError(
                 message=eligibility.reason or _("You are not eligible."), eligibility=eligibility

--- a/src/events/service/event_manager/service.py
+++ b/src/events/service/event_manager/service.py
@@ -19,7 +19,7 @@ from events.models import (
 )
 from questionnaires.models import Questionnaire, QuestionnaireSubmission
 
-from .gates import ELIGIBILITY_GATES, BaseEligibilityGate
+from .gates import ELIGIBILITY_GATES, AvailabilityGate, BaseEligibilityGate
 from .types import EventUserEligibility
 
 
@@ -140,10 +140,16 @@ class EligibilityService:
 
         self._gates: list[BaseEligibilityGate] = [gate(self) for gate in ELIGIBILITY_GATES]
 
-    def check_eligibility(self, bypass: bool = False) -> EventUserEligibility:
+    def check_eligibility(self, bypass: bool = False, skip_availability: bool = False) -> EventUserEligibility:
         """Check eligibility using the fully prefetched, in-memory data.
 
         This method SHOULD make ZERO database queries.
+
+        Args:
+            bypass: When True, skip all gates and return an allowed result.
+            skip_availability: When True, skip the capacity/availability gate. Used for
+                RSVP writes that don't claim a seat (NO/MAYBE), which must not be blocked
+                by a full event — every other eligibility gate still applies.
 
         Returns:
             EventUserEligibility with the result of the eligibility check.
@@ -152,6 +158,8 @@ class EligibilityService:
             return EventUserEligibility(allowed=True, event_id=self.event.pk)
 
         for gate in self._gates:
+            if skip_availability and isinstance(gate, AvailabilityGate):
+                continue
             if result := gate.check():
                 return result
 

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
@@ -353,7 +353,11 @@ class TestGuestServiceLayer:
         guest_event.save()
 
         token = guest_service.create_guest_rsvp_token(existing_guest_user, guest_event.id, "yes")
-        EventRSVP.objects.create(user=existing_guest_user, event=guest_event, status="yes")
+        # Fill the single seat with a *different* user so the guest's YES confirmation is a
+        # genuine new seat-claim that fails the capacity check (the guest has no prior RSVP,
+        # so it isn't a downgrade). See #691.
+        filler = RevelUser.objects.create_user(username="filler_guest", email="filler_guest@example.com")
+        EventRSVP.objects.create(user=filler, event=guest_event, status="yes")
 
         # Act & Assert
         with pytest.raises(UserIsIneligibleError):

--- a/src/events/tests/test_service/test_event_manager/test_rsvp.py
+++ b/src/events/tests/test_service/test_event_manager/test_rsvp.py
@@ -1,6 +1,5 @@
 """Tests for RSVP functionality and RSVP deadline gate."""
 
-import datetime as dt
 from datetime import timedelta
 from unittest import mock
 
@@ -244,26 +243,25 @@ def test_user_with_maybe_rsvp_cannot_change_to_yes_after_requirements_change(
 # --- Test Cases for RSVP Changes on a Full Event (issue #691) ---
 
 
-def _make_full_rsvp_event(event: Event, factory: RevelUserFactory) -> None:
-    """Turn ``event`` into an RSVP-only event with a single seat already taken."""
-    event.end = event.start + dt.timedelta(hours=2)
+def _configure_rsvp_event(event: Event, *, max_attendees: int = 1) -> None:
+    """Turn ``event`` into an RSVP-only, waitlist-open event with the given capacity."""
+    event.end = event.start + timedelta(hours=2)
     event.requires_ticket = False
-    event.max_attendees = 1
+    event.max_attendees = max_attendees
     event.waitlist_open = True
-    event.waitlist_time_window = dt.timedelta(hours=24)
+    event.waitlist_time_window = timedelta(hours=24)
     event.save()
-    # Fill the single seat with someone else's YES so the event is at capacity.
+
+
+def _make_full_rsvp_event(event: Event, factory: RevelUserFactory) -> None:
+    """Configure a 1-seat RSVP event and fill it with someone else's YES (at capacity)."""
+    _configure_rsvp_event(event)
     EventRSVP.objects.create(event=event, user=factory(), status=EventRSVP.RsvpStatus.YES)
 
 
 def test_yes_to_no_on_full_event_frees_seat(event: Event, revel_user_factory: RevelUserFactory) -> None:
     """A YES holder can downgrade to NO on a full event, freeing their seat (#691)."""
-    event.end = event.start + dt.timedelta(hours=2)
-    event.requires_ticket = False
-    event.max_attendees = 1
-    event.waitlist_open = True
-    event.waitlist_time_window = dt.timedelta(hours=24)
-    event.save()
+    _configure_rsvp_event(event)
     me = revel_user_factory()
     EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.YES)  # event now full
 
@@ -277,12 +275,7 @@ def test_yes_to_no_on_full_event_frees_seat(event: Event, revel_user_factory: Re
 
 def test_yes_to_maybe_on_full_event(event: Event, revel_user_factory: RevelUserFactory) -> None:
     """A YES holder can downgrade to MAYBE on a full event (#691)."""
-    event.end = event.start + dt.timedelta(hours=2)
-    event.requires_ticket = False
-    event.max_attendees = 1
-    event.waitlist_open = True
-    event.waitlist_time_window = dt.timedelta(hours=24)
-    event.save()
+    _configure_rsvp_event(event)
     me = revel_user_factory()
     EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.YES)  # event now full
 
@@ -322,3 +315,17 @@ def test_new_yes_rsvp_on_full_event_still_rejected(event: Event, revel_user_fact
 
     assert exc_info.value.eligibility.reason_code == Reasons.EVENT_IS_FULL.code
     assert not EventRSVP.objects.filter(event=event, user=me).exists()
+
+
+def test_maybe_to_yes_on_full_event_still_rejected(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """Regression guard: MAYBE -> YES claims a seat, so it is still capacity-gated on a full event (#691)."""
+    _make_full_rsvp_event(event, revel_user_factory)
+    me = revel_user_factory()
+    EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.MAYBE)
+
+    with pytest.raises(UserIsIneligibleError) as exc_info:
+        EventManager(me, event).rsvp(EventRSVP.RsvpStatus.YES)
+
+    assert exc_info.value.eligibility.reason_code == Reasons.EVENT_IS_FULL.code
+    # The RSVP must remain MAYBE — the failed upgrade must not have changed it.
+    assert EventRSVP.objects.get(event=event, user=me).status == EventRSVP.RsvpStatus.MAYBE

--- a/src/events/tests/test_service/test_event_manager/test_rsvp.py
+++ b/src/events/tests/test_service/test_event_manager/test_rsvp.py
@@ -1,11 +1,14 @@
 """Tests for RSVP functionality and RSVP deadline gate."""
 
+import datetime as dt
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.utils import timezone
 
 from accounts.models import RevelUser
+from conftest import RevelUserFactory
 from events.models import (
     Event,
     EventInvitation,
@@ -236,3 +239,86 @@ def test_user_with_maybe_rsvp_cannot_change_to_yes_after_requirements_change(
     # RSVP should still be MAYBE
     rsvp = EventRSVP.objects.get(user=public_user, event=public_event)
     assert rsvp.status == EventRSVP.RsvpStatus.MAYBE
+
+
+# --- Test Cases for RSVP Changes on a Full Event (issue #691) ---
+
+
+def _make_full_rsvp_event(event: Event, factory: RevelUserFactory) -> None:
+    """Turn ``event`` into an RSVP-only event with a single seat already taken."""
+    event.end = event.start + dt.timedelta(hours=2)
+    event.requires_ticket = False
+    event.max_attendees = 1
+    event.waitlist_open = True
+    event.waitlist_time_window = dt.timedelta(hours=24)
+    event.save()
+    # Fill the single seat with someone else's YES so the event is at capacity.
+    EventRSVP.objects.create(event=event, user=factory(), status=EventRSVP.RsvpStatus.YES)
+
+
+def test_yes_to_no_on_full_event_frees_seat(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """A YES holder can downgrade to NO on a full event, freeing their seat (#691)."""
+    event.end = event.start + dt.timedelta(hours=2)
+    event.requires_ticket = False
+    event.max_attendees = 1
+    event.waitlist_open = True
+    event.waitlist_time_window = dt.timedelta(hours=24)
+    event.save()
+    me = revel_user_factory()
+    EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.YES)  # event now full
+
+    with mock.patch("events.service.event_manager.manager.enqueue_waitlist_processing") as enqueue_mock:
+        rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.NO)
+
+    assert rsvp.status == EventRSVP.RsvpStatus.NO
+    # Freeing a seat must trigger the next waitlist batch.
+    enqueue_mock.assert_called_once_with(event.id)
+
+
+def test_yes_to_maybe_on_full_event(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """A YES holder can downgrade to MAYBE on a full event (#691)."""
+    event.end = event.start + dt.timedelta(hours=2)
+    event.requires_ticket = False
+    event.max_attendees = 1
+    event.waitlist_open = True
+    event.waitlist_time_window = dt.timedelta(hours=24)
+    event.save()
+    me = revel_user_factory()
+    EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.YES)  # event now full
+
+    rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.MAYBE)
+
+    assert rsvp.status == EventRSVP.RsvpStatus.MAYBE
+
+
+def test_maybe_to_no_on_full_event(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """A MAYBE holder can change to NO on a full event — neither answer consumes a seat (#691)."""
+    _make_full_rsvp_event(event, revel_user_factory)
+    me = revel_user_factory()
+    EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.MAYBE)
+
+    rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.NO)
+
+    assert rsvp.status == EventRSVP.RsvpStatus.NO
+
+
+def test_new_no_rsvp_on_full_event_allowed(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """A new NO RSVP (e.g. declining) is not seat-consuming and must pass on a full event (#691)."""
+    _make_full_rsvp_event(event, revel_user_factory)
+    me = revel_user_factory()
+
+    rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.NO)
+
+    assert rsvp.status == EventRSVP.RsvpStatus.NO
+
+
+def test_new_yes_rsvp_on_full_event_still_rejected(event: Event, revel_user_factory: RevelUserFactory) -> None:
+    """Regression guard: a brand-new YES on a full event is still capacity-gated (#691)."""
+    _make_full_rsvp_event(event, revel_user_factory)
+    me = revel_user_factory()
+
+    with pytest.raises(UserIsIneligibleError) as exc_info:
+        EventManager(me, event).rsvp(EventRSVP.RsvpStatus.YES)
+
+    assert exc_info.value.eligibility.reason_code == Reasons.EVENT_IS_FULL.code
+    assert not EventRSVP.objects.filter(event=event, user=me).exists()

--- a/src/events/tests/test_service/test_event_manager/test_rsvp.py
+++ b/src/events/tests/test_service/test_event_manager/test_rsvp.py
@@ -279,7 +279,10 @@ def test_yes_to_maybe_on_full_event(event: Event, revel_user_factory: RevelUserF
     me = revel_user_factory()
     EventRSVP.objects.create(event=event, user=me, status=EventRSVP.RsvpStatus.YES)  # event now full
 
-    rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.MAYBE)
+    # YES -> MAYBE frees a seat and enqueues the next waitlist batch; mock it (parity with
+    # test_yes_to_no_on_full_event_frees_seat) so the test doesn't dispatch a real task.
+    with mock.patch("events.service.event_manager.manager.enqueue_waitlist_processing"):
+        rsvp = EventManager(me, event).rsvp(EventRSVP.RsvpStatus.MAYBE)
 
     assert rsvp.status == EventRSVP.RsvpStatus.MAYBE
 


### PR DESCRIPTION
Closes #691.

## Problem

On a full RSVP event (`max_attendees` reached), any RSVP write was rejected with `event_is_full`, even writes that don't claim a seat:

- **YES → NO / YES → MAYBE** (a YES holder freeing their seat — the E2E-found bug).
- **MAYBE → NO** on a full event.
- A **new NO / MAYBE** by an eligible user (e.g. an invited user declining).

This blocked attendees from freeing their seat exactly when a waitlist was waiting for it.

## Root cause

Two gates fire on every RSVP write, regardless of the answer:

1. `EventManager._assert_capacity()` — ran unconditionally.
2. The eligibility `AvailabilityGate` (Gate #10) — blocks non-YES-holders on a full event. The `has_yes_rsvp` bypass only helped **downgrades** (which bypass eligibility entirely); a `maybe → no` or a new decline still hit it.

The issue's suggested one-line fix (guarding `_assert_capacity`) fixes downgrades but not the `maybe → no` / new-decline cases, because those are blocked by the eligibility gate, not `_assert_capacity`.

## Fix

Capacity/availability now only gates **seat-claiming** writes — a brand-new YES:

- `_assert_capacity()` runs only when `answer == YES and not has_yes_rsvp`.
- `check_eligibility(..., skip_availability=...)` skips **only** the `AvailabilityGate` for non-seat-claiming writes. Every other eligibility gate (invitation, membership, deadline, profile, questionnaire, blacklist) still applies to NO/MAYBE, so an un-invited user still can't RSVP to a private event.

Freeing a seat (YES → NO/MAYBE) still enqueues the next waitlist batch (existing behavior, now reachable).

## Tests

New `test_rsvp.py` cases: YES→NO frees a seat (+ asserts waitlist enqueue), YES→MAYBE, MAYBE→NO, and a new NO — all on a full 1-seat event — plus a regression guard that a **new YES** on a full event is still rejected with `event_is_full`.

Adjusted one guest-service atomicity test whose arrangement relied on the old behavior (it re-confirmed YES as the same user, now correctly a no-op) to fill the seat with a different user so it still exercises a genuine capacity failure.

Full `make check` green; event-manager, guest, integration, and waitlist suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3RqswtYv5TjXiqn5J51N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing attendees can now change a “Yes” RSVP to “No” or “Maybe” even when an event is full.
  * Changing an RSVP to free a seat can trigger waitlist processing.
  * “Maybe” to “No” changes and new “No” RSVPs remain available for full events.
  * New “Yes” RSVPs are still rejected when event capacity is reached.
  * RSVP failures continue to roll back safely without invalidating the RSVP token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->