### PR TITLE
fix(deps): pin anyio>=4.14.2 to patch GHSA-82r6-8w77-94w6 and GHSA-5p39-cfhj-2xmp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,12 @@ sentinel = [
 # CVEs flagged by pip-audit (CVE-2026-54273..54280, CVE-2026-50269).
 # httplib2 is pulled in by django-google-sso via google-auth-httplib2;
 # 0.32.0 fixes PYSEC-2026-3444.
+# anyio is pulled in by httpx and openai; 4.14.2 fixes GHSA-82r6-8w77-94w6
+# (TLS cert spoofing via IDNA 2003 host matching) and GHSA-5p39-cfhj-2xmp
+# (process-pool stderr deadlock).
 constraint-dependencies = [
     "aiohttp>=3.14.1",
+    "anyio>=4.14.2",
     "httplib2>=0.32.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,7 @@ requires-python = ">=3.14"
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "anyio", specifier = ">=4.14.2" },
     { name = "httplib2", specifier = ">=0.32.0" },
 ]
 
@@ -145,15 +146,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.9.0"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `anyio>=4.14.2` to `[tool.uv] constraint-dependencies`, bumping the resolved version from 4.9.0 to 4.14.2.

anyio is a transitive dependency (pulled in by `httpx` and `openai`; we don't import it directly). Three advisories were published on 2026-07-07, all patched in 4.14.2:

- **[GHSA-82r6-8w77-94w6](https://github.com/agronholm/anyio/security/advisories/GHSA-82r6-8w77-94w6)** — `TLSStream` matches internationalized host names against peer certificates using IDNA 2003 instead of IDNA 2008, enabling potential TLS certificate spoofing (affects ≤4.14.1)
- **[GHSA-5p39-cfhj-2xmp](https://github.com/agronholm/anyio/security/advisories/GHSA-5p39-cfhj-2xmp)** — process-pool workers can block indefinitely on undrained stderr (affects ≤4.14.1)
- **[GHSA-3w57-8xmc-8v26](https://github.com/agronholm/anyio/security/advisories/GHSA-3w57-8xmc-8v26)** — `run_process`/`open_process` ignores `extra_groups` (affects only 4.14.0, which we never resolved to)

None of the advisories have CVE IDs yet, so `make audit` (pip-audit) does not flag them — this pin gets ahead of that.

## Changes

- `pyproject.toml`: add `anyio>=4.14.2` security floor with explanatory comment (same pattern as the `aiohttp`/`httplib2` pins)
- `uv.lock`: anyio 4.9.0 → 4.14.2 (only anyio changed)

## Verification

- `uv sync --dev` resolves cleanly; only anyio moved in the lock
- `make check` passes (format, lint, mypy, migration-check, i18n-check, file-length, task-names)
- `make audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported AnyIO version to address known security issues.
  * Clarified dependency security guidance in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->