### PR TITLE
feat(events): expose venue metadata on the public seating chart (#755)

### DIFF
--- a/docs/guides/seating/buyer-experience.md
+++ b/docs/guides/seating/buyer-experience.md
@@ -204,7 +204,9 @@ buyer's screen would show at each step:
 
 1. **Buyer opens the seat map.**
    `GET /events/{event_id}/seating/chart` — the full venue layout: sectors, every seat, and the
-   price categories (colors) painted onto them. This is what draws the picture. The prices come
+   price categories (colors) painted onto them, plus the designer's venue-level `metadata`
+   (stage position, floors — see [venue-and-layout.md](venue-and-layout.md)). This is what draws
+   the picture. The prices come
    from the event's tiers: a tier that prices seats by zone returns a `seat_pricing` block — the
    effective price of each zone plus the unpainted fallback — which is what the legend renders.
    A flat tier returns nothing there, and the app shows one price, exactly as before.

--- a/docs/guides/seating/venue-and-layout.md
+++ b/docs/guides/seating/venue-and-layout.md
@@ -282,6 +282,21 @@ constraint, not a future promise.
 The seed data includes a ~1,350-seat theatre with three sector types (open floor, tiered balcony,
 private boxes) as a working reference point. There is no seat-count ceiling in the design.
 
+**"Can we show the stage, or a venue with several floors?"**
+Yes — both live in the venue's free-form `metadata`, written by the layout designer and now
+carried on the buyer-facing chart alongside the per-sector `metadata` that was already there, so
+the buyer's map draws the same picture the designer laid out. Two conventions the designer and the
+buyer map agree on:
+
+- `metadata.stage` — the stage's position/shape, drawn as-is on the map.
+- `metadata.floors` — `[{"id": ..., "name": ..., "order": ...}]`, the venue's floors; a sector says
+  which one it sits on with `metadata.floor = <floor id>`.
+
+Floors are **pure presentation**: they group sectors for display and nothing else. Pricing, zones,
+capacity and holds never look at them. The convention is a shared agreement, not an enforced
+schema — nothing rejects a sector pointing at a floor id the venue doesn't list, and such a sector
+simply has no floor to render under.
+
 **"Is there version history if we redraw the map?"**
 No — this is a known v1 limitation, worth saying plainly rather than glossing over: the seating
 chart is served straight from the live tables, with no snapshot/versioning layer yet. Changing a

--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -41,6 +41,10 @@ class VenueChartSchema(Schema):
     venue_id: UUID
     venue_name: str
     updated_at: AwareDatetime
+    # Venue-level counterpart of ChartSectorSchema.metadata: the layout designer's whole-venue
+    # config (stage position/shape, the `floors` list). Verbatim organizer-written JSON, `null`
+    # when the designer never wrote any — never `{}`.
+    metadata: dict[str, t.Any] | None = None
     price_categories: list[PriceCategorySchema] = Field(default_factory=list)
     sectors: list[ChartSectorSchema] = Field(default_factory=list)
 

--- a/src/events/service/seating/chart.py
+++ b/src/events/service/seating/chart.py
@@ -81,6 +81,7 @@ def build_chart(venue: Venue) -> VenueChartSchema:
         venue_id=venue.id,
         venue_name=venue.name,
         updated_at=venue.chart_version,
+        metadata=venue.metadata,
         price_categories=[PriceCategorySchema.from_orm(c) for c in categories],
         sectors=sector_schemas,
     )

--- a/src/events/tests/test_controllers/test_seating_public.py
+++ b/src/events/tests/test_controllers/test_seating_public.py
@@ -1,5 +1,7 @@
 """Public seating controller: chart, availability, holds (POST/DELETE)."""
 
+import typing as t
+
 import pytest
 from django.test.client import Client
 
@@ -9,6 +11,11 @@ from events.service.guest_hold_session import GUEST_HOLD_COOKIE
 from events.service.seating import holds as holds_service
 
 pytestmark = pytest.mark.django_db
+
+# Whole anonymous chart request: event visibility lookups, the venue row, then build_chart's
+# own prefetches (sectors, seats, price categories). Measured, and unchanged by #755 —
+# ``metadata`` rides on the venue row that is already fetched.
+_CHART_QUERIES = 9
 
 
 def _seated_tier(event: Event, seats: list[VenueSeat], *, paint: bool = True) -> TicketTier:
@@ -58,6 +65,57 @@ def test_chart_serializes_legacy_pair_shape(client: Client, seated_event: tuple[
         {"x": 4.0, "y": 2.0},
         {"x": 0.0, "y": 2.0},
     ]
+
+
+def test_chart_exposes_venue_metadata(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:
+    """The designer's venue-level config (stage, floors) round-trips verbatim to the buyer's map."""
+    event, seats = seated_event
+    venue = event.venue
+    assert venue is not None
+    metadata = {
+        "stage": {"shape": [{"x": 0.0, "y": 0.0}, {"x": 10.0, "y": 0.0}], "label": "Stage"},
+        "floors": [{"id": "ground", "name": "Ground", "order": 0}],
+    }
+    venue.metadata = metadata
+    venue.save(update_fields=["metadata"])
+    sector = seats[0].sector
+    sector.metadata = {"floor": "ground"}
+    sector.save(update_fields=["metadata"])
+
+    resp = client.get(f"/api/events/{event.id}/seating/chart")
+
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["metadata"] == metadata
+    # Same shape at both levels: sector metadata carries the floor id the venue list declares.
+    assert body["sectors"][0]["metadata"] == {"floor": "ground"}
+
+
+def test_chart_metadata_is_null_when_unset(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:
+    """No designer data serialises as ``null`` — never ``{}`` — so the FE has one emptiness check."""
+    event, _seats = seated_event
+    resp = client.get(f"/api/events/{event.id}/seating/chart")
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert "metadata" in body
+    assert body["metadata"] is None
+
+
+def test_chart_query_count_is_unaffected_by_venue_metadata(
+    client: Client, seated_event: tuple[Event, list[VenueSeat]], django_assert_num_queries: t.Any
+) -> None:
+    """``metadata`` rides on the venue row already fetched — the chart budget must not move."""
+    event, _seats = seated_event
+    venue = event.venue
+    assert venue is not None
+    client.get(f"/api/events/{event.id}/seating/chart")  # warm any per-process caches
+    with django_assert_num_queries(_CHART_QUERIES):
+        assert client.get(f"/api/events/{event.id}/seating/chart").status_code == 200
+
+    venue.metadata = {"stage": {"label": "Stage"}}
+    venue.save(update_fields=["metadata"])
+    with django_assert_num_queries(_CHART_QUERIES):
+        assert client.get(f"/api/events/{event.id}/seating/chart").status_code == 200
 
 
 def test_chart_404_when_event_has_no_venue(client: Client, event: Event) -> None:

--- a/src/events/tests/test_service/test_chart_version.py
+++ b/src/events/tests/test_service/test_chart_version.py
@@ -57,6 +57,15 @@ class TestVersionMovesOnEveryWriter:
         venue_service.update_venue(venue, schema.VenueUpdateSchema(name="Renamed Hall"))  # type: ignore[call-arg]
         assert version(venue.id) > before
 
+    def test_update_venue_metadata(self, venue: Venue) -> None:
+        """Venue metadata is on the chart (stage/floors), so editing it must move the poller's version."""
+        before = version(venue.id)
+        venue_service.update_venue(
+            venue,
+            schema.VenueUpdateSchema(metadata={"stage": {"label": "Stage"}}),  # type: ignore[call-arg]
+        )
+        assert version(venue.id) > before
+
     def test_create_price_category(self, venue: Venue) -> None:
         before = version(venue.id)
         venue_service.create_price_category(


### PR DESCRIPTION
## What

Adds one field to the public seating chart: `VenueChartSchema.metadata`.

```jsonc
GET /events/{event_id}/seating/chart
{
  "venue_id": "…", "venue_name": "…", "updated_at": "…",
  "metadata": { "stage": {…}, "floors": [{"id": …, "name": …, "order": …}] } | null,  // NEW
  "price_categories": [...],
  "sectors": [ { …, "metadata": {"floor": "<floor id>"} | null, "seats": [...] } ]
}
```

Same type (`dict[str, t.Any] | None`), same optionality and the same verbatim pass-through as the `ChartSectorSchema.metadata` already on the chart — one consistent shape at both levels. `null` (never `{}`) when the designer never wrote any. **Additive only**: no existing field changes shape or meaning.

The buyer's whole-venue map could not place the real stage: `Venue.metadata` (#736) holds the designer's venue-level config but only the sector-level counterpart was public. Unblocks letsrevel/revel-frontend#679 and #680.

## Notes

- **No new query.** `metadata` rides on the venue row `build_chart` already reads. The anonymous chart request stays at 9 queries — measured on both sides of the change and now pinned by a test.
- **`chart_version` already covers it.** `update_venue` stamps `chart_version` on every write, so a metadata edit moves the buyer's poller version. Verified, and pinned by a new `test_chart_version` case; no code change needed.
- **Floors convention** (issue item 2) is documented, not enforced: `venue.metadata.floors = [{id, name, order}]` + `sector.metadata.floor = <floor id>`, pure presentation (pricing/zones/holds never read it). A sector pointing at an unlisted floor id is not rejected — the guide says so plainly. Validating it would change the admin write contract, which is out of scope here.
- **Exposure**: the write path (`VenueCreateSchema`/`VenueUpdateSchema.metadata`, org-admin only) does no shape/size/depth validation beyond Django's 5 MB body cap. That is the pre-existing contract, unchanged — and identical to the sector metadata already public on this endpoint, so this adds no new class of exposure.

## Tests

`test_seating_public.py`: metadata round-trips verbatim (venue + sector floor id); `null` when unset; chart query count unchanged. `test_chart_version.py`: a metadata edit moves the version.

Green: `make format lint mypy file-length migration-check`, `mkdocs build --strict`, and the seating chart / public seating / venue admin / availability / box-office / tier-pricing suites (205 tests).

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Xbu26FXMZmfeGrYLyajNP