### PR TITLE
chore: three small v3 debt cleanups (dead code, i18n)

### DIFF
--- a/src/events/models/venue.py
+++ b/src/events/models/venue.py
@@ -2,6 +2,7 @@ import typing as t
 
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from common.models import TimeStampedModel
 
@@ -156,8 +157,8 @@ class VenueSector(TimeStampedModel):
     """
 
     class Kind(models.TextChoices):
-        SEATED = "seated", "Seated"
-        STANDING = "standing", "Standing"
+        SEATED = "seated", _("Seated")
+        STANDING = "standing", _("Standing")
 
     venue = models.ForeignKey(
         Venue,

--- a/src/events/service/attendee_invoice_service.py
+++ b/src/events/service/attendee_invoice_service.py
@@ -330,7 +330,7 @@ def update_draft_invoice(
 
     disallowed = set(update_data.keys()) - EDITABLE_DRAFT_FIELDS
     if disallowed:
-        raise HttpError(422, f"Cannot edit fields: {', '.join(sorted(disallowed))}")
+        raise HttpError(422, str(_("Cannot edit fields: {fields}")).format(fields=", ".join(sorted(disallowed))))
 
     # Normalize line_items to ensure string values (schema sends Decimals)
     if "line_items" in update_data:

--- a/src/events/service/attendee_vat_service.py
+++ b/src/events/service/attendee_vat_service.py
@@ -378,9 +378,9 @@ def _resolve_line_pricing(
 
     if price_per_ticket is not None:
         if tier.pwyc_min and price_per_ticket < tier.pwyc_min:
-            raise HttpError(400, f"PWYC amount must be at least {tier.pwyc_min}")
+            raise HttpError(400, str(_("PWYC amount must be at least {min_amount}")).format(min_amount=tier.pwyc_min))
         if tier.pwyc_max and price_per_ticket > tier.pwyc_max:
-            raise HttpError(400, f"PWYC amount must be at most {tier.pwyc_max}")
+            raise HttpError(400, str(_("PWYC amount must be at most {max_amount}")).format(max_amount=tier.pwyc_max))
         return build_batch_pricing(tier, seats, pwyc_amount=price_per_ticket)
 
     dc = None

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1166,6 +1166,12 @@ msgstr "Ein inaktiver Sitzplatz kann nicht zugewiesen werden."
 msgid "Seat must belong to the specified sector."
 msgstr "Der Sitzplatz muss zum angegebenen Sektor gehören."
 
+msgid "Seated"
+msgstr "Sitzplätze"
+
+msgid "Standing"
+msgstr "Stehplätze"
+
 msgid "Address visible to invited guests only"
 msgstr "Adresse nur für eingeladene Gäste sichtbar"
 
@@ -1180,6 +1186,10 @@ msgstr "Adresse nur für Teilnehmer:innen sichtbar"
 
 msgid "Only draft invoices can be edited."
 msgstr "Nur Rechnungsentwürfe können bearbeitet werden."
+
+#, python-brace-format
+msgid "Cannot edit fields: {fields}"
+msgstr "Diese Felder können nicht bearbeitet werden: {fields}"
 
 msgid "Cancelled invoices cannot be issued."
 msgstr "Stornierte Rechnungen können nicht ausgestellt werden."

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -1168,6 +1168,12 @@ msgstr "Impossible d'attribuer un siège inactif."
 msgid "Seat must belong to the specified sector."
 msgstr "Le siège doit appartenir au secteur spécifié."
 
+msgid "Seated"
+msgstr "Places assises"
+
+msgid "Standing"
+msgstr "Places debout"
+
 msgid "Address visible to invited guests only"
 msgstr "Adresse visible uniquement par les personnes invité·e·s"
 
@@ -1182,6 +1188,10 @@ msgstr "Adresse visible uniquement par les participant·e·s"
 
 msgid "Only draft invoices can be edited."
 msgstr "Seules les factures au statut de brouillon peuvent être modifiées."
+
+#, python-brace-format
+msgid "Cannot edit fields: {fields}"
+msgstr "Impossible de modifier les champs : {fields}"
 
 msgid "Cancelled invoices cannot be issued."
 msgstr "Les factures annulées ne peuvent pas être émises."

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -1140,6 +1140,12 @@ msgstr "Non è possibile assegnare un posto non attivo."
 msgid "Seat must belong to the specified sector."
 msgstr "Il posto deve appartenere al settore specificato."
 
+msgid "Seated"
+msgstr "Posti a sedere"
+
+msgid "Standing"
+msgstr "Posti in piedi"
+
 msgid "Address visible to invited guests only"
 msgstr "Indirizzo visibile solo agli ospiti invitati"
 
@@ -1154,6 +1160,10 @@ msgstr "Indirizzo visibile solo ai partecipanti"
 
 msgid "Only draft invoices can be edited."
 msgstr "Solo le fatture in bozza possono essere modificate."
+
+#, python-brace-format
+msgid "Cannot edit fields: {fields}"
+msgstr "Impossibile modificare i campi: {fields}"
 
 msgid "Cancelled invoices cannot be issued."
 msgstr "Le fatture annullate non possono essere emesse."

--- a/src/wallet/apple/generator.py
+++ b/src/wallet/apple/generator.py
@@ -314,7 +314,7 @@ class ApplePassGenerator:
             Tuple of (price, currency).
         """
         tier = ticket.tier
-        currency = tier.currency if tier else "EUR"
+        currency = tier.currency
 
         if ticket.price_paid is not None:
             return ticket.price_paid, currency


### PR DESCRIPTION
Three small, independent cleanups on top of `feature/venue-seating`.

### 1. `wallet/apple/generator.py` — delete unreachable null-tier fallback
`Ticket.tier` is a non-nullable FK (`events/models/ticket.py`, and `events_ticket.tier_id` is `NOT NULL` in the DB — no migration ever made it nullable, no construction site passes `tier=None`), so the `else` branch of `tier.currency if tier else "EUR"` in `_resolve_price` could never run. Removed.

The originally-flagged `tier.price if tier else Decimal(0)` had already been replaced by `recorded_or_resolved_price(...)` in #754; the currency fallback was the survivor of the same review note.

Not touched (pre-existing, same dead pattern, different function — flagged rather than deleted per the surgical-changes rule): `_build_pass_data`'s `if ticket.tier and …` guards and `ticket.tier.name if ticket.tier else "General Admission"`.

### 2. Wrap user-facing error strings for translation
- `attendee_vat_service._resolve_effective_price` — the two PWYC bound errors.
- `attendee_invoice_service.update_draft_invoice` — `Cannot edit fields: …`.

Follows the `str(_(msgid)).format(named=…)` idiom from `events/service/seating/pick.py` / `pricing.py` (translate first, interpolate second, named placeholders). The PWYC msgids are the ones already used by `events/service/guest.py` and `events/controllers/event_public/tickets.py`, so they reuse existing translations — only `"Cannot edit fields: {fields}"` is a new msgid.

### 3. Translate `VenueSector.Kind` labels
`"Seated"` / `"Standing"` are now `gettext_lazy`.

**No API contract change.** Django choice *labels* are display text; the OpenAPI enum serialises the *values*. Verified by dumping `.artifacts/openapi.json` before and after: `Kind` remains `{"enum": ["seated", "standing"], "type": "string"}` and the two specs are byte-identical apart from the `operationId` hash suffixes, which were confirmed to differ run-to-run on an unchanged tree (pre-existing `PYTHONHASHSEED` noise). `make migration-check` reports no missing migration.

### i18n
`make makemessages` → translated the three new msgids into it/de/fr → `make compilemessages`. Only `.po` committed (`.mo` is gitignored, ADR-0011).

gettext's fuzzy suggestion mapped `"Standing"` onto `"Pending"` ("In sospeso" / "Ausstehend" / "En attente") in all three catalogs — discarded and translated fresh. `msgattrib` per language: **0 fuzzy, 0 untranslated** (it, de, fr).

### Verification
- `make format`, `make lint`, `make mypy`, `make file-length`, `make i18n-check`, `make migration-check` — all green.
- Catalogs compiled before running pytest. Affected suites only: `wallet/tests`, attendee VAT/invoice service + endpoints, venue models/service/admin-venue controllers, VAT preview seating, coordinate2d schema, tier category prices, events admin — **513 passed**.
- `test_discount_parity.py` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Xbu26FXMZmfeGrYLyajNP