### PR TITLE
ci: label-triggered beta image publishing

### DIFF
--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -24,8 +24,16 @@ permissions:
 
 concurrency:
   # A rapid series of pushes should not race to overwrite the :beta tag.
+  #
+  # cancel-in-progress is deliberately FALSE. Concurrency is workflow-scoped,
+  # so any new trigger — including an unrelated label change while `beta`
+  # stays on — would cancel the whole in-progress run. Cancelling a docker
+  # push is harmless; cancelling the deploy job between `up -d` and `migrate`,
+  # or midway through reset.sh, leaves beta half-migrated or destroyed. A
+  # job-level concurrency block does NOT prevent workflow-level cancellation,
+  # so the guard has to live here. Runs queue instead; the last one wins.
   group: publish-beta
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   publish-beta:
@@ -114,5 +122,40 @@ jobs:
             echo ""
             echo '`ghcr.io/letsrevel/revel:beta` → `beta-${{ steps.sha.outputs.short }}`'
             echo ""
-            echo 'Deploy: `ssh personal "cd infra/revel-beta && ./deploy.sh"`'
+            echo 'Deploying automatically — see the **Deploy Beta** job.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Separate job on purpose: a deploy failure must be distinguishable from a
+  # build failure in the checks list.
+  deploy-beta:
+    needs: publish-beta
+    runs-on: ubuntu-latest
+    name: Deploy Beta
+    steps:
+      # Handing a server SSH key to a `pull_request`-triggered workflow is a
+      # real escalation — a same-repo PR can edit this file and the edited
+      # version is what runs. Two things make it tolerable:
+      #
+      #   1. The key is pinned to a FORCED COMMAND in the server's
+      #      authorized_keys: it can only exec ci-deploy.sh, and ci-deploy.sh
+      #      only accepts backend|frontend|both. It cannot get a shell, read
+      #      .env, port-forward, or reach demo/nozze. Verified, not assumed.
+      #   2. It is a dedicated key used nowhere else, so revoking it costs
+      #      nothing.
+      #
+      # If you ever need this job to do more, add it to ci-deploy.sh on the
+      # server — never by loosening the forced command.
+      - name: Deploy over SSH
+        env:
+          SSH_KEY: ${{ secrets.BETA_SSH_KEY }}
+          SSH_HOST: ${{ secrets.BETA_SSH_HOST }}
+          SSH_USER: ${{ secrets.BETA_SSH_USER }}
+          SSH_PORT: ${{ secrets.BETA_SSH_PORT }}
+          KNOWN_HOSTS: ${{ secrets.BETA_SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s' "$SSH_KEY" > ~/.ssh/beta_deploy
+          chmod 600 ~/.ssh/beta_deploy
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \
+              "$SSH_USER@$SSH_HOST" backend

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -15,7 +15,7 @@ name: Publish Beta
 # only so removing the label produces a cleanly-skipped run rather than nothing.
 on:
   pull_request:
-    types: [labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -23,16 +23,13 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # A rapid series of pushes should not race to overwrite the :beta tag.
-  #
-  # cancel-in-progress is deliberately FALSE. Concurrency is workflow-scoped,
-  # so any new trigger — including an unrelated label change while `beta`
-  # stays on — would cancel the whole in-progress run. Cancelling a docker
-  # push is harmless; cancelling the deploy job between `up -d` and `migrate`,
-  # or midway through reset.sh, leaves beta half-migrated or destroyed. A
-  # job-level concurrency block does NOT prevent workflow-level cancellation,
-  # so the guard has to live here. Runs queue instead; the last one wins.
-  group: publish-beta
+  # Scoped to the PR: a static group would be shared by every pull_request event
+  # in the repo, and GitHub keeps only ONE pending run per group — so unrelated
+  # PR activity could silently cancel a QUEUED beta deploy.
+  # cancel-in-progress stays false: this workflow SSHes to the box and runs
+  # migrations, and cancelling mid-deploy can leave beta half-migrated or, if it
+  # lands inside reset.sh, destroyed and offline.
+  group: publish-beta-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -75,6 +72,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Compute short SHA
         id: sha
@@ -131,6 +129,7 @@ jobs:
     needs: publish-beta
     runs-on: ubuntu-latest
     name: Deploy Beta
+    timeout-minutes: 10
     steps:
       # Handing a server SSH key to a `pull_request`-triggered workflow is a
       # real escalation — a same-repo PR can edit this file and the edited
@@ -159,5 +158,10 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/beta_deploy
           chmod 600 ~/.ssh/beta_deploy
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \
+          # BatchMode=yes forbids interactive prompts (host-key confirmation,
+          # passphrase) so a hung prompt fails fast instead of burning the
+          # job timeout. Host-key verification still runs — BatchMode just
+          # stops it from falling back to a prompt.
+          ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -o BatchMode=yes \
+              -o ConnectTimeout=15 -p "$SSH_PORT" \
               "$SSH_USER@$SSH_HOST" backend

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -1,7 +1,9 @@
 name: Publish Beta
 
-# Label-triggered, single-slot beta publishing. See
-# docs/superpowers/specs/2026-07-20-beta-environment-design.md
+# Label-triggered, single-slot beta publishing: labelling a PR "beta" builds
+# its Docker image and pushes it to GHCR as a mutable :beta tag. Only one open
+# PR may hold the label at a time — a guard step enforces this, since two
+# claimants would silently overwrite each other's image.
 #
 # `pull_request` (NOT pull_request_target) is deliberate: this repo holds the
 # revel-release-bot App private key, so no workflow may run PR-authored code
@@ -18,6 +20,7 @@ on:
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 concurrency:
   # A rapid series of pushes should not race to overwrite the :beta tag.
@@ -38,9 +41,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THIS_PR: ${{ github.event.pull_request.number }}
         run: |
+          # $THIS_PR comes from github.event.pull_request.number, a
+          # GitHub-controlled integer — safe to splice into the jq filter.
           OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
                      --state open --json number \
                      --jq "[.[] | select(.number != $THIS_PR)] | length")
+          if ! [[ "$OTHERS" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not determine the beta claimant count (got '$OTHERS')"
+            exit 1
+          fi
           if [ "$OTHERS" -gt 0 ]; then
             echo "::error::Another open PR already holds the 'beta' label. One slot, one claimant — remove it there first."
             exit 1

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -43,9 +43,16 @@ jobs:
         run: |
           # $THIS_PR comes from github.event.pull_request.number, a
           # GitHub-controlled integer — safe to splice into the jq filter.
-          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
-                     --state open --json number \
-                     --jq "[.[] | select(.number != $THIS_PR)] | length")
+          #
+          # Deliberately NOT `gh pr list --label beta`: that flag resolves
+          # through GitHub's issues search index, which is eventually
+          # consistent and was observed to keep returning a PR whose actual
+          # `labels` array was empty (survived even a delete+recreate of the
+          # label). Reading labels off the PR objects themselves is strongly
+          # consistent, so we filter client-side instead.
+          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+                     --json number,labels \
+                     --jq "[.[] | select(.number != $THIS_PR) | select(any(.labels[]; .name == \"beta\"))] | length")
           if ! [[ "$OTHERS" =~ ^[0-9]+$ ]]; then
             echo "::error::Could not determine the beta claimant count (got '$OTHERS')"
             exit 1

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -154,7 +154,9 @@ jobs:
           KNOWN_HOSTS: ${{ secrets.BETA_SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
-          printf '%s' "$SSH_KEY" > ~/.ssh/beta_deploy
+          # The trailing newline is load-bearing: OpenSSH rejects a private key
+          # whose final line is unterminated with "error in libcrypto".
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/beta_deploy
           chmod 600 ~/.ssh/beta_deploy
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/beta_deploy -o IdentitiesOnly=yes -p "$SSH_PORT" \

--- a/.github/workflows/publish-beta.yaml
+++ b/.github/workflows/publish-beta.yaml
@@ -1,0 +1,102 @@
+name: Publish Beta
+
+# Label-triggered, single-slot beta publishing. See
+# docs/superpowers/specs/2026-07-20-beta-environment-design.md
+#
+# `pull_request` (NOT pull_request_target) is deliberate: this repo holds the
+# revel-release-bot App private key, so no workflow may run PR-authored code
+# with access to secrets. A fork PR therefore gets a read-only GITHUB_TOKEN and
+# the GHCR push fails — that is the intended posture, not a bug to work around.
+#
+# `synchronize` means every push to a labelled PR rebuilds :beta, so the slot
+# tracks the branch. Remove the label to stop building. `unlabeled` is listed
+# only so removing the label produces a cleanly-skipped run rather than nothing.
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  # A rapid series of pushes should not race to overwrite the :beta tag.
+  group: publish-beta
+  cancel-in-progress: true
+
+jobs:
+  publish-beta:
+    if: contains(github.event.pull_request.labels.*.name, 'beta')
+    runs-on: ubuntu-latest
+    name: Publish Beta Image
+
+    steps:
+      # One slot, one claimant. Two labelled PRs would silently overwrite each
+      # other's :beta tag and produce a nonsense environment.
+      - name: Enforce a single beta claimant
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THIS_PR: ${{ github.event.pull_request.number }}
+        run: |
+          OTHERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --label beta \
+                     --state open --json number \
+                     --jq "[.[] | select(.number != $THIS_PR)] | length")
+          if [ "$OTHERS" -gt 0 ]; then
+            echo "::error::Another open PR already holds the 'beta' label. One slot, one claimant — remove it there first."
+            exit 1
+          fi
+          echo "✅ This PR is the sole beta claimant"
+
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(echo '${{ github.event.pull_request.head.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      # The backend image is large enough that the default runner disk is tight.
+      # Same cleanup publish.yaml does.
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android \
+                      /opt/hostedtoolcache \
+                      /usr/share/dotnet \
+                      /usr/share/swift \
+                      /usr/share/miniconda \
+                      /usr/local/share/boost
+          docker system prune -af
+          df -h
+
+      # No sbom/provenance attestations: those exist for released artifacts and
+      # materially slow this loop. Release publishing keeps them.
+      - name: Build and push image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/letsrevel/revel:beta
+            ghcr.io/letsrevel/revel:beta-${{ steps.sha.outputs.short }}
+
+      - name: Summary
+        run: |
+          {
+            echo "### 🧪 Beta image published"
+            echo ""
+            echo '`ghcr.io/letsrevel/revel:beta` → `beta-${{ steps.sha.outputs.short }}`'
+            echo ""
+            echo 'Deploy: `ssh personal "cd infra/revel-beta && ./deploy.sh"`'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Implements Task 1 of docs/superpowers/plans/2026-07-20-beta-environment.md. See the design spec for why this uses pull_request rather than pull_request_target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated beta workflow that runs on pull request label changes and synchronizations when the beta label is present.
  * Publishes Docker beta images to the container registry with both a stable beta tag and a short commit-specific tag.
  * Enforces a single open pull request can claim beta publishing at a time to prevent concurrent beta releases.
  * Records publishing and deployment information in the workflow summary.
  * Adds a follow-up remote beta deployment step after a successful image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->