### PR TITLE
feat(orgs): expose membership_refund_policy on public org schema (FE #633)

### DIFF
--- a/src/events/schema/organization.py
+++ b/src/events/schema/organization.py
@@ -157,6 +157,11 @@ class OrganizationRetrieveSchema(
     accept_membership_requests: bool
     contact_method: Organization.ContactMethod
     contact_email: str | None = None
+    # Member-facing subscription policy: shown to prospective subscribers before
+    # they request/pay for a membership (grace period stays admin-internal). Given a
+    # default so it's non-required in the public schema — narrower org payloads
+    # (list/minimal) that don't carry it stay structurally assignable.
+    membership_refund_policy: str = ""
 
     @staticmethod
     def resolve_contact_email(obj: Organization, context: t.Any) -> str | None:


### PR DESCRIPTION
## What

Adds `membership_refund_policy` to the public `OrganizationRetrieveSchema`. It was previously only on `OrganizationAdminDetailSchema` (the editing UI shipped in #631), so a prospective/active subscriber's page data never carried it.

## Why

Unblocks frontend **FE #633** — surfacing the org membership refund policy to subscribers before they request/pay for a membership.

## Notes

- Given a default (`= ""`) so the field is **non-required** in the public schema. This keeps narrower org payloads (`OrganizationInListSchema` / `MinimalOrganizationSchema`, which don't carry the field) structurally assignable to `OrganizationRetrieveSchema` on the generated TS client.
- Grace period (`membership_grace_period_days`) stays admin-internal — no member-facing display.
- `.artifacts/openapi.json` is gitignored; `make dump-openapi` verified the app imports cleanly and emits the field as non-required.

## Coordination

Lands together with the FE PR (letsrevel/revel-frontend). The FE display is a no-op until this merges and the app server is restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a membership refund policy field to organization details.
  * Displays the member-facing subscription policy before a membership request or payment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->