### PR TITLE
feat: cap venue/sector metadata writes and project public chart metadata (#761)

### DIFF
--- a/docs/guides/seating/venue-and-layout.md
+++ b/docs/guides/seating/venue-and-layout.md
@@ -283,10 +283,8 @@ The seed data includes a ~1,350-seat theatre with three sector types (open floor
 private boxes) as a working reference point. There is no seat-count ceiling in the design.
 
 **"Can we show the stage, or a venue with several floors?"**
-Yes — both live in the venue's free-form `metadata`, written by the layout designer and now
-carried on the buyer-facing chart alongside the per-sector `metadata` that was already there, so
-the buyer's map draws the same picture the designer laid out. Two conventions the designer and the
-buyer map agree on:
+Yes — both live in the venue's free-form `metadata`, written by the layout designer. Two
+conventions the designer and the buyer map agree on:
 
 - `metadata.stage` — the stage's position/shape, drawn as-is on the map.
 - `metadata.floors` — `[{"id": ..., "name": ..., "order": ...}]`, the venue's floors; a sector says
@@ -295,7 +293,20 @@ buyer map agree on:
 Floors are **pure presentation**: they group sectors for display and nothing else. Pricing, zones,
 capacity and holds never look at them. The convention is a shared agreement, not an enforced
 schema — nothing rejects a sector pointing at a floor id the venue doesn't list, and such a sector
-simply has no floor to render under.
+simply has no floor to render under. Note that of the two, only `stage` currently reaches the
+buyer-facing chart — see the metadata rules below.
+
+**"What can we store in `metadata`, and who can see it?"**
+Treat chart metadata as **public**: the seating chart is served to anonymous buyers, so never put
+notes, contact details, or anything internal in it. Two rules apply (#761):
+
+- **The public chart serves a whitelisted projection, not the whole blob.** Venue-level metadata:
+  only `stage`. Sector-level metadata: only `transform` and `aisles`. Anything else the designer
+  stores (including the `floors`/`floor` convention above) stays on the admin/designer endpoints
+  and never reaches buyers.
+- **Writes are capped**: metadata is rejected on save if it exceeds **16 KB** of compact JSON or
+  nests deeper than **6** levels. The field is layout config, not scratch space — the whole chart
+  is re-downloaded by every buyer polling the seat picker.
 
 **"Is there version history if we redraw the map?"**
 No — this is a known v1 limitation, worth saying plainly rather than glossing over: the seating

--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -25,6 +25,17 @@ class ChartSeatSchema(Schema):
     price_category_id: UUID | None = None
 
 
+# The anonymous chart serves a whitelisted PROJECTION of organizer-written metadata, not
+# the verbatim blob (#761) — exactly the keys the shipped buyer renderer consumes:
+# frontend `events/venue-overview.ts` parses venue `metadata.stage`; `tickets/seat-map-layout.ts`
+# and `tickets/sector-transform.ts` parse sector `metadata.aisles` / `metadata.transform`.
+# Admin/designer endpoints keep serving the full blob. Applied in
+# ``events.service.seating.chart.build_chart``; ``null`` stays ``null``, an object is reduced
+# to its whitelisted keys (possibly ``{}``).
+CHART_VENUE_METADATA_KEYS: t.Final = frozenset({"stage"})
+CHART_SECTOR_METADATA_KEYS: t.Final = frozenset({"transform", "aisles"})
+
+
 class ChartSectorSchema(Schema):
     id: UUID
     name: str
@@ -33,6 +44,7 @@ class ChartSectorSchema(Schema):
     shape: list[Coordinate2D] | None = None
     capacity: int | None = None
     display_order: int = 0
+    # Projection of the sector's metadata: only CHART_SECTOR_METADATA_KEYS survive.
     metadata: dict[str, t.Any] | None = None
     seats: list[ChartSeatSchema] = Field(default_factory=list)
 
@@ -42,8 +54,8 @@ class VenueChartSchema(Schema):
     venue_name: str
     updated_at: AwareDatetime
     # Venue-level counterpart of ChartSectorSchema.metadata: the layout designer's whole-venue
-    # config (stage position/shape, the `floors` list). Verbatim organizer-written JSON, `null`
-    # when the designer never wrote any — never `{}`.
+    # config, projected to CHART_VENUE_METADATA_KEYS (the stage position/shape). `null` when
+    # the designer never wrote any — never `{}`.
     metadata: dict[str, t.Any] | None = None
     price_categories: list[PriceCategorySchema] = Field(default_factory=list)
     sectors: list[ChartSectorSchema] = Field(default_factory=list)

--- a/src/events/schema/venue.py
+++ b/src/events/schema/venue.py
@@ -1,17 +1,54 @@
 """Venue-related schemas."""
 
+import json
 import typing as t
 from decimal import Decimal
 from uuid import UUID
 
 from ninja import ModelSchema, Schema
 from ninja.schema import DjangoGetter
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import AfterValidator, Field, StringConstraints, model_validator
 
 from common.schema import OneToOneFiftyString, StrippedString
 from events.models import Event, PriceCategory, Venue, VenueSeat, VenueSector
 
 from .mixins import CityEditMixin, CityRetrieveMixin
+
+# Hard bounds on organizer-written ``metadata`` JSON, enforced on all four write
+# surfaces (venue create/update, sector create/update). The blob is served on the
+# anonymous seating chart that every buyer polls, so it must stay small and flat (#761).
+# Size is measured as UTF-8 bytes of compact JSON: ``json.dumps(v, separators=(",", ":"),
+# ensure_ascii=False).encode()``. Depth counts nested dict/list containers along the
+# deepest path, the top-level object included (``{"a": {"b": 1}}`` has depth 2).
+METADATA_MAX_BYTES: t.Final = 16_384
+METADATA_MAX_DEPTH: t.Final = 6
+
+
+def _json_depth(value: t.Any) -> int:
+    """Nesting depth of a JSON value: scalars are 0, each dict/list level adds 1."""
+    if isinstance(value, dict):
+        return 1 + max((_json_depth(v) for v in value.values()), default=0)
+    if isinstance(value, list):
+        return 1 + max((_json_depth(v) for v in value), default=0)
+    return 0
+
+
+def _validate_metadata_bounds(v: dict[str, t.Any] | None) -> dict[str, t.Any] | None:
+    """Shared write-path guard for venue/sector metadata: compact-JSON size and nesting depth."""
+    if v is None:
+        return v
+    size = len(json.dumps(v, separators=(",", ":"), ensure_ascii=False).encode())
+    if size > METADATA_MAX_BYTES:
+        raise ValueError(f"metadata must serialize to at most {METADATA_MAX_BYTES} bytes of JSON (got {size}).")
+    depth = _json_depth(v)
+    if depth > METADATA_MAX_DEPTH:
+        raise ValueError(f"metadata must not nest deeper than {METADATA_MAX_DEPTH} levels (got {depth}).")
+    return v
+
+
+# Write-path type for venue/sector metadata. Response schemas keep plain dicts —
+# rows written before the cap landed must still serialize.
+BoundedMetadata = t.Annotated[dict[str, t.Any] | None, AfterValidator(_validate_metadata_bounds)]
 
 
 class Coordinate2D(Schema):
@@ -255,9 +292,13 @@ class VenueCreateSchema(CityEditMixin):
     name: OneToOneFiftyString
     description: StrippedString | None = None
     capacity: int | None = Field(None, ge=0)
-    metadata: dict[str, t.Any] | None = Field(
+    metadata: BoundedMetadata = Field(
         default=None,
-        description="Arbitrary JSON for venue-level layout config (e.g. stage position/shape).",
+        description=(
+            "JSON for venue-level layout config (e.g. stage position/shape). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `stage` key is served publicly on the "
+            "anonymous seating chart."
+        ),
     )
 
 
@@ -267,9 +308,13 @@ class VenueUpdateSchema(CityEditMixin):
     name: OneToOneFiftyString | None = None
     description: StrippedString | None = None
     capacity: int | None = Field(None, ge=0)
-    metadata: dict[str, t.Any] | None = Field(
+    metadata: BoundedMetadata = Field(
         default=None,
-        description="Arbitrary JSON for venue-level layout config (e.g. stage position/shape).",
+        description=(
+            "JSON for venue-level layout config (e.g. stage position/shape). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `stage` key is served publicly on the "
+            "anonymous seating chart."
+        ),
     )
 
 
@@ -314,9 +359,13 @@ class VenueSectorCreateSchema(Schema):
     )
     capacity: int | None = Field(None, ge=0)
     display_order: int = Field(0, ge=0)
-    metadata: dict[str, t.Any] | None = Field(
+    metadata: BoundedMetadata = Field(
         None,
-        description="Arbitrary JSON metadata for frontend rendering (e.g., aisle positions).",
+        description=(
+            "JSON metadata for frontend rendering (e.g., aisle positions). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `transform` and `aisles` keys are "
+            "served publicly on the anonymous seating chart."
+        ),
     )
     seats: list[VenueSeatInputSchema] = Field(default_factory=list)
 
@@ -349,9 +398,13 @@ class VenueSectorUpdateSchema(Schema):
     )
     capacity: int | None = Field(None, ge=0)
     display_order: int | None = Field(None, ge=0)
-    metadata: dict[str, t.Any] | None = Field(
+    metadata: BoundedMetadata = Field(
         None,
-        description="Arbitrary JSON metadata for frontend rendering (e.g., aisle positions).",
+        description=(
+            "JSON metadata for frontend rendering (e.g., aisle positions). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `transform` and `aisles` keys are "
+            "served publicly on the anonymous seating chart."
+        ),
     )
 
 

--- a/src/events/service/seating/chart.py
+++ b/src/events/service/seating/chart.py
@@ -9,13 +9,32 @@ polls, and :func:`bump_chart_version` is the only writer of.
 """
 
 import datetime
+import typing as t
 import uuid
 
 from django.utils import timezone
 
 from events.models import Venue, VenueSector
-from events.schema.seating import ChartSeatSchema, ChartSectorSchema, VenueChartSchema
+from events.schema.seating import (
+    CHART_SECTOR_METADATA_KEYS,
+    CHART_VENUE_METADATA_KEYS,
+    ChartSeatSchema,
+    ChartSectorSchema,
+    VenueChartSchema,
+)
 from events.schema.venue import PriceCategorySchema
+
+
+def _project_metadata(metadata: dict[str, t.Any] | None, allowed: frozenset[str]) -> dict[str, t.Any] | None:
+    """Reduce organizer-written metadata to the chart's public whitelist (#761).
+
+    ``None`` stays ``None`` (the FE's one emptiness check); an object keeps only its
+    whitelisted keys, verbatim — possibly ``{}``. The whitelists live next to the chart
+    schemas in :mod:`events.schema.seating`.
+    """
+    if metadata is None:
+        return None
+    return {k: v for k, v in metadata.items() if k in allowed}
 
 
 def bump_chart_version(venue_id: uuid.UUID) -> datetime.datetime:
@@ -73,7 +92,7 @@ def build_chart(venue: Venue) -> VenueChartSchema:
                 shape=sector.shape,
                 capacity=sector.capacity,
                 display_order=sector.display_order,
-                metadata=sector.metadata,
+                metadata=_project_metadata(sector.metadata, CHART_SECTOR_METADATA_KEYS),
                 seats=seat_schemas,
             )
         )
@@ -81,7 +100,7 @@ def build_chart(venue: Venue) -> VenueChartSchema:
         venue_id=venue.id,
         venue_name=venue.name,
         updated_at=venue.chart_version,
-        metadata=venue.metadata,
+        metadata=_project_metadata(venue.metadata, CHART_VENUE_METADATA_KEYS),
         price_categories=[PriceCategorySchema.from_orm(c) for c in categories],
         sectors=sector_schemas,
     )

--- a/src/events/tests/test_controllers/test_seating_public.py
+++ b/src/events/tests/test_controllers/test_seating_public.py
@@ -67,16 +67,47 @@ def test_chart_serializes_legacy_pair_shape(client: Client, seated_event: tuple[
     ]
 
 
-def test_chart_exposes_venue_metadata(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:
-    """The designer's venue-level config (stage, floors) round-trips verbatim to the buyer's map."""
+def test_chart_projects_metadata_to_whitelisted_keys(
+    client: Client, seated_event: tuple[Event, list[VenueSeat]]
+) -> None:
+    """The anonymous chart serves a whitelisted projection, not the verbatim blob (#761).
+
+    Venue level keeps only ``stage``; sector level only ``transform``/``aisles`` —
+    exactly the keys the shipped buyer renderer reads. Whitelisted values pass
+    through verbatim; everything else the designer wrote is stripped.
+    """
     event, seats = seated_event
     venue = event.venue
     assert venue is not None
-    metadata = {
-        "stage": {"shape": [{"x": 0.0, "y": 0.0}, {"x": 10.0, "y": 0.0}], "label": "Stage"},
+    stage = {"shape": [{"x": 0.0, "y": 0.0}, {"x": 10.0, "y": 0.0}], "label": "Stage"}
+    venue.metadata = {
+        "stage": stage,
         "floors": [{"id": "ground", "name": "Ground", "order": 0}],
+        "designer_note": "loading dock code 4711",
     }
-    venue.metadata = metadata
+    venue.save(update_fields=["metadata"])
+    sector = seats[0].sector
+    transform = {"x": 0.0, "y": 120.0, "rotation": 90.0}
+    aisles = {"verticalAisles": [4], "horizontalAisles": [2], "invertRowOrder": False}
+    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground"}
+    sector.save(update_fields=["metadata"])
+
+    resp = client.get(f"/api/events/{event.id}/seating/chart")
+
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["metadata"] == {"stage": stage}
+    assert body["sectors"][0]["metadata"] == {"transform": transform, "aisles": aisles}
+
+
+def test_chart_projects_non_whitelisted_metadata_to_empty_object(
+    client: Client, seated_event: tuple[Event, list[VenueSeat]]
+) -> None:
+    """An object with no whitelisted keys projects to ``{}`` — not ``null`` (#761)."""
+    event, seats = seated_event
+    venue = event.venue
+    assert venue is not None
+    venue.metadata = {"scratch": "not for buyers"}
     venue.save(update_fields=["metadata"])
     sector = seats[0].sector
     sector.metadata = {"floor": "ground"}
@@ -86,9 +117,8 @@ def test_chart_exposes_venue_metadata(client: Client, seated_event: tuple[Event,
 
     assert resp.status_code == 200, resp.content
     body = resp.json()
-    assert body["metadata"] == metadata
-    # Same shape at both levels: sector metadata carries the floor id the venue list declares.
-    assert body["sectors"][0]["metadata"] == {"floor": "ground"}
+    assert body["metadata"] == {}
+    assert body["sectors"][0]["metadata"] == {}
 
 
 def test_chart_metadata_is_null_when_unset(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:
@@ -99,6 +129,8 @@ def test_chart_metadata_is_null_when_unset(client: Client, seated_event: tuple[E
     body = resp.json()
     assert "metadata" in body
     assert body["metadata"] is None
+    # Same rule at sector level: the projection must not turn null into {}.
+    assert body["sectors"][0]["metadata"] is None
 
 
 def test_chart_query_count_is_unaffected_by_venue_metadata(

--- a/src/events/tests/test_schema/test_venue_metadata_limits.py
+++ b/src/events/tests/test_schema/test_venue_metadata_limits.py
@@ -1,0 +1,102 @@
+"""Shared size/depth bounds on organizer-written venue/sector ``metadata`` (#761).
+
+The blob is public (served on the anonymous seating chart), so the write path caps
+it at ``METADATA_MAX_BYTES`` of compact JSON and ``METADATA_MAX_DEPTH`` nested
+containers on all four write surfaces: venue create/update, sector create/update.
+"""
+
+import json
+import typing as t
+
+import pytest
+from pydantic import ValidationError
+
+from events.schema.venue import (
+    METADATA_MAX_BYTES,
+    METADATA_MAX_DEPTH,
+    VenueCreateSchema,
+    VenueSectorCreateSchema,
+    VenueSectorUpdateSchema,
+    VenueUpdateSchema,
+)
+
+MetadataFactory = t.Callable[[dict[str, t.Any] | None], t.Any]
+
+# One factory per metadata write surface, so every case below runs against all four.
+FACTORIES: dict[str, MetadataFactory] = {
+    "venue_create": lambda md: VenueCreateSchema(name="Hall", metadata=md),  # type: ignore[call-arg]
+    "venue_update": lambda md: VenueUpdateSchema(metadata=md),  # type: ignore[call-arg]
+    "sector_create": lambda md: VenueSectorCreateSchema(name="Floor", metadata=md),  # type: ignore[call-arg]
+    "sector_update": lambda md: VenueSectorUpdateSchema(metadata=md),  # type: ignore[call-arg]
+}
+
+
+def _nested(depth: int) -> dict[str, t.Any]:
+    """A metadata dict whose deepest path crosses exactly ``depth`` containers."""
+    value: dict[str, t.Any] = {"leaf": 1}
+    for _ in range(depth - 1):
+        value = {"nested": value}
+    return value
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_oversized_metadata_rejected(factory: MetadataFactory) -> None:
+    oversized = {"junk": "x" * METADATA_MAX_BYTES}
+    with pytest.raises(ValidationError, match="bytes"):
+        factory(oversized)
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_metadata_at_exact_byte_limit_accepted(factory: MetadataFactory) -> None:
+    # {"k":"xxx...x"} — compact JSON overhead is 8 bytes, so pad to exactly the cap.
+    boundary = {"k": "x" * (METADATA_MAX_BYTES - 8)}
+    assert len(json.dumps(boundary, separators=(",", ":"), ensure_ascii=False).encode()) == METADATA_MAX_BYTES
+    assert factory(boundary).metadata == boundary
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_one_byte_over_limit_rejected(factory: MetadataFactory) -> None:
+    over = {"k": "x" * (METADATA_MAX_BYTES - 7)}
+    assert len(json.dumps(over, separators=(",", ":"), ensure_ascii=False).encode()) == METADATA_MAX_BYTES + 1
+    with pytest.raises(ValidationError, match="bytes"):
+        factory(over)
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_over_deep_metadata_rejected(factory: MetadataFactory) -> None:
+    with pytest.raises(ValidationError, match="nest deeper"):
+        factory(_nested(METADATA_MAX_DEPTH + 1))
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_metadata_at_exact_depth_limit_accepted(factory: MetadataFactory) -> None:
+    boundary = _nested(METADATA_MAX_DEPTH)
+    assert factory(boundary).metadata == boundary
+
+
+@pytest.mark.parametrize("factory", FACTORIES.values(), ids=FACTORIES.keys())
+def test_null_metadata_accepted(factory: MetadataFactory) -> None:
+    assert factory(None).metadata is None
+
+
+@pytest.mark.parametrize("factory", [FACTORIES["venue_create"], FACTORIES["venue_update"]], ids=["create", "update"])
+def test_real_world_venue_metadata_accepted(factory: MetadataFactory) -> None:
+    """The stage config the designer actually writes (venue-overview.ts contract)."""
+    stage = {
+        "stage": {
+            "position": {"x": 5.0, "y": -2.0},
+            "shape": [{"x": 0.0, "y": 0.0}, {"x": 10.0, "y": 0.0}, {"x": 10.0, "y": 2.0}],
+            "label": "Stage",
+        }
+    }
+    assert factory(stage).metadata == stage
+
+
+@pytest.mark.parametrize("factory", [FACTORIES["sector_create"], FACTORIES["sector_update"]], ids=["create", "update"])
+def test_real_world_sector_metadata_accepted(factory: MetadataFactory) -> None:
+    """The transform/aisles config the grid editor actually writes (seat-map-layout.ts contract)."""
+    md = {
+        "transform": {"x": 0.0, "y": 120.0, "rotation": 90.0},
+        "aisles": {"verticalAisles": [4, 8], "horizontalAisles": [2], "invertRowOrder": False},
+    }
+    assert factory(md).metadata == md


### PR DESCRIPTION
Implements the decided resolution of #761 (Refs #761 — closing keywords handled centrally on #724).

## The two decisions

1. **Write path — shared size/depth cap.** A single validator (`events/schema/venue.py`: `METADATA_MAX_BYTES = 16_384`, `METADATA_MAX_DEPTH = 6`) applied to all four metadata write surfaces: `VenueCreateSchema`, `VenueUpdateSchema`, `VenueSectorCreateSchema`, `VenueSectorUpdateSchema`. Size is UTF-8 bytes of compact JSON (`json.dumps(v, separators=(",", ":"), ensure_ascii=False).encode()`); depth counts nested dict/list containers including the top-level object.
2. **Read path — whitelisted public projection.** The anonymous `GET /events/{event_id}/seating/chart` now serves a projection of metadata, not the verbatim blob: venue-level → only `stage`; sector-level → only `transform` and `aisles`. `null` stays `null`; an object projects to its whitelisted keys (possibly `{}`). Field name/type unchanged (`dict | null`). Whitelists live next to the chart schemas (`events/schema/seating.py`) with the frontend consumers named; projection applied in `build_chart` (`events/service/seating/chart.py`), which is called only by the public chart endpoint. Admin/designer endpoints keep the full blob.

## What changes for admins (contract note)

- **Saves can now fail** where they previously succeeded: venue/sector `metadata` exceeding 16 KB of compact JSON or nesting deeper than 6 levels is rejected with a 400 validation error. Existing oversized DB rows still serialize on admin reads; they fail only on the next write.
- **The public chart no longer echoes arbitrary metadata keys.** Anything outside `stage` (venue) / `transform`, `aisles` (sector) is no longer visible to buyers. Docs updated (`docs/guides/seating/venue-and-layout.md`) to say chart metadata is public and what the caps are.
- The documented `floors`/`floor` display convention no longer reaches the buyer chart. Verified the shipped frontend never reads it (no consumer of `metadata.floors`/`metadata.floor` anywhere in `revel-frontend/src`); if floor rendering ships later, those keys must be added to the whitelists.

## Evidence

- **Probe (before):** `VenueCreateSchema` accepted a 1 MB blob and 40-level-deep nesting; `test_chart_exposes_venue_metadata` passed, echoing `designer_note: "loading dock code 4711"` and arbitrary sector keys to anonymous callers.
- **Fail-before-fix:** new projection tests failed against the old behaviour (`assert {'stage': ..., 'floors': ..., 'designer_note': ...} == {'stage': ...}`); the write-path suite could not even import the constants.
- **After:** 46/46 new+seating-public tests pass; 170/170 tests across venue admin, seating admin, chart version, seat availability and venue service pass; `make check` green (format, lint, mypy --strict, migration-check, i18n-check, file-length, task-names); `mkdocs build --strict` green.
- **OpenAPI diff:** exactly four `description` changes on the metadata write fields — no name/type change to any existing request or response field. (The `operationId` hash suffixes churn on every dump — verified nondeterministic by dumping twice at identical code state — so they are excluded as noise; `.artifacts/openapi.json` is not git-tracked.)
- **i18n:** untouched — pydantic validator messages in this repo are plain English (matched existing convention), so no catalog regeneration.
- No migrations (metadata columns unchanged).

## Out of scope, flagged

`GET /events/{event_id}/tickets/{tier_id}/seats` (`SectorAvailabilitySchema`, also reachable anonymously) still serves sector metadata verbatim. The shipped frontend does not call it, and the new write cap bounds its size, but it remains a second unprojected read surface — follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
