### PR TITLE
fix(events): checkout consumes the buyer's exact held block; prune stale i18n entry

### DIFF
--- a/src/events/service/batch_ticket_service.py
+++ b/src/events/service/batch_ticket_service.py
@@ -17,6 +17,7 @@ from events.models import (
     EventInvitation,
     EventSeatOverride,
     OrganizationMember,
+    SeatHold,
     Ticket,
     TicketTier,
     VenueSeat,
@@ -283,8 +284,97 @@ class BatchTicketService:
             guest_session=self.guest_session,
         )
 
+    def _lock_and_verify_block(self, picked_ids: list[UUID]) -> list[VenueSeat]:
+        """Lock a picked seat block PK-ordered and re-verify it under the lock.
+
+        Must run inside a savepoint (nested ``transaction.atomic()``): raises
+        ``_SeatConflictError`` when a seat vanished/deactivated, got ticketed,
+        was box-office overridden, or is live-held by another identity — the
+        caller's savepoint rollback then releases this attempt's row locks.
+        On success the buyer's own holds on the block are consumed.
+
+        Args:
+            picked_ids: Seat ids to secure, in desired assignment order.
+
+        Returns:
+            The locked VenueSeat rows in ``picked_ids`` order.
+
+        Raises:
+            _SeatConflictError: If any seat can no longer be assigned.
+        """
+        # Locked in PK order per the global seat-lock protocol (holds/overrides).
+        # is_active is re-evaluated against the locked row version (EvalPlanQual),
+        # so a just-deactivated seat drops out here as a length mismatch.
+        seats = list(VenueSeat.objects.filter(id__in=picked_ids, is_active=True).order_by("pk").select_for_update())
+        if len(seats) != len(picked_ids):  # a picked seat vanished/deactivated — re-pick
+            raise _SeatConflictError
+        # Non-cancelled = occupied, matching unique_ticket_event_seat.
+        taken = (
+            Ticket.objects.filter(event=self.event, seat_id__in=picked_ids)
+            .exclude(status=Ticket.TicketStatus.CANCELLED)
+            .exists()
+        )
+        if taken:
+            raise _SeatConflictError
+        # Post-lock override re-check: the pick/hold read overrides unlocked, so a
+        # seat killed/held by box office in between must be caught here (mirrors
+        # _resolve_seats_user_choice).
+        if EventSeatOverride.objects.filter(event=self.event, seat_id__in=picked_ids).exists():
+            raise _SeatConflictError
+        try:
+            self._verify_and_consume_holds(picked_ids)
+        except holds_service.SeatHoldConflictError:
+            raise _SeatConflictError from None
+        id_order = {sid: i for i, sid in enumerate(picked_ids)}
+        return sorted(seats, key=lambda s: id_order[s.id])
+
+    def _try_consume_held_block(self, count: int) -> list[VenueSeat] | None:
+        """Consume the buyer's own held seats directly instead of re-running the picker.
+
+        A buyer who pre-held a block (e.g. via POST /seating/holds/best-available)
+        must get EXACTLY the seats they were shown: re-running the picker could
+        settle on a different equally-scored block (seeded tiebreak), stranding
+        the original holds until TTL, and an accessible held block would be
+        skipped entirely when checkout doesn't set ``accessible_required``.
+
+        The buyer's ACTIVE holds on seats in the tier's price category (same
+        identity rule as ``_verify_and_consume_holds``) are taken in deterministic
+        adjacency order — (sector display_order, row_order, adjacency_index) —
+        first ``count`` of them. Contiguity is deliberately NOT enforced: the
+        buyer explicitly holds these exact seats (a best-available hold block is
+        already adjacent) and gets exactly what they held. Accessible held seats
+        are likewise consumed without ``accessible_required`` at checkout.
+
+        Returns:
+            The seats to assign, or None to fall through to the normal picker:
+            when the buyer holds fewer than ``count`` matching seats, or a held
+            seat conflicts post-lock (ticketed/overridden/deactivated/sniped) —
+            the savepoint rollback releases the locks and restores the holds.
+        """
+        if not self.tier.price_category_id:
+            return None
+        owner_q = SeatHold.owner_q(None if self.guest_session else self.user, self.guest_session)
+        held_ids = list(
+            SeatHold.objects.active()
+            .filter(owner_q, event=self.event, seat__default_price_category_id=self.tier.price_category_id)
+            .order_by("seat__sector__display_order", "seat__row_order", "seat__adjacency_index")
+            .values_list("seat_id", flat=True)
+        )
+        if len(held_ids) < count:
+            return None
+        try:
+            with transaction.atomic():  # savepoint: rollback releases locks + restores holds
+                return self._lock_and_verify_block(held_ids[:count])
+        except _SeatConflictError:
+            return None
+
     def _resolve_seats_best_available(self, count: int) -> list[VenueSeat]:
         """Adjacency-aware assignment: optimistic pick, then lock + verify the chosen seats only.
+
+        When the buyer already holds enough seats for this tier's price category,
+        the exact held block is consumed instead of re-running the picker (see
+        ``_try_consume_held_block``); the picker below only runs when there is no
+        (sufficient, still-valid) own hold.
 
         Retries with a fresh read when a picked seat got ticketed, overridden,
         deactivated, or foreign-held between the unlocked pick and the lock.
@@ -310,6 +400,9 @@ class BatchTicketService:
         from events.service.seating.best_available import pick_best_available
         from events.service.seating.pick import load_candidates
 
+        if (held := self._try_consume_held_block(count)) is not None:
+            return held
+
         for _attempt in range(3):
             # Same identity rule as _verify_and_consume_holds: a guest session, when
             # present, IS the hold identity — the buyer's own holds stay candidates.
@@ -329,34 +422,7 @@ class BatchTicketService:
                 raise HttpError(409, str(_("Not enough adjacent seats available for this tier.")))
             try:
                 with transaction.atomic():  # savepoint per attempt (see docstring)
-                    # Locked in PK order per the global seat-lock protocol
-                    # (holds/overrides). is_active is re-evaluated against the
-                    # locked row version (EvalPlanQual), so a just-deactivated
-                    # seat drops out here as a length mismatch.
-                    seats = list(
-                        VenueSeat.objects.filter(id__in=picked_ids, is_active=True).order_by("pk").select_for_update()
-                    )
-                    if len(seats) != len(picked_ids):  # a picked seat vanished/deactivated — re-pick
-                        raise _SeatConflictError
-                    # Non-cancelled = occupied, matching unique_ticket_event_seat.
-                    taken = (
-                        Ticket.objects.filter(event=self.event, seat_id__in=picked_ids)
-                        .exclude(status=Ticket.TicketStatus.CANCELLED)
-                        .exists()
-                    )
-                    if taken:
-                        raise _SeatConflictError
-                    # Post-lock override re-check: load_candidates read overrides
-                    # unlocked, so a seat killed/held by box office in between must
-                    # be caught here (mirrors _resolve_seats_user_choice).
-                    if EventSeatOverride.objects.filter(event=self.event, seat_id__in=picked_ids).exists():
-                        raise _SeatConflictError
-                    try:
-                        self._verify_and_consume_holds(picked_ids)
-                    except holds_service.SeatHoldConflictError:
-                        raise _SeatConflictError from None
-                    id_order = {sid: i for i, sid in enumerate(picked_ids)}
-                    return sorted(seats, key=lambda s: id_order[s.id])
+                    return self._lock_and_verify_block(picked_ids)
             except _SeatConflictError:
                 continue
         raise HttpError(409, str(_("Could not secure adjacent seats — please try again.")))

--- a/src/events/tests/test_service/test_seating_purchase_integration.py
+++ b/src/events/tests/test_service/test_seating_purchase_integration.py
@@ -274,6 +274,93 @@ def test_best_available_foreign_hold_on_last_pair_still_409(
     assert SeatHold.objects.filter(event=event).count() == 2  # foreign holds untouched
 
 
+def test_best_available_checkout_consumes_exact_held_block_over_better_pick(
+    seated_event: SeatedEvent, revel_user: RevelUser
+) -> None:
+    """Checkout must consume the buyer's exact held block, not re-run the picker.
+
+    The buyer holds A1/A2 while A3/A4 is strictly better-scored (centrality 0
+    vs 2.0): a re-pick would prefer A3/A4 and strand the original holds until
+    TTL. The held-block fast path must return exactly the held seats.
+    """
+    event, seats = seated_event
+    tier = _best_available_tier(event, seats)
+    holds_service.acquire_seats(event, [seats[0].id, seats[1].id], user=revel_user, guest_session=None)
+    BatchTicketService(event, tier, revel_user).create_batch(items=[_item(), _item()])
+    assigned = {ticket.seat_id for ticket in Ticket.objects.filter(event=event)}
+    assert assigned == {seats[0].id, seats[1].id}
+    assert not SeatHold.objects.filter(event=event).exists()
+
+
+def test_best_available_checkout_consumes_accessible_held_block_without_flag(
+    seated_event: SeatedEvent, revel_user: RevelUser
+) -> None:
+    """An accessible held block is consumed even when checkout omits accessible_required.
+
+    The buyer held accessible seats (accessible_required hold); the general
+    picker pool excludes accessible seats, so a re-pick would assign different
+    (non-accessible) seats — the shown block would be unpurchasable.
+    """
+    from events.service.seating.pick import hold_best_available
+
+    event, seats = seated_event
+    tier = _best_available_tier(event, seats)
+    VenueSeat.objects.filter(id__in=[seats[4].id, seats[5].id]).update(is_accessible=True)
+    result = hold_best_available(event, tier, 2, user=revel_user, guest_session=None, accessible_required=True)
+    assert {h.seat_id for h in result.held} == {seats[4].id, seats[5].id}
+    BatchTicketService(event, tier, revel_user).create_batch(items=[_item(), _item()])  # no accessible_required
+    assigned = {ticket.seat_id for ticket in Ticket.objects.filter(event=event)}
+    assert assigned == {seats[4].id, seats[5].id}
+    assert not SeatHold.objects.filter(event=event).exists()
+
+
+def test_best_available_partial_hold_falls_through_to_picker(seated_event: SeatedEvent, revel_user: RevelUser) -> None:
+    """Fewer held seats than requested → normal picker path, own hold still a candidate.
+
+    Holding only A3 and buying two seats picks the best pair (A3/A4, centrality
+    0), which includes the held seat — the hold is consumed, none linger.
+    """
+    event, seats = seated_event
+    tier = _best_available_tier(event, seats)
+    holds_service.acquire_seats(event, [seats[2].id], user=revel_user, guest_session=None)
+    BatchTicketService(event, tier, revel_user).create_batch(items=[_item(), _item()])
+    assigned = {ticket.seat_id for ticket in Ticket.objects.filter(event=event)}
+    assert assigned == {seats[2].id, seats[3].id}
+    assert not SeatHold.objects.filter(event=event).exists()
+
+
+def test_best_available_sniped_held_seat_falls_through_to_picker(
+    seated_event: SeatedEvent, revel_user: RevelUser, other_user: RevelUser
+) -> None:
+    """A held seat ticketed post-hold (holds are advisory) → clean fall-through.
+
+    The fast path's post-lock re-check conflicts on the sniped seat; the
+    savepoint rollback restores the buyer's holds untouched and the picker
+    assigns a clean block instead. No partial state.
+    """
+    event, seats = seated_event
+    tier = _best_available_tier(event, seats)
+    holds_service.acquire_seats(event, [seats[0].id, seats[1].id], user=revel_user, guest_session=None)
+    Ticket.objects.create(
+        event=event,
+        tier=tier,
+        user=other_user,
+        status=Ticket.TicketStatus.ACTIVE,
+        guest_name="Sniper",
+        seat=seats[0],
+        sector=seats[0].sector,
+        venue=seats[0].sector.venue,
+    )
+    BatchTicketService(event, tier, revel_user).create_batch(items=[_item(), _item()])
+    assigned = {ticket.seat_id for ticket in Ticket.objects.filter(event=event, user=revel_user)}
+    assert assigned == {seats[2].id, seats[3].id}  # picker's best clean pair
+    # Fast-path savepoint rolled back: the buyer's holds survive untouched (until TTL).
+    assert set(SeatHold.objects.filter(event=event).values_list("seat_id", flat=True)) == {
+        seats[0].id,
+        seats[1].id,
+    }
+
+
 def test_best_available_post_lock_recheck_retries_on_stale_pick(
     seated_event: SeatedEvent, revel_user: RevelUser, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -921,11 +921,6 @@ msgstr "Dieser Endpunkt ist nur für \"Zahl-was-du-kannst\"-Tickets"
 msgid "No pending reservation found."
 msgstr "Keine ausstehende Reservierung gefunden."
 
-msgid "Not enough adjacent seats — pick manually or reduce quantity."
-msgstr ""
-"Nicht genügend zusammenhängende Sitzplätze — bitte manuell auswählen oder "
-"Anzahl reduzieren."
-
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Verwende den Endpunkt /checkout/pwyc für \"Zahl-was-du-kannst\"-Tickets"

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -931,11 +931,6 @@ msgstr ""
 msgid "No pending reservation found."
 msgstr "Aucune réservation en attente trouvée."
 
-msgid "Not enough adjacent seats — pick manually or reduce quantity."
-msgstr ""
-"Pas assez de sièges adjacents — choisissez manuellement ou réduisez la "
-"quantité."
-
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Utilise le point d'accès /checkout/pwyc pour les tickets avec tarif libre "

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -909,11 +909,6 @@ msgstr "Questo endpoint è solo per biglietti a offerta libera"
 msgid "No pending reservation found."
 msgstr "Nessuna prenotazione in sospeso trovata."
 
-msgid "Not enough adjacent seats — pick manually or reduce quantity."
-msgstr ""
-"Non ci sono abbastanza posti adiacenti — scegli manualmente o riduci la "
-"quantità."
-
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr "Usa l'endpoint /checkout/pwyc per i biglietti a offerta libera"
 


### PR DESCRIPTION
Addresses CodeRabbit review comment [3608971688](https://github.com/letsrevel/revel-backend/pull/724#discussion_r3608971688) on #724: *"Consume the exact held block instead of running best-available again."*

## Problem

`_resolve_seats_best_available` re-ran the picker with the buyer's own holds merely **included** in the candidate pool:

- **(a) Different seats than shown** — the seeded randomized tiebreak could settle on a different equally-scored block, so the buyer got seats other than the block they pre-held via `POST /seating/holds/best-available`, and the original holds lingered until TTL.
- **(b) Accessible held block unpurchasable** — an `accessible_required` hold picks accessible seats, but the general checkout pool *excludes* accessible seats; without `accessible_required` at checkout the shown block could never be assigned.

## Fix

Before running the picker, `_try_consume_held_block` resolves the buyer's own ACTIVE holds for this event on seats in the tier's price category (same `user=None if guest_session else user` identity rule as `_verify_and_consume_holds`):

- **Enough held seats (`>= count`)** → take the first `count` in deterministic adjacency order (sector `display_order`, `row_order`, `adjacency_index`), lock PK-ordered inside a savepoint, run the same post-lock re-checks (tickets, overrides, `is_active`, foreign holds), consume the holds, and return exactly those seats. Contiguity is deliberately **not** re-enforced — the buyer explicitly holds these exact seats. This also fixes (b) structurally: accessible held seats are consumed directly, no `accessible_required` needed at checkout.
- **Post-lock conflict** (sniped/overridden/deactivated) → savepoint rollback releases locks and restores the holds; fall through to the normal picker path.
- **No/insufficient own holds** → behavior unchanged: picker runs with own holds included in candidates (the false-409 fix from #724 stays), `accessible_required` threading (#727) intact.

The post-lock verification shared by both paths is extracted into `_lock_and_verify_block`.

Also prunes the stale `"Not enough adjacent seats — pick manually or reduce quantity."` catalog entry (de/fr/it) left behind by the unified 409 shape (#729).

## Tests

New in `test_seating_purchase_integration.py` (file now 22 tests, all passing):

- `test_best_available_checkout_consumes_exact_held_block_over_better_pick` — a strictly better-scored block exists; the held block still wins.
- `test_best_available_checkout_consumes_accessible_held_block_without_flag` — accessible hold via `hold_best_available(accessible_required=True)`, checkout without the flag succeeds on exactly those seats.
- `test_best_available_partial_hold_falls_through_to_picker` — held < count → picker path, own hold consumed cleanly.
- `test_best_available_sniped_held_seat_falls_through_to_picker` — conflicting ticket on a held seat → clean fall-through, holds restored by savepoint rollback, no partial state.

Scoped run: `uv run pytest src/events/tests/ -q -k "seating or best_available or purchase or guest"` → **258 passed**. `make check` green. `batch_ticket_service.py` at 951 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)