### PR TITLE
docs(events): pin the online price_paid carve-out as permanent (#758)

### DIFF
--- a/docs/architecture/billing-and-vat.md
+++ b/docs/architecture/billing-and-vat.md
@@ -418,6 +418,8 @@ Unlike platform fee VAT (which is B2B between Revel and the org), attendee VAT f
 
 This means the Stripe checkout amount varies per buyer. The platform fee is calculated on the **amount actually charged** (reduced for reverse charge/export).
 
+Because the charged amount can be **net**, online tickets never copy `Payment.amount` into `Ticket.price_paid` — it stays `NULL` **permanently**, and the 1:1 `Payment` row is authoritative (decision on issue #758). Stamping it would make `price_paid`'s meaning depend on the buyer's VAT status. Every money-bearing reader of an online ticket consults its `Payment` row (the revenue report aggregates payments directly; the Apple Wallet pass checks `ticket.payment` before any fallback) — see `should_stamp_price_paid` in `events/service/seating/pricing.py`.
+
 ### Service: `events.service.attendee_vat_service`
 
 | Function | Purpose |

--- a/src/events/service/batch_ticket_service/checkout.py
+++ b/src/events/service/batch_ticket_service/checkout.py
@@ -55,7 +55,9 @@ class CheckoutMixin(TicketWriterMixin):
 
         reservation_id = uuid4()
 
-        # PENDING tickets; price_paid stays NULL online — Payment.amount is authoritative (spec §5.5).
+        # PENDING tickets; price_paid stays NULL online — PERMANENTLY (#758). Payment.amount is
+        # authoritative (spec §5.5) and is net for a reverse-charge buyer, so stamping it would
+        # make price_paid's meaning depend on the buyer's VAT status. Never pass stamp_price_paid.
         tickets = self.create_tickets(items, seats, Ticket.TicketStatus.PENDING, pricing.lines)
 
         # Update quantity sold

--- a/src/events/service/batch_ticket_service/service.py
+++ b/src/events/service/batch_ticket_service/service.py
@@ -115,9 +115,10 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
         # One authority for every writer (spec §5.5). Computed ONCE and handed to every
         # branch that stamps — a branch that recomputes, or silently drops it, is exactly
         # how a category-priced tier ended up with NULL price_paid rows. The ONLINE branch
-        # is the sole exception and does not take it at all: Payment.amount is
-        # authoritative there (and is *net* for a reverse-charge buyer). An ONLINE cart the
-        # buyer zeroed has no Payment row, so it reroutes to free and does stamp.
+        # is the sole exception and does not take it at all — a PERMANENT carve-out (#758):
+        # Payment.amount is authoritative there (and is *net* for a reverse-charge buyer).
+        # An ONLINE cart the buyer zeroed has no Payment row, so it reroutes to free and
+        # does stamp.
         stamp_price_paid = should_stamp_price_paid(
             locked_tier, pwyc_amount=pwyc_amount, has_discount=self.discount_code is not None
         )

--- a/src/events/service/seating/pricing.py
+++ b/src/events/service/seating/pricing.py
@@ -165,6 +165,14 @@ def recorded_or_resolved_price(
     an anomaly, priced from the seat (flat price if its category is unpriced), and
     allowed through.
 
+    **Online tickets are the other legitimate NULL — permanently** (#758, see
+    :func:`should_stamp_price_paid`): their 1:1 ``Payment`` row is authoritative, and
+    its amount can be *net* (reverse charge), which no tier or seat price reconstructs.
+    Callers that can see online rows must consult ``ticket.payment`` before falling
+    back here (as ``ApplePassGenerator._resolve_price`` does); the paths that call this
+    directly (offline refunds, the revenue report's offline rows) never carry online
+    tickets.
+
     Callers pass ``ticket.tier``/``ticket.seat`` — pre-fetch both (``select_related``)
     when calling this in a loop.
 
@@ -212,10 +220,18 @@ def should_stamp_price_paid(
       survive a later repricing.
 
     Otherwise leave it NULL: a plain purchase on a flat tier (``tier.price`` stands) and
-    every online row (``Payment.amount`` is authoritative there, and is *net* for a
-    reverse-charge buyer — two "price paid" numbers on one row is worse than none). The
-    online and free-checkout paths therefore never ask this question; they simply do not
-    stamp.
+    every online row. The online carve-out is **permanent** (decision on #758, option a):
+    the 1:1 ``Payment`` row is authoritative there, and ``Payment.amount`` is the amount
+    actually charged — *net* for a reverse-charge buyer — so copying it into
+    ``price_paid`` would make the column's meaning depend on the buyer's VAT status
+    (and two "price paid" numbers on one row is worse than none). ``_online_checkout``
+    therefore never asks this question and never stamps, even when this function would
+    say True (e.g. a category-priced tier); every money-bearing reader of an online
+    ticket consults its ``Payment`` row instead (the revenue report aggregates the
+    payments directly; the wallet pass checks ``ticket.payment`` before falling back).
+    Pinned in ``test_online_checkout_price_paid.py`` — do not "fix" a NULL online row
+    by stamping. The zeroed-ONLINE reroute to free checkout is not part of the
+    carve-out: it has no ``Payment`` row, so it stamps like any free sale.
 
     The invariant is **time-scoped** — tickets sold before a tier opted into category
     pricing legitimately carry NULL — so it can never be a DB constraint or a raise, and

--- a/src/events/tests/test_service/test_batch_ticket_service/test_online_checkout_price_paid.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_online_checkout_price_paid.py
@@ -1,0 +1,142 @@
+"""The online ``price_paid`` carve-out is permanent — pin it (#758, spec §5.5).
+
+``should_stamp_price_paid`` is the single stamp authority for every checkout
+branch except one: ``_online_checkout`` never asks it, and online tickets keep
+``price_paid`` NULL **permanently**. The 1:1 ``Payment`` row is authoritative,
+and ``Payment.amount`` is the amount actually charged — *net* for a
+reverse-charge buyer — so copying it into ``price_paid`` would make the
+column's meaning depend on the buyer's VAT status (decision on #758, option a).
+
+These tests are the assertion half of that decision: a future reader must not
+"fix" a NULL online row by stamping, and the money-bearing read path must keep
+resolving an online ticket's price from its ``Payment`` row, never from the
+tier or seat.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events.models import (
+    Event,
+    Organization,
+    Payment,
+    PriceCategory,
+    Ticket,
+    TicketTier,
+    VenueSeat,
+    VenueSector,
+)
+from events.schema import TicketPurchaseItem
+from events.service.batch_ticket_service import BatchTicketService
+from events.service.seating.pricing import should_stamp_price_paid
+from events.tests.test_service.test_batch_ticket_service.conftest import PREMIUM, make_category_tier
+from wallet.apple.generator import ApplePassGenerator
+
+pytestmark = pytest.mark.django_db
+
+FLAT_ONLINE_PRICE = Decimal("50.00")
+
+
+@pytest.fixture
+def online_event(organization: Organization) -> Event:
+    """Open public event on a Stripe-connected org."""
+    organization.stripe_account_id = "acct_online_758"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.save()
+    return Event.objects.create(
+        organization=organization,
+        name="Online Carveout Event",
+        slug="online-carveout-event",
+        event_type=Event.EventType.PUBLIC,
+        visibility=Event.Visibility.PUBLIC,
+        start=timezone.now() + timedelta(days=7),
+        status=Event.EventStatus.OPEN,
+        max_attendees=100,
+        max_tickets_per_user=5,
+    )
+
+
+def test_online_checkout_leaves_price_paid_null_and_payment_row_carries_the_amount(
+    online_event: Event, member_user: RevelUser
+) -> None:
+    """A plain online sale: NULL ``price_paid``, one PENDING Payment per ticket with the amount.
+
+    The NULL is not "unknown" and not a bug — it is the permanent carve-out: the
+    amount lives on the ``Payment`` row, whose value can legitimately differ from
+    any tier price (net for reverse charge). The wallet pass — the reader that can
+    see online rows — resolves the price from that row.
+    """
+    tier = TicketTier.objects.create(
+        event=online_event,
+        name="Online Flat",
+        price=FLAT_ONLINE_PRICE,
+        currency="EUR",
+        payment_method=TicketTier.PaymentMethod.ONLINE,
+        price_type=TicketTier.PriceType.FIXED,
+        total_quantity=50,
+        max_tickets_per_user=5,
+    )
+
+    result = BatchTicketService(online_event, tier, member_user).create_batch(
+        [TicketPurchaseItem(guest_name="Guest 1"), TicketPurchaseItem(guest_name="Guest 2")]
+    )
+
+    assert isinstance(result, tuple), "an ONLINE tier returns (tickets, reservation_id)"
+    tickets, _reservation_id = result
+    assert len(tickets) == 2
+    for ticket in Ticket.objects.filter(tier=tier).select_related("tier", "seat"):
+        assert ticket.status == Ticket.TicketStatus.PENDING
+        assert ticket.price_paid is None, "online tickets must NEVER stamp price_paid (#758)"
+        payment = Payment.objects.get(ticket=ticket)
+        assert payment.amount == FLAT_ONLINE_PRICE
+        # The money-bearing read path resolves via the Payment row.
+        price, currency = ApplePassGenerator._resolve_price(ticket)
+        assert (price, currency) == (payment.amount, "EUR")
+
+
+def test_online_checkout_never_asks_the_stamp_authority_even_when_it_says_true(
+    seated_event: Event,
+    sector: VenueSector,
+    categories: tuple[PriceCategory, PriceCategory],
+    seats: list[VenueSeat],
+    member_user: RevelUser,
+) -> None:
+    """Category-priced ONLINE tier: the stamp authority says True, online still leaves NULL.
+
+    This is the exact shape of the carve-out — ``should_stamp_price_paid`` returns
+    True for a category-priced tier, and every other branch stamps. Online does not,
+    because the Payment row already carries the charged amount, and the reader
+    prefers that row over re-resolving the seat: mutating ``Payment.amount`` to a
+    sentinel (the shape a reverse-charge *net* amount takes — different from the
+    seat's gross 80.00) must move what the reader reports.
+    """
+    tier = make_category_tier(seated_event, sector, categories, TicketTier.PaymentMethod.ONLINE)
+    assert should_stamp_price_paid(tier) is True, "a category-priced tier demands a stamp everywhere else"
+
+    premium_seat = seats[0]
+    result = BatchTicketService(seated_event, tier, member_user).create_batch(
+        [TicketPurchaseItem(guest_name="Guest", seat_id=premium_seat.pk)]
+    )
+
+    assert isinstance(result, tuple)
+    ticket = Ticket.objects.select_related("tier", "seat").get(tier=tier)
+    assert ticket.seat_id == premium_seat.pk
+    assert ticket.price_paid is None, "the carve-out is permanent — online never stamps (#758)"
+
+    payment = Payment.objects.get(ticket=ticket)
+    assert payment.amount == PREMIUM, "domestic buyer: charged the seat's gross category price"
+
+    # Reader precedence: Payment beats seat resolution. A reverse-charge buyer's
+    # Payment.amount is net (< the seat's gross price); the reader must report what
+    # was charged, not what the seat lists.
+    net_amount = Decimal("64.00")
+    Payment.objects.filter(pk=payment.pk).update(amount=net_amount)
+    fresh_ticket = Ticket.objects.select_related("tier", "seat").get(pk=ticket.pk)
+    price, currency = ApplePassGenerator._resolve_price(fresh_ticket)
+    assert (price, currency) == (net_amount, "EUR"), "the reader must consult the Payment row first"
+    assert price != PREMIUM, "falling back to the seat's price would misreport a reverse-charge sale"


### PR DESCRIPTION
## Decision (maintainer, issue #758 — option a)

Online tickets keep `price_paid` NULL **permanently**; the 1:1 `Payment` row stays authoritative. `_online_checkout` is deliberately the one branch that never asks `should_stamp_price_paid()`.

**Rationale:** `Payment.amount` is the amount actually charged, which is **net** for a reverse-charge buyer. Copying it into `price_paid` would make that column's meaning depend on the buyer's VAT status — two "price paid" numbers on one row is worse than none.

## What changed

- `should_stamp_price_paid` / `recorded_or_resolved_price` docstrings now state the carve-out is permanent, why, and where it is pinned; inline comments in `_online_checkout` and `create_batch` say the same.
- `docs/architecture/billing-and-vat.md` documents the carve-out next to the buyer-specific VAT section that explains the net charge.
- New `test_online_checkout_price_paid.py`:
  - flat ONLINE tier: `price_paid IS NULL`, 1:1 PENDING Payment rows carry the amount, and the money-bearing reader (`ApplePassGenerator._resolve_price`) resolves it from the Payment row;
  - category-priced ONLINE tier: `should_stamp_price_paid()` returns True yet online still leaves NULL, and the reader prefers `Payment.amount` (sentinel net amount) over re-resolving the seat's gross price.

## Evidence

- Probe: existing `test_pwyc_online_does_not_store_price_paid` and `test_online_records_one_payment_per_ticket_at_its_own_price` already pass — the carve-out is true today.
- Pin-down proof: temporarily making `_online_checkout` pass `stamp_price_paid=True` makes **both** new tests fail; reverting makes them pass (not committed).
- Full covering suites green: 228 passed (`test_batch_ticket_service/` incl. untouched `test_discount_parity.py`, plus `test_category_pricing.py`).
- No production behaviour change: `.artifacts/openapi.json` regenerated — **empty diff**.
- `make check` and `mkdocs build --strict` green.

Refs #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)