### PR TITLE
fix(events): seeder mints pydantic-valid emails and no fake telegram ids

### DIFF
--- a/src/events/management/commands/seeder/telegram.py
+++ b/src/events/management/commands/seeder/telegram.py
@@ -1,40 +1,17 @@
 """Telegram user seeding module."""
 
 from events.management.commands.seeder.base import BaseSeeder
-from telegram.models import TelegramUser
 
 
 class TelegramSeeder(BaseSeeder):
-    """Seeder for Telegram users."""
+    """Seeder for Telegram users.
+
+    Intentionally a no-op: a randomly generated telegram_id never corresponds to a
+    real Telegram chat, so every notification dispatch to it fails with an
+    AiogramError — pure noise in logs and load tests. Seeded users are left
+    unlinked; real accounts get linked through the actual bot /start flow.
+    """
 
     def seed(self) -> None:
-        """Seed Telegram user links."""
-        self._create_telegram_users()
-
-    def _create_telegram_users(self) -> None:
-        """Link some users to fake Telegram accounts."""
-        self.log("Creating Telegram user links...")
-
-        tg_users_to_create: list[TelegramUser] = []
-
-        # ~30% of users have Telegram linked
-        users_with_telegram = self.random_sample(self.state.users, int(len(self.state.users) * 0.3))
-
-        for user in users_with_telegram:
-            # Generate a fake Telegram ID (positive integer)
-            telegram_id = self.random_int(100000000, 999999999)
-
-            tg_users_to_create.append(
-                TelegramUser(
-                    user=user,
-                    telegram_id=telegram_id,
-                    telegram_username=f"tg_{user.username.split('@')[0]}" if self.random_bool(0.7) else None,
-                    blocked_by_user=self.random_bool(0.05),
-                    user_is_deactivated=self.random_bool(0.02),
-                    was_welcomed=self.random_bool(0.9),
-                )
-            )
-
-        # Use ignore_conflicts for unique telegram_id constraint
-        TelegramUser.objects.bulk_create(tg_users_to_create, ignore_conflicts=True)
-        self.log(f"  Created Telegram links (up to {len(tg_users_to_create)})")
+        """Skip creating fake Telegram user links (see class docstring)."""
+        self.log("Skipping Telegram user links (seeded users are never linked to real chats)")

--- a/src/events/management/commands/seeder/users.py
+++ b/src/events/management/commands/seeder/users.py
@@ -147,8 +147,8 @@ class UserSeeder(BaseSeeder):
             email_verified = self.random_bool(0.6)
 
         return RevelUser(
-            username=f"{username_base}@seed.test",
-            email=f"{username_base}@seed.test",
+            username=f"{username_base}@seed.letsrevel.io",
+            email=f"{username_base}@seed.letsrevel.io",
             password=self.state.hashed_password,
             first_name=first_name,
             last_name=last_name,


### PR DESCRIPTION
## Summary
- Seeded users' emails used the `@seed.test` domain — a reserved-TLD that pydantic's `EmailStr` (used in `notifications/service/unsubscribe.py::UnsubscribeJWTPayloadSchema`) rejects outright, so **every** notification render for a seeded user failed (`notification_render_failed`, 258 in one load-test run) before anything reached mailpit. This breaks FE e2e tests that assert on rendered emails. Switched the domain to `seed.letsrevel.io` (RFC-valid, project-owned, still caught entirely by mailpit locally; prod never runs the seeder).
- Verified empirically: `owner_0@seed.test` is rejected by `UnsubscribeJWTPayloadSchema` ("special-use or reserved name"), `owner_0@seed.letsrevel.io` validates cleanly.
- Stopped minting fake Telegram chat ids in `TelegramSeeder`: the seeder generated random `telegram_id` values that never correspond to a real Telegram chat, so every notification dispatch to a seeded user with telegram enabled failed with `AiogramError` (8 per load-test run) — pure log noise. `TelegramSeeder.seed()` is now an explicit no-op with a docstring explaining why; nothing else in the codebase depended on these fake links existing.
- Checked `bootstrap_test_events.py` / `reset_events.py` for the same pattern: they use `@example.com`, which (unlike `.test`) pydantic's email validator does not reject — verified empirically — so no change needed there.
- Grepped tests for the old `seed.test` domain string: no references found, nothing to update.

## Test plan
- [x] `make format && make lint && make mypy` — all clean
- [x] `uv run pytest -k "seed"` — 6 passed
- [x] `uv run pytest src/notifications/tests/test_unsubscribe.py` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)