### PR TITLE
fix(events): serialize per-event attendee visibility rebuilds to prevent deadlock under concurrent checkout

### DIFF
--- a/src/events/tasks/attendees.py
+++ b/src/events/tasks/attendees.py
@@ -1,8 +1,10 @@
 """Celery tasks for attendee visibility flags and guest confirmation emails."""
 
+import hashlib
+
 import structlog
 from celery import shared_task
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
@@ -13,6 +15,17 @@ from common.tasks import send_email
 from events.models import AttendeeVisibilityFlag, Event, EventRSVP, Ticket
 
 logger = structlog.get_logger(__name__)
+
+
+def visibility_rebuild_lock_key(event_id: str) -> int:
+    """Derive a stable signed 64-bit Postgres advisory-lock key for a per-event visibility rebuild.
+
+    The key is namespaced so it can't collide with other advisory-lock users, and is
+    derived deterministically from the event UUID so every worker rebuilding the same
+    event's matrix contends on the same lock.
+    """
+    digest = hashlib.sha256(f"events.attendee_visibility:{event_id}".encode()).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
 
 
 @shared_task(name="events.tasks.build_attendee_visibility_flags")
@@ -62,6 +75,15 @@ def build_attendee_visibility_flags(event_id: str) -> None:
     flags = []
 
     with transaction.atomic():
+        # Serialize concurrent rebuilds of the same event's matrix. Every confirmed
+        # ticket/RSVP dispatches this task, so a checkout rush runs several rebuilds
+        # at once and the delete + bulk_create below interleave row locks across
+        # workers and deadlock. A transaction-scoped advisory lock keyed on the event
+        # serializes the rebuild without touching the Event row that checkout paths
+        # select_for_update (so it adds no checkout latency). Released automatically
+        # at commit/rollback.
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_xact_lock(%s)", [visibility_rebuild_lock_key(event_id)])
         AttendeeVisibilityFlag.objects.filter(event=event).delete()
         for viewer in viewers:
             for target in attendees:

--- a/src/events/tests/test_tasks/test_misc.py
+++ b/src/events/tests/test_tasks/test_misc.py
@@ -1,10 +1,13 @@
 import typing as t
+import uuid
 from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.files.base import ContentFile
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from accounts.models import RevelUser
@@ -27,6 +30,7 @@ from events.tasks import (
     cleanup_ticket_file_cache,
     generate_recurring_events_task,
 )
+from events.tasks.attendees import visibility_rebuild_lock_key
 
 pytestmark = pytest.mark.django_db
 
@@ -170,6 +174,63 @@ def test_build_attendee_visibility_flags_replaces_existing(
     # The flags should be replaced with new ones where is_visible=True
     assert AttendeeVisibilityFlag.objects.get(user=attendee1, event=event, target=attendee2).is_visible
     assert AttendeeVisibilityFlag.objects.get(user=attendee2, event=event, target=attendee1).is_visible
+
+
+def test_visibility_rebuild_lock_key_is_stable_and_64_bit() -> None:
+    """The advisory-lock key is deterministic, event-specific, and fits Postgres's signed bigint.
+
+    A true two-thread deadlock reproduction is deliberately not attempted:
+    ``pg_advisory_xact_lock`` serializes concurrent rebuilds by construction, so the
+    regression contract is (a) the key derivation is stable per event and (b) the task
+    actually takes the lock (see test below).
+    """
+    event_id = str(uuid.uuid4())
+
+    key = visibility_rebuild_lock_key(event_id)
+
+    # Deterministic for the same event.
+    assert visibility_rebuild_lock_key(event_id) == key
+    # Fits a signed 64-bit bigint (pg_advisory_xact_lock's argument type).
+    assert -(2**63) <= key < 2**63
+    # Distinct events get distinct keys.
+    assert visibility_rebuild_lock_key(str(uuid.uuid4())) != key
+
+
+def test_build_attendee_visibility_flags_takes_per_event_advisory_lock(
+    event: Event,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    """The rebuild transaction acquires the per-event advisory xact lock, and repeated
+    sequential runs still produce a complete, correct matrix.
+
+    This is the deadlock regression guard: concurrent rebuilds of the same event's
+    matrix deadlocked in production because delete + bulk_create interleaved row locks
+    across workers. The advisory lock serializes them by construction, so we assert the
+    lock is taken with the derived key rather than reproducing a two-thread deadlock.
+    """
+    attendee1 = revel_user_factory()
+    attendee2 = revel_user_factory()
+    tier = event.ticket_tiers.first()
+    assert tier is not None
+    Ticket.objects.create(
+        guest_name="Test Guest", event=event, user=attendee1, tier=tier, status=Ticket.TicketStatus.ACTIVE
+    )
+    EventRSVP.objects.create(event=event, user=attendee2, status=EventRSVP.RsvpStatus.YES)
+
+    with CaptureQueriesContext(connection) as ctx:
+        build_attendee_visibility_flags(str(event.id))
+
+    lock_queries = [q["sql"] for q in ctx.captured_queries if "pg_advisory_xact_lock" in q["sql"]]
+    assert len(lock_queries) == 1
+    assert str(visibility_rebuild_lock_key(str(event.id))) in lock_queries[0]
+
+    # A second sequential run (what the lock enforces for concurrent dispatches)
+    # still yields a complete matrix: every viewer/target pair has exactly one flag.
+    build_attendee_visibility_flags(str(event.id))
+    assert AttendeeVisibilityFlag.objects.filter(event=event).count() == 4
+    for viewer in (attendee1, attendee2):
+        for target in (attendee1, attendee2):
+            assert AttendeeVisibilityFlag.objects.filter(user=viewer, event=event, target=target).count() == 1
 
 
 class TestCleanupTicketFileCache:


### PR DESCRIPTION
## The deadlock

`build_attendee_visibility_flags` (dispatched after **every** confirmed ticket/RSVP) rebuilds the per-event attendee-visibility matrix with a `delete()` + `bulk_create(update_conflicts=True)` inside one transaction — with **no serialization between concurrent runs for the same event**. Under a 30-user concurrent-checkout load test this deadlocked **5 times**: two workers rebuilding the same event interleave row deletes/upserts, each ends up waiting on row locks the other holds, and Postgres kills one. A failed task means stale visibility flags, and any ticket rush on any event can trigger it in production.

## The fix

Take a **transaction-scoped Postgres advisory lock** (`pg_advisory_xact_lock`) keyed per event as the first statement of the rebuild transaction. The 64-bit key is derived deterministically from the event UUID (`sha256("events.attendee_visibility:<uuid>")[:8]`, signed, namespaced against other advisory-lock users). Concurrent rebuilds of the same event now queue instead of interleaving; different events don't contend at all. The lock is released automatically at commit/rollback.

**Why not `select_for_update()` on the Event row:** checkout paths lock the Event row — an advisory lock serializes the rebuilds without touching that row, so this fix adds zero checkout latency. The pre-existing `attendee_count` block's short Event lock is unchanged.

**No debounce added:** the codebase has no task-dedup/debounce infrastructure, and serialization alone restores correctness — N concurrent purchases now mean N cheap sequential rebuilds instead of deadlocks. The task name stays pinned verbatim.

## Tests

- `test_visibility_rebuild_lock_key_is_stable_and_64_bit` — key derivation is deterministic, event-specific, and fits a signed bigint.
- `test_build_attendee_visibility_flags_takes_per_event_advisory_lock` — asserts via query capture that the rebuild transaction executes `pg_advisory_xact_lock` with the derived key, and that repeated sequential runs (what the lock enforces for concurrent dispatches) produce a complete, correct matrix. A true two-thread deadlock repro is deliberately omitted: the advisory xact lock serializes by construction.
- All 338 existing `visibility or attendee`-scoped tests pass; `make format/lint/mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when attendee visibility information is rebuilt concurrently for the same event.
  * Prevented conflicting rebuilds from producing incomplete or inconsistent attendee visibility results.
  * Reduced locking impact on related event checkout activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->