### PR TITLE
chore: fix glued .gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,5 @@ privacy.md
 .research/
 
 # Superpowers / Claude Code session artefacts (plans, specs, research drafts)
-docs/superpowers/.playwright-mcp/
+docs/superpowers/
+.playwright-mcp/


### PR DESCRIPTION
A squash-merge glued two \`.gitignore\` lines into one (missing trailing newline before the squash), leaving:

\`\`\`
docs/superpowers/.playwright-mcp/
\`\`\`

This single glued line broke both entries: it un-ignored \`docs/superpowers/\` (local spec docs started showing as untracked) and never actually ignored \`.playwright-mcp/\`.

This PR splits it back into two lines:

\`\`\`
docs/superpowers/
.playwright-mcp/
\`\`\`

Verified with \`git check-ignore\` that both \`docs/superpowers/...\` and \`.playwright-mcp/...\` paths are now ignored, and confirmed \`.gitignore\` ends with a trailing newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude generated documentation tooling files and top-level browser automation artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->