### PR TITLE
feat(events)!: paint response reports tiers whose prices changed (#747)

### DIFF
--- a/docs/guides/seating/venue-and-layout.md
+++ b/docs/guides/seating/venue-and-layout.md
@@ -132,9 +132,14 @@ they pay. Either way, painting is what tells the platform which seats are which.
 > (with a message naming the category) until the organizer prices it. Sales in priced categories
 > are unaffected.
 >
-> Practical advice for organizers running live on-sales: repaint before a show goes on sale, or
-> check the affected events' tiers straight after. The tier admin screen flags any category it
-> doesn't price.
+> Moving seats between two categories a tier **does** price is the quieter hazard: coverage stays
+> complete, nothing errors, and the seats simply start selling at the other price. So the save
+> itself reports back — it names every live tier whose seat prices it just changed, the event each
+> belongs to, and how many seats moved from which price to which. That's the only place the
+> venue-wide blast radius is visible, since the change spans events the organizer isn't looking at.
+>
+> Practical advice for organizers running live on-sales: repaint before a show goes on sale, and
+> read what the save reports back. The tier admin screen also flags any category it doesn't price.
 
 ## Demo it
 

--- a/docs/guides/seating/venue-and-layout.md
+++ b/docs/guides/seating/venue-and-layout.md
@@ -138,8 +138,17 @@ they pay. Either way, painting is what tells the platform which seats are which.
 > belongs to, and how many seats moved from which price to which. That's the only place the
 > venue-wide blast radius is visible, since the change spans events the organizer isn't looking at.
 >
-> Practical advice for organizers running live on-sales: repaint before a show goes on sale, and
-> read what the save reports back. The tier admin screen also flags any category it doesn't price.
+> **And the editor can ask first.** The same report is available *before* anything is written:
+> the grid can check "what would this repaint do?" and get back the identical answer — the tiers,
+> the events, the seat counts, the old and new prices — with not a single seat touched. So a
+> repaint on a venue with live shows can be a confirmation ("this moves 400 seats from €80 to €30
+> across 3 events — continue?") instead of an apology. Asking is exactly as strict as doing: if
+> the real repaint would be rejected, the question is rejected the same way, so nobody confirms
+> a change that then fails.
+>
+> Practical advice for organizers running live on-sales: repaint before a show goes on sale, check
+> before you save, and read what the save reports back. The tier admin screen also flags any
+> category it doesn't price.
 
 ## Demo it
 

--- a/src/events/controllers/organization_admin/venues.py
+++ b/src/events/controllers/organization_admin/venues.py
@@ -1,7 +1,9 @@
+import typing as t
 from uuid import UUID
 
 from django.db.models import Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
+from ninja import Query
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
 from ninja_extra.searching import Searching, searching
@@ -199,7 +201,19 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         response=schema.SeatPaintResultSchema,
     )
     def paint_seats(
-        self, slug: str, venue_id: UUID, payload: schema.VenueSeatPaintSchema
+        self,
+        slug: str,
+        venue_id: UUID,
+        payload: schema.VenueSeatPaintSchema,
+        preview: t.Annotated[
+            bool,
+            Query(
+                description=(
+                    "Dry run: validate the request and return the identical response, "
+                    "without painting anything. Use it to confirm a repricing before it happens."
+                )
+            ),
+        ] = False,
     ) -> schema.SeatPaintResultSchema:
         """Bulk paint seats with a price category (null = unpaint).
 
@@ -210,10 +224,14 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         it can change what buyers are charged on every event at this venue, or leave a
         user-choice tier without a price for a category now painted in its sector (checkout
         refuses those seats). Both come back in ``affected_tiers`` (advisory).
+
+        Because that report is computed before the write, ``?preview=true`` returns exactly
+        the same payload with nothing written — the same request, answered in advance.
+        Validation is unchanged: a preview of a paint that would 404 or 400 still does.
         """
         organization = self.get_one(slug)
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)
-        return venue_service.paint_seats(venue, payload)
+        return venue_service.paint_seats(venue, payload, preview=preview)
 
     # ---- Venue Sector Management ----
 

--- a/src/events/controllers/organization_admin/venues.py
+++ b/src/events/controllers/organization_admin/venues.py
@@ -206,9 +206,10 @@ class OrganizationAdminVenuesController(OrganizationAdminBaseController):
         All seats must belong to this venue (across any of its sectors) and the
         category, when given, must belong to this venue. Executes a single UPDATE.
 
-        Painting always succeeds, but it can leave a user-choice tier pricing that
-        sector without a price for a category now painted there — checkout refuses
-        those seats. Such tiers come back in ``under_covered_tiers`` (advisory).
+        Painting always succeeds, but it is venue-scoped and takes effect immediately:
+        it can change what buyers are charged on every event at this venue, or leave a
+        user-choice tier without a price for a category now painted in its sector (checkout
+        refuses those seats). Both come back in ``affected_tiers`` (advisory).
         """
         organization = self.get_one(slug)
         venue = get_object_or_404(models.Venue, pk=venue_id, organization=organization)

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -351,6 +351,7 @@ from .ticket import (
 
 # Venue schemas
 from .venue import (
+    AffectedTierSchema,
     Coordinate2D,
     MinimalSeatSchema,
     PolygonShape,
@@ -358,9 +359,9 @@ from .venue import (
     PriceCategorySchema,
     PriceCategoryUpdateSchema,
     SeatPaintResultSchema,
+    SeatPriceChangeSchema,
     SectorAvailabilitySchema,
     TierPricingGapSchema,
-    UnderCoveredTierSchema,
     VenueAvailabilitySchema,
     VenueCreateSchema,
     VenueDetailSchema,
@@ -432,6 +433,7 @@ __all__ = [
     "EventSeriesRetrieveSchema",
     "MinimalEventSeriesSchema",
     # Venue
+    "AffectedTierSchema",
     "Coordinate2D",
     "MinimalSeatSchema",
     "PolygonShape",
@@ -439,9 +441,9 @@ __all__ = [
     "PriceCategorySchema",
     "PriceCategoryUpdateSchema",
     "SeatPaintResultSchema",
+    "SeatPriceChangeSchema",
     "SectorAvailabilitySchema",
     "TierPricingGapSchema",
-    "UnderCoveredTierSchema",
     "VenueAvailabilitySchema",
     "VenueCreateSchema",
     "VenueDetailSchema",

--- a/src/events/schema/venue.py
+++ b/src/events/schema/venue.py
@@ -1,6 +1,7 @@
 """Venue-related schemas."""
 
 import typing as t
+from decimal import Decimal
 from uuid import UUID
 
 from ninja import ModelSchema, Schema
@@ -8,7 +9,7 @@ from ninja.schema import DjangoGetter
 from pydantic import Field, StringConstraints, model_validator
 
 from common.schema import OneToOneFiftyString, StrippedString
-from events.models import PriceCategory, Venue, VenueSeat, VenueSector
+from events.models import Event, PriceCategory, Venue, VenueSeat, VenueSector
 
 from .mixins import CityEditMixin, CityRetrieveMixin
 
@@ -469,28 +470,61 @@ class TierPricingGapSchema(Schema):
     color: str
 
 
-class UnderCoveredTierSchema(Schema):
-    """A category-priced tier left with painted-but-unpriced categories in its sector."""
+class SeatPriceChangeSchema(Schema):
+    """One before→after price move a paint caused on a tier, and how many seats made it.
+
+    A single paint writes one category, but the seats it overwrites can have come from
+    several different ones, so a tier can report more than one move.
+
+    Attributes:
+        seat_count: Active seats in this paint that moved from ``from_price`` to ``to_price``.
+        from_price: What each of those seats cost on this tier **before** the paint.
+            ``None`` means the seat was in a category the tier does not price, so checkout
+            was refusing it (spec §4.3) and there was no honest number.
+        to_price: What each now costs. ``None`` means checkout now refuses it — the paint
+            moved the seats into a category this tier has no price for.
+    """
+
+    seat_count: int
+    from_price: Decimal | None = None
+    to_price: Decimal | None = None
+
+
+class AffectedTierSchema(Schema):
+    """A live, category-priced tier this paint changed the economics of.
+
+    A tier is reported when the paint moved the price of at least one of its seats
+    (``price_changes``), or when it is left unable to sell some of its sector
+    (``missing_categories``), or both.
+
+    Attributes:
+        event_status: So the frontend can rank a live on-sale above the draft the admin
+            is currently configuring — both are worth reporting, but only one is urgent.
+        price_changes: Empty when the paint moved nothing on this tier.
+        missing_categories: The tier's **current** coverage gap, not this paint's delta —
+            a category painted in its sector that it does not price. Non-empty means seats
+            in those categories are refused at checkout until the tier prices them.
+    """
 
     tier_id: UUID
     tier_name: str
     event_id: UUID
     event_name: str
-    missing_categories: list[TierPricingGapSchema] = Field(
-        default_factory=list,
-        description="Categories painted in the tier's sector that the tier does not price.",
-    )
+    event_status: Event.EventStatus
+    price_changes: list[SeatPriceChangeSchema] = Field(default_factory=list)
+    missing_categories: list[TierPricingGapSchema] = Field(default_factory=list)
 
 
 class SeatPaintResultSchema(Schema):
-    """Result of a bulk paint: what changed, and what it left unsellable."""
+    """Result of a bulk paint: what changed, and what it cost or left unsellable."""
 
     painted: int = Field(..., description="Number of seats updated.")
-    under_covered_tiers: list[UnderCoveredTierSchema] = Field(
+    affected_tiers: list[AffectedTierSchema] = Field(
         default_factory=list,
         description=(
-            "User-choice, category-priced tiers on the painted sectors whose price map does not "
-            "cover every painted category. Their seats in those categories are refused at checkout "
-            "until the tier prices them. Advisory only — the paint itself always succeeds."
+            "User-choice, category-priced tiers on the painted sectors whose seat prices this "
+            "paint changed, and/or whose price map no longer covers every category painted in "
+            "their sector. Painting is venue-scoped, so this is the only place the blast radius "
+            "across other events is visible. Advisory only — the paint itself always succeeds."
         ),
     )

--- a/src/events/service/venue_service.py
+++ b/src/events/service/venue_service.py
@@ -663,24 +663,40 @@ class PriorPaint(t.NamedTuple):
 
 
 @transaction.atomic
-def paint_seats(venue: models.Venue, payload: schema.VenueSeatPaintSchema) -> schema.SeatPaintResultSchema:
+def paint_seats(
+    venue: models.Venue,
+    payload: schema.VenueSeatPaintSchema,
+    *,
+    preview: bool = False,
+) -> schema.SeatPaintResultSchema:
     """Bulk paint (or unpaint) seats with a price category in a single UPDATE.
 
     Painting always succeeds (spec §4.3): a venue-wide map operation must never be
     blocked by one event's pricing config. The consequence is reported instead —
     see :func:`affected_tiers`.
 
+    Every input to the report is UPDATE-independent: the prior categories are captured
+    before it (the UPDATE overwrites them), and the coverage state is *derived* rather
+    than re-read — see ``painted_seat_ids`` on :func:`affected_tiers`. So ``preview``
+    needs no second code path: it skips the one statement that writes, and everything
+    else — validation, the 404, ``painted``, the report — is the same line of code
+    producing the same value. A dry run that disagreed with the paint would have to be
+    a different function.
+
     Args:
         venue: The venue the seats and the category must belong to
         payload: Seat ids and the category to paint (null = unpaint)
+        preview: Dry run — compute and return the identical report, write nothing.
 
     Returns:
-        The number of seats painted, plus every live category-priced tier whose seat
-        prices this changed or whose sector it left partly unsellable.
+        The number of seats painted (or that *would* be, under ``preview``), plus every
+        live category-priced tier whose seat prices this changed or whose sector it left
+        partly unsellable.
 
     Raises:
         HttpError: 400 if the category belongs to another venue, 404 if any seat
-            does not belong to this venue
+            does not belong to this venue — in preview too, because an admin
+            confirming a paint that would fail is worse than no preview at all
     """
     if payload.price_category_id is not None:
         _validate_seat_categories(venue.id, {payload.price_category_id})
@@ -695,7 +711,10 @@ def paint_seats(venue: models.Venue, payload: schema.VenueSeatPaintSchema) -> sc
     prior_rows = list(
         seats.values("sector_id", "default_price_category_id", "is_active").order_by().annotate(seat_count=Count("id"))
     )
-    if sum(row["seat_count"] for row in prior_rows) != len(seat_ids):
+    # Every requested seat matched, so this is exactly what the UPDATE below reports back —
+    # which is why the preview can report it without running the UPDATE.
+    painted = sum(row["seat_count"] for row in prior_rows)
+    if painted != len(seat_ids):
         raise HttpError(404, str(_("Some seats were not found in this venue.")))
     sector_ids = {row["sector_id"] for row in prior_rows}
     # Only active seats can be sold, so only they can be repriced — the same rule
@@ -706,13 +725,15 @@ def paint_seats(venue: models.Venue, payload: schema.VenueSeatPaintSchema) -> sc
         if row["is_active"]
     ]
 
+    # The single conditional step, and the only statement in this function that writes.
     # A queryset .update() bypasses auto_now, which would leave the chart version unchanged
     # after a repaint — and a repaint now changes what buyers are charged, so the poller has
-    # to see it.
-    painted = seats.update(default_price_category_id=payload.price_category_id, updated_at=timezone.now())
+    # to see it. Under `preview` nothing is written, so nothing bumps the version either.
+    if not preview:
+        seats.update(default_price_category_id=payload.price_category_id, updated_at=timezone.now())
     return schema.SeatPaintResultSchema(
         painted=painted,
-        affected_tiers=affected_tiers(sector_ids, prior, payload.price_category_id),
+        affected_tiers=affected_tiers(sector_ids, prior, payload.price_category_id, seat_ids),
     )
 
 
@@ -758,10 +779,33 @@ def _price_changes(
     ]
 
 
+def _painted_after(
+    sector_ids: t.Collection[UUID],
+    prior: t.Sequence[PriorPaint],
+    new_category_id: UUID | None,
+    painted_seat_ids: t.Collection[UUID],
+) -> dict[UUID, set[UUID]]:
+    """Which categories each touched sector carries once this paint has landed.
+
+    Derived, not re-read: everything painted on the sector's *other* seats, plus the
+    category this paint writes wherever it touches an active seat. That equals what a
+    plain post-UPDATE read returns — and it equals it just as well before the UPDATE,
+    which is what lets the dry run and the real paint share this line instead of each
+    computing coverage its own way.
+    """
+    painted = tier_pricing.painted_categories_by_sector(sector_ids, exclude_seat_ids=painted_seat_ids)
+    if new_category_id is not None:
+        # `prior` holds active seats only, and only active seats count as painted.
+        for row in prior:
+            painted.setdefault(row.sector_id, set()).add(new_category_id)
+    return painted
+
+
 def affected_tiers(
     sector_ids: t.Collection[UUID],
     prior: t.Sequence[PriorPaint],
     new_category_id: UUID | None,
+    painted_seat_ids: t.Collection[UUID],
 ) -> list[schema.AffectedTierSchema]:
     """The live category-priced tiers a paint repriced, under-covered, or both.
 
@@ -791,6 +835,10 @@ def affected_tiers(
         sector_ids: The sectors that were touched.
         prior: The active seats' categories as captured *before* the UPDATE.
         new_category_id: The category just painted, or ``None`` for an unpaint.
+        painted_seat_ids: The seats this paint writes. Excluded from the coverage read
+            and replaced by ``new_category_id``, so the gap is computed the same way
+            whether or not the UPDATE has run — which is what makes the dry run's
+            answer identical to the real one rather than merely similar.
 
     Returns:
         One entry per affected tier, ordered by event start then tier name. Empty when
@@ -813,7 +861,7 @@ def affected_tiers(
     if not tiers:
         return []
 
-    painted = tier_pricing.painted_categories_by_sector(sector_ids)
+    painted = _painted_after(sector_ids, prior, new_category_id, painted_seat_ids)
     prior_by_sector: dict[UUID, list[PriorPaint]] = {}
     for row in prior:
         prior_by_sector.setdefault(row.sector_id, []).append(row)

--- a/src/events/service/venue_service.py
+++ b/src/events/service/venue_service.py
@@ -2,11 +2,12 @@
 
 import re
 import typing as t
+from decimal import Decimal
 from uuid import UUID
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
-from django.db.models import Case, Exists, OuterRef, Q, Value, When
+from django.db.models import Case, Count, Exists, OuterRef, Q, Value, When
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
@@ -653,21 +654,29 @@ def bulk_update_seats(
     return [by_id[s.id] for s in updated_seats]
 
 
+class PriorPaint(t.NamedTuple):
+    """How many active seats of one sector carried one category *before* a paint ran."""
+
+    sector_id: UUID
+    category_id: UUID | None
+    seat_count: int
+
+
 @transaction.atomic
 def paint_seats(venue: models.Venue, payload: schema.VenueSeatPaintSchema) -> schema.SeatPaintResultSchema:
     """Bulk paint (or unpaint) seats with a price category in a single UPDATE.
 
     Painting always succeeds (spec §4.3): a venue-wide map operation must never be
     blocked by one event's pricing config. The consequence is reported instead —
-    see :func:`under_covered_tiers`.
+    see :func:`affected_tiers`.
 
     Args:
         venue: The venue the seats and the category must belong to
         payload: Seat ids and the category to paint (null = unpaint)
 
     Returns:
-        The number of seats painted, plus the tiers left under-covered on the
-        sectors that were touched.
+        The number of seats painted, plus every live category-priced tier whose seat
+        prices this changed or whose sector it left partly unsellable.
 
     Raises:
         HttpError: 400 if the category belongs to another venue, 404 if any seat
@@ -678,36 +687,110 @@ def paint_seats(venue: models.Venue, payload: schema.VenueSeatPaintSchema) -> sc
 
     seat_ids = set(payload.seat_ids)
     seats = models.VenueSeat.objects.filter(id__in=seat_ids, sector__venue=venue)
-    sector_ids = set(seats.values_list("sector_id", flat=True).distinct())
-    if seats.count() != len(seat_ids):
+    # One grouped read serves all three pre-UPDATE needs — the 404 check, which sectors were
+    # touched, and the categories the seats carried *before* the UPDATE overwrites them.
+    # Grouped, not per-seat: its cost is bounded by (sector × category × is_active), never by
+    # how many seats are painted. `.order_by()` clears the model's Meta ordering, which would
+    # otherwise leak into the GROUP BY.
+    prior_rows = list(
+        seats.values("sector_id", "default_price_category_id", "is_active").order_by().annotate(seat_count=Count("id"))
+    )
+    if sum(row["seat_count"] for row in prior_rows) != len(seat_ids):
         raise HttpError(404, str(_("Some seats were not found in this venue.")))
+    sector_ids = {row["sector_id"] for row in prior_rows}
+    # Only active seats can be sold, so only they can be repriced — the same rule
+    # `tier_pricing._painted_seats` applies to coverage.
+    prior = [
+        PriorPaint(row["sector_id"], row["default_price_category_id"], row["seat_count"])
+        for row in prior_rows
+        if row["is_active"]
+    ]
 
     # A queryset .update() bypasses auto_now, which would leave the chart version unchanged
     # after a repaint — and a repaint now changes what buyers are charged, so the poller has
     # to see it.
     painted = seats.update(default_price_category_id=payload.price_category_id, updated_at=timezone.now())
-    return schema.SeatPaintResultSchema(painted=painted, under_covered_tiers=under_covered_tiers(sector_ids))
+    return schema.SeatPaintResultSchema(
+        painted=painted,
+        affected_tiers=affected_tiers(sector_ids, prior, payload.price_category_id),
+    )
 
 
-def under_covered_tiers(sector_ids: t.Collection[UUID]) -> list[schema.UnderCoveredTierSchema]:
-    """The category-priced tiers on these sectors that do not price everything painted there.
+def _tier_seat_price(price_map: dict[UUID, Decimal], category_id: UUID | None, flat_price: Decimal) -> Decimal | None:
+    """What one seat in ``category_id`` costs on a category-priced tier, or ``None``.
 
-    Reports the **current** gap of every affected tier, not the delta of one paint: a tier
-    that was already under-covered still has unsellable seats, and the admin standing in the
-    grid editor needs the whole picture — telling them "all clear" while checkout keeps
-    refusing seats is worse than saying nothing.
+    ``None`` is not "free": it is the reporting projection of
+    :func:`events.service.seating.pricing.resolve_seat_price`'s refusal — a seat painted
+    into a category the tier does not price has no honest price, and checkout returns a 400
+    for it (spec §4.3). Same convention as ``TierCategoryPriceSchema.price``.
+    """
+    if category_id is not None and category_id not in price_map:
+        return None
+    return tier_pricing.effective_category_price(price_map, category_id, flat_price)
 
-    Scope is deliberately narrow, because a warning that cries wolf gets ignored:
 
-    - only ``USER_CHOICE`` tiers with a non-empty price map can be under-covered at all;
-    - only events that have not ended and are not cancelled — nobody can sell those seats
-      anyway, so reporting them is pure noise.
+def _price_changes(
+    prior: t.Sequence[PriorPaint],
+    price_map: dict[UUID, Decimal],
+    new_category_id: UUID | None,
+    flat_price: Decimal,
+) -> list[schema.SeatPriceChangeSchema]:
+    """Group one tier's repriced seats by the price they moved away from.
+
+    A paint writes a single category, so ``to_price`` is one number per tier, but the seats
+    it overwrote can have come from several — hence a list. Seats whose price is unchanged
+    (a no-op repaint, or two categories priced the same) are omitted: reporting them would
+    make the advisory fire on every paint and train the admin to dismiss it.
+    """
+    to_price = _tier_seat_price(price_map, new_category_id, flat_price)
+    moved: dict[Decimal | None, int] = {}
+    for row in prior:
+        from_price = _tier_seat_price(price_map, row.category_id, flat_price)
+        if from_price == to_price:
+            continue
+        moved[from_price] = moved.get(from_price, 0) + row.seat_count
+    return [
+        schema.SeatPriceChangeSchema(seat_count=count, from_price=from_price, to_price=to_price)
+        # Biggest move first; ties broken by price so the payload is deterministic.
+        for from_price, count in sorted(
+            moved.items(), key=lambda kv: (-kv[1], kv[0] is None, kv[0] if kv[0] is not None else Decimal(0))
+        )
+    ]
+
+
+def affected_tiers(
+    sector_ids: t.Collection[UUID],
+    prior: t.Sequence[PriorPaint],
+    new_category_id: UUID | None,
+) -> list[schema.AffectedTierSchema]:
+    """The live category-priced tiers a paint repriced, under-covered, or both.
+
+    Every other signal in the pricing system fires on the *absence* of a price: write-time
+    validation, the checkout refusal, ``pricing_gaps``. Moving a seat between two categories
+    the tier prices leaves coverage complete, so all of them stay silent while the seat's
+    price changes for every event at the venue — ``paint_seats`` is venue-scoped. That silent
+    case is what this reports; under-coverage is folded in as ``missing_categories`` rather
+    than being the entry condition.
+
+    The two halves have deliberately different tenses:
+
+    - ``price_changes`` is the **delta of this paint** — what it just did to the money.
+    - ``missing_categories`` is the tier's **current** gap, not the delta. A gap this paint
+      did not open still leaves seats unsellable, and telling the admin "all clear" while
+      checkout keeps refusing seats is worse than saying nothing.
+
+    Scope is deliberately narrow, because a warning that cries wolf gets ignored: only
+    ``USER_CHOICE`` tiers with a non-empty price map read the paint at all, and only events
+    that have not ended and are not cancelled — nobody can sell those seats anyway. DRAFT
+    events stay in: the event being configured right now is the most valuable warning.
 
     Query cost is constant in the number of seats painted: one query for the tiers, one for
     what is painted on the sectors, one to name the missing categories.
 
     Args:
         sector_ids: The sectors that were touched.
+        prior: The active seats' categories as captured *before* the UPDATE.
+        new_category_id: The category just painted, or ``None`` for an unpaint.
 
     Returns:
         One entry per affected tier, ordered by event start then tier name. Empty when
@@ -731,39 +814,55 @@ def under_covered_tiers(sector_ids: t.Collection[UUID]) -> list[schema.UnderCove
         return []
 
     painted = tier_pricing.painted_categories_by_sector(sector_ids)
-    missing_per_tier: list[tuple[models.TicketTier, set[UUID]]] = []
+    prior_by_sector: dict[UUID, list[PriorPaint]] = {}
+    for row in prior:
+        prior_by_sector.setdefault(row.sector_id, []).append(row)
+
+    entries: list[tuple[models.TicketTier, list[schema.SeatPriceChangeSchema], set[UUID]]] = []
     for tier in tiers:
         try:
-            priced = tier_pricing.parse_price_map(tier.category_prices)
+            price_map = tier_pricing.parse_price_map(tier.category_prices)
         except DjangoValidationError:
             # A malformed legacy map must never turn a paint into an error (spec §4.3).
             continue
+        if not price_map:
+            # A map that parses to nothing is flat-priced at checkout; paint cannot move it.
+            continue
         # sector_id is non-null by the filter above; the guard is for the type checker.
-        missing = (painted.get(tier.sector_id, set()) if tier.sector_id else set()) - priced.keys()
-        if missing:
-            missing_per_tier.append((tier, missing))
-    if not missing_per_tier:
+        sector_id = tier.sector_id
+        missing = (painted.get(sector_id, set()) if sector_id else set()) - price_map.keys()
+        changes = _price_changes(
+            prior_by_sector.get(sector_id, []) if sector_id else [],
+            price_map,
+            new_category_id,
+            tier.price,
+        )
+        if changes or missing:
+            entries.append((tier, changes, missing))
+    if not entries:
         return []
 
     categories = {
         c.id: c
         for c in models.PriceCategory.objects.filter(
-            id__in={cid for _tier, missing in missing_per_tier for cid in missing}
+            id__in={cid for _tier, _changes, missing in entries for cid in missing}
         ).order_by("display_order", "name")
     }
     return [
-        schema.UnderCoveredTierSchema(
+        schema.AffectedTierSchema(
             tier_id=tier.id,
             tier_name=tier.name,
             event_id=tier.event_id,
             event_name=tier.event.name,
+            event_status=models.Event.EventStatus(tier.event.status),
+            price_changes=changes,
             missing_categories=[
                 schema.TierPricingGapSchema(id=c.id, name=c.name, color=c.color)
                 for cid, c in categories.items()
                 if cid in missing
             ],
         )
-        for tier, missing in missing_per_tier
+        for tier, changes, missing in entries
     ]
 
 

--- a/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
@@ -50,7 +50,7 @@ class TestPaintSeatsEndpoint:
         )
 
         assert response.status_code == 200, response.content
-        assert response.json() == {"painted": 2, "under_covered_tiers": []}
+        assert response.json() == {"painted": 2, "affected_tiers": []}
         assert VenueSeat.objects.filter(default_price_category=category).count() == 2
 
     def test_unpaint_with_null(
@@ -69,7 +69,7 @@ class TestPaintSeatsEndpoint:
         )
 
         assert response.status_code == 200, response.content
-        assert response.json() == {"painted": 1, "under_covered_tiers": []}
+        assert response.json() == {"painted": 1, "affected_tiers": []}
         seat.refresh_from_db()
         assert seat.default_price_category_id is None
 
@@ -169,7 +169,7 @@ class TestPaintSeatsEndpoint:
 
         assert count_queries_for(2) == count_queries_for(12)
 
-    def test_response_reports_the_tier_left_under_covered(
+    def test_response_reports_the_tier_it_repriced_and_under_covered(
         self,
         organization_owner_client: Client,
         organization: Organization,
@@ -178,7 +178,7 @@ class TestPaintSeatsEndpoint:
         sector: VenueSector,
         category: PriceCategory,
     ) -> None:
-        """The advisory the grid editor renders after a paint (#746)."""
+        """The advisory the grid editor renders after a paint (#746, #747)."""
         event.venue = venue
         event.save(update_fields=["venue"])
         seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
@@ -203,13 +203,63 @@ class TestPaintSeatsEndpoint:
         assert response.status_code == 200, response.content
         assert response.json() == {
             "painted": 1,
-            "under_covered_tiers": [
+            "affected_tiers": [
                 {
                     "tier_id": str(tier.id),
                     "tier_name": "Stalls",
                     "event_id": str(event.id),
                     "event_name": event.name,
+                    "event_status": event.status,
+                    # An 80.00 seat now has no price at all on this tier: checkout refuses it.
+                    "price_changes": [{"seat_count": 1, "from_price": "80.00", "to_price": None}],
                     "missing_categories": [{"id": str(balcony.id), "name": "Balcony", "color": "#00aa00"}],
+                }
+            ],
+        }
+
+    def test_response_reports_a_repricing_with_no_coverage_gap(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        event: Event,
+        venue: Venue,
+        sector: VenueSector,
+        category: PriceCategory,
+    ) -> None:
+        """The silent case (#747): both categories priced, so every other signal stays quiet."""
+        event.venue = venue
+        event.save(update_fields=["venue"])
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+        standard = PriceCategory.objects.create(venue=venue, name="Standard", color="#0000aa")
+        tier = TicketTier.objects.create(
+            event=event,
+            name="Stalls",
+            price=Decimal("50.00"),
+            payment_method=TicketTier.PaymentMethod.OFFLINE,
+            venue=venue,
+            sector=sector,
+            seat_assignment_mode=TicketTier.SeatAssignmentMode.USER_CHOICE,
+            category_prices={str(category.id): "80.00", str(standard.id): "30.00"},
+        )
+
+        response = organization_owner_client.put(
+            _url(organization, venue),
+            data=orjson.dumps({"seat_ids": [str(seat.id)], "price_category_id": str(standard.id)}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.json() == {
+            "painted": 1,
+            "affected_tiers": [
+                {
+                    "tier_id": str(tier.id),
+                    "tier_name": "Stalls",
+                    "event_id": str(event.id),
+                    "event_name": event.name,
+                    "event_status": event.status,
+                    "price_changes": [{"seat_count": 1, "from_price": "80.00", "to_price": "30.00"}],
+                    "missing_categories": [],
                 }
             ],
         }

--- a/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_venues/test_seat_paint.py
@@ -264,6 +264,119 @@ class TestPaintSeatsEndpoint:
             ],
         }
 
+    def test_preview_returns_the_same_body_as_the_paint_and_writes_nothing(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        event: Event,
+        venue: Venue,
+        sector: VenueSector,
+        category: PriceCategory,
+    ) -> None:
+        """``?preview=true``: the admin sees the repricing before the money moves (#747)."""
+        event.venue = venue
+        event.save(update_fields=["venue"])
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+        standard = PriceCategory.objects.create(venue=venue, name="Standard", color="#0000aa")
+        TicketTier.objects.create(
+            event=event,
+            name="Stalls",
+            price=Decimal("50.00"),
+            payment_method=TicketTier.PaymentMethod.OFFLINE,
+            venue=venue,
+            sector=sector,
+            seat_assignment_mode=TicketTier.SeatAssignmentMode.USER_CHOICE,
+            category_prices={str(category.id): "80.00", str(standard.id): "30.00"},
+        )
+        body = orjson.dumps({"seat_ids": [str(seat.id)], "price_category_id": str(standard.id)})
+        before = VenueSeat.objects.values_list("id", "default_price_category_id", "updated_at").get()
+
+        preview = organization_owner_client.put(
+            f"{_url(organization, venue)}?preview=true", data=body, content_type="application/json"
+        )
+
+        assert preview.status_code == 200, preview.content
+        assert VenueSeat.objects.values_list("id", "default_price_category_id", "updated_at").get() == before
+
+        real = organization_owner_client.put(_url(organization, venue), data=body, content_type="application/json")
+
+        assert real.status_code == 200, real.content
+        assert preview.json() == real.json()
+        assert preview.json()["affected_tiers"][0]["price_changes"] == [
+            {"seat_count": 1, "from_price": "80.00", "to_price": "30.00"}
+        ]
+        seat.refresh_from_db()
+        assert seat.default_price_category_id == standard.id
+
+    @pytest.mark.parametrize("preview", ["true", "false"])
+    def test_preview_rejects_a_foreign_seat_exactly_like_the_paint(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        venue: Venue,
+        category: PriceCategory,
+        preview: str,
+    ) -> None:
+        """A preview of a paint that would 404 must 404 — confirming an impossible paint is worse."""
+        other = Venue.objects.create(organization=organization, name="Other Hall")
+        other_sector = VenueSector.objects.create(venue=other, name="Foreign")
+        foreign_seat = VenueSeat.objects.create(sector=other_sector, label="X1")
+        payload = {"seat_ids": [str(foreign_seat.id)], "price_category_id": str(category.id)}
+
+        response = organization_owner_client.put(
+            f"{_url(organization, venue)}?preview={preview}",
+            data=orjson.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404, response.content
+        foreign_seat.refresh_from_db()
+        assert foreign_seat.default_price_category_id is None
+
+    @pytest.mark.parametrize("preview", ["true", "false"])
+    def test_preview_rejects_a_foreign_category_exactly_like_the_paint(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        venue: Venue,
+        sector: VenueSector,
+        preview: str,
+    ) -> None:
+        other = Venue.objects.create(organization=organization, name="Other Hall")
+        foreign_category = PriceCategory.objects.create(venue=other, name="Foreign", color="#00aa00")
+        seat = VenueSeat.objects.create(sector=sector, label="A1")
+        payload = {"seat_ids": [str(seat.id)], "price_category_id": str(foreign_category.id)}
+
+        response = organization_owner_client.put(
+            f"{_url(organization, venue)}?preview={preview}",
+            data=orjson.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400, response.content
+        seat.refresh_from_db()
+        assert seat.default_price_category_id is None
+
+    def test_preview_needs_the_same_permission_as_the_paint(
+        self,
+        nonmember_client: Client,
+        organization: Organization,
+        venue: Venue,
+        sector: VenueSector,
+        category: PriceCategory,
+    ) -> None:
+        """The dry run reads pricing across every event at the venue: same gate, no shortcut."""
+        seat = VenueSeat.objects.create(sector=sector, label="A1")
+        payload = {"seat_ids": [str(seat.id)], "price_category_id": str(category.id)}
+
+        response = nonmember_client.put(
+            f"{_url(organization, venue)}?preview=true",
+            data=orjson.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code in (403, 404)
+
     def test_nonmember_gets_403(
         self,
         nonmember_client: Client,

--- a/src/events/tests/test_service/test_category_pricing_lifecycle.py
+++ b/src/events/tests/test_service/test_category_pricing_lifecycle.py
@@ -245,14 +245,20 @@ class TestRepaintLifecycle:
     def test_repaint_into_a_priced_category_keeps_everything_consistent(
         self, tier: TicketTier, venue: Venue, seats: list[VenueSeat], premium: PriceCategory
     ) -> None:
-        """Moving a seat between two priced categories just reprices it."""
+        """Moving a seat between two priced categories just reprices it — loudly (#747)."""
         standard_seat = seats[1]
         result = venue_service.paint_seats(
             venue, schema.VenueSeatPaintSchema(seat_ids=[standard_seat.id], price_category_id=premium.id)
         )
 
         assert result.painted == 1
-        assert result.under_covered_tiers == []
+        # Coverage stays complete, so there is no gap — but the money moved, and that is
+        # the whole point of the report: nothing else in the system would have said so.
+        assert len(result.affected_tiers) == 1
+        assert result.affected_tiers[0].missing_categories == []
+        assert [(c.seat_count, c.from_price, c.to_price) for c in result.affected_tiers[0].price_changes] == [
+            (1, STANDARD, PREMIUM)
+        ]
         standard_seat.refresh_from_db()
         price_map = parse_price_map(tier.category_prices)
         assert pricing.resolve_seat_price(tier, standard_seat, price_map) == PREMIUM

--- a/src/events/tests/test_service/test_seat_painting.py
+++ b/src/events/tests/test_service/test_seat_painting.py
@@ -242,13 +242,16 @@ def balcony(venue: Venue) -> PriceCategory:
     return PriceCategory.objects.create(venue=venue, name="Balcony", color="#00aa00", display_order=2)
 
 
-def _paint(venue: Venue, seats: list[VenueSeat], category: PriceCategory | None) -> schema.SeatPaintResultSchema:
+def _paint(
+    venue: Venue, seats: list[VenueSeat], category: PriceCategory | None, *, preview: bool = False
+) -> schema.SeatPaintResultSchema:
     return venue_service.paint_seats(
         venue,
         schema.VenueSeatPaintSchema(
             seat_ids=[s.id for s in seats],
             price_category_id=category.id if category else None,
         ),
+        preview=preview,
     )
 
 
@@ -268,6 +271,24 @@ PREMIUM_PRICE = Decimal("80.00")
 STANDARD_PRICE = Decimal("30.00")
 
 
+@pytest.fixture
+def priced_tier(
+    seated_venue_event: Event,
+    venue: Venue,
+    sector: VenueSector,
+    category: PriceCategory,
+    standard: PriceCategory,
+    matching: PriceCategory,
+) -> TicketTier:
+    """Premium 80, Standard 30, Matching 50 (== flat). Balcony/Gallery unpriced."""
+    return _make_tier(
+        seated_venue_event,
+        venue,
+        sector,
+        prices={category: str(PREMIUM_PRICE), standard: str(STANDARD_PRICE), matching: str(FLAT)},
+    )
+
+
 class TestPaintAffectedTierReport:
     """Paint always succeeds; what it did to the money comes back in the response.
 
@@ -278,24 +299,6 @@ class TestPaintAffectedTierReport:
     report is advisory and deliberately quiet: it must stay empty when nothing moved, or
     the frontend warning it feeds becomes noise the admin learns to dismiss.
     """
-
-    @pytest.fixture
-    def priced_tier(
-        self,
-        seated_venue_event: Event,
-        venue: Venue,
-        sector: VenueSector,
-        category: PriceCategory,
-        standard: PriceCategory,
-        matching: PriceCategory,
-    ) -> TicketTier:
-        """Premium 80, Standard 30, Matching 50 (== flat). Balcony/Gallery unpriced."""
-        return _make_tier(
-            seated_venue_event,
-            venue,
-            sector,
-            prices={category: str(PREMIUM_PRICE), standard: str(STANDARD_PRICE), matching: str(FLAT)},
-        )
 
     @pytest.fixture
     def categories(
@@ -576,3 +579,168 @@ class TestPaintAffectedTierReport:
             (200, PREMIUM_PRICE, None)
         ]
         assert [c.name for c in large_result.affected_tiers[0].missing_categories] == ["Balcony"]
+
+
+class TestPaintPreview:
+    """``preview=True``: the same answer, in advance, with nothing written.
+
+    The report has to be computed before the UPDATE anyway (the UPDATE overwrites the
+    categories it reports on), so the preview is the same code path with the write
+    skipped. These tests exist to keep it that way: a preview that could disagree with
+    the paint would let an admin confirm one repricing and get another.
+    """
+
+    def test_preview_payload_is_identical_to_the_real_paint(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        balcony: PriceCategory,
+    ) -> None:
+        """Whole-payload equality, not spot checks: this is the promise the button makes.
+
+        The paint deliberately *opens* a coverage gap, because that is the half of the
+        report that reads the sector's current state — a preview that simply skipped the
+        UPDATE and re-read would report the pre-paint gap and be wrong here.
+        """
+        seats = [
+            VenueSeat.objects.create(sector=sector, label=f"A{i}", default_price_category=category) for i in range(3)
+        ]
+
+        previewed = _paint(venue, seats, balcony, preview=True)
+        real = _paint(venue, seats, balcony)
+
+        assert previewed.model_dump() == real.model_dump()
+        assert [c.name for c in previewed.affected_tiers[0].missing_categories] == ["Balcony"]
+        assert previewed.affected_tiers[0].price_changes, "the case must be non-trivial, or this proves nothing"
+
+    def test_preview_of_a_paint_that_closes_the_last_gap_reports_it_closed(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        balcony: PriceCategory,
+        standard: PriceCategory,
+    ) -> None:
+        """The other direction: the gap the paint removes must be gone in the preview too."""
+        seats = [
+            VenueSeat.objects.create(sector=sector, label=f"A{i}", default_price_category=balcony) for i in range(2)
+        ]
+
+        previewed = _paint(venue, seats, standard, preview=True)
+        real = _paint(venue, seats, standard)
+
+        assert previewed.model_dump() == real.model_dump()
+        assert previewed.affected_tiers[0].missing_categories == []
+
+    def test_preview_then_real_reports_the_same_thing_twice_and_only_then_paints(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        standard: PriceCategory,
+    ) -> None:
+        """The actual flow: preview, admin confirms, paint. The confirmation must hold."""
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+
+        previewed = _paint(venue, [seat], standard, preview=True)
+        seat.refresh_from_db()
+        assert seat.default_price_category_id == category.id
+
+        real = _paint(venue, [seat], standard)
+
+        assert previewed.model_dump() == real.model_dump()
+        assert [(c.seat_count, c.from_price, c.to_price) for c in real.affected_tiers[0].price_changes] == [
+            (1, PREMIUM_PRICE, STANDARD_PRICE)
+        ]
+        seat.refresh_from_db()
+        assert seat.default_price_category_id == standard.id
+
+    def test_preview_writes_nothing_not_even_updated_at(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        balcony: PriceCategory,
+    ) -> None:
+        """``paint_seats`` stamps ``updated_at`` on purpose (the chart version, and therefore
+        the buyer's poller, is derived from it). A preview must not move it — a dry run that
+        invalidated every open seat chart would be a write in all the ways that matter."""
+        seats = [
+            VenueSeat.objects.create(sector=sector, label=f"A{i}", default_price_category=category) for i in range(3)
+        ]
+        before = {s.id: (s.default_price_category_id, s.updated_at) for s in VenueSeat.objects.all()}
+
+        _paint(venue, seats, balcony, preview=True)
+
+        after = {s.id: (s.default_price_category_id, s.updated_at) for s in VenueSeat.objects.all()}
+        assert after == before
+
+    def test_preview_still_404s_on_a_foreign_seat_and_writes_nothing(
+        self, venue: Venue, sector: VenueSector, organization: Organization, category: PriceCategory
+    ) -> None:
+        """Previewing a paint that would fail must fail — the alternative is a confirmed lie."""
+        other = Venue.objects.create(organization=organization, name="Other Hall")
+        other_sector = VenueSector.objects.create(venue=other, name="Foreign")
+        foreign_seat = VenueSeat.objects.create(sector=other_sector, label="X1")
+        mine = VenueSeat.objects.create(sector=sector, label="A1")
+
+        with pytest.raises(HttpError) as exc_info:
+            _paint(venue, [mine, foreign_seat], category, preview=True)
+
+        assert exc_info.value.status_code == 404
+        for seat in (mine, foreign_seat):
+            seat.refresh_from_db()
+            assert seat.default_price_category_id is None
+
+    def test_preview_still_400s_on_a_foreign_category_and_writes_nothing(
+        self, venue: Venue, sector: VenueSector, other_venue_category: PriceCategory
+    ) -> None:
+        seat = VenueSeat.objects.create(sector=sector, label="A1")
+
+        with pytest.raises(HttpError) as exc_info:
+            _paint(venue, [seat], other_venue_category, preview=True)
+
+        assert exc_info.value.status_code == 400
+        seat.refresh_from_db()
+        assert seat.default_price_category_id is None
+
+    def test_preview_is_one_query_cheaper_and_does_not_scale_with_seats(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        balcony: PriceCategory,
+        django_assert_num_queries: t.Any,
+    ) -> None:
+        """Preview = the real paint (9) minus the UPDATE, at any size.
+
+        Flat in the number of seats for the same reason the paint is: the prior-state read
+        is grouped by (sector × category × is_active), never per seat.
+        """
+        VenueSeat.objects.create(sector=sector, label="anchor", default_price_category=category)
+
+        def make(n: int, prefix: str) -> list[UUID]:
+            seats = VenueSeat.objects.bulk_create(
+                [VenueSeat(sector=sector, label=f"{prefix}-{i}", default_price_category=category) for i in range(n)]
+            )
+            return [s.id for s in seats]
+
+        small = make(2, "small")
+        with django_assert_num_queries(8):
+            small_result = venue_service.paint_seats(
+                venue, schema.VenueSeatPaintSchema(seat_ids=small, price_category_id=balcony.id), preview=True
+            )
+
+        large = make(200, "large")
+        with django_assert_num_queries(8):
+            large_result = venue_service.paint_seats(
+                venue, schema.VenueSeatPaintSchema(seat_ids=large, price_category_id=balcony.id), preview=True
+            )
+
+        assert (small_result.painted, large_result.painted) == (2, 200)
+        assert VenueSeat.objects.filter(default_price_category=balcony).count() == 0

--- a/src/events/tests/test_service/test_seat_painting.py
+++ b/src/events/tests/test_service/test_seat_painting.py
@@ -136,7 +136,7 @@ class TestPaintSeats:
         )
 
         assert result.painted == 2
-        assert result.under_covered_tiers == []
+        assert result.affected_tiers == []
         assert VenueSeat.objects.filter(default_price_category=category).count() == 2
         seats[2].refresh_from_db()
         assert seats[2].default_price_category_id is None
@@ -192,10 +192,11 @@ class TestPaintSeats:
 
 
 FLAT = Decimal("50.00")
+DEFAULT_CATEGORY_PRICE = Decimal("80.00")
 
 
 def _price_map(*categories: PriceCategory) -> dict[str, str]:
-    return {str(c.id): "80.00" for c in categories}
+    return {str(c.id): str(DEFAULT_CATEGORY_PRICE) for c in categories}
 
 
 def _make_tier(
@@ -203,10 +204,15 @@ def _make_tier(
     venue: Venue,
     sector: VenueSector,
     *categories: PriceCategory,
+    prices: dict[PriceCategory, str] | None = None,
     name: str = "Stalls",
     mode: str = TicketTier.SeatAssignmentMode.USER_CHOICE,
 ) -> TicketTier:
-    """A tier on ``sector``, category-priced for ``categories`` (none = flat)."""
+    """A tier on ``sector``, category-priced for ``categories`` (none = flat).
+
+    ``prices`` gives explicit per-category amounts; without it every listed category
+    costs :data:`DEFAULT_CATEGORY_PRICE`.
+    """
     return TicketTier.objects.create(
         event=event,
         name=name,
@@ -215,7 +221,7 @@ def _make_tier(
         venue=venue,
         sector=sector,
         seat_assignment_mode=mode,
-        category_prices=_price_map(*categories),
+        category_prices={str(c.id): p for c, p in prices.items()} if prices else _price_map(*categories),
     )
 
 
@@ -246,58 +252,195 @@ def _paint(venue: Venue, seats: list[VenueSeat], category: PriceCategory | None)
     )
 
 
-class TestPaintUnderCoverageReport:
-    """Paint always succeeds; the tiers it leaves unable to sell come back in the response.
+@pytest.fixture
+def gallery(venue: Venue) -> PriceCategory:
+    """A category no tier prices — the under-coverage half of the report."""
+    return PriceCategory.objects.create(venue=venue, name="Gallery", color="#aa00aa", display_order=3)
 
-    The report is advisory and deliberately quiet: it must stay empty in the common case
-    (no category-priced tier anywhere near these sectors), or the frontend warning it feeds
-    becomes noise the admin learns to dismiss.
+
+@pytest.fixture
+def matching(venue: Venue) -> PriceCategory:
+    """A category priced at exactly the tier's flat price: painted, but not a repricing."""
+    return PriceCategory.objects.create(venue=venue, name="Matching", color="#555555", display_order=4)
+
+
+PREMIUM_PRICE = Decimal("80.00")
+STANDARD_PRICE = Decimal("30.00")
+
+
+class TestPaintAffectedTierReport:
+    """Paint always succeeds; what it did to the money comes back in the response.
+
+    Two failure modes, one report. Under-coverage **fails closed** (the seat stops selling
+    and the buyer gets a 400) — loud, someone notices. Repainting between two *priced*
+    categories **fails open**: sales continue at the wrong price, for every event at the
+    venue, with every other signal in the system silent because no price is missing. The
+    report is advisory and deliberately quiet: it must stay empty when nothing moved, or
+    the frontend warning it feeds becomes noise the admin learns to dismiss.
     """
 
-    def test_no_priced_tier_reports_nothing(
-        self, venue: Venue, sector: VenueSector, standard: PriceCategory, seated_venue_event: Event
+    @pytest.fixture
+    def priced_tier(
+        self,
+        seated_venue_event: Event,
+        venue: Venue,
+        sector: VenueSector,
+        category: PriceCategory,
+        standard: PriceCategory,
+        matching: PriceCategory,
+    ) -> TicketTier:
+        """Premium 80, Standard 30, Matching 50 (== flat). Balcony/Gallery unpriced."""
+        return _make_tier(
+            seated_venue_event,
+            venue,
+            sector,
+            prices={category: str(PREMIUM_PRICE), standard: str(STANDARD_PRICE), matching: str(FLAT)},
+        )
+
+    @pytest.fixture
+    def categories(
+        self,
+        category: PriceCategory,
+        standard: PriceCategory,
+        balcony: PriceCategory,
+        gallery: PriceCategory,
+        matching: PriceCategory,
+    ) -> dict[str, PriceCategory]:
+        return {
+            "premium": category,
+            "standard": standard,
+            "balcony": balcony,
+            "gallery": gallery,
+            "matching": matching,
+        }
+
+    @pytest.mark.parametrize(
+        ("start", "target", "expected_changes", "expected_missing"),
+        [
+            # --- no-ops: nothing moved, nothing to say ---
+            pytest.param("premium", "premium", [], [], id="repaint-same-category-is-a-no-op"),
+            pytest.param(None, None, [], [], id="unpaint-an-unpainted-seat-is-a-no-op"),
+            pytest.param(None, "matching", [], [], id="paint-into-a-category-priced-at-the-flat-price"),
+            pytest.param("balcony", "gallery", [], ["Gallery"], id="unpriced-to-unpriced-moves-no-money"),
+            # --- the silent repricings this report exists for ---
+            pytest.param("premium", "standard", [(1, PREMIUM_PRICE, STANDARD_PRICE)], [], id="priced-to-priced"),
+            pytest.param(None, "premium", [(1, FLAT, PREMIUM_PRICE)], [], id="unpainted-to-priced"),
+            pytest.param("premium", None, [(1, PREMIUM_PRICE, FLAT)], [], id="unpaint-falls-back-to-flat"),
+            # --- crossing the sellable boundary (None == checkout refuses the seat) ---
+            pytest.param("premium", "balcony", [(1, PREMIUM_PRICE, None)], ["Balcony"], id="priced-to-unpriced"),
+            pytest.param(None, "balcony", [(1, FLAT, None)], ["Balcony"], id="unpainted-to-unpriced"),
+            pytest.param("balcony", "standard", [(1, None, STANDARD_PRICE)], [], id="unpriced-to-priced-recovers"),
+            pytest.param("balcony", None, [(1, None, FLAT)], [], id="unpaint-an-unpriced-seat-recovers"),
+        ],
+    )
+    def test_every_transition_lands_in_the_right_bucket(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        categories: dict[str, PriceCategory],
+        start: str | None,
+        target: str | None,
+        expected_changes: list[tuple[int, Decimal | None, Decimal | None]],
+        expected_missing: list[str],
     ) -> None:
-        """The common case: a flat tier on the sector cannot be under-covered."""
+        """The full from-category → to-category table, against one tier."""
+        seat = VenueSeat.objects.create(
+            sector=sector, label="A1", default_price_category=categories[start] if start else None
+        )
+
+        result = _paint(venue, [seat], categories[target] if target else None)
+
+        assert result.painted == 1
+        if not expected_changes and not expected_missing:
+            assert result.affected_tiers == []
+            return
+        reported = result.affected_tiers[0]
+        assert reported.tier_id == priced_tier.id
+        assert [(c.seat_count, c.from_price, c.to_price) for c in reported.price_changes] == expected_changes
+        assert [c.name for c in reported.missing_categories] == expected_missing
+
+    def test_one_paint_reports_every_price_it_moved_seats_away_from(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        standard: PriceCategory,
+    ) -> None:
+        """A paint writes one category but overwrites many, so ``to`` is one price and ``from`` is not."""
+        premium_seats = [
+            VenueSeat.objects.create(sector=sector, label=f"P{i}", default_price_category=category) for i in range(3)
+        ]
+        unpainted = VenueSeat.objects.create(sector=sector, label="U1")
+
+        result = _paint(venue, [*premium_seats, unpainted], standard)
+
+        # Biggest move first, so the frontend can lead with the headline.
+        assert [(c.seat_count, c.from_price, c.to_price) for c in result.affected_tiers[0].price_changes] == [
+            (3, PREMIUM_PRICE, STANDARD_PRICE),
+            (1, FLAT, STANDARD_PRICE),
+        ]
+
+    def test_inactive_seats_are_not_counted_as_repriced(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
+        standard: PriceCategory,
+    ) -> None:
+        """A decommissioned seat cannot be sold, so its price cannot have moved."""
+        active = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+        inactive = VenueSeat.objects.create(sector=sector, label="A2", default_price_category=category, is_active=False)
+
+        result = _paint(venue, [active, inactive], standard)
+
+        assert result.painted == 2
+        assert [c.seat_count for c in result.affected_tiers[0].price_changes] == [1]
+
+    def test_report_names_the_event_and_its_status(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        seated_venue_event: Event,
+        category: PriceCategory,
+        standard: PriceCategory,
+    ) -> None:
+        """The frontend deep-links to the event and ranks a live on-sale above a draft."""
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+
+        reported = _paint(venue, [seat], standard).affected_tiers[0]
+
+        assert (reported.tier_name, reported.event_id, reported.event_name, reported.event_status) == (
+            "Stalls",
+            seated_venue_event.id,
+            seated_venue_event.name,
+            seated_venue_event.status,
+        )
+
+    def test_a_paint_on_another_sector_is_not_reported(
+        self,
+        venue: Venue,
+        sector: VenueSector,
+        priced_tier: TicketTier,
+        standard: PriceCategory,
+    ) -> None:
+        """A tier selling a sector the paint never touched is unaffected by it."""
+        other_sector = VenueSector.objects.create(venue=venue, name="Balcony Sector")
+        seat = VenueSeat.objects.create(sector=other_sector, label="B1")
+
+        assert _paint(venue, [seat], standard).affected_tiers == []
+
+    def test_flat_tier_is_not_reported(
+        self, venue: Venue, sector: VenueSector, seated_venue_event: Event, standard: PriceCategory
+    ) -> None:
+        """The common case: a tier with no price map charges its flat price whatever is painted."""
         _make_tier(seated_venue_event, venue, sector, name="General")
         seat = VenueSeat.objects.create(sector=sector, label="A1")
 
-        assert _paint(venue, [seat], standard).under_covered_tiers == []
-
-    def test_tier_made_under_covered_is_reported(
-        self,
-        venue: Venue,
-        sector: VenueSector,
-        standard: PriceCategory,
-        balcony: PriceCategory,
-        seated_venue_event: Event,
-    ) -> None:
-        """Painting a category the tier does not price names the tier, its event, and the gap."""
-        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
-        tier = _make_tier(seated_venue_event, venue, sector, standard)
-
-        result = _paint(venue, [seat], balcony)
-
-        assert result.painted == 1
-        assert len(result.under_covered_tiers) == 1
-        reported = result.under_covered_tiers[0]
-        assert reported.tier_id == tier.id
-        assert reported.tier_name == "Stalls"
-        assert reported.event_id == seated_venue_event.id
-        assert reported.event_name == seated_venue_event.name
-        assert [(c.id, c.name, c.color) for c in reported.missing_categories] == [(balcony.id, "Balcony", "#00aa00")]
-
-    def test_tier_pricing_everything_is_not_reported(
-        self,
-        venue: Venue,
-        sector: VenueSector,
-        standard: PriceCategory,
-        balcony: PriceCategory,
-        seated_venue_event: Event,
-    ) -> None:
-        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard, balcony)
-
-        assert _paint(venue, [seat], balcony).under_covered_tiers == []
+        assert _paint(venue, [seat], standard).affected_tiers == []
 
     def test_best_available_tier_is_not_reported(
         self,
@@ -307,7 +450,7 @@ class TestPaintUnderCoverageReport:
         balcony: PriceCategory,
         seated_venue_event: Event,
     ) -> None:
-        """Only user-choice tiers read the category map; the rest cannot be under-covered."""
+        """Only user-choice tiers read the category map; the rest cannot be repriced by a paint."""
         seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
         TicketTier.objects.create(
             event=seated_venue_event,
@@ -320,137 +463,116 @@ class TestPaintUnderCoverageReport:
             seat_assignment_mode=TicketTier.SeatAssignmentMode.BEST_AVAILABLE,
         )
 
-        assert _paint(venue, [seat], balcony).under_covered_tiers == []
-
-    def test_tier_on_another_sector_is_not_reported(
-        self,
-        venue: Venue,
-        sector: VenueSector,
-        standard: PriceCategory,
-        balcony: PriceCategory,
-        seated_venue_event: Event,
-    ) -> None:
-        """A tier selling a sector the paint never touched is unaffected by it."""
-        other_sector = VenueSector.objects.create(venue=venue, name="Balcony Sector")
-        other_seat = VenueSeat.objects.create(sector=other_sector, label="B1", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, other_sector, standard, name="Balcony Tier")
-        painted_seat = VenueSeat.objects.create(sector=sector, label="A1")
-
-        result = _paint(venue, [painted_seat], balcony)
-
-        assert result.under_covered_tiers == []
-        other_seat.refresh_from_db()
-        assert other_seat.default_price_category_id == standard.id
+        assert _paint(venue, [seat], balcony).affected_tiers == []
 
     def test_past_event_is_not_reported(
         self,
         venue: Venue,
         sector: VenueSector,
-        standard: PriceCategory,
-        balcony: PriceCategory,
+        priced_tier: TicketTier,
         seated_venue_event: Event,
+        category: PriceCategory,
+        standard: PriceCategory,
     ) -> None:
-        """Nobody can sell a finished event's seats, so its gaps are noise."""
-        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard)
+        """Nobody can sell a finished event's seats, so its prices are noise."""
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
         now = timezone.now()
         Event.objects.filter(pk=seated_venue_event.pk).update(
             start=now - timedelta(days=3), end=now - timedelta(days=2)
         )
 
-        assert _paint(venue, [seat], balcony).under_covered_tiers == []
+        assert _paint(venue, [seat], standard).affected_tiers == []
 
     def test_cancelled_event_is_not_reported(
         self,
         venue: Venue,
         sector: VenueSector,
-        standard: PriceCategory,
-        balcony: PriceCategory,
+        priced_tier: TicketTier,
         seated_venue_event: Event,
+        category: PriceCategory,
+        standard: PriceCategory,
     ) -> None:
-        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard)
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
         Event.objects.filter(pk=seated_venue_event.pk).update(status=Event.EventStatus.CANCELLED)
 
-        assert _paint(venue, [seat], balcony).under_covered_tiers == []
+        assert _paint(venue, [seat], standard).affected_tiers == []
 
-    def test_unpaint_cannot_create_a_gap_and_closes_the_one_it_empties(
+    def test_malformed_price_map_is_skipped_not_raised(
         self,
         venue: Venue,
         sector: VenueSector,
+        priced_tier: TicketTier,
+        category: PriceCategory,
         standard: PriceCategory,
-        balcony: PriceCategory,
-        seated_venue_event: Event,
     ) -> None:
-        """Unpainting removes a category from the sector; it can only ever shrink the gap."""
-        priced_seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
-        drifted = VenueSeat.objects.create(sector=sector, label="A2", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard)
-        assert len(_paint(venue, [drifted], balcony).under_covered_tiers) == 1
+        """A legacy map that will not parse must never turn a paint into a 500 (spec §4.3)."""
+        seat = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
+        TicketTier.objects.filter(pk=priced_tier.pk).update(category_prices={"not-a-uuid": "nope"})
 
-        result = _paint(venue, [drifted], None)
+        result = _paint(venue, [seat], standard)
 
         assert result.painted == 1
-        # The seat now falls back to the tier's flat price — the one legitimate fallback.
-        assert result.under_covered_tiers == []
-        priced_seat.refresh_from_db()
-        assert priced_seat.default_price_category_id == standard.id
+        assert result.affected_tiers == []
 
-    def test_report_is_the_current_gap_not_the_delta(
+    def test_gap_is_the_current_state_price_change_is_the_delta(
         self,
         venue: Venue,
         sector: VenueSector,
-        standard: PriceCategory,
+        priced_tier: TicketTier,
+        category: PriceCategory,
         balcony: PriceCategory,
-        seated_venue_event: Event,
+        standard: PriceCategory,
     ) -> None:
-        """A gap this paint did not open is still a gap: the seats are still unsellable."""
-        stuck = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=standard)
+        """A gap this paint did not open is still a gap; a price this paint did not move is not news."""
+        stuck = VenueSeat.objects.create(sector=sector, label="A1", default_price_category=category)
         other = VenueSeat.objects.create(sector=sector, label="A2", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard)
-        _paint(venue, [stuck], balcony)
+        assert _paint(venue, [stuck], balcony).affected_tiers[0].price_changes  # opens the gap
 
-        # Repainting an unrelated seat into an already-priced category changes nothing,
-        # but the balcony seat is still refused at checkout — say so.
+        # Repainting an unrelated seat into the category it already has moves nothing —
+        # but A1 is still refused at checkout, so the tier is still reported.
         result = _paint(venue, [other], standard)
 
-        assert [c.name for c in result.under_covered_tiers[0].missing_categories] == ["Balcony"]
+        assert result.affected_tiers[0].price_changes == []
+        assert [c.name for c in result.affected_tiers[0].missing_categories] == ["Balcony"]
 
     def test_query_count_does_not_scale_with_seats_painted(
         self,
         venue: Venue,
         sector: VenueSector,
-        standard: PriceCategory,
+        priced_tier: TicketTier,
+        category: PriceCategory,
         balcony: PriceCategory,
-        seated_venue_event: Event,
         django_assert_num_queries: t.Any,
     ) -> None:
         """Painting hundreds of seats must cost the same as painting two.
 
-        The report adds three bounded queries (affected tiers, what is painted on the
-        sectors, the missing categories' names) — none of them per-seat or per-tier.
+        Capturing the seats' prices *before* the UPDATE is the expensive-looking part of
+        #747, and it must not become a per-seat read: one grouped query bounded by
+        (sector × category × is_active) serves the 404 check, the touched sectors, and the
+        prior paint state all at once — one query fewer than #746 needed for the first two.
         """
-        VenueSeat.objects.create(sector=sector, label="anchor", default_price_category=standard)
-        _make_tier(seated_venue_event, venue, sector, standard)
+        VenueSeat.objects.create(sector=sector, label="anchor", default_price_category=category)
 
-        def paint(n: int, category: PriceCategory) -> list[UUID]:
+        def make(n: int, prefix: str) -> list[UUID]:
             seats = VenueSeat.objects.bulk_create(
-                [VenueSeat(sector=sector, label=f"{category.name}-{n}-{i}") for i in range(n)]
+                [VenueSeat(sector=sector, label=f"{prefix}-{i}", default_price_category=category) for i in range(n)]
             )
             return [s.id for s in seats]
 
-        small = paint(2, balcony)
-        with django_assert_num_queries(10):
+        small = make(2, "small")
+        with django_assert_num_queries(9):
             small_result = venue_service.paint_seats(
                 venue, schema.VenueSeatPaintSchema(seat_ids=small, price_category_id=balcony.id)
             )
 
-        large = paint(200, balcony)
-        with django_assert_num_queries(10):
+        large = make(200, "large")
+        with django_assert_num_queries(9):
             large_result = venue_service.paint_seats(
                 venue, schema.VenueSeatPaintSchema(seat_ids=large, price_category_id=balcony.id)
             )
 
-        assert small_result.painted == 2
-        assert large_result.painted == 200
-        assert len(large_result.under_covered_tiers) == 1
+        assert (small_result.painted, large_result.painted) == (2, 200)
+        assert [(c.seat_count, c.from_price, c.to_price) for c in large_result.affected_tiers[0].price_changes] == [
+            (200, PREMIUM_PRICE, None)
+        ]
+        assert [c.name for c in large_result.affected_tiers[0].missing_categories] == ["Balcony"]

--- a/src/events/utils/tier_pricing.py
+++ b/src/events/utils/tier_pricing.py
@@ -117,7 +117,10 @@ def painted_categories(sector_id: t.Any) -> "QuerySet[PriceCategory]":
     ).distinct()
 
 
-def painted_categories_by_sector(sector_ids: t.Collection[t.Any]) -> dict[UUID, set[UUID]]:
+def painted_categories_by_sector(
+    sector_ids: t.Collection[t.Any],
+    exclude_seat_ids: t.Collection[t.Any] = (),
+) -> dict[UUID, set[UUID]]:
     """The multi-sector, grouped form of :func:`painted_categories`, in one query.
 
     Same rule, batched: used when several sectors must be inspected at once (a paint
@@ -125,6 +128,9 @@ def painted_categories_by_sector(sector_ids: t.Collection[t.Any]) -> dict[UUID, 
 
     Args:
         sector_ids: The sectors to inspect.
+        exclude_seat_ids: Seats to leave out. Used by the paint report to read "what
+            everything *else* carries", so the answer does not depend on whether the
+            paint's UPDATE has run yet.
 
     Returns:
         ``{sector_id: {category_id, ...}}``. Sectors with nothing painted are absent.
@@ -132,7 +138,10 @@ def painted_categories_by_sector(sector_ids: t.Collection[t.Any]) -> dict[UUID, 
     grouped: dict[UUID, set[UUID]] = {}
     if not sector_ids:
         return grouped
-    rows = _painted_seats(sector_ids).values_list("sector_id", "default_price_category_id").distinct()
+    seats = _painted_seats(sector_ids)
+    if exclude_seat_ids:
+        seats = seats.exclude(id__in=exclude_seat_ids)
+    rows = seats.values_list("sector_id", "default_price_category_id").distinct()
     for sector_id, category_id in rows:
         grouped.setdefault(sector_id, set()).add(category_id)
     return grouped


### PR DESCRIPTION
Closes #747 when this reaches `main` via #724.

Base is `feature/venue-seating`.

## The gap this closes

Every pricing signal we have triggers on the **absence** of a price: write-time coverage validation, the checkout refusal, `pricing_gaps` on the tier detail, and #746's under-coverage report. So moving a seat between **two categories that are both priced** — Premium €80 → Standard €30 — passes all four in silence and immediately changes what buyers are charged **for every event at that venue**.

Under-coverage **fails closed**: the seat stops selling, a buyer gets a 400, somebody notices. A repricing **fails open**: sales continue at the wrong price. That is the more damaging half, and it was invisible.

## What changed

`under_covered_tiers` becomes `affected_tiers`, with under-coverage demoted from the entry condition to a sub-flag:

```json
{"painted": 1,
 "affected_tiers": [
   {"tier_id": "…", "tier_name": "Stalls",
    "event_id": "…", "event_name": "Gala Night", "event_status": "open",
    "price_changes": [{"seat_count": 1, "from_price": "80.00", "to_price": "30.00"}],
    "missing_categories": []}]}
```

`to_price: null` means "checkout now refuses this seat" — which is what turns under-coverage into a *transition* rather than a separate concept, matching the established `TierCategoryPriceSchema.price` convention.

## Transition table (all eleven are parametrized tests)

| from | to | `price_changes` | `missing_categories` |
|---|---|---|---|
| Premium | Premium | — | — |
| unpainted | unpainted | — | — |
| unpainted | Matching (= flat price) | — | — |
| Balcony | Gallery | — | `[Gallery]` |
| Premium | Standard | `1 × 80.00 → 30.00` | — |
| unpainted | Premium | `1 × 50.00 → 80.00` | — |
| Premium | unpainted | `1 × 80.00 → 50.00` | — |
| Premium | Balcony | `1 × 80.00 → null` | `[Balcony]` |
| unpainted | Balcony | `1 × 50.00 → null` | `[Balcony]` |
| Balcony | Standard | `1 × null → 30.00` | — |
| Balcony | unpainted | `1 × null → 50.00` | — |

The two quiet no-ops matter as much as the noisy cases: a same-category repaint, and painting into a category priced at exactly the flat price, both report nothing. An advisory that fires when nothing changed is the failure mode we are fixing.

## ⚠️ Breaking, and deliberately so

`under_covered_tiers` is **removed**, not deprecated. It shipped on this same unreleased integration branch days ago, so a clean break costs almost nothing now and gets expensive after release. Keeping both would mean two overlapping arrays naming the same tiers, with the FE having to decide which to render when a tier is in both — which is the *common* under-coverage case, since 80.00 → unsellable is also a repricing.

**Frontend migration** (letsrevel/revel-frontend#673): rename the array; the `missing_categories` objects inside each entry are byte-identical. The old list is one expression away:

```ts
affected_tiers.filter(t => t.missing_categories.length)
```

## Performance

The endpoint went from **10 queries to 9**, verified identical for 2 and 200 seats painted.

Capturing the "before" state has to happen before the bulk `UPDATE` overwrites it. One grouped read does it, bounded by (sector × category × is_active) rather than by seat count — and it **subsumes** two queries #746 needed, since the touched-sector set and the 404 count both fall out of the same grouping. `.order_by()` on that query is load-bearing: `VenueSeat.Meta.ordering` would otherwise leak into the `GROUP BY`.

## Safety

- Read-only reporting. No migration. Painting still always succeeds — a malformed legacy price map is skipped per tier rather than turning a paint into a 500.
- Only active seats enter the price report: a decommissioned seat cannot be sold, so its price cannot have moved.
- 1839 service tests green; `test_discount_parity.py` unmodified; `make check` clean.

## Known limits, filed not built

- **The report is after-the-fact.** For an event with live sales, "you just moved 400 seats from €80 to €30" arrives after the money did. A dry-run (`?preview=true`, same payload without the UPDATE) is nearly free given the prior state is already computed before the write — but it needs a product decision on whether the FE gates on it.
- `missing_categories` is the tier's **current** gap while `price_changes` is this paint's delta. Both are correct; the FE must not render them as one sentence.
- Entries are per-tier, so an event with three category-priced tiers on the sector appears three times. Grouping to "N events" is the FE's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Xbu26FXMZmfeGrYLyajNP
