### PR TITLE
fix(deps): pin httplib2>=0.32.0 to patch PYSEC-2026-3444

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,11 @@ sentinel = [
 # Security floors for transitive dependencies we don't import directly.
 # aiohttp is pulled in by aiogram and instructor; 3.14.1 fixes a batch of
 # CVEs flagged by pip-audit (CVE-2026-54273..54280, CVE-2026-50269).
+# httplib2 is pulled in by django-google-sso via google-auth-httplib2;
+# 0.32.0 fixes PYSEC-2026-3444.
 constraint-dependencies = [
     "aiohttp>=3.14.1",
+    "httplib2>=0.32.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.14"
 
 [manifest]
-constraints = [{ name = "aiohttp", specifier = ">=3.14.1" }]
+constraints = [
+    { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "httplib2", specifier = ">=0.32.0" },
+]
 
 [[package]]
 name = "aiofiles"
@@ -1540,14 +1543,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.22.0"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116, upload-time = "2023-03-21T22:29:37.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854, upload-time = "2023-03-21T22:29:35.683Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pip-audit` fails on `main` (and blocks the v1.71.0 release PR #703): `httplib2 0.22.0` is flagged for **PYSEC-2026-3444**, fixed in **0.32.0**.

`httplib2` is transitive — `django-google-sso` → `google-auth-httplib2` → `httplib2` — so this adds a uv `constraint-dependencies` security floor (same mechanism as the existing `aiohttp>=3.14.1` pin) rather than a direct dependency.

## Change

- `constraint-dependencies`: add `httplib2>=0.32.0`
- `uv.lock`: `httplib2 0.22.0 → 0.32.0` (only line changed)

## Verification

- `make audit` → **No known vulnerabilities found**
- `uv lock` clean; only `httplib2` moved in the graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)