### PR TITLE
fix: PUT /organization-admin/{slug} echoes the full admin schema (#697)

### DIFF
--- a/src/events/controllers/organization_admin/core.py
+++ b/src/events/controllers/organization_admin/core.py
@@ -38,11 +38,15 @@ class OrganizationAdminCoreController(OrganizationAdminBaseController):
     @route.put(
         "",
         url_name="edit_organization",
-        response=schema.OrganizationRetrieveSchema,
+        response=schema.OrganizationAdminDetailSchema,
         permissions=[OrganizationPermission("edit_organization")],
     )
     def update_organization(self, slug: str, payload: schema.OrganizationEditSchema) -> models.Organization:
         """Update organization by slug.
+
+        Echoes the full admin representation (same schema as ``GET``) so callers get
+        every updated field back — including subscription policy and billing/VAT — and
+        don't have to re-fetch after a write (issue #697).
 
         Note: contact_email cannot be updated through this endpoint.
         Use the update-contact-email endpoint instead for email changes.

--- a/src/events/tests/test_controllers/test_organization_admin/test_core.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_core.py
@@ -50,9 +50,30 @@ def test_update_membership_subscription_policy(organization_owner_client: Client
     response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
 
     assert response.status_code == 200
+    # The PUT echoes the full admin representation, so the written fields come back (issue #697).
+    data = response.json()
+    assert data["membership_grace_period_days"] == 14
+    assert data["membership_refund_policy"] == "Full refund within 7 days."
     organization.refresh_from_db()
     assert organization.membership_grace_period_days == 14
     assert organization.membership_refund_policy == "Full refund within 7 days."
+
+
+def test_update_response_uses_admin_detail_schema(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """PUT echoes OrganizationAdminDetailSchema, not the leaner retrieve schema (issue #697)."""
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public"}
+
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    # Fields exclusive to the admin detail schema (absent from OrganizationRetrieveSchema).
+    assert "contact_email_verified" in data
+    assert "revenue_report_cadence" in data
+    assert "membership_grace_period_days" in data
 
 
 def test_update_membership_grace_period_rejects_negative(


### PR DESCRIPTION
Closes #697.

## Problem

`GET` and `PUT` on the org-admin core endpoint returned **different schemas**, so a `PUT` response silently dropped fields the caller just wrote:

- `GET /organization-admin/{slug}` → `OrganizationAdminDetailSchema` (includes `membership_grace_period_days`, `membership_refund_policy`, `revenue_report_cadence`, billing/VAT, etc.)
- `PUT /organization-admin/{slug}` → `OrganizationRetrieveSchema` (omits them)

A client PUTting `membership_grace_period_days=21` got a `200` whose body lacked that field, even though the write persisted — forcing an extra `GET` round-trip.

## Fix

Return `OrganizationAdminDetailSchema` from the `PUT` so it echoes the full updated admin representation (same schema as `GET`). The frontend can then consume the PUT response directly instead of re-fetching.

**No new disclosure:** `PUT` requires the `edit_organization` staff permission, and `GET` already exposes `OrganizationAdminDetailSchema` to any org staff — so anyone who can PUT could already read this schema.

## Tests

- Extended `test_update_membership_subscription_policy` to assert the written fields come back in the PUT response body.
- Added `test_update_response_uses_admin_detail_schema` asserting admin-only keys (`contact_email_verified`, `revenue_report_cadence`, `membership_grace_period_days`) are present — a regression guard against reverting to the leaner schema.
- The existing PUT tests that assert `description`/`visibility` in the response still pass (the admin schema is a superset).

Ruff + strict mypy clean; the 17 org-admin update tests pass.

Note: the OpenAPI surface changes, so the frontend needs a `pnpm generate:api` (this is exactly what FE #631/#634 wants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)