### PR TITLE
feat(events): expose seat price category + sector kind on admin read schemas (#733 round-trip)

### DIFF
--- a/src/events/controllers/organization_admin/venues.py
+++ b/src/events/controllers/organization_admin/venues.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
@@ -13,6 +13,9 @@ from events.controllers.permissions import IsOrganizationStaff, OrganizationPerm
 from events.service import venue_service
 
 from .base import OrganizationAdminBaseController
+
+# Prefetch a sector's seats with their painted category (avoids an N+1 in VenueSeatSchema, #733).
+_SEATS_PREFETCH = Prefetch("seats", queryset=models.VenueSeat.objects.select_related("default_price_category"))
 
 
 @api_controller(
@@ -224,7 +227,7 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         """
         organization = self.get_one(slug)
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)
-        return models.VenueSector.objects.filter(venue=venue).prefetch_related("seats")
+        return models.VenueSector.objects.filter(venue=venue).prefetch_related(_SEATS_PREFETCH)
 
     @route.post(
         "/venues/{venue_id}/sectors",
@@ -244,7 +247,7 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)
         sector = venue_service.create_sector(venue, payload)
         # Refresh to get prefetched seats
-        return 201, models.VenueSector.objects.prefetch_related("seats").get(pk=sector.pk)
+        return 201, models.VenueSector.objects.prefetch_related(_SEATS_PREFETCH).get(pk=sector.pk)
 
     @route.get(
         "/venues/{venue_id}/sectors/{sector_id}",
@@ -258,7 +261,7 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         organization = self.get_one(slug)
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)
         return get_object_or_404(
-            models.VenueSector.objects.prefetch_related("seats"),
+            models.VenueSector.objects.prefetch_related(_SEATS_PREFETCH),
             pk=sector_id,
             venue=venue,
         )
@@ -279,7 +282,7 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)
         sector = get_object_or_404(models.VenueSector, pk=sector_id, venue=venue)
         venue_service.update_sector(sector, payload)
-        return models.VenueSector.objects.prefetch_related("seats").get(pk=sector.pk)
+        return models.VenueSector.objects.prefetch_related(_SEATS_PREFETCH).get(pk=sector.pk)
 
     @route.delete(
         "/venues/{venue_id}/sectors/{sector_id}",

--- a/src/events/schema/venue.py
+++ b/src/events/schema/venue.py
@@ -106,6 +106,11 @@ class VenueSeatSchema(ModelSchema):
     row_label: str | None = None
     # Transitional alias so the deployed FE (reads `row`) keeps working until Phase 2 regen.
     row: str | None = None
+    # Paint round-trip: expose the seat's category so the admin grid editor can re-hydrate
+    # existing paint on reload. `price_category_id` mirrors ChartSeatSchema; `price_category`
+    # carries the color/name for rendering. The model field is `default_price_category`.
+    price_category_id: UUID | None = None
+    price_category: PriceCategorySchema | None = None
 
     class Meta:
         model = VenueSeat
@@ -123,6 +128,16 @@ class VenueSeatSchema(ModelSchema):
     def resolve_row(obj: VenueSeat) -> str | None:
         """Transitional alias exposing `row_label` under the legacy `row` key."""
         return obj.row_label
+
+    @staticmethod
+    def resolve_price_category_id(obj: VenueSeat) -> UUID | None:
+        """Expose the seat's `default_price_category` FK id under `price_category_id`."""
+        return obj.default_price_category_id
+
+    @staticmethod
+    def resolve_price_category(obj: VenueSeat) -> PriceCategory | None:
+        """Expose the resolved category object (color/name) for grid rendering."""
+        return obj.default_price_category
 
 
 class MinimalSeatSchema(ModelSchema):
@@ -147,6 +162,8 @@ class VenueSectorSchema(ModelSchema):
 
     shape: list[Coordinate2D] | None = None
     metadata: dict[str, t.Any] | None = None
+    # Exposed so the admin SectorModal can prefill the current kind on edit.
+    kind: VenueSector.Kind = VenueSector.Kind.SEATED
 
     class Meta:
         model = VenueSector

--- a/src/events/service/venue_service.py
+++ b/src/events/service/venue_service.py
@@ -377,9 +377,10 @@ def bulk_create_seats(
     created = list(models.VenueSeat.objects.bulk_create(seats_to_create))
     if not _has_explicit_ranks(seats):
         derive_sector_seat_ranks(sector)
-        ranked = {s.id: s for s in models.VenueSeat.objects.filter(id__in=[s.id for s in created])}
-        created = [ranked[s.id] for s in created]
-    return created
+    # Refetch with the painted category so the VenueSeatSchema response has it without an N+1
+    # (also picks up any derived row_order/adjacency_index). Order preserved via `created`.
+    by_id = models.VenueSeat.objects.select_related("default_price_category").in_bulk([s.id for s in created])
+    return [by_id[s.id] for s in created]
 
 
 def get_seat_by_label(sector: models.VenueSector, label: str) -> models.VenueSeat:
@@ -621,10 +622,11 @@ def bulk_update_seats(
 
     if not _has_explicit_ranks(updates) and ({"row_label", "number"} & update_fields):
         derive_sector_seat_ranks(sector)
-        ranked = {s.id: s for s in models.VenueSeat.objects.filter(id__in=[s.id for s in updated_seats])}
-        updated_seats = [ranked[s.id] for s in updated_seats]
 
-    return updated_seats
+    # Refetch with the painted category so the VenueSeatSchema response has it without an N+1
+    # (also picks up any derived row_order/adjacency_index). Order preserved via `updated_seats`.
+    by_id = models.VenueSeat.objects.select_related("default_price_category").in_bulk([s.id for s in updated_seats])
+    return [by_id[s.id] for s in updated_seats]
 
 
 @transaction.atomic

--- a/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
@@ -2,7 +2,9 @@
 
 import orjson
 import pytest
+from django.db import connection
 from django.test.client import Client
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from events.models import Organization, PriceCategory, Venue, VenueSeat, VenueSector
@@ -108,6 +110,62 @@ class TestPaintSeatsEndpoint:
         assert response.status_code == 404, response.content
         foreign_seat.refresh_from_db()
         assert foreign_seat.default_price_category_id is None
+
+    def test_painted_seat_round_trips_category_on_sector_read(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        venue: Venue,
+        sector: VenueSector,
+        category: PriceCategory,
+    ) -> None:
+        """After painting, the admin sector-detail read serializes the seat's category (#733)."""
+        painted = VenueSeat.objects.create(sector=sector, label="A1")
+        VenueSeat.objects.create(sector=sector, label="A2")  # left unpainted
+
+        paint = organization_owner_client.put(
+            _url(organization, venue),
+            data=orjson.dumps({"seat_ids": [str(painted.id)], "price_category_id": str(category.id)}),
+            content_type="application/json",
+        )
+        assert paint.status_code == 200, paint.content
+
+        detail_url = reverse(
+            "api:get_venue_sector",
+            kwargs={"slug": organization.slug, "venue_id": venue.id, "sector_id": sector.id},
+        )
+        detail = organization_owner_client.get(detail_url)
+        assert detail.status_code == 200, detail.content
+        seats = {s["label"]: s for s in detail.json()["seats"]}
+
+        assert seats["A1"]["price_category_id"] == str(category.id)
+        assert seats["A1"]["price_category"]["name"] == category.name
+        assert seats["A1"]["price_category"]["color"] == category.color
+
+        assert seats["A2"]["price_category_id"] is None
+        assert seats["A2"]["price_category"] is None
+
+    def test_sector_read_category_is_not_n_plus_one(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+    ) -> None:
+        """The sector list query count is constant regardless of painted-seat count (#733)."""
+
+        def count_queries_for(n_seats: int) -> int:
+            venue = Venue.objects.create(organization=organization, name=f"Hall {n_seats}")
+            sector = VenueSector.objects.create(venue=venue, name="Main")
+            cat = PriceCategory.objects.create(venue=venue, name="P", color="#123456")
+            VenueSeat.objects.bulk_create(
+                [VenueSeat(sector=sector, label=f"S{i}", default_price_category=cat) for i in range(n_seats)]
+            )
+            url = reverse("api:list_venue_sectors", kwargs={"slug": organization.slug, "venue_id": venue.id})
+            with CaptureQueriesContext(connection) as ctx:
+                response = organization_owner_client.get(url)
+                assert response.status_code == 200, response.content
+            return len(ctx.captured_queries)
+
+        assert count_queries_for(2) == count_queries_for(12)
 
     def test_nonmember_gets_403(
         self,

--- a/src/events/tests/test_controllers/test_organization_admin/test_venues/test_sectors.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_venues/test_sectors.py
@@ -29,6 +29,20 @@ class TestVenueSectorManagement:
         assert data[0]["name"] == "Balcony"
         assert len(data[0]["seats"]) == 2
 
+    def test_sector_read_serializes_kind(self, organization_owner_client: Client, organization: Organization) -> None:
+        """The admin sector read exposes `kind` so SectorModal can prefill it (#733)."""
+        venue = Venue.objects.create(organization=organization, name="Arena")
+        sector = VenueSector.objects.create(venue=venue, name="Pit", kind=VenueSector.Kind.STANDING)
+
+        url = reverse(
+            "api:get_venue_sector",
+            kwargs={"slug": organization.slug, "venue_id": venue.id, "sector_id": sector.id},
+        )
+        response = organization_owner_client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.json()["kind"] == "standing"
+
     def test_create_sector_without_seats(self, organization_owner_client: Client, organization: Organization) -> None:
         """Test creating a sector without any seats."""
         venue = Venue.objects.create(organization=organization, name="Theater")


### PR DESCRIPTION
## Summary

Closes the admin seating **read round-trip** gap from #733. After an admin paints seats (persisted via `paint_seats`), the GET sector/seats admin response carried no category, so the FE grid editor rendered everything "Unpainted" on reload.

### Changes (additive, schema-only — no migrations)

- **`VenueSeatSchema`** now serializes the seat's painted category:
  - `price_category_id: UUID | None` — mirrors buyer-side `ChartSeatSchema`; resolves `obj.default_price_category_id`.
  - `price_category: PriceCategorySchema | None` — resolved category object (color/name) for grid rendering; resolves `obj.default_price_category`.
- **`VenueSectorSchema`** (extended by `VenueSectorWithSeatsSchema`) now exposes `kind: VenueSector.Kind` so `SectorModal` can prefill the current kind.
- **N+1 avoidance**: the four sector read endpoints (`list_sectors`, `create_sector`, `get_sector`, `update_sector`) prefetch seats with `select_related("default_price_category")`; `bulk_create_seats` / `bulk_update_seats` refetch returned seats with the same `select_related`. A test asserts the sector-list query count is constant regardless of painted-seat count.

Write schemas, the paint endpoint, and buyer-side `ChartSeatSchema` are unchanged.

### Tests
- Paint a seat, GET the sector detail → assert serialized `price_category_id` and `price_category.name`/`.color`; unpainted seat serializes `price_category_id: None` / `price_category: null`.
- Standing sector GET → assert `kind == "standing"`.
- N+1 guard comparing query counts across seat counts.

Refs #733 (base is `feature/venue-seating`, not `main`, so no closing keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)