### PR TITLE
chore(i18n): translate model validation messages outside the seating surface

### DIFF
--- a/src/events/models/discount_code.py
+++ b/src/events/models/discount_code.py
@@ -3,6 +3,7 @@ import typing as t
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from common.models import TimeStampedModel
 
@@ -156,16 +157,16 @@ class DiscountCode(TimeStampedModel):
 
         # Validate date range
         if self.valid_from and self.valid_until and self.valid_from >= self.valid_until:
-            raise ValidationError({"valid_until": "valid_until must be after valid_from."})
+            raise ValidationError({"valid_until": _("valid_until must be after valid_from.")})
 
         # Validate percentage range
         if self.discount_type == self.DiscountType.PERCENTAGE:
             if self.discount_value > Decimal("100"):
-                raise ValidationError({"discount_value": "Percentage discount cannot exceed 100."})
+                raise ValidationError({"discount_value": _("Percentage discount cannot exceed 100.")})
 
         # Validate currency for FIXED_AMOUNT
         if self.discount_type == self.DiscountType.FIXED_AMOUNT and not self.currency:
-            raise ValidationError({"currency": "Currency is required for fixed amount discounts."})
+            raise ValidationError({"currency": _("Currency is required for fixed amount discounts.")})
 
     def __str__(self) -> str:
         return f"{self.code} ({self.organization})"

--- a/src/events/models/event.py
+++ b/src/events/models/event.py
@@ -8,6 +8,7 @@ from django.contrib.gis.db import models
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import BooleanField, Exists, OuterRef, Prefetch, Q, Value
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from pydantic import ValidationError as PydanticValidationError
 
 from accounts.models import RevelUser
@@ -584,23 +585,23 @@ class Event(
         if self.event_series and self.event_series.organization_id != self.organization_id:
             raise DjangoValidationError(
                 {
-                    "event_series": "Event series must belong to the same organization as the event.",
+                    "event_series": _("Event series must belong to the same organization as the event."),
                 }
             )
         if self.end and self.end < self.start:
-            raise DjangoValidationError({"end": "End date must be after start date."})
+            raise DjangoValidationError({"end": _("End date must be after start date.")})
 
         # Validate check-in window
         if self.check_in_starts_at and self.check_in_ends_at:
             if self.check_in_ends_at <= self.check_in_starts_at:
                 raise DjangoValidationError(
-                    {"check_in_ends_at": "Check-in end time must be after check-in start time."}
+                    {"check_in_ends_at": _("Check-in end time must be after check-in start time.")}
                 )
 
         # Validate venue belongs to the same organization
         venue = self.venue
         if venue and venue.organization_id != self.organization_id:
-            raise DjangoValidationError({"venue": "Venue must belong to the same organization as the event."})
+            raise DjangoValidationError({"venue": _("Venue must belong to the same organization as the event.")})
 
         # Validate the display-only schedule blob (also guards the admin raw-JSON widget).
         try:
@@ -613,18 +614,18 @@ class Event(
     def _clean_waitlist_config(self) -> None:
         if self.waitlist_time_window is not None:
             if self.waitlist_time_window < timedelta(hours=1):
-                raise DjangoValidationError({"waitlist_time_window": "Time window must be at least 1 hour."})
+                raise DjangoValidationError({"waitlist_time_window": _("Time window must be at least 1 hour.")})
             if self.waitlist_time_window > timedelta(days=7):
-                raise DjangoValidationError({"waitlist_time_window": "Time window cannot exceed 7 days."})
+                raise DjangoValidationError({"waitlist_time_window": _("Time window cannot exceed 7 days.")})
 
         if self.waitlist_cutoff_date is None:
             return
         if self.waitlist_time_window is None:
             raise DjangoValidationError(
-                {"waitlist_cutoff_date": "Cutoff date requires waitlist_time_window to be set."}
+                {"waitlist_cutoff_date": _("Cutoff date requires waitlist_time_window to be set.")}
             )
         if self.start and self.waitlist_cutoff_date >= self.start:
-            raise DjangoValidationError({"waitlist_cutoff_date": "Cutoff date must be before event start."})
+            raise DjangoValidationError({"waitlist_cutoff_date": _("Cutoff date must be before event start.")})
 
     def is_check_in_open(self) -> bool:
         """Check if check-in is currently open for this event."""

--- a/src/events/models/organization.py
+++ b/src/events/models/organization.py
@@ -683,7 +683,7 @@ class OrganizationMember(TimeStampedModel):
         """Validate that tier belongs to the same organization."""
         super().clean()
         if self.tier and self.tier.organization_id != self.organization_id:
-            raise DjangoValidationError({"tier": "The tier must belong to the same organization as the membership."})
+            raise DjangoValidationError({"tier": _("The tier must belong to the same organization as the membership.")})
 
 
 class OrganizationToken(TokenMixin):

--- a/src/events/models/series_pass.py
+++ b/src/events/models/series_pass.py
@@ -5,6 +5,7 @@ from django.contrib.gis.db import models
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MinValueValidator
+from django.utils.translation import gettext_lazy as _
 
 from common.fields import MarkdownField, ProtectedFileField
 from common.models import TimeStampedModel
@@ -64,12 +65,14 @@ class SeriesPass(TimeStampedModel, VisibilityMixin):
         """Reject unsupported payment methods, inconsistent purchasable_by values, and unsafe field changes."""
         super().clean()
         if self.payment_method == TicketTier.PaymentMethod.AT_THE_DOOR:
-            raise DjangoValidationError({"payment_method": "At-the-door payment is not supported for series passes."})
+            raise DjangoValidationError(
+                {"payment_method": _("At-the-door payment is not supported for series passes.")}
+            )
         if self.purchasable_by in (
             TicketTier.PurchasableBy.INVITED,
             TicketTier.PurchasableBy.INVITED_AND_MEMBERS,
         ):
-            raise DjangoValidationError({"purchasable_by": "Series passes cannot be invitation-restricted."})
+            raise DjangoValidationError({"purchasable_by": _("Series passes cannot be invitation-restricted.")})
         if self.pk:
             old = SeriesPass.objects.filter(pk=self.pk).values("currency", "payment_method").first()
             if old is None:
@@ -77,7 +80,7 @@ class SeriesPass(TimeStampedModel, VisibilityMixin):
             # Tier links are validated against the pass currency at link time;
             # changing it afterwards would silently break that contract.
             if self.currency != old["currency"] and self.tier_links.exists():
-                raise DjangoValidationError({"currency": "Currency cannot be changed once the pass covers events."})
+                raise DjangoValidationError({"currency": _("Currency cannot be changed once the pass covers events.")})
             # Held passes were purchased (and their tickets materialized) under
             # the original payment semantics; switching mid-flight would corrupt
             # confirmation/refund flows for existing holders.
@@ -85,7 +88,7 @@ class SeriesPass(TimeStampedModel, VisibilityMixin):
                 self.held_passes.exclude(status=HeldSeriesPass.HeldSeriesPassStatus.CANCELLED).exists()
             ):
                 raise DjangoValidationError(
-                    {"payment_method": "Payment method cannot be changed while the pass has holders."}
+                    {"payment_method": _("Payment method cannot be changed while the pass has holders.")}
                 )
 
 
@@ -109,17 +112,17 @@ class SeriesPassTierLink(TimeStampedModel):
         super().clean()
         try:
             if self.tier.event_id != self.event_id:
-                raise DjangoValidationError({"tier": "Tier must belong to the covered event."})
+                raise DjangoValidationError({"tier": _("Tier must belong to the covered event.")})
             if self.event.event_series_id != self.series_pass.event_series_id:
-                raise DjangoValidationError({"event": "Event must belong to the pass's series."})
+                raise DjangoValidationError({"event": _("Event must belong to the pass's series.")})
             if self.tier.currency != self.series_pass.currency:
-                raise DjangoValidationError({"tier": "Tier currency must match the pass currency."})
+                raise DjangoValidationError({"tier": _("Tier currency must match the pass currency.")})
             if self.tier.seat_assignment_mode != TicketTier.SeatAssignmentMode.NONE:
-                raise DjangoValidationError({"tier": "Assigned-seating tiers cannot back a series pass."})
+                raise DjangoValidationError({"tier": _("Assigned-seating tiers cannot back a series pass.")})
             if self.tier.price_type == TicketTier.PriceType.PWYC:
                 # A pass has one fixed price; PWYC per-ticket price semantics don't
                 # compose with materialized pass tickets (nothing is paid per ticket).
-                raise DjangoValidationError({"tier": "Pay What You Can tiers cannot back a series pass."})
+                raise DjangoValidationError({"tier": _("Pay What You Can tiers cannot back a series pass.")})
         except ObjectDoesNotExist:
             # A nonexistent tier/event/series id: clean_fields() (run by full_clean()
             # just before clean()) already recorded the FK-existence check as a

--- a/src/events/models/ticket.py
+++ b/src/events/models/ticket.py
@@ -397,17 +397,19 @@ class TicketTier(TimeStampedModel, VisibilityMixin):
         """Validate sales window constraints."""
         if self.sales_start_at and self.sales_start_at > self.event.start:
             raise DjangoValidationError(
-                {"sales_start_at": "Ticket sales must start before or at the event start time."}
+                {"sales_start_at": _("Ticket sales must start before or at the event start time.")}
             )
         if self.sales_start_at and self.sales_end_at and self.sales_end_at <= self.sales_start_at:
-            raise DjangoValidationError({"sales_end_at": "Ticket sales end time must be after the sales start time."})
+            raise DjangoValidationError(
+                {"sales_end_at": _("Ticket sales end time must be after the sales start time.")}
+            )
 
     def _validate_pwyc(self) -> None:
         """Validate pay-what-you-can pricing constraints."""
         if self.price_type == self.PriceType.PWYC:
             if self.pwyc_max and self.pwyc_max < self.pwyc_min:
                 raise DjangoValidationError(
-                    {"pwyc_max": "Maximum pay-what-you-can amount must be greater than or equal to minimum amount."}
+                    {"pwyc_max": _("Maximum pay-what-you-can amount must be greater than or equal to minimum amount.")}
                 )
 
     def _validate_membership_tiers(self) -> None:
@@ -415,7 +417,7 @@ class TicketTier(TimeStampedModel, VisibilityMixin):
         for membership_tier in self.restricted_to_membership_tiers.all():
             if membership_tier.organization_id != self.event.organization_id:
                 raise DjangoValidationError(
-                    {"restricted_to_tiers": "All linked membership tiers must belong to the event's organization."}
+                    {"restricted_to_tiers": _("All linked membership tiers must belong to the event's organization.")}
                 )
         if self.restricted_to_membership_tiers.exists() and self.purchasable_by not in [
             self.PurchasableBy.MEMBERS,
@@ -423,8 +425,10 @@ class TicketTier(TimeStampedModel, VisibilityMixin):
         ]:
             raise DjangoValidationError(
                 {
-                    "restricted_to_tiers": "If tickets are restricted to specific tiers, 'Purchasable By' must be set "
-                    "to 'Members only' or 'Invited and Members only'."
+                    "restricted_to_tiers": _(
+                        "If tickets are restricted to specific tiers, 'Purchasable By' must be set "
+                        "to 'Members only' or 'Invited and Members only'."
+                    )
                 }
             )
 
@@ -496,7 +500,7 @@ class TicketTier(TimeStampedModel, VisibilityMixin):
         if self.restrict_visibility_to_linked_invitations and self.visibility != self.Visibility.PRIVATE:
             raise DjangoValidationError(
                 {
-                    "restrict_visibility_to_linked_invitations": (
+                    "restrict_visibility_to_linked_invitations": _(
                         "This option is only valid when visibility is set to 'Private'."
                     )
                 }
@@ -507,7 +511,7 @@ class TicketTier(TimeStampedModel, VisibilityMixin):
         ]:
             raise DjangoValidationError(
                 {
-                    "restrict_purchase_to_linked_invitations": (
+                    "restrict_purchase_to_linked_invitations": _(
                         "This option is only valid when purchasable by is set to "
                         "'Invitees only' or 'Invited and Members only'."
                     )

--- a/src/events/tests/test_models/test_event_waitlist_fields.py
+++ b/src/events/tests/test_models/test_event_waitlist_fields.py
@@ -4,6 +4,7 @@ import datetime as dt
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.utils import translation
 
 from events.models import Event
 
@@ -72,3 +73,20 @@ class TestWaitlistConfigValidation:
         event.full_clean()  # must not raise
         assert event.waitlist_lottery_mode is True
         assert event.waitlist_batch_size == 5
+
+
+# --- i18n: the messages are organizer-facing, so they must actually translate ---
+
+
+@pytest.mark.django_db
+class TestWaitlistConfigValidationI18n:
+    def test_time_window_message_renders_in_the_active_language(self, event: Event) -> None:
+        """Guards both the ``gettext`` wrapping and the catalog entry (see ADR-0011)."""
+        _prepare(event)
+        event.waitlist_time_window = dt.timedelta(minutes=30)
+        with translation.override("it"):
+            with pytest.raises(ValidationError) as exc_info:
+                event.full_clean()
+            assert exc_info.value.message_dict["waitlist_time_window"] == [
+                "La finestra temporale deve essere di almeno 1 ora."
+            ]

--- a/src/events/tests/test_models/test_models.py
+++ b/src/events/tests/test_models/test_models.py
@@ -1,14 +1,16 @@
 import datetime
 import typing as t
+from decimal import Decimal
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.utils import timezone
+from django.utils import timezone, translation
 
 from accounts.models import RevelUser
 from events import exceptions
 from events.models import (
     AdditionalResource,
+    DiscountCode,
     Event,
     EventInvitation,
     EventRSVP,
@@ -910,3 +912,35 @@ class TestCanUserSeeCancellationReason:
     def test_superuser_can_see(self, cancelled_event: Event, nonmember_user: RevelUser) -> None:
         nonmember_user.is_superuser = True
         assert cancelled_event.can_user_see_cancellation_reason(nonmember_user) is True
+
+
+# --- i18n: model validation messages are organizer-facing, so they must actually translate ---
+
+
+@pytest.mark.django_db
+def test_member_tier_message_renders_in_the_active_language(
+    organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """Guards both the ``gettext`` wrapping and the catalog entry (see ADR-0011)."""
+    other_org = Organization.objects.create(name="Other Org", slug="other-org", owner=organization_owner_user)
+    tier = MembershipTier.objects.create(organization=other_org, name="Gold")
+    member = OrganizationMember(organization=organization, user=organization_owner_user, tier=tier)
+    with translation.override("it"):
+        with pytest.raises(ValidationError) as exc_info:
+            member.full_clean()
+        assert exc_info.value.message_dict["tier"] == [
+            "Il livello deve appartenere alla stessa organizzazione dell'iscrizione."
+        ]
+
+
+def test_discount_code_message_renders_in_the_active_language() -> None:
+    """DiscountCode.clean() is pure field validation — no database needed."""
+    code = DiscountCode(
+        code="SALE",
+        discount_type=DiscountCode.DiscountType.PERCENTAGE,
+        discount_value=Decimal("150"),
+    )
+    with translation.override("it"):
+        with pytest.raises(ValidationError) as exc_info:
+            code.clean()
+        assert exc_info.value.message_dict["discount_value"] == ["Lo sconto percentuale non può superare 100."]

--- a/src/events/tests/test_models/test_ticket_tier_validation.py
+++ b/src/events/tests/test_models/test_ticket_tier_validation.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.utils import timezone
+from django.utils import timezone, translation
 
 from events.models import Event, TicketTier
 
@@ -110,3 +110,22 @@ class TestTicketTierValidation:
         )
         # Should not raise ValidationError
         tier.clean()
+
+
+# --- i18n: the messages are organizer-facing, so they must actually translate ---
+
+
+def test_sales_window_message_renders_in_the_active_language(public_event: Event) -> None:
+    """Guards both the ``gettext`` wrapping and the catalog entry (see ADR-0011)."""
+    tier = TicketTier(
+        event=public_event,
+        name="Invalid End",
+        sales_start_at=timezone.now() + timedelta(hours=12),
+        sales_end_at=timezone.now() + timedelta(hours=6),
+    )
+    with translation.override("it"):
+        with pytest.raises(ValidationError) as exc_info:
+            tier.clean()
+        assert exc_info.value.message_dict["sales_end_at"] == [
+            "L'orario di fine vendita dei biglietti deve essere successivo all'orario di inizio vendita."
+        ]

--- a/src/events/tests/test_series_pass/test_models.py
+++ b/src/events/tests/test_series_pass/test_models.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
+from django.utils import translation
 
 from events.models import Event, EventSeries, HeldSeriesPass, Organization, SeriesPass, SeriesPassTierLink, TicketTier
 
@@ -120,3 +121,25 @@ class TestSeriesPassModels:
     def test_held_pass_defaults(self, series_pass: SeriesPass, revel_user: t.Any) -> None:
         hp = HeldSeriesPass.objects.create(series_pass=series_pass, user=revel_user, price_paid=Decimal("36.00"))
         assert hp.status == HeldSeriesPass.HeldSeriesPassStatus.PENDING
+
+
+# --- i18n: the messages are organizer-facing, so they must actually translate ---
+
+
+@pytest.mark.django_db
+def test_at_the_door_message_renders_in_the_active_language(event_series: EventSeries) -> None:
+    """Guards both the ``gettext`` wrapping and the catalog entry (see ADR-0011)."""
+    sp = SeriesPass(
+        event_series=event_series,
+        name="Bad",
+        price=Decimal("10.00"),
+        pro_rata_discount=Decimal("1.00"),
+        currency="EUR",
+        payment_method=TicketTier.PaymentMethod.AT_THE_DOOR,
+    )
+    with translation.override("it"):
+        with pytest.raises(ValidationError) as exc_info:
+            sp.full_clean()
+        assert exc_info.value.message_dict["payment_method"] == [
+            "Il pagamento in loco non è supportato per i pass stagionali."
+        ]

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1064,6 +1064,40 @@ msgstr ""
 "Das erneute Senden an neue Anmeldungen erfordert eine auf ein Event "
 "gerichtete Ankündigung."
 
+msgid "valid_until must be after valid_from."
+msgstr "valid_until muss nach valid_from liegen."
+
+msgid "Percentage discount cannot exceed 100."
+msgstr "Der prozentuale Rabatt darf 100 nicht überschreiten."
+
+msgid "Currency is required for fixed amount discounts."
+msgstr "Für Rabatte mit festem Betrag ist eine Währung erforderlich."
+
+msgid "Event series must belong to the same organization as the event."
+msgstr "Die Eventserie muss zur selben Organisation gehören wie das Event."
+
+msgid "End date must be after start date."
+msgstr "Das Enddatum muss nach dem Startdatum liegen."
+
+msgid "Check-in end time must be after check-in start time."
+msgstr "Die Check-in-Endzeit muss nach der Check-in-Startzeit liegen."
+
+msgid "Venue must belong to the same organization as the event."
+msgstr ""
+"Der Veranstaltungsort muss zur selben Organisation gehören wie das Event."
+
+msgid "Time window must be at least 1 hour."
+msgstr "Das Zeitfenster muss mindestens 1 Stunde betragen."
+
+msgid "Time window cannot exceed 7 days."
+msgstr "Das Zeitfenster darf 7 Tage nicht überschreiten."
+
+msgid "Cutoff date requires waitlist_time_window to be set."
+msgstr "Der Stichtag erfordert, dass waitlist_time_window gesetzt ist."
+
+msgid "Cutoff date must be before event start."
+msgstr "Der Stichtag muss vor dem Eventbeginn liegen."
+
 msgid "Days a PAST_DUE subscription stays valid before expiring."
 msgstr ""
 "Anzahl der Tage, die ein Abonnement mit dem Status PAST_DUE gültig bleibt, "
@@ -1075,6 +1109,10 @@ msgid ""
 msgstr ""
 "Eine verifizierte Kontakt-E-Mail-Adresse ist erforderlich, um eine andere "
 "Kontaktmethode als NONE zu aktivieren."
+
+msgid "The tier must belong to the same organization as the membership."
+msgstr ""
+"Die Stufe muss zur selben Organisation gehören wie die Mitgliedschaft."
 
 msgid "Membership tier is required when granting membership."
 msgstr ""
@@ -1088,6 +1126,42 @@ msgstr ""
 
 msgid "Token must be a single non-empty slug segment."
 msgstr "Token muss ein einzelnes, nicht leeres Slug-Segment sein."
+
+msgid "At-the-door payment is not supported for series passes."
+msgstr "Zahlung vor Ort wird für Serienpässe nicht unterstützt."
+
+msgid "Series passes cannot be invitation-restricted."
+msgstr "Serienpässe können nicht auf Einladungen beschränkt werden."
+
+msgid "Currency cannot be changed once the pass covers events."
+msgstr ""
+"Die Währung kann nicht mehr geändert werden, sobald der Pass Events abdeckt."
+
+msgid "Payment method cannot be changed while the pass has holders."
+msgstr ""
+"Die Zahlungsmethode kann nicht geändert werden, solange der Pass Inhaber "
+"hat."
+
+msgid "Tier must belong to the covered event."
+msgstr "Die Ticket-Kategorie muss zum abgedeckten Event gehören."
+
+msgid "Event must belong to the pass's series."
+msgstr "Das Event muss zur Serie des Passes gehören."
+
+msgid "Tier currency must match the pass currency."
+msgstr ""
+"Die Währung der Ticket-Kategorie muss mit der Währung des Passes "
+"übereinstimmen."
+
+msgid "Assigned-seating tiers cannot back a series pass."
+msgstr ""
+"Ticket-Kategorien mit Sitzplatzzuweisung können nicht mit einem Serienpass "
+"verknüpft werden."
+
+msgid "Pay What You Can tiers cannot back a series pass."
+msgstr ""
+"\"Zahl-was-du-kannst\"-Kategorien können nicht mit einem Serienpass "
+"verknüpft werden."
 
 msgid "Month"
 msgstr "Monat"
@@ -1127,12 +1201,33 @@ msgstr "Fehlgeschlagen"
 msgid "Refunded"
 msgstr "Erstattet"
 
+msgid "Ticket sales must start before or at the event start time."
+msgstr "Der Ticketverkauf muss spätestens zum Eventbeginn starten."
+
+msgid "Ticket sales end time must be after the sales start time."
+msgstr "Das Verkaufsende der Tickets muss nach dem Verkaufsbeginn liegen."
+
+msgid ""
+"Maximum pay-what-you-can amount must be greater than or equal to minimum "
+"amount."
+msgstr ""
+"Der maximale \"Zahl-was-du-kannst\"-Betrag muss größer oder gleich dem "
+"Mindestbetrag sein."
+
+msgid "All linked membership tiers must belong to the event's organization."
+msgstr ""
+"Alle verknüpften Mitgliedschaftsstufen müssen zur Organisation des Events "
+"gehören."
+
+msgid ""
+"If tickets are restricted to specific tiers, 'Purchasable By' must be set to "
+"'Members only' or 'Invited and Members only'."
+msgstr ""
+"Wenn Tickets auf bestimmte Stufen beschränkt sind, muss 'Kaufbar von' auf "
+"'Nur Mitglieder' oder 'Nur Eingeladene und Mitglieder' gesetzt sein."
+
 msgid "Sector must belong to the specified venue."
 msgstr "Der Sektor muss zum angegebenen Veranstaltungsort gehören."
-
-msgid "Venue must belong to the same organization as the event."
-msgstr ""
-"Der Veranstaltungsort muss zur selben Organisation gehören wie das Event."
 
 msgid "Tier venue must match the event venue."
 msgstr ""
@@ -1159,6 +1254,17 @@ msgid ""
 msgstr ""
 "Die Zuweisung des besten verfügbaren Sitzplatzes erfordert einen Sitzplatz-"
 "Sektor, keinen Stehplatz-Sektor."
+
+msgid "This option is only valid when visibility is set to 'Private'."
+msgstr ""
+"Diese Option ist nur gültig, wenn die Sichtbarkeit auf 'Privat' gesetzt ist."
+
+msgid ""
+"This option is only valid when purchasable by is set to 'Invitees only' or "
+"'Invited and Members only'."
+msgstr ""
+"Diese Option ist nur gültig, wenn 'Kaufbar von' auf 'Nur Eingeladene' oder "
+"'Nur Eingeladene und Mitglieder' gesetzt ist."
 
 msgid "Cannot assign an inactive seat."
 msgstr "Ein inaktiver Sitzplatz kann nicht zugewiesen werden."

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -1074,6 +1074,43 @@ msgstr ""
 "Le renvoi aux nouvelles inscriptions nécessite une annonce ciblant un "
 "événement."
 
+msgid "valid_until must be after valid_from."
+msgstr "valid_until doit être postérieur à valid_from."
+
+msgid "Percentage discount cannot exceed 100."
+msgstr "La réduction en pourcentage ne peut pas dépasser 100."
+
+msgid "Currency is required for fixed amount discounts."
+msgstr "La devise est requise pour les réductions à montant fixe."
+
+msgid "Event series must belong to the same organization as the event."
+msgstr ""
+"La série d'événements doit appartenir à la même organisation que "
+"l'événement."
+
+msgid "End date must be after start date."
+msgstr "La date de fin doit être postérieure à la date de début."
+
+msgid "Check-in end time must be after check-in start time."
+msgstr ""
+"L'heure de fin du check-in doit être postérieure à l'heure de début du "
+"check-in."
+
+msgid "Venue must belong to the same organization as the event."
+msgstr "Le lieu doit appartenir à la même organisation que l'événement."
+
+msgid "Time window must be at least 1 hour."
+msgstr "La fenêtre de temps doit être d'au moins 1 heure."
+
+msgid "Time window cannot exceed 7 days."
+msgstr "La fenêtre de temps ne peut pas dépasser 7 jours."
+
+msgid "Cutoff date requires waitlist_time_window to be set."
+msgstr "La date limite nécessite que waitlist_time_window soit défini."
+
+msgid "Cutoff date must be before event start."
+msgstr "La date limite doit être antérieure au début de l'événement."
+
 msgid "Days a PAST_DUE subscription stays valid before expiring."
 msgstr ""
 "Nombre de jours pendant lesquels un abonnement PAST_DUE reste valide avant "
@@ -1086,6 +1123,9 @@ msgstr ""
 "Une adresse e-mail de contact vérifiée est requise pour activer un moyen de "
 "contact autre que NONE."
 
+msgid "The tier must belong to the same organization as the membership."
+msgstr "Le niveau doit appartenir à la même organisation que l'adhésion."
+
 msgid "Membership tier is required when granting membership."
 msgstr "Le niveau d'adhésion est requis lors de l'octroi d'une adhésion."
 
@@ -1095,6 +1135,43 @@ msgstr ""
 
 msgid "Token must be a single non-empty slug segment."
 msgstr "Le jeton doit être un segment de slug non vide."
+
+msgid "At-the-door payment is not supported for series passes."
+msgstr ""
+"Le paiement sur place n'est pas pris en charge pour les pass de série."
+
+msgid "Series passes cannot be invitation-restricted."
+msgstr "Les pass de série ne peuvent pas être réservés aux invités."
+
+msgid "Currency cannot be changed once the pass covers events."
+msgstr ""
+"La devise ne peut plus être modifiée une fois que le pass couvre des "
+"événements."
+
+msgid "Payment method cannot be changed while the pass has holders."
+msgstr ""
+"La méthode de paiement ne peut pas être modifiée tant que le pass a des "
+"détenteurs."
+
+msgid "Tier must belong to the covered event."
+msgstr "La catégorie de tickets doit appartenir à l'événement couvert."
+
+msgid "Event must belong to the pass's series."
+msgstr "L'événement doit appartenir à la série du pass."
+
+msgid "Tier currency must match the pass currency."
+msgstr ""
+"La devise de la catégorie de tickets doit correspondre à celle du pass."
+
+msgid "Assigned-seating tiers cannot back a series pass."
+msgstr ""
+"Les catégories de tickets avec places assignées ne peuvent pas être "
+"associées à un pass de série."
+
+msgid "Pay What You Can tiers cannot back a series pass."
+msgstr ""
+"Les catégories de tickets à tarif libre ne peuvent pas être associées à un "
+"pass de série."
 
 msgid "Month"
 msgstr "Mois"
@@ -1134,11 +1211,37 @@ msgstr "Échoué"
 msgid "Refunded"
 msgstr "Remboursé"
 
+msgid "Ticket sales must start before or at the event start time."
+msgstr ""
+"La vente des tickets doit commencer au plus tard au début de l'événement."
+
+msgid "Ticket sales end time must be after the sales start time."
+msgstr ""
+"L'heure de fin de vente des tickets doit être postérieure à l'heure de "
+"début de vente."
+
+msgid ""
+"Maximum pay-what-you-can amount must be greater than or equal to minimum "
+"amount."
+msgstr ""
+"Le montant maximum du tarif libre doit être supérieur ou égal au montant "
+"minimum."
+
+msgid "All linked membership tiers must belong to the event's organization."
+msgstr ""
+"Tous les niveaux d'adhésion liés doivent appartenir à l'organisation de "
+"l'événement."
+
+msgid ""
+"If tickets are restricted to specific tiers, 'Purchasable By' must be set to "
+"'Members only' or 'Invited and Members only'."
+msgstr ""
+"Si les tickets sont réservés à des niveaux spécifiques, 'Achetable par' "
+"doit être défini sur 'Membres uniquement' ou 'Invités et membres "
+"uniquement'."
+
 msgid "Sector must belong to the specified venue."
 msgstr "Le secteur doit appartenir au lieu spécifié."
-
-msgid "Venue must belong to the same organization as the event."
-msgstr "Le lieu doit appartenir à la même organisation que l'événement."
 
 msgid "Tier venue must match the event venue."
 msgstr ""
@@ -1161,6 +1264,17 @@ msgid ""
 msgstr ""
 "L'attribution du meilleur siège disponible requiert un secteur assis, pas un "
 "secteur debout."
+
+msgid "This option is only valid when visibility is set to 'Private'."
+msgstr ""
+"Cette option n'est valide que lorsque la visibilité est définie sur 'Privé'."
+
+msgid ""
+"This option is only valid when purchasable by is set to 'Invitees only' or "
+"'Invited and Members only'."
+msgstr ""
+"Cette option n'est valide que lorsque 'Achetable par' est défini sur "
+"'Invités uniquement' ou 'Invités et membres uniquement'."
 
 msgid "Cannot assign an inactive seat."
 msgstr "Impossible d'attribuer un siège inactif."

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -1046,6 +1046,42 @@ msgid "Re-sending to new sign-ups requires an event-targeted announcement."
 msgstr ""
 "Il reinvio alle nuove iscrizioni richiede un annuncio rivolto a un evento."
 
+msgid "valid_until must be after valid_from."
+msgstr "valid_until deve essere successivo a valid_from."
+
+msgid "Percentage discount cannot exceed 100."
+msgstr "Lo sconto percentuale non può superare 100."
+
+msgid "Currency is required for fixed amount discounts."
+msgstr "La valuta è obbligatoria per gli sconti a importo fisso."
+
+msgid "Event series must belong to the same organization as the event."
+msgstr ""
+"La serie di eventi deve appartenere alla stessa organizzazione dell'evento."
+
+msgid "End date must be after start date."
+msgstr "La data di fine deve essere successiva alla data di inizio."
+
+msgid "Check-in end time must be after check-in start time."
+msgstr ""
+"L'orario di fine del check-in deve essere successivo all'orario di inizio "
+"del check-in."
+
+msgid "Venue must belong to the same organization as the event."
+msgstr "La sede deve appartenere alla stessa organizzazione dell'evento."
+
+msgid "Time window must be at least 1 hour."
+msgstr "La finestra temporale deve essere di almeno 1 ora."
+
+msgid "Time window cannot exceed 7 days."
+msgstr "La finestra temporale non può superare i 7 giorni."
+
+msgid "Cutoff date requires waitlist_time_window to be set."
+msgstr "La data limite richiede che waitlist_time_window sia impostato."
+
+msgid "Cutoff date must be before event start."
+msgstr "La data limite deve essere precedente all'inizio dell'evento."
+
 msgid "Days a PAST_DUE subscription stays valid before expiring."
 msgstr "Giorni in cui un abbonamento PAST_DUE resta valido prima di scadere."
 
@@ -1055,6 +1091,10 @@ msgid ""
 msgstr ""
 "È richiesta un'email di contatto verificata per abilitare un metodo di "
 "contatto diverso da NONE."
+
+msgid "The tier must belong to the same organization as the membership."
+msgstr ""
+"Il livello deve appartenere alla stessa organizzazione dell'iscrizione."
 
 msgid "Membership tier is required when granting membership."
 msgstr ""
@@ -1067,6 +1107,41 @@ msgstr ""
 
 msgid "Token must be a single non-empty slug segment."
 msgstr "Il token deve essere un singolo segmento di slug non vuoto."
+
+msgid "At-the-door payment is not supported for series passes."
+msgstr "Il pagamento in loco non è supportato per i pass stagionali."
+
+msgid "Series passes cannot be invitation-restricted."
+msgstr "I pass stagionali non possono essere riservati agli invitati."
+
+msgid "Currency cannot be changed once the pass covers events."
+msgstr ""
+"La valuta non può essere cambiata una volta che il pass copre degli eventi."
+
+msgid "Payment method cannot be changed while the pass has holders."
+msgstr ""
+"Il metodo di pagamento non può essere cambiato finché il pass ha dei "
+"titolari."
+
+msgid "Tier must belong to the covered event."
+msgstr "Il livello di biglietto deve appartenere all'evento coperto."
+
+msgid "Event must belong to the pass's series."
+msgstr "L'evento deve appartenere alla serie del pass."
+
+msgid "Tier currency must match the pass currency."
+msgstr ""
+"La valuta del livello di biglietto deve corrispondere alla valuta del pass."
+
+msgid "Assigned-seating tiers cannot back a series pass."
+msgstr ""
+"I livelli di biglietto con posti assegnati non possono essere associati a "
+"un pass stagionale."
+
+msgid "Pay What You Can tiers cannot back a series pass."
+msgstr ""
+"I livelli di biglietto a offerta libera non possono essere associati a un "
+"pass stagionale."
 
 msgid "Month"
 msgstr "Mese"
@@ -1106,11 +1181,36 @@ msgstr "Fallito"
 msgid "Refunded"
 msgstr "Rimborsato"
 
+msgid "Ticket sales must start before or at the event start time."
+msgstr ""
+"La vendita dei biglietti deve iniziare entro l'orario di inizio dell'evento."
+
+msgid "Ticket sales end time must be after the sales start time."
+msgstr ""
+"L'orario di fine vendita dei biglietti deve essere successivo all'orario di "
+"inizio vendita."
+
+msgid ""
+"Maximum pay-what-you-can amount must be greater than or equal to minimum "
+"amount."
+msgstr ""
+"L'importo massimo dell'offerta libera deve essere maggiore o uguale "
+"all'importo minimo."
+
+msgid "All linked membership tiers must belong to the event's organization."
+msgstr ""
+"Tutti i livelli di iscrizione collegati devono appartenere "
+"all'organizzazione dell'evento."
+
+msgid ""
+"If tickets are restricted to specific tiers, 'Purchasable By' must be set to "
+"'Members only' or 'Invited and Members only'."
+msgstr ""
+"Se i biglietti sono riservati a livelli specifici, 'Acquistabile da' deve "
+"essere impostato su 'Solo membri' o 'Solo invitati e membri'."
+
 msgid "Sector must belong to the specified venue."
 msgstr "Il settore deve appartenere alla sede specificata."
-
-msgid "Venue must belong to the same organization as the event."
-msgstr "La sede deve appartenere alla stessa organizzazione dell'evento."
 
 msgid "Tier venue must match the event venue."
 msgstr ""
@@ -1133,6 +1233,17 @@ msgid ""
 msgstr ""
 "L'assegnazione al miglior posto disponibile richiede un settore a sedere, "
 "non un settore in piedi."
+
+msgid "This option is only valid when visibility is set to 'Private'."
+msgstr ""
+"Questa opzione è valida solo quando la visibilità è impostata su 'Privato'."
+
+msgid ""
+"This option is only valid when purchasable by is set to 'Invitees only' or "
+"'Invited and Members only'."
+msgstr ""
+"Questa opzione è valida solo quando 'Acquistabile da' è impostato su 'Solo "
+"invitati' o 'Solo invitati e membri'."
 
 msgid "Cannot assign an inactive seat."
 msgstr "Non è possibile assegnare un posto non attivo."


### PR DESCRIPTION
## What

Model `clean()` validation messages raised as plain string literals reached organizers in English while the rest of the app is localised. This wraps the remaining messages in `gettext_lazy` (deferred lookup — the `ValidationError` travels through `full_clean()` into `message_dict` and is rendered later by the exception handler) and translates them into it/de/fr, following the idiom already established for the seating surface on this branch.

Touched surfaces:
- `src/events/models/event.py` — 8 messages (series/org ownership, end date, check-in window, venue ownership, waitlist config)
- `src/events/models/discount_code.py` — 3 messages (date range, percentage cap, currency requirement)
- `src/events/models/series_pass.py` — 9 messages (payment method, purchasable_by, currency/payment-method change guards, tier-link contract)
- `src/events/models/organization.py` — 1 message (member tier ownership)
- `src/events/models/ticket.py` — 7 non-seating messages (sales window, PWYC, membership tiers, invitation restrictions); the already-translated seating msgids are untouched

## msgid counts

- 28 messages wrapped; **27 new msgids per language** (it, de, fr) — one message ("Venue must belong to the same organization as the event.") already existed in the catalogs from the seating work and is reused verbatim.
- All messages are static strings — no interpolation placeholders were needed.
- All gettext fuzzy suggestions were discarded (they were semantically wrong again, e.g. "The tier must belong to the same organization as the membership." ← "Venue must belong to the same organization as the event."); translated fresh. `msgattrib --only-fuzzy` and `msgattrib --untranslated` are both empty for it, de, and fr.
- `.po` only committed; `.mo` compiled locally for `i18n-check` (ADR-0011).

## Evidence

- TDD: 5 new i18n regression tests (one per touched model file) asserting a representative message renders in Italian under `translation.override("it")` — all 5 shown failing in English before the source change, all passing after.
- 408 tests pass across the covering test files (`test_models/`, `test_series_pass/`, discount code validation).
- Existing English-substring assertions untouched — the default language remains English and msgids are unchanged, so nothing broke.
- `make check` green (ruff, mypy --strict, migration-check, i18n-check, file-length, task-names) and `uv run mkdocs build --strict` green.
- `test_discount_parity.py` not modified.

The API contract is unchanged — only message localisation.

Refs #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)