### PR TITLE
fix(ci): authenticate GHCR publish with GITHUB_TOKEN instead of a PAT

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,11 @@ jobs:
           echo "✅ Version consistency validated: $TAG_VERSION"
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Problem

The `Publish` workflow failed for v1.71.1 and v1.71.2 at the `Log in to GHCR` step with:

```
Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
```

Root cause: `GHCR_TOKEN` is a classic PAT set on **2026-04-15**; it hit the default 90-day expiry on **2026-07-14** — right after the last successful publish (v1.71.0, July 14).

## Fix

Authenticate with the ephemeral, auto-issued `GITHUB_TOKEN` via `docker/login-action` instead of a stored PAT — the job already declares `packages: write`, and this matches how `revel-frontend`'s publish workflow logs in. No more rotation to remember.

## Follow-ups (not in this PR)

- **First run caveat**: `ghcr.io/letsrevel/revel` was historically pushed with a PAT. If the first `GITHUB_TOKEN` push is denied, grant `letsrevel/revel-backend` **write** access under the package's *Manage Actions access* settings.
- Once a publish succeeds with this change, delete the now-unused `GHCR_TOKEN` and `GHCR_USERNAME` repo secrets.
- v1.71.2's image still needs publishing (interim: rotate the PAT and `gh run rerun 29495319254`, since re-runs use the workflow file from the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
