### PR TITLE
feat(events): box-office door sales, comps, reseat, seat in check-in payload

### DIFF
--- a/src/events/controllers/event_admin/seating.py
+++ b/src/events/controllers/event_admin/seating.py
@@ -1,11 +1,13 @@
 from uuid import UUID
 
+from django.shortcuts import get_object_or_404
 from ninja_extra import api_controller, route
 
 from common.authentication import I18nJWTAuth
 from common.throttling import WriteThrottle
-from events import schema
+from events import models, schema
 from events.controllers.permissions import EventPermission
+from events.service.seating import box_office
 from events.service.seating import overrides as overrides_service
 
 from .base import EventAdminBaseController
@@ -19,7 +21,7 @@ from .base import EventAdminBaseController
     throttle=WriteThrottle(),
 )
 class EventAdminSeatingController(EventAdminBaseController):
-    """Box-office seat overrides: bulk hold/kill/release with reasons."""
+    """Box-office seat overrides, door sales/comps, and reseat."""
 
     @route.put(
         "/seating/overrides",
@@ -39,3 +41,39 @@ class EventAdminSeatingController(EventAdminBaseController):
             set_items=[(i.seat_id, i.status.value, i.reason) for i in payload.set],
             release_seat_ids=payload.release_seat_ids,
         )
+
+    @route.post(
+        "/seating/sell",
+        url_name="event_seating_sell",
+        response=schema.AdminTicketSchema,
+    )
+    def box_office_sell(self, event_id: UUID, payload: schema.BoxOfficeSellRequest) -> models.Ticket:
+        """Door sale / comp: issue an ACTIVE ticket directly on a seat.
+
+        The recipient is an email (guest user get-or-create) or an existing
+        ``user_id``. A box-office HELD override on the seat is released as part
+        of the sale; a KILLED seat is rejected.
+        """
+        event = self.get_one(event_id)
+        tier = get_object_or_404(models.TicketTier, pk=payload.tier_id, event=event)
+        recipient = box_office.resolve_recipient(payload.email, payload.user_id, payload.first_name, payload.last_name)
+        ticket = box_office.sell(
+            event,
+            tier,
+            seat_id=payload.seat_id,
+            payment_method=payload.payment_method,
+            recipient=recipient,
+            guest_name=payload.guest_name,
+        )
+        return models.Ticket.objects.full().get(pk=ticket.pk)
+
+    @route.post(
+        "/seating/reseat",
+        url_name="event_seating_reseat",
+        response=schema.AdminTicketSchema,
+    )
+    def box_office_reseat(self, event_id: UUID, payload: schema.BoxOfficeReseatRequest) -> models.Ticket:
+        """Move a PENDING/ACTIVE ticket to another free seat in the same price category."""
+        event = self.get_one(event_id)
+        ticket = box_office.reseat(event, ticket_id=payload.ticket_id, target_seat_id=payload.target_seat_id)
+        return models.Ticket.objects.full().get(pk=ticket.pk)

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -247,6 +247,8 @@ from .rsvp import (
 # Seating schemas
 from .seating import (
     BestAvailableHoldRequest,
+    BoxOfficeReseatRequest,
+    BoxOfficeSellRequest,
     ChartSeatSchema,
     ChartSectorSchema,
     HoldResponseSchema,
@@ -540,6 +542,8 @@ __all__ = [
     "WaitlistEntrySchema",
     # Seating
     "BestAvailableHoldRequest",
+    "BoxOfficeReseatRequest",
+    "BoxOfficeSellRequest",
     "ChartSeatSchema",
     "ChartSectorSchema",
     "HoldResponseSchema",

--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -4,9 +4,9 @@ import typing as t
 from uuid import UUID
 
 from ninja import Schema
-from pydantic import AwareDatetime, Field, field_serializer
+from pydantic import AwareDatetime, EmailStr, Field, field_serializer, field_validator, model_validator
 
-from events.models import EventSeatOverride
+from events.models import EventSeatOverride, TicketTier
 
 from .venue import Coordinate2D, PriceCategorySchema
 
@@ -101,6 +101,41 @@ class SeatOverrideItemSchema(Schema):
 class SeatOverridesRequest(Schema):
     set: list[SeatOverrideItemSchema] = Field(default_factory=list)
     release_seat_ids: list[UUID] = Field(default_factory=list)
+
+
+class BoxOfficeSellRequest(Schema):
+    """Door sale / comp: staff issues a ticket directly on a seat (spec §2)."""
+
+    seat_id: UUID
+    tier_id: UUID
+    payment_method: TicketTier.PaymentMethod
+    # Recipient: exactly one of email (guest get-or-create) or user_id (existing account).
+    email: EmailStr | None = None
+    user_id: UUID | None = None
+    guest_name: str | None = Field(default=None, max_length=255)
+    # Used only when a new guest user is created for the email.
+    first_name: str = Field(default="", max_length=150)
+    last_name: str = Field(default="", max_length=150)
+
+    @field_validator("payment_method")
+    @classmethod
+    def _door_methods_only(cls, v: TicketTier.PaymentMethod) -> TicketTier.PaymentMethod:
+        if v not in (TicketTier.PaymentMethod.AT_THE_DOOR, TicketTier.PaymentMethod.FREE):
+            raise ValueError("payment_method must be 'at_the_door' or 'free'")
+        return v
+
+    @model_validator(mode="after")
+    def _exactly_one_recipient(self) -> "BoxOfficeSellRequest":
+        if (self.email is None) == (self.user_id is None):
+            raise ValueError("Provide exactly one of 'email' or 'user_id'")
+        return self
+
+
+class BoxOfficeReseatRequest(Schema):
+    """Move a ticket to another free seat in the same price category (spec §2)."""
+
+    ticket_id: UUID
+    target_seat_id: UUID
 
 
 class SeatOverridesResponse(Schema):

--- a/src/events/schema/ticket.py
+++ b/src/events/schema/ticket.py
@@ -277,10 +277,17 @@ class CheckInResponseSchema(ModelSchema):
     user: MinimalRevelUserSchema
     tier: TicketTierSchema | None = None
     price_paid: Decimal | None = None
+    seat: MinimalSeatSchema | None = None
+    sector_name: str | None = None
 
     class Meta:
         model = Ticket
-        fields = ["id", "status", "checked_in_at", "tier", "price_paid"]
+        fields = ["id", "status", "checked_in_at", "tier", "price_paid", "seat"]
+
+    @staticmethod
+    def resolve_sector_name(obj: Ticket) -> str | None:
+        """Sector name for door staff redirecting attendees ("Stalls, Row C seat 12")."""
+        return obj.sector.name if obj.sector is not None else None
 
 
 class ConfirmPaymentSchema(Schema):

--- a/src/events/service/batch_ticket_service.py
+++ b/src/events/service/batch_ticket_service.py
@@ -147,7 +147,7 @@ class BatchTicketService:
         2. Event capacity remaining (if provided)
 
         Note: Tier capacity (total_quantity - quantity_sold) is NOT included here
-        because it's checked separately by _assert_tier_capacity with proper
+        because it's checked separately by assert_tier_capacity with proper
         "sold out" error handling (429 status code).
 
         Args:
@@ -455,7 +455,7 @@ class BatchTicketService:
 
         raise HttpError(400, str(_("Unknown seat assignment mode.")))
 
-    def _assert_tier_capacity(self, locked_tier: TicketTier, count: int) -> None:
+    def assert_tier_capacity(self, locked_tier: TicketTier, count: int) -> None:
         """Assert that the tier has capacity for the requested tickets.
 
         Args:
@@ -477,7 +477,7 @@ class BatchTicketService:
                 str(_("Only {available} ticket(s) remaining for this tier.")).format(available=available),
             )
 
-    def _assert_event_capacity(self, count: int) -> None:
+    def assert_event_capacity(self, count: int) -> None:
         """Assert that the event has capacity for the requested tickets.
 
         Uses effective_capacity (min of max_attendees and venue.capacity) as the soft limit.
@@ -634,10 +634,10 @@ class BatchTicketService:
         locked_tier = TicketTier.objects.select_for_update().get(pk=self.tier.pk)
 
         # Check tier capacity
-        self._assert_tier_capacity(locked_tier, len(items))
+        self.assert_tier_capacity(locked_tier, len(items))
 
         # Check event capacity (effective_capacity - soft limit)
-        self._assert_event_capacity(len(items))
+        self.assert_event_capacity(len(items))
 
         # Check sector capacity for GA tiers (hard limit - cannot be overridden)
         self._assert_sector_capacity(len(items))
@@ -678,7 +678,7 @@ class BatchTicketService:
             case _:
                 raise HttpError(400, str(_("Unknown payment method.")))
 
-    def _create_tickets(
+    def create_tickets(
         self,
         items: list[TicketPurchaseItem],
         seats: list[VenueSeat | None],
@@ -817,7 +817,7 @@ class BatchTicketService:
         reservation_id = uuid4()
 
         # Create PENDING tickets
-        tickets = self._create_tickets(items, seats, Ticket.TicketStatus.PENDING)
+        tickets = self.create_tickets(items, seats, Ticket.TicketStatus.PENDING)
 
         # Update quantity sold
         TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + len(items))
@@ -836,7 +836,7 @@ class BatchTicketService:
 
         return tickets, reservation_id
 
-    def _trigger_bulk_create_side_effects(self, tickets: list[Ticket]) -> None:
+    def trigger_bulk_create_side_effects(self, tickets: list[Ticket]) -> None:
         """Trigger side effects that post_save signals would normally handle.
 
         Django's bulk_create does NOT trigger post_save signals, so we must
@@ -881,13 +881,13 @@ class BatchTicketService:
         Returns:
             List of created PENDING tickets.
         """
-        tickets = self._create_tickets(items, seats, Ticket.TicketStatus.PENDING, price_paid=price_override)
+        tickets = self.create_tickets(items, seats, Ticket.TicketStatus.PENDING, price_paid=price_override)
 
         # Update quantity sold
         TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + len(items))
 
         # Trigger side effects that bulk_create doesn't handle
-        self._trigger_bulk_create_side_effects(tickets)
+        self.trigger_bulk_create_side_effects(tickets)
 
         return tickets
 
@@ -912,13 +912,13 @@ class BatchTicketService:
         Returns:
             List of created ACTIVE tickets.
         """
-        tickets = self._create_tickets(items, seats, Ticket.TicketStatus.ACTIVE, price_paid=price_override)
+        tickets = self.create_tickets(items, seats, Ticket.TicketStatus.ACTIVE, price_paid=price_override)
 
         # Update quantity sold
         TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + len(items))
 
         # Trigger side effects that bulk_create doesn't handle
-        self._trigger_bulk_create_side_effects(tickets)
+        self.trigger_bulk_create_side_effects(tickets)
 
         return tickets
 
@@ -940,12 +940,12 @@ class BatchTicketService:
         Returns:
             List of created ACTIVE tickets.
         """
-        tickets = self._create_tickets(items, seats, Ticket.TicketStatus.ACTIVE)
+        tickets = self.create_tickets(items, seats, Ticket.TicketStatus.ACTIVE)
 
         # Update quantity sold
         TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + len(items))
 
         # Trigger side effects that bulk_create doesn't handle
-        self._trigger_bulk_create_side_effects(tickets)
+        self.trigger_bulk_create_side_effects(tickets)
 
         return tickets

--- a/src/events/service/seating/box_office.py
+++ b/src/events/service/seating/box_office.py
@@ -1,0 +1,181 @@
+"""Box-office door sales, comps, and reseat (spec §2, Phase 4).
+
+Both writers follow the global seat-lock protocol: coarse rows (tier → event)
+first, then the affected ``VenueSeat`` rows PK-ordered under ``select_for_update``,
+then re-check tickets + overrides + live holds before writing.
+"""
+
+import uuid
+from decimal import Decimal
+
+from django.db import transaction
+from django.db.models import F
+from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
+from ninja.errors import HttpError
+
+from accounts.models import RevelUser
+from events.models import Event, EventSeatOverride, Ticket, TicketTier, VenueSeat
+from events.schema import TicketPurchaseItem
+from events.service.batch_ticket_service import BatchTicketService
+from events.service.guest import get_or_create_guest_user
+from events.service.seating import holds as holds_service
+
+
+def resolve_recipient(
+    email: str | None, user_id: uuid.UUID | None, first_name: str = "", last_name: str = ""
+) -> RevelUser:
+    """Resolve the ticket recipient for a box-office sale.
+
+    ``user_id`` wins when given. An email matching ANY existing account (guest or
+    not) reuses that account — unlike the self-service guest flow, a staff-driven
+    door sale attaching a ticket to a registered user's account is exactly right.
+    Unknown emails get a guest user via the existing helper.
+
+    Args:
+        email: Recipient email (guest checkout style).
+        user_id: Existing RevelUser id.
+        first_name: Used only when a new guest user is created.
+        last_name: Used only when a new guest user is created.
+
+    Returns:
+        The RevelUser the ticket will belong to.
+    """
+    if user_id is not None:
+        return get_object_or_404(RevelUser, pk=user_id)
+    assert email is not None  # schema enforces exactly one of email/user_id
+    existing = RevelUser.objects.filter(email__iexact=email).first()
+    if existing is not None:
+        return existing
+    return get_or_create_guest_user(email, first_name, last_name)
+
+
+def _lock_seat_for_sale(event: Event, seat_id: uuid.UUID, recipient: RevelUser) -> VenueSeat:
+    """Lock the seat row and re-verify it is sellable; release a box-office HELD override.
+
+    Raises:
+        HttpError: 400 for unknown/inactive/wrong-venue/killed seats,
+            409 for occupied or foreign-held seats.
+    """
+    seat = VenueSeat.objects.select_for_update().filter(pk=seat_id).first()
+    if seat is None or not seat.is_active or event.venue_id is None or seat.sector.venue_id != event.venue_id:
+        raise HttpError(400, str(_("This seat is not available for this event.")))
+
+    # Non-cancelled = occupied, matching the unique_ticket_event_seat constraint.
+    if Ticket.objects.filter(event=event, seat=seat).exclude(status=Ticket.TicketStatus.CANCELLED).exists():
+        raise HttpError(409, str(_("This seat already has a ticket.")))
+
+    override = EventSeatOverride.objects.filter(event=event, seat=seat).first()
+    if override is not None:
+        if override.status == EventSeatOverride.OverrideStatus.KILLED:
+            raise HttpError(400, str(_("This seat is blocked for this event.")))
+        # HELD → sold is what box-office holds are for: release it as part of the sale.
+        override.delete()
+
+    try:
+        holds_service.verify_and_consume_holds(event, [seat.id], user=recipient, guest_session=None)
+    except holds_service.SeatHoldConflictError:
+        raise HttpError(409, str(_("This seat is currently held by another buyer."))) from None
+    return seat
+
+
+@transaction.atomic
+def sell(
+    event: Event,
+    tier: TicketTier,
+    *,
+    seat_id: uuid.UUID,
+    payment_method: TicketTier.PaymentMethod,
+    recipient: RevelUser,
+    guest_name: str | None = None,
+) -> Ticket:
+    """Issue an ACTIVE ticket directly on a seat (door sale or comp).
+
+    Reuses the purchase path's invariants via ``BatchTicketService``: tier/event
+    capacity gates, denormalized venue/sector/seat, ``quantity_sold`` accounting,
+    and bulk-create side effects. ``payment_method`` FREE records ``price_paid=0``
+    (a comp must not report tier-price revenue); AT_THE_DOOR leaves it null so
+    fixed-price reporting falls back to the tier price.
+
+    Args:
+        event: The event being sold.
+        tier: Tier chosen for price/reporting (must belong to the event — enforced
+            by the controller lookup).
+        seat_id: The seat to sell.
+        payment_method: AT_THE_DOOR or FREE (schema-enforced).
+        recipient: The user the ticket belongs to.
+        guest_name: Ticket-holder name; defaults to the recipient's display name.
+
+    Returns:
+        The created ACTIVE ticket.
+
+    Raises:
+        HttpError: On capacity (429/400), seat conflicts (400/409).
+    """
+    service = BatchTicketService(event, tier, recipient)
+    # Coarse locks first (tier → event), matching create_batch's order.
+    locked_tier = TicketTier.objects.select_for_update().get(pk=tier.pk)
+    service._assert_tier_capacity(locked_tier, 1)
+    service._assert_event_capacity(1)
+
+    seat = _lock_seat_for_sale(event, seat_id, recipient)
+
+    item = TicketPurchaseItem(guest_name=guest_name or recipient.get_display_name())
+    price_paid = Decimal("0.00") if payment_method == TicketTier.PaymentMethod.FREE else None
+    tickets = service._create_tickets([item], [seat], Ticket.TicketStatus.ACTIVE, price_paid=price_paid)
+    TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + 1)
+    service._trigger_bulk_create_side_effects(tickets)
+    return tickets[0]
+
+
+@transaction.atomic
+def reseat(event: Event, *, ticket_id: uuid.UUID, target_seat_id: uuid.UUID) -> Ticket:
+    """Move a PENDING/ACTIVE ticket to another free seat in the same price category.
+
+    v1 restricts reseat to seats whose ``default_price_category`` equals the
+    current seat's (cross-category reseat has an unresolved money question —
+    spec §8). Both seat rows are locked PK-ordered before re-checking.
+
+    Args:
+        event: The event the ticket belongs to.
+        ticket_id: The ticket to move.
+        target_seat_id: The seat to move it onto.
+
+    Returns:
+        The updated ticket.
+
+    Raises:
+        HttpError: 400 for invalid ticket state/target, 409 for occupied or
+            foreign-held targets.
+    """
+    ticket = get_object_or_404(Ticket.objects.select_related("seat__sector", "user"), pk=ticket_id, event=event)
+    if ticket.status not in (Ticket.TicketStatus.PENDING, Ticket.TicketStatus.ACTIVE):
+        raise HttpError(400, str(_("Only pending or active tickets can be reseated.")))
+    current = ticket.seat
+    if current is None:
+        raise HttpError(400, str(_("This ticket has no seat assigned.")))
+    if target_seat_id == current.id:
+        raise HttpError(400, str(_("The ticket is already on this seat.")))
+
+    locked = {
+        s.pk: s
+        for s in VenueSeat.objects.filter(pk__in=[current.pk, target_seat_id]).order_by("pk").select_for_update()
+    }
+    target = locked.get(target_seat_id)
+    if target is None or not target.is_active or target.sector.venue_id != current.sector.venue_id:
+        raise HttpError(400, str(_("The target seat is not available for this event.")))
+    if target.default_price_category_id != current.default_price_category_id:
+        raise HttpError(400, str(_("Reseat is limited to seats in the same price category.")))
+    if Ticket.objects.filter(event=event, seat=target).exclude(status=Ticket.TicketStatus.CANCELLED).exists():
+        raise HttpError(409, str(_("The target seat already has a ticket.")))
+    if EventSeatOverride.objects.filter(event=event, seat=target).exists():
+        raise HttpError(400, str(_("The target seat is blocked for this event.")))
+    try:
+        holds_service.verify_and_consume_holds(event, [target.id], user=ticket.user, guest_session=None)
+    except holds_service.SeatHoldConflictError:
+        raise HttpError(409, str(_("The target seat is currently held by another buyer."))) from None
+
+    ticket.seat = target
+    ticket.sector_id = target.sector_id
+    ticket.save(update_fields=["seat", "sector"])
+    return ticket

--- a/src/events/service/seating/box_office.py
+++ b/src/events/service/seating/box_office.py
@@ -115,16 +115,16 @@ def sell(
     service = BatchTicketService(event, tier, recipient)
     # Coarse locks first (tier → event), matching create_batch's order.
     locked_tier = TicketTier.objects.select_for_update().get(pk=tier.pk)
-    service._assert_tier_capacity(locked_tier, 1)
-    service._assert_event_capacity(1)
+    service.assert_tier_capacity(locked_tier, 1)
+    service.assert_event_capacity(1)
 
     seat = _lock_seat_for_sale(event, seat_id, recipient)
 
     item = TicketPurchaseItem(guest_name=guest_name or recipient.get_display_name())
     price_paid = Decimal("0.00") if payment_method == TicketTier.PaymentMethod.FREE else None
-    tickets = service._create_tickets([item], [seat], Ticket.TicketStatus.ACTIVE, price_paid=price_paid)
+    tickets = service.create_tickets([item], [seat], Ticket.TicketStatus.ACTIVE, price_paid=price_paid)
     TicketTier.objects.filter(pk=locked_tier.pk).update(quantity_sold=F("quantity_sold") + 1)
-    service._trigger_bulk_create_side_effects(tickets)
+    service.trigger_bulk_create_side_effects(tickets)
     return tickets[0]
 
 

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -499,7 +499,8 @@ def check_in_ticket(
     """
     # Get the ticket
     ticket = get_object_or_404(
-        Ticket.objects.select_related("user", "tier", "held_pass__series_pass"),
+        # seat/sector feed the check-in response payload (door staff see "Row C seat 12").
+        Ticket.objects.select_related("user", "tier", "held_pass__series_pass", "seat", "sector"),
         pk=ticket_id,
         event=event,
     )

--- a/src/events/tests/test_controllers/test_event_admin/test_tickets/test_check_in.py
+++ b/src/events/tests/test_controllers/test_event_admin/test_tickets/test_check_in.py
@@ -5,7 +5,8 @@ import pytest
 from django.test.client import Client
 from django.urls import reverse
 
-from events.models import Event, OrganizationStaff, Ticket
+from accounts.models import RevelUser
+from events.models import Event, OrganizationStaff, Ticket, TicketTier, VenueSeat
 
 pytestmark = pytest.mark.django_db
 
@@ -168,3 +169,62 @@ def test_check_in_requires_authentication(event: Event, active_online_ticket: Ti
     response = client.post(url, content_type="application/json")
 
     assert response.status_code == 401
+
+
+def test_check_in_response_includes_seat(
+    organization_owner_client: Client,
+    seated_event: tuple[Event, list[VenueSeat]],
+    event_ticket_tier: TicketTier,
+    public_user: RevelUser,
+) -> None:
+    """Door staff scanning a QR see the ticket's seat (row/number/label) and sector."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    event, seats = seated_event
+    ticket = Ticket.objects.create(
+        guest_name="Seated Guest",
+        user=public_user,
+        event=event,
+        tier=event_ticket_tier,
+        seat=seats[2],
+        sector=seats[2].sector,
+        status=Ticket.TicketStatus.ACTIVE,
+    )
+    now = timezone.now()
+    event.check_in_starts_at = now - timedelta(hours=1)
+    event.check_in_ends_at = now + timedelta(hours=1)
+    event.save(update_fields=["check_in_starts_at", "check_in_ends_at"])
+
+    url = reverse("api:check_in_ticket", kwargs={"event_id": event.pk, "code": ticket.pk})
+    response = organization_owner_client.post(url, content_type="application/json")
+
+    assert response.status_code == 200, response.content
+    data = response.json()
+    assert data["seat"]["label"] == "A3"
+    assert data["seat"]["row_label"] == "A"
+    assert data["seat"]["number"] == 3
+    assert data["sector_name"] == "Stalls"
+
+
+def test_check_in_response_without_seat_is_null(
+    organization_owner_client: Client, event: Event, active_online_ticket: Ticket
+) -> None:
+    """GA tickets (no seat) keep a null seat/sector in the check-in payload."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    now = timezone.now()
+    event.check_in_starts_at = now - timedelta(hours=1)
+    event.check_in_ends_at = now + timedelta(hours=1)
+    event.save(update_fields=["check_in_starts_at", "check_in_ends_at"])
+
+    url = reverse("api:check_in_ticket", kwargs={"event_id": event.pk, "code": active_online_ticket.pk})
+    response = organization_owner_client.post(url, content_type="application/json")
+
+    assert response.status_code == 200, response.content
+    data = response.json()
+    assert data["seat"] is None
+    assert data["sector_name"] is None

--- a/src/events/tests/test_controllers/test_seating_box_office.py
+++ b/src/events/tests/test_controllers/test_seating_box_office.py
@@ -1,0 +1,251 @@
+"""Box-office endpoints: POST /event-admin/{event_id}/seating/sell and /seating/reseat."""
+
+from decimal import Decimal
+
+import orjson
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+
+from accounts.models import RevelUser
+from events.models import Event, EventSeatOverride, OrganizationStaff, Ticket, TicketTier, VenueSeat
+
+pytestmark = pytest.mark.django_db
+
+
+def _sell_url(event: Event) -> str:
+    return reverse("api:event_seating_sell", kwargs={"event_id": event.pk})
+
+
+def _reseat_url(event: Event) -> str:
+    return reverse("api:event_seating_reseat", kwargs={"event_id": event.pk})
+
+
+@pytest.fixture
+def tier(event: Event) -> TicketTier:
+    return TicketTier.objects.create(
+        event=event, name="Stalls", price=Decimal("25.00"), payment_method=TicketTier.PaymentMethod.ONLINE
+    )
+
+
+def test_owner_can_sell_to_guest_email(
+    organization_owner_client: Client, seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier
+) -> None:
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "at_the_door",
+        "email": "walkup@example.com",
+        "guest_name": "Walk Up",
+    }
+    resp = organization_owner_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["status"] == Ticket.TicketStatus.ACTIVE
+    assert body["seat"]["id"] == str(seats[0].id)
+    assert body["guest_name"] == "Walk Up"
+    ticket = Ticket.objects.get(pk=body["id"])
+    assert ticket.user.email == "walkup@example.com"
+    assert ticket.user.guest is True
+
+
+def test_owner_can_sell_to_existing_user(
+    organization_owner_client: Client,
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+    public_user: RevelUser,
+) -> None:
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[1].id),
+        "tier_id": str(tier.id),
+        "payment_method": "free",
+        "user_id": str(public_user.id),
+    }
+    resp = organization_owner_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 200, resp.content
+    ticket = Ticket.objects.get(pk=resp.json()["id"])
+    assert ticket.user == public_user
+    assert ticket.price_paid == Decimal("0.00")
+
+
+def test_sell_requires_exactly_one_recipient(
+    organization_owner_client: Client,
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+    public_user: RevelUser,
+) -> None:
+    event, seats = seated_event
+    base = {"seat_id": str(seats[0].id), "tier_id": str(tier.id), "payment_method": "free"}
+    both = base | {"email": "x@example.com", "user_id": str(public_user.id)}
+    neither = base
+    for payload in (both, neither):
+        resp = organization_owner_client.post(
+            _sell_url(event), data=orjson.dumps(payload), content_type="application/json"
+        )
+        assert resp.status_code == 422, resp.content
+
+
+def test_sell_rejects_online_payment_method(
+    organization_owner_client: Client, seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier
+) -> None:
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "online",
+        "email": "walkup@example.com",
+    }
+    resp = organization_owner_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 422, resp.content
+
+
+def test_sell_tier_must_belong_to_event(
+    organization_owner_client: Client,
+    seated_event: tuple[Event, list[VenueSeat]],
+    organization: object,
+) -> None:
+    event, seats = seated_event
+    other_event = Event.objects.create(
+        organization=event.organization, name="Other", slug="other", start=event.start, status="open"
+    )
+    foreign_tier = TicketTier.objects.create(event=other_event, name="Foreign", price=Decimal("10.00"))
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(foreign_tier.id),
+        "payment_method": "free",
+        "email": "walkup@example.com",
+    }
+    resp = organization_owner_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 404
+
+
+def test_staff_with_manage_tickets_can_sell(
+    organization_staff_client: Client,
+    staff_member: OrganizationStaff,
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+) -> None:
+    perms = staff_member.permissions
+    perms["default"]["manage_tickets"] = True
+    staff_member.permissions = perms
+    staff_member.save()
+
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "at_the_door",
+        "email": "walkup@example.com",
+    }
+    resp = organization_staff_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 200, resp.content
+
+
+def test_staff_without_manage_tickets_cannot_sell(
+    organization_staff_client: Client,
+    staff_member: OrganizationStaff,
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+) -> None:
+    perms = staff_member.permissions
+    perms["default"]["manage_tickets"] = False
+    staff_member.permissions = perms
+    staff_member.save()
+
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "free",
+        "email": "walkup@example.com",
+    }
+    resp = organization_staff_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 403
+
+
+def test_nonmember_cannot_sell(
+    nonmember_client: Client, seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier
+) -> None:
+    event, seats = seated_event
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "free",
+        "email": "walkup@example.com",
+    }
+    resp = nonmember_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 403
+
+
+def test_sell_killed_seat_returns_400(
+    organization_owner_client: Client, seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier
+) -> None:
+    event, seats = seated_event
+    EventSeatOverride.objects.create(event=event, seat=seats[0], status=EventSeatOverride.OverrideStatus.KILLED)
+    payload = {
+        "seat_id": str(seats[0].id),
+        "tier_id": str(tier.id),
+        "payment_method": "at_the_door",
+        "email": "walkup@example.com",
+    }
+    resp = organization_owner_client.post(_sell_url(event), data=orjson.dumps(payload), content_type="application/json")
+    assert resp.status_code == 400
+
+
+# ---- reseat ----
+
+
+@pytest.fixture
+def seated_ticket(seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, public_user: RevelUser) -> Ticket:
+    event, seats = seated_event
+    return Ticket.objects.create(
+        event=event, tier=tier, user=public_user, seat=seats[0], sector=seats[0].sector, guest_name="Buyer"
+    )
+
+
+def test_owner_can_reseat(
+    organization_owner_client: Client, seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket
+) -> None:
+    event, seats = seated_event
+    payload = {"ticket_id": str(seated_ticket.id), "target_seat_id": str(seats[3].id)}
+    resp = organization_owner_client.post(
+        _reseat_url(event), data=orjson.dumps(payload), content_type="application/json"
+    )
+    assert resp.status_code == 200, resp.content
+    assert resp.json()["seat"]["id"] == str(seats[3].id)
+    seated_ticket.refresh_from_db()
+    assert seated_ticket.seat_id == seats[3].id
+
+
+def test_staff_without_manage_tickets_cannot_reseat(
+    organization_staff_client: Client,
+    staff_member: OrganizationStaff,
+    seated_event: tuple[Event, list[VenueSeat]],
+    seated_ticket: Ticket,
+) -> None:
+    perms = staff_member.permissions
+    perms["default"]["manage_tickets"] = False
+    staff_member.permissions = perms
+    staff_member.save()
+
+    event, seats = seated_event
+    payload = {"ticket_id": str(seated_ticket.id), "target_seat_id": str(seats[3].id)}
+    resp = organization_staff_client.post(
+        _reseat_url(event), data=orjson.dumps(payload), content_type="application/json"
+    )
+    assert resp.status_code == 403
+
+
+def test_reseat_checked_in_ticket_returns_400(
+    organization_owner_client: Client, seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket
+) -> None:
+    event, seats = seated_event
+    seated_ticket.status = Ticket.TicketStatus.CHECKED_IN
+    seated_ticket.save(update_fields=["status"])
+    payload = {"ticket_id": str(seated_ticket.id), "target_seat_id": str(seats[3].id)}
+    resp = organization_owner_client.post(
+        _reseat_url(event), data=orjson.dumps(payload), content_type="application/json"
+    )
+    assert resp.status_code == 400

--- a/src/events/tests/test_service/test_batch_ticket_service/test_ticket_counting.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_ticket_counting.py
@@ -288,7 +288,7 @@ class TestGetRemainingTickets:
         tier: TicketTier,
         member_user: RevelUser,
     ) -> None:
-        """Should NOT include tier capacity - that's handled by _assert_tier_capacity.
+        """Should NOT include tier capacity - that's handled by assert_tier_capacity.
 
         Tier capacity check returns 429 "sold out" error which is different from
         user limit check's 400 error. Keeping them separate preserves correct semantics.

--- a/src/events/tests/test_service/test_box_office.py
+++ b/src/events/tests/test_service/test_box_office.py
@@ -1,0 +1,406 @@
+"""Box-office door sales, comps, and reseat (spec §2, Phase 4)."""
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+from ninja.errors import HttpError
+
+from accounts.models import RevelUser
+from conftest import RevelUserFactory
+from events.models import (
+    Event,
+    EventSeatOverride,
+    PriceCategory,
+    SeatHold,
+    Ticket,
+    TicketTier,
+    Venue,
+    VenueSeat,
+    VenueSector,
+)
+from events.service.seating import box_office
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tier(event: Event) -> TicketTier:
+    """A paid online tier — box office sells against any tier regardless of its payment method."""
+    return TicketTier.objects.create(
+        event=event, name="Stalls", price=Decimal("25.00"), payment_method=TicketTier.PaymentMethod.ONLINE
+    )
+
+
+@pytest.fixture
+def recipient(revel_user_factory: RevelUserFactory) -> RevelUser:
+    return revel_user_factory(username="doorbuyer@example.com", email="doorbuyer@example.com")
+
+
+def _live_hold(event: Event, seat: VenueSeat, *, user: RevelUser | None = None, guest_session: str = "") -> SeatHold:
+    now = timezone.now()
+    return SeatHold.objects.create(
+        event=event,
+        seat=seat,
+        user=user,
+        guest_session=guest_session,
+        acquired_at=now,
+        expires_at=now + timedelta(minutes=10),
+    )
+
+
+# ---- resolve_recipient ----
+
+
+def test_resolve_recipient_creates_guest_for_new_email() -> None:
+    user = box_office.resolve_recipient("new-guest@example.com", None, first_name="Jane", last_name="Doe")
+    assert user.guest is True
+    assert user.email == "new-guest@example.com"
+
+
+def test_resolve_recipient_reuses_existing_non_guest_account(recipient: RevelUser) -> None:
+    user = box_office.resolve_recipient(recipient.email, None)
+    assert user == recipient
+
+
+def test_resolve_recipient_by_user_id(recipient: RevelUser) -> None:
+    assert box_office.resolve_recipient(None, recipient.id) == recipient
+
+
+# ---- sell ----
+
+
+def test_sell_at_the_door_on_free_seat(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    ticket = box_office.sell(
+        event,
+        tier,
+        seat_id=seats[0].id,
+        payment_method=TicketTier.PaymentMethod.AT_THE_DOOR,
+        recipient=recipient,
+    )
+    assert ticket.status == Ticket.TicketStatus.ACTIVE
+    assert ticket.user == recipient
+    assert ticket.seat == seats[0]
+    assert ticket.sector == seats[0].sector
+    assert ticket.venue == event.venue
+    assert ticket.price_paid is None  # tier price applies for reporting
+    tier.refresh_from_db()
+    assert tier.quantity_sold == 1
+
+
+def test_sell_comp_records_zero_price_paid(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    ticket = box_office.sell(
+        event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.FREE, recipient=recipient
+    )
+    assert ticket.status == Ticket.TicketStatus.ACTIVE
+    assert ticket.price_paid == Decimal("0.00")
+
+
+def test_sell_guest_name_defaults_to_recipient_display_name(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    ticket = box_office.sell(
+        event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.FREE, recipient=recipient
+    )
+    assert ticket.guest_name == recipient.get_display_name()
+
+
+def test_sell_on_held_seat_releases_override(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    EventSeatOverride.objects.create(
+        event=event, seat=seats[0], status=EventSeatOverride.OverrideStatus.HELD, reason="promoter"
+    )
+    ticket = box_office.sell(
+        event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+    )
+    assert ticket.seat == seats[0]
+    assert not EventSeatOverride.objects.filter(event=event, seat=seats[0]).exists()
+
+
+def test_sell_on_killed_seat_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    EventSeatOverride.objects.create(
+        event=event, seat=seats[0], status=EventSeatOverride.OverrideStatus.KILLED, reason="broken"
+    )
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 400
+    assert EventSeatOverride.objects.filter(event=event, seat=seats[0]).exists()
+
+
+def test_sell_foreign_held_seat_conflicts(
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+    recipient: RevelUser,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    event, seats = seated_event
+    other = revel_user_factory(username="cartuser@example.com", email="cartuser@example.com")
+    _live_hold(event, seats[0], user=other)
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 409
+
+
+def test_sell_consumes_recipients_own_hold(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    _live_hold(event, seats[0], user=recipient)
+    ticket = box_office.sell(
+        event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+    )
+    assert ticket.seat == seats[0]
+    assert not SeatHold.objects.filter(event=event, seat=seats[0]).exists()
+
+
+def test_sell_occupied_seat_conflicts(
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+    recipient: RevelUser,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    event, seats = seated_event
+    other = revel_user_factory(username="sitting@example.com", email="sitting@example.com")
+    Ticket.objects.create(
+        event=event, tier=tier, user=other, seat=seats[0], sector=seats[0].sector, guest_name="Someone"
+    )
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 409
+
+
+def test_sell_cancelled_ticket_does_not_block(
+    seated_event: tuple[Event, list[VenueSeat]],
+    tier: TicketTier,
+    recipient: RevelUser,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    event, seats = seated_event
+    other = revel_user_factory(username="wasthere@example.com", email="wasthere@example.com")
+    Ticket.objects.create(
+        event=event,
+        tier=tier,
+        user=other,
+        seat=seats[0],
+        sector=seats[0].sector,
+        guest_name="Someone",
+        status=Ticket.TicketStatus.CANCELLED,
+    )
+    ticket = box_office.sell(
+        event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+    )
+    assert ticket.seat == seats[0]
+
+
+def test_sell_respects_tier_capacity(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    tier.total_quantity = 1
+    tier.quantity_sold = 1
+    tier.save(update_fields=["total_quantity", "quantity_sold"])
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 429
+
+
+def test_sell_seat_from_another_venue_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, _seats = seated_event
+    other_venue = Venue.objects.create(organization=event.organization, name="Other Hall")
+    other_sector = VenueSector.objects.create(venue=other_venue, name="Balcony")
+    foreign_seat = VenueSeat.objects.create(sector=other_sector, label="Z1")
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event,
+            tier,
+            seat_id=foreign_seat.id,
+            payment_method=TicketTier.PaymentMethod.AT_THE_DOOR,
+            recipient=recipient,
+        )
+    assert exc.value.status_code == 400
+
+
+def test_sell_inactive_seat_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser
+) -> None:
+    event, seats = seated_event
+    seats[0].is_active = False
+    seats[0].save(update_fields=["is_active"])
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=seats[0].id, payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 400
+
+
+def test_sell_event_without_venue_rejected(event: Event, tier: TicketTier, recipient: RevelUser) -> None:
+    with pytest.raises(HttpError) as exc:
+        box_office.sell(
+            event, tier, seat_id=uuid.uuid4(), payment_method=TicketTier.PaymentMethod.AT_THE_DOOR, recipient=recipient
+        )
+    assert exc.value.status_code == 400
+
+
+# ---- reseat ----
+
+
+@pytest.fixture
+def seated_ticket(seated_event: tuple[Event, list[VenueSeat]], tier: TicketTier, recipient: RevelUser) -> Ticket:
+    event, seats = seated_event
+    return Ticket.objects.create(
+        event=event, tier=tier, user=recipient, seat=seats[0], sector=seats[0].sector, guest_name="Door Buyer"
+    )
+
+
+def test_reseat_happy_path(seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket) -> None:
+    event, seats = seated_event
+    old_venue_id = seated_ticket.venue_id
+    ticket = box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert ticket.seat == seats[3]
+    assert ticket.sector == seats[3].sector
+    assert ticket.venue_id == old_venue_id
+    seated_ticket.refresh_from_db()
+    assert seated_ticket.seat == seats[3]
+    # old seat is free again
+    assert not Ticket.objects.filter(event=event, seat=seats[0]).exclude(status=Ticket.TicketStatus.CANCELLED).exists()
+
+
+def test_reseat_across_sectors_updates_sector(
+    seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket
+) -> None:
+    event, _seats = seated_event
+    assert event.venue is not None
+    other_sector = VenueSector.objects.create(venue=event.venue, name="Balcony")
+    target = VenueSeat.objects.create(sector=other_sector, label="B1")
+    ticket = box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=target.id)
+    assert ticket.sector == other_sector
+
+
+def test_reseat_cross_category_rejected(seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket) -> None:
+    event, seats = seated_event
+    assert event.venue is not None
+    gold = PriceCategory.objects.create(venue=event.venue, name="Gold", color="#ffd700")
+    seats[3].default_price_category = gold
+    seats[3].save(update_fields=["default_price_category"])
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 400
+
+
+def test_reseat_occupied_target_conflicts(
+    seated_event: tuple[Event, list[VenueSeat]],
+    seated_ticket: Ticket,
+    tier: TicketTier,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    event, seats = seated_event
+    other = revel_user_factory(username="neighbor@example.com", email="neighbor@example.com")
+    Ticket.objects.create(
+        event=event, tier=tier, user=other, seat=seats[3], sector=seats[3].sector, guest_name="Neighbor"
+    )
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.parametrize("status", [EventSeatOverride.OverrideStatus.KILLED, EventSeatOverride.OverrideStatus.HELD])
+def test_reseat_overridden_target_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket, status: EventSeatOverride.OverrideStatus
+) -> None:
+    event, seats = seated_event
+    EventSeatOverride.objects.create(event=event, seat=seats[3], status=status)
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 400
+
+
+def test_reseat_foreign_held_target_conflicts(
+    seated_event: tuple[Event, list[VenueSeat]],
+    seated_ticket: Ticket,
+    revel_user_factory: RevelUserFactory,
+) -> None:
+    event, seats = seated_event
+    other = revel_user_factory(username="holder@example.com", email="holder@example.com")
+    _live_hold(event, seats[3], user=other)
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.parametrize("status", [Ticket.TicketStatus.CHECKED_IN, Ticket.TicketStatus.CANCELLED])
+def test_reseat_non_reseatable_status_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket, status: Ticket.TicketStatus
+) -> None:
+    event, seats = seated_event
+    seated_ticket.status = status
+    seated_ticket.save(update_fields=["status"])
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 400
+
+
+def test_reseat_pending_ticket_allowed(seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket) -> None:
+    event, seats = seated_event
+    seated_ticket.status = Ticket.TicketStatus.PENDING
+    seated_ticket.save(update_fields=["status"])
+    ticket = box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert ticket.seat == seats[3]
+
+
+def test_reseat_ticket_without_seat_rejected(event: Event, tier: TicketTier, recipient: RevelUser) -> None:
+    ticket = Ticket.objects.create(event=event, tier=tier, user=recipient, guest_name="GA Buyer")
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=ticket.id, target_seat_id=uuid.uuid4())
+    assert exc.value.status_code == 400
+
+
+def test_reseat_to_same_seat_rejected(seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket) -> None:
+    event, seats = seated_event
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[0].id)
+    assert exc.value.status_code == 400
+
+
+def test_reseat_inactive_target_rejected(seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket) -> None:
+    event, seats = seated_event
+    seats[3].is_active = False
+    seats[3].save(update_fields=["is_active"])
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=seats[3].id)
+    assert exc.value.status_code == 400
+
+
+def test_reseat_target_in_other_venue_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], seated_ticket: Ticket
+) -> None:
+    event, _seats = seated_event
+    other_venue = Venue.objects.create(organization=event.organization, name="Other Hall")
+    other_sector = VenueSector.objects.create(venue=other_venue, name="Balcony")
+    foreign_seat = VenueSeat.objects.create(sector=other_sector, label="Z1")
+    with pytest.raises(HttpError) as exc:
+        box_office.reseat(event, ticket_id=seated_ticket.id, target_seat_id=foreign_seat.id)
+    assert exc.value.status_code == 400

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1552,6 +1552,42 @@ msgstr "Nur ausstehende Zahlungen können storniert werden."
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "Eine Datei muss bereitgestellt werden, wenn resource_type 'file' ist."
 
+msgid "This seat is not available for this event."
+msgstr "Dieser Sitzplatz ist für dieses Event nicht verfügbar."
+
+msgid "This seat already has a ticket."
+msgstr "Für diesen Sitzplatz existiert bereits ein Ticket."
+
+msgid "This seat is blocked for this event."
+msgstr "Dieser Sitzplatz ist für dieses Event gesperrt."
+
+msgid "This seat is currently held by another buyer."
+msgstr "Dieser Sitzplatz ist derzeit von einem anderen Käufer reserviert."
+
+msgid "Only pending or active tickets can be reseated."
+msgstr "Nur ausstehende oder aktive Tickets können umgesetzt werden."
+
+msgid "This ticket has no seat assigned."
+msgstr "Diesem Ticket ist kein Sitzplatz zugewiesen."
+
+msgid "The ticket is already on this seat."
+msgstr "Das Ticket ist bereits auf diesem Sitzplatz."
+
+msgid "The target seat is not available for this event."
+msgstr "Der Zielsitzplatz ist für dieses Event nicht verfügbar."
+
+msgid "Reseat is limited to seats in the same price category."
+msgstr "Umsetzen ist nur auf Sitzplätze derselben Preiskategorie möglich."
+
+msgid "The target seat already has a ticket."
+msgstr "Für den Zielsitzplatz existiert bereits ein Ticket."
+
+msgid "The target seat is blocked for this event."
+msgstr "Der Zielsitzplatz ist für dieses Event gesperrt."
+
+msgid "The target seat is currently held by another buyer."
+msgstr "Der Zielsitzplatz ist derzeit von einem anderen Käufer reserviert."
+
 msgid "You cannot purchase from this organization."
 msgstr "Du kannst bei dieser Organisation nichts kaufen."
 

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -1181,8 +1181,7 @@ msgstr ""
 
 msgid "Not enough accessible seats available — please contact the organizer."
 msgstr ""
-"Pas assez de sièges accessibles disponibles — contacte "
-"l'organisateur·rice."
+"Pas assez de sièges accessibles disponibles — contacte l'organisateur·rice."
 
 msgid "Not enough adjacent seats available for this tier."
 msgstr ""
@@ -1560,6 +1559,42 @@ msgid "A file must be provided when resource_type is 'file'."
 msgstr ""
 "Un fichier doit être fourni lorsque le type de ressource (resource_type) est "
 "'file'."
+
+msgid "This seat is not available for this event."
+msgstr "Ce siège n'est pas disponible pour cet événement."
+
+msgid "This seat already has a ticket."
+msgstr "Ce siège a déjà un ticket."
+
+msgid "This seat is blocked for this event."
+msgstr "Ce siège est bloqué pour cet événement."
+
+msgid "This seat is currently held by another buyer."
+msgstr "Ce siège est actuellement réservé par un autre acheteur."
+
+msgid "Only pending or active tickets can be reseated."
+msgstr "Seuls les tickets en attente ou actifs peuvent être replacés."
+
+msgid "This ticket has no seat assigned."
+msgstr "Ce ticket n'a pas de siège attribué."
+
+msgid "The ticket is already on this seat."
+msgstr "Le ticket est déjà sur ce siège."
+
+msgid "The target seat is not available for this event."
+msgstr "Le siège cible n'est pas disponible pour cet événement."
+
+msgid "Reseat is limited to seats in the same price category."
+msgstr "Le replacement est limité aux sièges de la même catégorie tarifaire."
+
+msgid "The target seat already has a ticket."
+msgstr "Le siège cible a déjà un ticket."
+
+msgid "The target seat is blocked for this event."
+msgstr "Le siège cible est bloqué pour cet événement."
+
+msgid "The target seat is currently held by another buyer."
+msgstr "Le siège cible est actuellement réservé par un autre acheteur."
 
 msgid "You cannot purchase from this organization."
 msgstr "Tu ne peux pas acheter auprès de cette organisation."

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -1524,6 +1524,42 @@ msgstr "Solo i pagamenti in sospeso possono essere annullati."
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "È necessario fornire un file quando resource_type è 'file'."
 
+msgid "This seat is not available for this event."
+msgstr "Questo posto non è disponibile per questo evento."
+
+msgid "This seat already has a ticket."
+msgstr "Questo posto ha già un biglietto."
+
+msgid "This seat is blocked for this event."
+msgstr "Questo posto è bloccato per questo evento."
+
+msgid "This seat is currently held by another buyer."
+msgstr "Questo posto è attualmente riservato da un altro acquirente."
+
+msgid "Only pending or active tickets can be reseated."
+msgstr "Solo i biglietti in sospeso o attivi possono essere spostati."
+
+msgid "This ticket has no seat assigned."
+msgstr "Questo biglietto non ha un posto assegnato."
+
+msgid "The ticket is already on this seat."
+msgstr "Il biglietto è già su questo posto."
+
+msgid "The target seat is not available for this event."
+msgstr "Il posto di destinazione non è disponibile per questo evento."
+
+msgid "Reseat is limited to seats in the same price category."
+msgstr "Lo spostamento è limitato ai posti della stessa categoria di prezzo."
+
+msgid "The target seat already has a ticket."
+msgstr "Il posto di destinazione ha già un biglietto."
+
+msgid "The target seat is blocked for this event."
+msgstr "Il posto di destinazione è bloccato per questo evento."
+
+msgid "The target seat is currently held by another buyer."
+msgstr "Il posto di destinazione è attualmente riservato da un altro acquirente."
+
 msgid "You cannot purchase from this organization."
 msgstr "Non puoi acquistare da questa organizzazione."
 


### PR DESCRIPTION
Phase 4 of the venue seating stack (spec §2 "Per-event control (admin)" + §8 Phase 4). Three additions, all under the existing `manage_tickets` permission and the global seat-lock protocol (coarse rows first, then seat rows PK-ordered under `select_for_update`, then re-check tickets/overrides/live holds).

## 1. Door sale / comp — `POST /event-admin/{event_id}/seating/sell`

Staff issues an ACTIVE ticket directly on a seat.

- **Payload**: `seat_id`, `tier_id` (must belong to the event → 404 otherwise), `payment_method` restricted to `at_the_door` | `free` (schema-enforced, 422 otherwise), recipient (`email` XOR `user_id`, 422 otherwise), optional `guest_name`/`first_name`/`last_name`.
- **Rules**: seat must be on the event's venue and `is_active` (400); occupied seat → 409; **KILLED override → 400**; **HELD override → allowed, and the override is released as part of the sale** (HELD→sold is what box-office holds are for — spec §2); live foreign `SeatHold` → 409 (someone's cart); the recipient's *own* live hold is consumed.
- **Invariants reused, not forked**: the sale drives `BatchTicketService` pieces — tier lock + `_assert_tier_capacity` (429 when sold out), `_assert_event_capacity` (event row lock, waitlist-offer-aware), `_create_tickets` (denormalized venue/sector/seat, refund-policy snapshot, waitlist-offer claim, `unique_ticket_event_seat` backstop), `quantity_sold` F-expression bump, and the bulk-create side effects (attendee flags, notifications, waitlist removal).
- **Reporting**: `free` (comp) records `price_paid=0.00` so comps never report tier-price revenue; `at_the_door` leaves `price_paid` null so fixed-price reporting falls back to the tier price (PWYC price is still collected at check-in via the existing flow).

### Recipient design decision

`Ticket.user` is a required FK, so every door sale needs a `RevelUser`. The recipient is either:
- an existing `user_id`, or
- an `email`: **any existing account (guest or not) is reused**; unknown emails get a guest user via the existing `get_or_create_guest_user` helper. The helper's own "account already exists, please log in" 400 is deliberately bypassed for box office — that guard exists to stop self-service guests hijacking accounts, whereas a staff-driven door sale attaching a ticket to a registered user's account is exactly the desired outcome.

`guest_name` defaults to the recipient's display name.

### Capacity notes

Enforced like a normal sale: tier `total_quantity` (429 when sold out) and event `effective_capacity` (including pending waitlist offers) via the existing purchase-path gates. **Not** enforced (deliberate, staff-driven): `purchasable_by` restrictions, per-user `max_tickets_per_user`, and tier sales windows — the box office overrides those by definition.

## 2. Reseat — `POST /event-admin/{event_id}/seating/reseat`

- **Payload**: `ticket_id`, `target_seat_id`.
- Ticket must be PENDING or ACTIVE (checked-in/cancelled → 400) and have a seat.
- v1 rule (spec §8): target seat's `default_price_category` must **equal** the current seat's → 400 otherwise (cross-category reseat = parked money question).
- Target must be same venue + active (400), carry no non-cancelled ticket (409), no KILLED/**or HELD** override (400 — a hold is only released by *selling* the seat, not by reseating onto it), no live foreign hold (409; the ticket holder's own hold is consumed).
- Both seats locked PK-ordered (sorted), re-checked under lock; `ticket.seat`/`sector` updated with `update_fields`, venue unchanged.

## 3. Seat in check-in scan payload

`CheckInResponseSchema` now carries `seat` (nested `MinimalSeatSchema`: label, row_label, number, accessibility flags) and `sector_name`, so door staff scanning a QR see "Stalls, Row C seat 12". `check_in_ticket` select_related extended with `seat`/`sector` (no N+1). Purely additive; GA tickets serialize both as null.

## Tests & quality

- 30 new service tests (`test_box_office.py`), 13 new controller tests incl. `manage_tickets` 200/403 permission matrix (`test_seating_box_office.py`), 2 check-in payload tests.
- Scoped runs green: `pytest src/events/tests -k "seating or sell or reseat or check_in or box"` (152 passed) and the full event-admin controller dir + seating suites (334 passed).
- `make check` green (format, lint, mypy --strict, migration-check, i18n-check, file-length, task-names). No migrations needed.
- New user-facing strings translated in de/fr/it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)