### PR TITLE
fix(events): scope seat overrides to the event's venue

### DIFF
--- a/src/events/service/seating/overrides.py
+++ b/src/events/service/seating/overrides.py
@@ -33,9 +33,15 @@ def apply_overrides(
         holding a non-cancelled ticket on this event).
     """
     all_ids = sorted({sid for sid, _, _ in set_items} | set(release_seat_ids))
-    locked_ids = set(
-        VenueSeat.objects.filter(id__in=all_ids).order_by("pk").select_for_update().values_list("id", flat=True)
-    )
+    if event.venue_id is None:
+        locked_ids: set[uuid.UUID] = set()
+    else:
+        locked_ids = set(
+            VenueSeat.objects.filter(id__in=all_ids, sector__venue_id=event.venue_id)
+            .order_by("pk")
+            .select_for_update()
+            .values_list("id", flat=True)
+        )
     rejected: dict[uuid.UUID, str] = {sid: "unknown_seat" for sid in all_ids if sid not in locked_ids}
 
     ticketed = set(

--- a/src/events/tests/test_service/test_seat_overrides.py
+++ b/src/events/tests/test_service/test_seat_overrides.py
@@ -4,7 +4,7 @@ import pytest
 
 from accounts.models import RevelUser
 from conftest import RevelUserFactory
-from events.models import Event, EventSeatOverride, Ticket, TicketTier, VenueSeat
+from events.models import Event, EventSeatOverride, Organization, Ticket, TicketTier, Venue, VenueSeat, VenueSector
 from events.service.seating import overrides as overrides_service
 
 pytestmark = pytest.mark.django_db
@@ -134,3 +134,53 @@ def test_unknown_seat_rejected(seated_event: tuple[Event, list[VenueSeat]]) -> N
     resp = overrides_service.apply_overrides(event, set_items=[(ghost, "held", "")], release_seat_ids=[])
     assert resp.applied == 0
     assert resp.rejected[ghost] == "unknown_seat"
+
+
+def test_seat_from_other_venue_same_org_rejected(
+    seated_event: tuple[Event, list[VenueSeat]], organization: Organization
+) -> None:
+    event, _ = seated_event
+    other_venue = Venue.objects.create(organization=organization, name="Other Hall")
+    other_sector = VenueSector.objects.create(venue=other_venue, name="Pit")
+    other_seat = VenueSeat.objects.create(sector=other_sector, label="B1", row_label="B", number=1)
+
+    resp = overrides_service.apply_overrides(event, set_items=[(other_seat.id, "held", "")], release_seat_ids=[])
+    assert resp.applied == 0
+    assert resp.rejected[other_seat.id] == "unknown_seat"
+    assert not EventSeatOverride.objects.filter(event=event, seat=other_seat).exists()
+
+
+def test_seat_from_other_org_venue_rejected(seated_event: tuple[Event, list[VenueSeat]]) -> None:
+    event, _ = seated_event
+    other_owner = RevelUser.objects.create_user(
+        username="other_org_owner@example.com", email="other_org_owner@example.com", password="pass"
+    )
+    other_org = Organization.objects.create(name="Other Org", slug="other-org", owner=other_owner)
+    other_venue = Venue.objects.create(organization=other_org, name="Rival Hall")
+    other_sector = VenueSector.objects.create(venue=other_venue, name="Floor")
+    other_seat = VenueSeat.objects.create(sector=other_sector, label="C1", row_label="C", number=1)
+
+    resp = overrides_service.apply_overrides(event, set_items=[(other_seat.id, "held", "")], release_seat_ids=[])
+    assert resp.applied == 0
+    assert resp.rejected[other_seat.id] == "unknown_seat"
+    assert not EventSeatOverride.objects.filter(event=event, seat=other_seat).exists()
+
+
+def test_event_without_venue_rejects_all_seats(seated_event: tuple[Event, list[VenueSeat]]) -> None:
+    event, seats = seated_event
+    event.venue = None
+    event.save(update_fields=["venue"])
+
+    resp = overrides_service.apply_overrides(
+        event,
+        set_items=[(seats[0].id, "held", ""), (seats[1].id, "killed", "")],
+        release_seat_ids=[seats[2].id],
+    )
+    assert resp.applied == 0
+    assert resp.released == 0
+    assert resp.rejected == {
+        seats[0].id: "unknown_seat",
+        seats[1].id: "unknown_seat",
+        seats[2].id: "unknown_seat",
+    }
+    assert not EventSeatOverride.objects.filter(event=event).exists()


### PR DESCRIPTION
## Summary
- `apply_overrides` locked seats via a bare `id__in` filter with no venue restriction, so an admin could create an `EventSeatOverride` on a seat belonging to a different venue (even another org's), violating the documented `"unknown_seat"` contract.
- Restrict the locked-seat query to `sector__venue_id=event.venue_id`; if the event has no venue, all requested seat ids are rejected as `unknown_seat`.

## Test plan
- [x] `uv run pytest src/events/tests/test_service/test_seat_overrides.py src/events/tests/test_controllers/test_seating_admin.py -q` — 16 passed
- [x] `make format && make lint && make mypy` clean
- [x] New tests: seat from another venue (same org) rejected; seat from another org's venue rejected; event without venue rejects all seat ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)