### PR TITLE
chore: make backend Prometheus-multiproc-ready, gated on PROMETHEUS_MULTIPROC_DIR

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -180,12 +180,33 @@ increase(revel_stripe_session_paid_without_payments_total[5m]) > 0
 Each increment is paired with a self-contained `ERROR` log line carrying the identifiers to
 act on — see [the money-correctness runbook](#money-correctness-stripe-session-total-mismatch).
 
-!!! warning "Counters are per gunicorn worker"
+!!! warning "Counters are per gunicorn worker until multiproc lands in deployment"
     Production runs several gunicorn workers with no `PROMETHEUS_MULTIPROC_DIR`, so each
     worker keeps its own counters and a scrape reaches one of them. That is fine for
     "did this ever happen" alerting — the incremented worker holds its non-zero value and is
-    eventually scraped — but these values are **not** exact rates. Only define
-    alert-on-any-occurrence metrics here until multiprocess mode is configured.
+    eventually scraped — but these values are **not** exact rates. Until the deployment half
+    of [#757](https://github.com/letsrevel/revel-backend/issues/757)
+    (tracked as [letsrevel/infra#35](https://github.com/letsrevel/infra/issues/35)) sets the
+    env var, **every alert or dashboard built on these metrics must be a presence check
+    (`increase(...) > 0`) — never a rate or an absolute count.** Only define
+    alert-on-any-occurrence metrics here until then.
+
+    The backend is already multiproc-ready; everything is gated on the
+    `PROMETHEUS_MULTIPROC_DIR` env var and inert while it is unset:
+
+    - `prometheus_client` switches metric storage to per-process mmap files in that
+      directory automatically (the env var is read at import time, so it must be set in the
+      container environment — it cannot be turned on from Django settings).
+    - `django_prometheus`' `/metrics` view detects the env var per request and serves the
+      aggregated `MultiProcessCollector` registry instead of the in-process one.
+    - `src/gunicorn.conf.py` (auto-loaded by gunicorn from its working directory) wipes
+      stale metric files when the master starts and runs
+      `multiprocess.mark_process_dead()` on `child_exit`.
+
+    Once deployment sets the env var and mounts a writable shared directory (tmpfs) for it,
+    rates and absolute counts become trustworthy. One trade-off: the default per-process
+    collectors (`process_*`, `python_gc_*`, `python_info`) disappear from `/metrics`, as
+    they only exist on the in-process registry.
 
 ---
 

--- a/src/common/tests/test_prometheus_multiproc.py
+++ b/src/common/tests/test_prometheus_multiproc.py
@@ -1,0 +1,151 @@
+"""Tests for Prometheus multiprocess support (#757).
+
+Two halves, both gated on the ``PROMETHEUS_MULTIPROC_DIR`` env var:
+
+- The ``/metrics`` view behaviour we depend on from the installed libraries,
+  pinned here so an upgrade that breaks it fails loudly: with the env var
+  unset the default in-process registry is served (today's behaviour); with
+  it set, ``django_prometheus.exports.ExportToDjangoView`` serves a fresh
+  registry backed by ``prometheus_client.multiprocess.MultiProcessCollector``,
+  aggregating the mmap files that every worker process writes.
+- The gunicorn hooks in ``src/gunicorn.conf.py`` (auto-loaded by gunicorn from
+  its working directory): wipe stale files when the master starts, clean up
+  live-gauge files when a worker dies. Both must be no-ops when the env var
+  is unset.
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+import typing as t
+from pathlib import Path
+
+import pytest
+
+SRC_DIR = Path(__file__).resolve().parents[2]
+GUNICORN_CONF = SRC_DIR / "gunicorn.conf.py"
+
+# A minimal script for a child process: import prometheus_client under
+# PROMETHEUS_MULTIPROC_DIR (so ValueClass resolves to MmapedValue at import
+# time, exactly as in a gunicorn worker) and increment a counter.
+_CHILD_SCRIPT = """
+import sys
+from prometheus_client import Counter
+
+Counter("demo_multiproc", "Cross-process demo counter").inc(float(sys.argv[1]))
+"""
+
+
+def _load_gunicorn_conf() -> types.ModuleType:
+    """Load src/gunicorn.conf.py as a module (its name is not importable)."""
+    spec = importlib.util.spec_from_file_location("gunicorn_conf", GUNICORN_CONF)
+    assert spec is not None and spec.loader is not None, f"missing {GUNICORN_CONF}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _increment_counter_in_subprocess(multiproc_dir: Path, amount: float) -> None:
+    """Increment the demo counter from a separate process (its own pid file)."""
+    env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": str(multiproc_dir)}
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _CHILD_SCRIPT, str(amount)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+
+class _FakeWorker:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
+# ---------------------------------------------------------------------------
+# /metrics view behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_metrics_view_serves_default_registry_without_env_var(client: t.Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset env var: today's behaviour — the in-process default registry."""
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    body = response.content
+    # Registered on the default in-process registry at import time.
+    assert b"revel_stripe_session_total_mismatch" in body
+    assert b"demo_multiproc_total" not in body
+
+
+@pytest.mark.django_db
+def test_metrics_view_serves_multiprocess_registry_with_env_var(
+    client: t.Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Set env var: the view aggregates mmap files from all worker processes."""
+    _increment_counter_in_subprocess(tmp_path, 3)
+    _increment_counter_in_subprocess(tmp_path, 4)
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    body = response.content
+    # Values written by two distinct processes are summed in one scrape.
+    assert b"demo_multiproc_total 7.0" in body
+    # And it is the multiprocess registry, not the in-process default one:
+    # platform/process collectors only live on the default registry.
+    assert b"python_info" not in body
+
+
+# ---------------------------------------------------------------------------
+# gunicorn.conf.py hooks
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_are_noops_without_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without the env var both hooks return without touching anything."""
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    conf = _load_gunicorn_conf()
+    stray = tmp_path / "counter_1.db"
+    stray.touch()
+    conf.on_starting(None)
+    conf.child_exit(None, _FakeWorker(pid=1))
+    assert stray.exists()
+
+
+def test_on_starting_wipes_stale_metric_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Master start wipes leftover *.db files from a previous run."""
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    stale = [tmp_path / "counter_123.db", tmp_path / "gauge_all_456.db"]
+    for f in stale:
+        f.touch()
+    unrelated = tmp_path / "not-a-metric.txt"
+    unrelated.touch()
+
+    conf = _load_gunicorn_conf()
+    conf.on_starting(None)
+
+    assert not any(f.exists() for f in stale)
+    assert unrelated.exists()
+
+
+def test_child_exit_removes_dead_workers_live_gauge_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Worker death removes its live-gauge files; counter files must survive."""
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    live = [tmp_path / "gauge_livesum_123.db", tmp_path / "gauge_liveall_123.db"]
+    for f in live:
+        f.touch()
+    keep = [
+        tmp_path / "counter_123.db",  # counters are monotonic totals
+        tmp_path / "gauge_livesum_999.db",  # other, still-alive worker
+    ]
+    for f in keep:
+        f.touch()
+
+    conf = _load_gunicorn_conf()
+    conf.child_exit(None, _FakeWorker(pid=123))
+
+    assert not any(f.exists() for f in live)
+    assert all(f.exists() for f in keep)

--- a/src/gunicorn.conf.py
+++ b/src/gunicorn.conf.py
@@ -1,0 +1,52 @@
+"""Gunicorn configuration, auto-loaded from the working directory.
+
+Gunicorn reads ``./gunicorn.conf.py`` from its working directory when no
+``-c`` flag is given. Production runs gunicorn from ``/app/src`` (the image's
+``WORKDIR``) and ``make run-e2e`` runs it from ``src/``, so this file applies
+to both without any change to the launch command.
+
+Its only job is Prometheus multiprocess hygiene (#757). Both hooks are no-ops
+unless ``PROMETHEUS_MULTIPROC_DIR`` is set, so behaviour is unchanged until
+the deployment half (letsrevel/infra#35) sets the env var and mounts a
+writable shared directory for the metric files.
+"""
+
+import glob
+import os
+import typing as t
+
+
+def on_starting(server: t.Any) -> None:
+    """Wipe stale metric files before any worker starts.
+
+    ``prometheus_client`` requires the multiprocess directory to be emptied
+    whenever the gunicorn master (re)starts: leftover mmap files from a
+    previous run would otherwise be merged into every scrape forever.
+
+    Args:
+        server: The gunicorn Arbiter instance (unused).
+    """
+    multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if not multiproc_dir:
+        return
+    for path in glob.glob(os.path.join(multiproc_dir, "*.db")):
+        os.remove(path)
+
+
+def child_exit(server: t.Any, worker: t.Any) -> None:
+    """Clean up a dead worker's live-gauge metric files.
+
+    ``multiprocess.mark_process_dead`` removes only ``gauge_live*_<pid>.db``
+    files; counter/histogram files persist by design so totals never go
+    backwards. Relevant here because ``--max-requests`` recycles workers
+    routinely.
+
+    Args:
+        server: The gunicorn Arbiter instance (unused).
+        worker: The exited worker; only ``worker.pid`` is used.
+    """
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)  # type: ignore[no-untyped-call]


### PR DESCRIPTION
## What

Backend half of the Prometheus multiprocess fix (#757). Counters are currently per-gunicorn-worker because `PROMETHEUS_MULTIPROC_DIR` is not set; the deployment half is tracked in letsrevel/infra#35.

Changes:

- **`src/gunicorn.conf.py`** (new) — gunicorn auto-loads `./gunicorn.conf.py` from its working directory (`/app/src` in the image, `src/` in `make run-e2e`), so no launch-command change is needed anywhere. Two hooks, both no-ops while the env var is unset:
  - `on_starting`: wipes stale `*.db` metric files when the master starts (required by `prometheus_client` for the multiproc dir).
  - `child_exit`: `multiprocess.mark_process_dead(worker.pid)` — removes a dead worker's live-gauge files; matters because `--max-requests 4000` recycles workers routinely.
- **`docs/guides/observability.md`** — until infra#35 lands, every alert/dashboard on these metrics must be a presence check (`increase(...) > 0`), never a rate or absolute count; documents what changes once the env var is set.
- **Tests** (`src/common/tests/test_prometheus_multiproc.py`) — pin both hook behaviour and the library behaviour we depend on.

## Why so small: the libraries already do the heavy lifting

No settings/registry/export-view change is needed. Evidence from the installed code:

**`prometheus_client` 0.25.0, `values.py`** — storage backend is chosen from the env var at import time; when set, every metric value is a per-process mmap file in that directory:

```python
def get_value_class():
    # This needs to be chosen before the first metric is constructed, ...
    if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
        return MultiProcessValue()
    else:
        return MutexValue

ValueClass = get_value_class()
```

Consequence: the env var **must be set in the container environment before Python starts** — it cannot be turned on from Django settings, which is why there is no settings change here.

**`django_prometheus` 2.5.0, `exports.py::ExportToDjangoView`** (our `/metrics` view via `django_prometheus.urls`) — already multiproc-aware, per request:

```python
if "PROMETHEUS_MULTIPROC_DIR" in os.environ or "prometheus_multiproc_dir" in os.environ:
    registry = prometheus_client.CollectorRegistry()
    multiprocess.MultiProcessCollector(registry)
else:
    registry = prometheus_client.REGISTRY
```

**`prometheus_client`, `multiprocess.py::mark_process_dead`** — only removes `gauge_live*_<pid>.db` files (counters persist by design, so totals never go backwards), which is exactly why the `child_exit` hook is the right cleanup and why the multiproc dir must be wiped on master start:

```python
def mark_process_dead(pid, path=None):
    ...
    for mode in _LIVE_GAUGE_MULTIPROCESS_MODES:
        for f in glob.glob(os.path.join(path, f'gauge_{mode}_{pid}.db')):
            os.remove(f)
```

**gunicorn 26.0.0, `config.py::get_default_config_file`** — `./gunicorn.conf.py` in the cwd is loaded when no `-c` is given (`app/base.py` lines 177–179), and the production command in `infra/docker-compose.yml` passes no `-c`; verified locally with `gunicorn --print-config` showing `config = ./gunicorn.conf.py` and both hooks bound.

## Test evidence

Run with the hooks file absent (pre-implementation):

- `test_metrics_view_serves_default_registry_without_env_var` — **passed** (env unset ⇒ today's behaviour, in-process registry).
- `test_metrics_view_serves_multiprocess_registry_with_env_var` — **passed with no backend change**: two real subprocesses each increment a counter (3 and 4) under `PROMETHEUS_MULTIPROC_DIR`; `/metrics` then serves `demo_multiproc_total 7.0` and no `python_info` (proof it is the aggregated multiproc registry, not the default one).
- The three `gunicorn.conf.py` hook tests — **failed** (file missing), then pass after adding it. Hooks verified inert with the env var unset.

`make check` and `uv run mkdocs build --strict` are green. One known trade-off once multiproc is live: the default per-process collectors (`process_*`, `python_gc_*`, `python_info`) disappear from `/metrics` — they only exist on the in-process registry.

## Deployment contract

Spelled out for infra in a comment on letsrevel/infra#35 (env var on the web service only, tmpfs mount, no command change needed — the hooks ship in the image).

Refs #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)