### PR TITLE
refactor(wallet): drop unreachable null-tier branches in _build_pass_data

### DIFF
--- a/src/wallet/apple/generator.py
+++ b/src/wallet/apple/generator.py
@@ -245,7 +245,7 @@ class ApplePassGenerator:
 
         # Extract venue (from tier's venue, ticket's venue, or event's venue)
         venue = None
-        if ticket.tier and ticket.tier.venue:
+        if ticket.tier.venue:
             venue = ticket.tier.venue
         elif ticket.venue:
             venue = ticket.venue
@@ -255,7 +255,7 @@ class ApplePassGenerator:
 
         # Extract sector name (from tier's sector or ticket's sector)
         sector_name: str | None = None
-        if ticket.tier and ticket.tier.sector:
+        if ticket.tier.sector:
             sector_name = ticket.tier.sector.name
         elif ticket.sector:
             sector_name = ticket.sector.name
@@ -272,7 +272,7 @@ class ApplePassGenerator:
             event_end=event.end,
             event_tz=get_event_timezone(event),
             address=(venue.full_address() if venue else None) or event.address or None,
-            ticket_tier=ticket.tier.name if ticket.tier else "General Admission",
+            ticket_tier=ticket.tier.name,
             ticket_price=ticket_price,
             colors=get_theme_colors(),
             logo_image=logo_image,


### PR DESCRIPTION
## What

Removes three dead `... if ticket.tier else ...` branches in `src/wallet/apple/generator.py` (`_build_pass_data`, lines 248/258/275):

- `if ticket.tier and ticket.tier.venue:` → `if ticket.tier.venue:`
- `if ticket.tier and ticket.tier.sector:` → `if ticket.tier.sector:`
- `ticket_tier=ticket.tier.name if ticket.tier else "General Admission"` → `ticket_tier=ticket.tier.name`

## Why

`Ticket.tier` is a non-nullable FK (`src/events/models/ticket.py:665` — `models.ForeignKey(TicketTier, on_delete=models.CASCADE, related_name="tickets")`, no `null=True`), so the else/short-circuit paths were unreachable. `_build_pass_data` only ever receives a `Ticket`, so all three sites are genuinely dead.

Surfaced in PR review of the seating branch — no issue filed. Same rationale and style as the `_resolve_price` cleanup that already landed in #762 ("drop unreachable null-tier fallback").

The remaining `ticket.tier.venue` / `ticket.tier.sector` checks stay: `TicketTier.venue`/`.sector` are nullable (`null=True`, `on_delete=SET_NULL`).

## Evidence / verification

- All 167 wallet tests pass (`DB_NAME=revel_wallet uv run pytest src/wallet/tests/`)
- `generator.py` coverage unchanged at 91% before/after (coverage.py doesn't trace short-circuit `and` arcs or conditional expressions, so the dead code was invisible to it; still above the 90% bar)
- `make check` green (format, lint, mypy --strict, migrations, i18n, file-length, task-names)
- `uv run mkdocs build --strict` green
- No test references the "General Admission" fallback in wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)