### PR TITLE
fix(events): CodeRabbit wave — visibility-lock ordering, full-row centrality, unified 409 shape, harness hardening

### DIFF
--- a/benchmark/seating_load/__main__.py
+++ b/benchmark/seating_load/__main__.py
@@ -11,6 +11,7 @@ Exits non-zero if any hard assertion fails (soft latency targets never fail the 
 
 import argparse
 import sys
+import typing as t
 
 from .harness import DEFAULT_BASE_URL, LoadClient, LogWatcher, ScenarioResult, setup_django
 
@@ -44,18 +45,24 @@ def main() -> int:
     watcher = LogWatcher(args.log_path) if args.log_path else None
     client = LoadClient(args.base_url)
     print(f"Target: {args.base_url}  seed={args.seed}")
-    fixtures = prepare_fixtures()
 
-    runners = {
-        "storm": lambda: scenario_hold_storm(client, fixtures, args.seed),
-        "herd": lambda: scenario_best_available_herd(client, fixtures, args.seed),
-        "poll": lambda: scenario_availability_polling(client, fixtures, args.seed),
-        "purchase": lambda: scenario_purchase_race(client, fixtures, args.seed),
-        "probes": lambda: scenario_probes(client, fixtures, args.seed),
-    }
-    order = ["storm", "herd", "poll", "purchase", "probes"] if args.scenario in ("all", "sweep") else [args.scenario]
-    if args.scenario == "sweep":
-        order = []
+    if args.scenario == "all":
+        order = ["storm", "herd", "poll", "purchase", "probes"]
+    elif args.scenario == "sweep":
+        order = []  # read-only ORM sweep: no HTTP scenarios, no fixture mutations
+    else:
+        order = [args.scenario]
+
+    runners: dict[str, t.Callable[[], ScenarioResult]] = {}
+    if order:
+        fixtures = prepare_fixtures()
+        runners = {
+            "storm": lambda: scenario_hold_storm(client, fixtures, args.seed),
+            "herd": lambda: scenario_best_available_herd(client, fixtures, args.seed),
+            "poll": lambda: scenario_availability_polling(client, fixtures, args.seed),
+            "purchase": lambda: scenario_purchase_race(client, fixtures, args.seed),
+            "probes": lambda: scenario_probes(client, fixtures, args.seed),
+        }
 
     results: list[ScenarioResult] = []
     log_errors: dict[str, list[str]] = {}

--- a/benchmark/seating_load/scenarios.py
+++ b/benchmark/seating_load/scenarios.py
@@ -181,6 +181,13 @@ def scenario_hold_storm(client: LoadClient, fx: Fixtures, seed: int) -> Scenario
     counts = status_counts(calls)
     ok = check(counts["5xx"] == 0 and counts["transport"] == 0, "zero 5xx", f"5xx/transport: {counts}", notes)
 
+    # A misconfigured run must not pass green: only 200/409 are legitimate hold
+    # outcomes, and at least one hold must actually succeed.
+    unexpected = sorted({c.status for c in calls if c.status not in (200, 409)})
+    ok &= check(not unexpected, "all hold responses in {200, 409}", f"unexpected statuses: {unexpected}", notes)
+    wins = sum(1 for _, call in results if call.status == 200)
+    ok &= check(wins >= 1, f"{wins} holds succeeded (>=1 required)", "zero successful holds", notes)
+
     # Response-level: for each contested seat at most one 200 claims it.
     claims: dict[str, int] = {}
     for _, call in results:
@@ -282,6 +289,11 @@ def _herd_wave(
         f"{wave}: {dupes} overlapping seats",
         notes,
     )
+    # Hard floor: a wave that fulfills nobody (or returns non-hold statuses) is a
+    # misconfigured run, not a pass.
+    unexpected = sorted({c.status for c in calls if c.status not in (200, 409)})
+    ok &= check(not unexpected, f"{wave}: all responses in {{200, 409}}", f"{wave}: unexpected: {unexpected}", notes)
+    ok &= check(fulfilled >= 1, f"{wave}: >=1 party fulfilled", f"{wave}: zero parties fulfilled", notes)
     print(f"    parties fulfilled: {fulfilled}/{len(tokens)} (seats granted: {len(assigned)})")
     notes.append(
         f"{wave}: {fulfilled}/{len(tokens)} parties fulfilled, {counts['409']}x409, "
@@ -358,6 +370,21 @@ def scenario_availability_polling(client: LoadClient, fx: Fixtures, seed: int) -
 
     counts = status_counts(calls)
     ok = check(counts["5xx"] == 0 and counts["transport"] == 0, "zero 5xx", f"5xx/transport: {counts}", notes)
+    # Hard floor: every expected poll/chart call must have happened and returned 200 —
+    # a run where pollers silently error or skip iterations must not pass green.
+    expected_avail = len(poll_tokens) * 20
+    ok &= check(
+        len(avail_calls) == expected_avail and all(c.status == 200 for c in avail_calls),
+        f"all {expected_avail} availability calls made, all 200",
+        f"availability: {len(avail_calls)}/{expected_avail} calls, statuses={sorted({c.status for c in avail_calls})}",
+        notes,
+    )
+    ok &= check(
+        len(chart_calls) == len(poll_tokens) and all(c.status == 200 for c in chart_calls),
+        f"all {len(poll_tokens)} chart calls made, all 200",
+        f"chart: {len(chart_calls)}/{len(poll_tokens)} calls, statuses={sorted({c.status for c in chart_calls})}",
+        notes,
+    )
     avail_p95 = percentile([c.elapsed_ms for c in avail_calls], 95)
     chart_p95 = percentile([c.elapsed_ms for c in chart_calls], 95)
     # Soft targets: report actuals either way.

--- a/src/events/controllers/event_public/seating.py
+++ b/src/events/controllers/event_public/seating.py
@@ -5,7 +5,6 @@ from uuid import UUID
 
 from django.conf import settings
 from django.shortcuts import get_object_or_404
-from django.utils.translation import gettext_lazy as _
 from ninja import Body
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -143,7 +142,11 @@ class EventPublicSeatingController(EventPublicBaseController):
             accessible_required=payload.accessible_required,
         )
         if not result.held and not result.conflicts:
-            raise HttpError(409, str(_("Not enough adjacent seats — pick manually or reduce quantity.")))
+            # Same HoldResponseSchema shape as every other hold 409 (not an HttpError
+            # {detail} body): no block of the requested size fits.
+            return 409, schema.HoldResponseSchema(
+                held_seat_ids=[], conflicts=[], expires_at=None, conflict_reason="no_block"
+            )
         status = 409 if result.conflicts else 200
         return status, schema.HoldResponseSchema(
             held_seat_ids=[h.seat_id for h in result.held],

--- a/src/events/migrations/0100_add_cleanup_expired_seat_holds_periodic_task.py
+++ b/src/events/migrations/0100_add_cleanup_expired_seat_holds_periodic_task.py
@@ -1,7 +1,9 @@
+import typing as t
+
 from django.db import migrations
 
 
-def create_cleanup_expired_seat_holds_task(apps, schema_editor):
+def create_cleanup_expired_seat_holds_task(apps: t.Any, schema_editor: t.Any) -> None:
     CrontabSchedule = apps.get_model("django_celery_beat", "CrontabSchedule")
     PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
 
@@ -24,14 +26,9 @@ def create_cleanup_expired_seat_holds_task(apps, schema_editor):
     )
 
 
-def delete_cleanup_expired_seat_holds_task(apps, schema_editor):
+def delete_cleanup_expired_seat_holds_task(apps: t.Any, schema_editor: t.Any) -> None:
     PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
-
-    try:
-        task = PeriodicTask.objects.get(name="Cleanup expired seat holds")
-        task.delete()
-    except PeriodicTask.DoesNotExist:
-        pass  # Task already gone, nothing to do
+    PeriodicTask.objects.filter(name="Cleanup expired seat holds").delete()
 
 
 class Migration(migrations.Migration):

--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -85,7 +85,9 @@ class ReleaseSeatsRequest(Schema):
 class HoldResponseSchema(Schema):
     held_seat_ids: list[UUID] = Field(default_factory=list)
     conflicts: list[UUID] = Field(default_factory=list)
-    # "capacity" (caller holds too many seats) vs "unavailable" (seats taken/blocked); None on success.
+    # "capacity" (caller holds too many seats) vs "unavailable" (seats taken/blocked)
+    # vs "no_block" (best-available: no adjacent block of the requested size fits);
+    # None on success.
     conflict_reason: str | None = None
     expires_at: AwareDatetime | None = None
 

--- a/src/events/service/seating/best_available.py
+++ b/src/events/service/seating/best_available.py
@@ -17,6 +17,10 @@ class CandidateSeat:
     adjacency_index: int
     is_accessible: bool
     sector_display_order: int
+    # Full physical row length (max adjacency_index over ALL active seats in the row,
+    # + 1) — NOT the available pool's extent. Centrality is scored against the real
+    # row midpoint, so sold/held high-index seats don't shift the perceived center.
+    row_length: int
 
 
 def _contiguous_runs(seats: list[CandidateSeat]) -> list[list[CandidateSeat]]:
@@ -52,7 +56,9 @@ def _pick_general(pool: list[CandidateSeat], quantity: int, seed: int | None) ->
     rows: dict[tuple[int, int], list[CandidateSeat]] = {}
     for s in pool:
         rows.setdefault((s.sector_display_order, s.row_order), []).append(s)
-    row_len = {key: max(s.adjacency_index for s in seats) + 1 for key, seats in rows.items()}
+    # Full-row bounds carried by the candidates themselves — never derived from the
+    # (already filtered) pool, which would move the midpoint when edge seats are taken.
+    row_len = {key: max(s.row_length for s in seats) for key, seats in rows.items()}
 
     placements: list[tuple[tuple[float, ...], list[CandidateSeat]]] = []
     for key, seats in rows.items():

--- a/src/events/service/seating/pick.py
+++ b/src/events/service/seating/pick.py
@@ -2,6 +2,8 @@
 
 import typing as t
 
+from django.db.models import Max
+
 from accounts.models import RevelUser
 from events.models import Event, EventSeatOverride, SeatHold, Ticket, TicketTier, VenueSeat, VenueSector
 from events.service.seating.best_available import CandidateSeat, pick_best_available
@@ -42,6 +44,18 @@ def load_candidates(
     taken |= set(holds_qs.values_list("seat_id", flat=True))
     taken |= set(EventSeatOverride.objects.filter(event=event).values_list("seat_id", flat=True))
     taken |= exclude
+    # Full-row bounds over ALL active seats (sold/held included) so centrality is
+    # scored against the real row midpoint, not the shrinking available pool.
+    row_bounds = {
+        (r["sector__display_order"], r["row_order"]): r["max_adjacency"] + 1
+        for r in VenueSeat.objects.filter(
+            is_active=True,
+            sector__kind=VenueSector.Kind.SEATED,
+            sector__venue_id=event.venue_id,
+        )
+        .values("sector__display_order", "row_order")
+        .annotate(max_adjacency=Max("adjacency_index"))
+    }
     qs = (
         VenueSeat.objects.filter(
             default_price_category_id=tier.price_category_id,
@@ -54,7 +68,14 @@ def load_candidates(
         .values_list("id", "row_order", "adjacency_index", "is_accessible", "sector__display_order")
     )
     return [
-        CandidateSeat(id=r[0], row_order=r[1], adjacency_index=r[2], is_accessible=r[3], sector_display_order=r[4])
+        CandidateSeat(
+            id=r[0],
+            row_order=r[1],
+            adjacency_index=r[2],
+            is_accessible=r[3],
+            sector_display_order=r[4],
+            row_length=row_bounds[(r[4], r[1])],
+        )
         for r in qs
     ]
 

--- a/src/events/tasks/attendees.py
+++ b/src/events/tasks/attendees.py
@@ -50,30 +50,6 @@ def build_attendee_visibility_flags(event_id: str) -> None:
         event.attendee_count = ticket_count + rsvp_count
         event.save(update_fields=["attendee_count"])
 
-    # Re-fetch event without lock for visibility flag building (read-only operations)
-    event = Event.objects.with_organization().get(pk=event_id)
-
-    organization = event.organization
-    owner_id = organization.owner_id
-    staff_ids = {sm.id for sm in organization.staff_members.all()}
-
-    # Pre-load all relationship data in 4 queries (instead of N queries per pair)
-    context = VisibilityContext.for_event(event, owner_id, staff_ids)
-
-    # Users attending the event (for visibility purposes)
-    # Prefetch general_preferences to avoid N+1 when accessing target.general_preferences
-    attendees_q = Q(
-        tickets__event=event,
-        tickets__status__in=[Ticket.TicketStatus.ACTIVE, Ticket.TicketStatus.CHECKED_IN],
-    ) | Q(rsvps__event=event, rsvps__status=EventRSVP.RsvpStatus.YES)
-
-    attendees = list(RevelUser.objects.filter(attendees_q).select_related("general_preferences").distinct())
-
-    # Users invited or attending = potential viewers
-    viewers = list(RevelUser.objects.filter(Q(invitations__event=event) | attendees_q).distinct())
-
-    flags = []
-
     with transaction.atomic():
         # Serialize concurrent rebuilds of the same event's matrix. Every confirmed
         # ticket/RSVP dispatches this task, so a checkout rush runs several rebuilds
@@ -82,8 +58,37 @@ def build_attendee_visibility_flags(event_id: str) -> None:
         # serializes the rebuild without touching the Event row that checkout paths
         # select_for_update (so it adds no checkout latency). Released automatically
         # at commit/rollback.
+        #
+        # The lock is taken FIRST, before the visibility snapshot below: a task that
+        # waits here must read the state left by the rebuild it waited on, otherwise
+        # it would overwrite a newer matrix with stale flags.
         with connection.cursor() as cursor:
             cursor.execute("SELECT pg_advisory_xact_lock(%s)", [visibility_rebuild_lock_key(event_id)])
+
+        # Re-fetch event without a row lock for visibility flag building (read-only)
+        event = Event.objects.with_organization().get(pk=event_id)
+
+        organization = event.organization
+        owner_id = organization.owner_id
+        staff_ids = {sm.id for sm in organization.staff_members.all()}
+
+        # Pre-load all relationship data in 4 queries (instead of N queries per pair)
+        context = VisibilityContext.for_event(event, owner_id, staff_ids)
+
+        # Users attending the event (for visibility purposes)
+        # Prefetch general_preferences to avoid N+1 when accessing target.general_preferences
+        attendees_q = Q(
+            tickets__event=event,
+            tickets__status__in=[Ticket.TicketStatus.ACTIVE, Ticket.TicketStatus.CHECKED_IN],
+        ) | Q(rsvps__event=event, rsvps__status=EventRSVP.RsvpStatus.YES)
+
+        attendees = list(RevelUser.objects.filter(attendees_q).select_related("general_preferences").distinct())
+
+        # Users invited or attending = potential viewers
+        viewers = list(RevelUser.objects.filter(Q(invitations__event=event) | attendees_q).distinct())
+
+        flags = []
+
         AttendeeVisibilityFlag.objects.filter(event=event).delete()
         for viewer in viewers:
             for target in attendees:

--- a/src/events/tests/test_controllers/test_seating_public.py
+++ b/src/events/tests/test_controllers/test_seating_public.py
@@ -171,6 +171,12 @@ def test_best_available_hold_409_when_no_block_fits(
         content_type="application/json",
     )
     assert resp.status_code == 409, resp.content
+    # Same HoldResponseSchema shape as every other hold 409, not an HttpError {detail}.
+    body = resp.json()
+    assert body["conflict_reason"] == "no_block"
+    assert body["held_seat_ids"] == []
+    assert body["conflicts"] == []
+    assert body["expires_at"] is None
 
 
 def test_anonymous_best_available_hold_sets_guest_cookie(

--- a/src/events/tests/test_models/test_venue_models.py
+++ b/src/events/tests/test_models/test_venue_models.py
@@ -412,24 +412,30 @@ def test_venue_seat_position_json_field(organization: Organization) -> None:
 
 @pytest.mark.django_db
 def test_venue_seat_ordering(organization: Organization) -> None:
-    """Test that seats are ordered by row, number, and label."""
+    """Test that seats are ordered by row_order then adjacency_index (Meta.ordering)."""
     venue = Venue.objects.create(organization=organization, name="Theater")
     sector = VenueSector.objects.create(venue=venue, name="Orchestra")
 
-    # Create seats in random order
-    seat_b2 = VenueSeat.objects.create(sector=sector, label="B2", row_label="B", number=2)
-    seat_a1 = VenueSeat.objects.create(sector=sector, label="A1", row_label="A", number=1)
-    seat_a2 = VenueSeat.objects.create(sector=sector, label="A2", row_label="A", number=2)
-    seat_b1 = VenueSeat.objects.create(sector=sector, label="B1", row_label="B", number=1)
+    # row_order/adjacency_index deliberately INVERT the lexical label order, so a
+    # regression to label (or row_label/number) sorting flips the result.
+    seat_b2 = VenueSeat.objects.create(
+        sector=sector, label="B2", row_label="B", number=2, row_order=0, adjacency_index=0
+    )
+    seat_a1 = VenueSeat.objects.create(
+        sector=sector, label="A1", row_label="A", number=1, row_order=1, adjacency_index=1
+    )
+    seat_a2 = VenueSeat.objects.create(
+        sector=sector, label="A2", row_label="A", number=2, row_order=1, adjacency_index=0
+    )
+    seat_b1 = VenueSeat.objects.create(
+        sector=sector, label="B1", row_label="B", number=1, row_order=0, adjacency_index=1
+    )
 
     # Query seats
     seats = list(VenueSeat.objects.filter(sector=sector))
 
-    # Should be ordered by row, then number, then label
-    assert seats[0] == seat_a1
-    assert seats[1] == seat_a2
-    assert seats[2] == seat_b1
-    assert seats[3] == seat_b2
+    # Physical order (row_order, adjacency_index) — the reverse of lexical label order.
+    assert seats == [seat_b2, seat_b1, seat_a2, seat_a1]
 
 
 @pytest.mark.django_db

--- a/src/events/tests/test_service/test_best_available.py
+++ b/src/events/tests/test_service/test_best_available.py
@@ -16,6 +16,7 @@ def _row(
             adjacency_index=i,
             is_accessible=i in accessible,
             sector_display_order=0,
+            row_length=count,
         )
         for i in range(count)
         if i not in taken
@@ -58,6 +59,16 @@ def test_row_rank_beats_fragmentation() -> None:
     assert all(by_id[p].row_order == 0 for p in picked)  # front row wins despite stranding
 
 
+def test_centrality_uses_full_row_not_available_pool() -> None:
+    # Row of 10 with the high half (6-9) sold: the real midpoint is 4.5, so the pair
+    # (4, 5) must win. Deriving row length from the available pool (max free index 5
+    # -> fake midpoint 2.5) would pick the off-center pair (2, 3) instead.
+    row = _row(0, 10, taken={6, 7, 8, 9})
+    picked = pick_best_available(row, 2, seed=1)
+    by_id = {s.id: s for s in row}
+    assert sorted(by_id[p].adjacency_index for p in picked) == [4, 5]
+
+
 def test_returns_empty_when_no_contiguous_block() -> None:
     row = _row(0, 6, taken={1, 3, 5})  # singles only
     assert pick_best_available(row, 2, seed=1) == []
@@ -73,7 +84,9 @@ def test_accessible_seats_protected_from_general_sale() -> None:
 def test_accessible_required_relaxed_contiguity() -> None:
     row = _row(0, 6, taken={1}, accessible={0, 2})
     picked = pick_best_available(row, 2, accessible_required=True, seed=1)
-    assert len(picked) == 2  # 0 and 2 despite the gap
+    by_id = {s.id: s for s in row}
+    # Exactly the accessible seats, despite the gap — never ordinary fillers.
+    assert sorted(by_id[p].adjacency_index for p in picked) == [0, 2]
 
 
 def test_deterministic_for_fixed_seed() -> None:

--- a/src/events/tests/test_service/test_seating_purchase_integration.py
+++ b/src/events/tests/test_service/test_seating_purchase_integration.py
@@ -304,6 +304,7 @@ def test_best_available_post_lock_recheck_retries_on_stale_pick(
                     adjacency_index=s.adjacency_index,
                     is_accessible=s.is_accessible,
                     sector_display_order=s.sector.display_order,
+                    row_length=max(x.adjacency_index for x in seats) + 1,
                 )
                 for s in seats[:2]
             ]
@@ -346,6 +347,7 @@ def test_best_available_deactivated_seat_conflicts_post_lock(
                     adjacency_index=s.adjacency_index,
                     is_accessible=s.is_accessible,
                     sector_display_order=s.sector.display_order,
+                    row_length=max(x.adjacency_index for x in seats) + 1,
                 )
                 for s in seats[:2]
             ]

--- a/src/events/tests/test_tasks/test_misc.py
+++ b/src/events/tests/test_tasks/test_misc.py
@@ -196,17 +196,27 @@ def test_visibility_rebuild_lock_key_is_stable_and_64_bit() -> None:
     assert visibility_rebuild_lock_key(str(uuid.uuid4())) != key
 
 
+@pytest.mark.django_db(transaction=True)
 def test_build_attendee_visibility_flags_takes_per_event_advisory_lock(
     event: Event,
     revel_user_factory: RevelUserFactory,
 ) -> None:
-    """The rebuild transaction acquires the per-event advisory xact lock, and repeated
-    sequential runs still produce a complete, correct matrix.
+    """The rebuild transaction acquires the per-event advisory xact lock BEFORE the
+    visibility snapshot reads, and repeated sequential runs still produce a complete,
+    correct matrix.
 
-    This is the deadlock regression guard: concurrent rebuilds of the same event's
-    matrix deadlocked in production because delete + bulk_create interleaved row locks
-    across workers. The advisory lock serializes them by construction, so we assert the
-    lock is taken with the derived key rather than reproducing a two-thread deadlock.
+    This is the deadlock + stale-overwrite regression guard: concurrent rebuilds of
+    the same event's matrix deadlocked in production because delete + bulk_create
+    interleaved row locks across workers, and a task that waits on the lock must read
+    AFTER acquiring it or it overwrites a newer matrix with stale flags. We assert the
+    lock query runs exactly once, with the derived key, and strictly before every
+    snapshot read and the destructive delete (query-order inspection) rather than
+    reproducing a two-thread race.
+
+    ``transaction=True`` is required: under pytest-django's default outer transaction
+    the task's ``transaction.atomic()`` degrades to a savepoint, so
+    ``pg_advisory_xact_lock`` would attach to the test's long-lived outer transaction
+    and the "lock taken inside the task's own transaction" contract could never fail.
     """
     attendee1 = revel_user_factory()
     attendee2 = revel_user_factory()
@@ -220,9 +230,30 @@ def test_build_attendee_visibility_flags_takes_per_event_advisory_lock(
     with CaptureQueriesContext(connection) as ctx:
         build_attendee_visibility_flags(str(event.id))
 
-    lock_queries = [q["sql"] for q in ctx.captured_queries if "pg_advisory_xact_lock" in q["sql"]]
-    assert len(lock_queries) == 1
-    assert str(visibility_rebuild_lock_key(str(event.id))) in lock_queries[0]
+    sqls = [q["sql"] for q in ctx.captured_queries]
+    lock_indices = [i for i, sql in enumerate(sqls) if "pg_advisory_xact_lock" in sql]
+    assert len(lock_indices) == 1
+    lock_idx = lock_indices[0]
+    assert str(visibility_rebuild_lock_key(str(event.id))) in sqls[lock_idx]
+
+    # The visibility snapshot (attendee/viewer reads) and the destructive rewrite must
+    # all happen AFTER the advisory lock — a stale pre-lock snapshot would let a queued
+    # rebuild overwrite a newer matrix. The attendee/viewer reads are the reveluser
+    # selects joined against tickets/rsvps/invitations (the pre-lock attendee-count
+    # block also prefetches staff members, so a bare reveluser match would be wrong).
+    snapshot_reads = [
+        i
+        for i, sql in enumerate(sqls)
+        if "accounts_reveluser" in sql
+        and sql.startswith("SELECT")
+        and ("events_ticket" in sql or "events_eventrsvp" in sql or "events_eventinvitation" in sql)
+    ]
+    delete_indices = [
+        i for i, sql in enumerate(sqls) if "events_attendeevisibilityflag" in sql and sql.startswith("DELETE")
+    ]
+    assert snapshot_reads, "expected attendee/viewer snapshot reads"
+    assert delete_indices, "expected the matrix delete"
+    assert all(lock_idx < i for i in snapshot_reads + delete_indices)
 
     # A second sequential run (what the lock enforces for concurrent dispatches)
     # still yields a complete matrix: every viewer/target pair has exactly one flag.


### PR DESCRIPTION
Addresses the CodeRabbit review wave on #724: six findings fixed, three dismissed with threaded replies.

## Fixed

1. **Visibility-rebuild lock ordering** (`events/tasks/attendees.py`) — the advisory lock is now acquired *before* the event/relationship/attendee/viewer snapshot reads, so a task that waits on the lock can no longer overwrite a newer matrix with stale flags. The regression test now runs with `django_db(transaction=True)` (the atomic block degrades to a savepoint under pytest-django's outer transaction) and asserts via query-order inspection that the lock precedes every snapshot read and the destructive delete.
2. **Full-row centrality** (`seating/best_available.py`, `seating/pick.py`) — `CandidateSeat` gains `row_length` (max `adjacency_index` over ALL active seats in the row, one cheap aggregate in `load_candidates`), so sold/held high-index seats no longer shift the perceived row midpoint. New pure test: a centered pair in a half-sold row beats the edge pair (fails pre-fix).
3. **Unified no-block 409** (`event_public/seating.py`) — the best-available no-fit branch returns `409, HoldResponseSchema(conflict_reason="no_block")` instead of an `HttpError` `{detail}` body; all hold-endpoint 409s now share one shape, and `"no_block"` is documented in the schema. Retries-exhausted still reports `"unavailable"`.
4. **Migration 0100** — type-hinted both `RunPython` functions; reverse is now an idempotent `filter(...).delete()`.
5. **Benchmark harness** — `--scenario sweep` no longer runs `prepare_fixtures()` (read-only invariant sweep); storm/herd/poll scenarios hard-require ≥1 expected success and restrict responses to their expected status sets so a misconfigured run can't pass green on zero successes.
6. **Test strength** — `VenueSeat` ordering test now uses explicit `row_order`/`adjacency_index` that invert the lexical label order; the accessible-required test asserts the exact accessible seats are returned.

## Dismissed with threaded replies

- **holds.py "lock seats before upsert"** — deliberate: holds are advisory UX, tickets are truth (partial unique constraint + locked purchase-path re-checks); a transient hold on a just-sold seat is harmless and self-heals at TTL.
- **0098 "adjacency from printed numbers"** — documented mechanical backfill for grid-generated data (the only data at that point); explicit adjacency + server-side derivation landed via #725/#728.
- **test_seat_holds tamper "flake"** — impossible: only 16 base64url characters are reachable as the HMAC-SHA256 token tail (alphabet index ≡ 0 mod 4); `x` is not one of them. Verified empirically.

Scoped tests: 728 passed. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)