### PR TITLE
feat(seating): project seats-endpoint metadata and whitelist floors keys

### DIFF
--- a/docs/guides/seating/venue-and-layout.md
+++ b/docs/guides/seating/venue-and-layout.md
@@ -293,16 +293,18 @@ conventions the designer and the buyer map agree on:
 Floors are **pure presentation**: they group sectors for display and nothing else. Pricing, zones,
 capacity and holds never look at them. The convention is a shared agreement, not an enforced
 schema — nothing rejects a sector pointing at a floor id the venue doesn't list, and such a sector
-simply has no floor to render under. Note that of the two, only `stage` currently reaches the
-buyer-facing chart — see the metadata rules below.
+simply has no floor to render under. Both conventions reach the buyer-facing chart: `stage`,
+`floors` and `floor` are on the public whitelists — see the metadata rules below.
 
 **"What can we store in `metadata`, and who can see it?"**
 Treat chart metadata as **public**: the seating chart is served to anonymous buyers, so never put
 notes, contact details, or anything internal in it. Two rules apply (#761):
 
-- **The public chart serves a whitelisted projection, not the whole blob.** Venue-level metadata:
-  only `stage`. Sector-level metadata: only `transform` and `aisles`. Anything else the designer
-  stores (including the `floors`/`floor` convention above) stays on the admin/designer endpoints
+- **Public surfaces serve a whitelisted projection, not the whole blob.** Venue-level metadata:
+  only `stage` and `floors`. Sector-level metadata: only `transform`, `aisles` and `floor`.
+  The same sector projection applies to the tier seats endpoint
+  (`GET /events/{event_id}/tickets/{tier_id}/seats`), the second anonymous surface carrying
+  sector metadata. Anything else the designer stores stays on the admin/designer endpoints
   and never reaches buyers.
 - **Writes are capped**: metadata is rejected on save if it exceeds **16 KB** of compact JSON or
   nests deeper than **6** levels. The field is layout config, not scratch space — the whole chart

--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -25,15 +25,29 @@ class ChartSeatSchema(Schema):
     price_category_id: UUID | None = None
 
 
-# The anonymous chart serves a whitelisted PROJECTION of organizer-written metadata, not
-# the verbatim blob (#761) — exactly the keys the shipped buyer renderer consumes:
-# frontend `events/venue-overview.ts` parses venue `metadata.stage`; `tickets/seat-map-layout.ts`
-# and `tickets/sector-transform.ts` parse sector `metadata.aisles` / `metadata.transform`.
-# Admin/designer endpoints keep serving the full blob. Applied in
-# ``events.service.seating.chart.build_chart``; ``null`` stays ``null``, an object is reduced
-# to its whitelisted keys (possibly ``{}``).
-CHART_VENUE_METADATA_KEYS: t.Final = frozenset({"stage"})
-CHART_SECTOR_METADATA_KEYS: t.Final = frozenset({"transform", "aisles"})
+# Anonymous surfaces serve a whitelisted PROJECTION of organizer-written metadata, not
+# the verbatim blob (#761, #769) — the union of two consumers' keys:
+# - the shipped buyer chart renderer: frontend `events/venue-overview.ts` parses venue
+#   `metadata.stage`; `tickets/seat-map-layout.ts` and `tickets/sector-transform.ts` parse
+#   sector `metadata.aisles` / `metadata.transform`;
+# - the multi-floor convention (letsrevel/revel-frontend#680): venue
+#   `metadata.floors = [{id, name, order}]`, sector `metadata.floor = <floor id>`.
+# Admin/designer endpoints keep serving the full blob. Applied via
+# ``project_chart_metadata`` in ``events.service.seating.chart.build_chart`` (both levels)
+# and ``events.service.venue_service.get_tier_seat_availability`` (sector level).
+CHART_VENUE_METADATA_KEYS: t.Final = frozenset({"stage", "floors"})
+CHART_SECTOR_METADATA_KEYS: t.Final = frozenset({"transform", "aisles", "floor"})
+
+
+def project_chart_metadata(metadata: dict[str, t.Any] | None, allowed: frozenset[str]) -> dict[str, t.Any] | None:
+    """Reduce organizer-written metadata to an anonymous surface's public whitelist (#761, #769).
+
+    ``None`` stays ``None`` (the FE's one emptiness check); an object keeps only its
+    whitelisted keys, verbatim — possibly ``{}``.
+    """
+    if metadata is None:
+        return None
+    return {k: v for k, v in metadata.items() if k in allowed}
 
 
 class ChartSectorSchema(Schema):
@@ -54,8 +68,8 @@ class VenueChartSchema(Schema):
     venue_name: str
     updated_at: AwareDatetime
     # Venue-level counterpart of ChartSectorSchema.metadata: the layout designer's whole-venue
-    # config, projected to CHART_VENUE_METADATA_KEYS (the stage position/shape). `null` when
-    # the designer never wrote any — never `{}`.
+    # config, projected to CHART_VENUE_METADATA_KEYS (stage position/shape, floors list).
+    # `null` when the designer never wrote any — never `{}`.
     metadata: dict[str, t.Any] | None = None
     price_categories: list[PriceCategorySchema] = Field(default_factory=list)
     sectors: list[ChartSectorSchema] = Field(default_factory=list)

--- a/src/events/schema/venue.py
+++ b/src/events/schema/venue.py
@@ -270,7 +270,9 @@ class SectorAvailabilitySchema(Schema):
     shape: list[Coordinate2D] | None = None
     capacity: int | None = None
     display_order: int = 0
-    metadata: dict[str, t.Any] | None = None  # For frontend rendering (e.g., aisle positions)
+    # Anonymous surface (#769): the chart's whitelisted sector projection
+    # (CHART_SECTOR_METADATA_KEYS), never the verbatim designer blob.
+    metadata: dict[str, t.Any] | None = None
     seats: list[VenueSeatSchema] = Field(default_factory=list)
     available_count: int = 0  # Number of available seats
     total_count: int = 0  # Total active seats
@@ -295,9 +297,9 @@ class VenueCreateSchema(CityEditMixin):
     metadata: BoundedMetadata = Field(
         default=None,
         description=(
-            "JSON for venue-level layout config (e.g. stage position/shape). Max 16 KB of "
-            "compact JSON, max 6 nesting levels. The `stage` key is served publicly on the "
-            "anonymous seating chart."
+            "JSON for venue-level layout config (e.g. stage position/shape, floors). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `stage` and `floors` keys are served "
+            "publicly on the anonymous seating chart."
         ),
     )
 
@@ -311,9 +313,9 @@ class VenueUpdateSchema(CityEditMixin):
     metadata: BoundedMetadata = Field(
         default=None,
         description=(
-            "JSON for venue-level layout config (e.g. stage position/shape). Max 16 KB of "
-            "compact JSON, max 6 nesting levels. The `stage` key is served publicly on the "
-            "anonymous seating chart."
+            "JSON for venue-level layout config (e.g. stage position/shape, floors). Max 16 KB of "
+            "compact JSON, max 6 nesting levels. The `stage` and `floors` keys are served "
+            "publicly on the anonymous seating chart."
         ),
     )
 
@@ -363,8 +365,8 @@ class VenueSectorCreateSchema(Schema):
         None,
         description=(
             "JSON metadata for frontend rendering (e.g., aisle positions). Max 16 KB of "
-            "compact JSON, max 6 nesting levels. The `transform` and `aisles` keys are "
-            "served publicly on the anonymous seating chart."
+            "compact JSON, max 6 nesting levels. The `transform`, `aisles` and `floor` keys "
+            "are served publicly on the anonymous seating chart and tier seats endpoint."
         ),
     )
     seats: list[VenueSeatInputSchema] = Field(default_factory=list)
@@ -402,8 +404,8 @@ class VenueSectorUpdateSchema(Schema):
         None,
         description=(
             "JSON metadata for frontend rendering (e.g., aisle positions). Max 16 KB of "
-            "compact JSON, max 6 nesting levels. The `transform` and `aisles` keys are "
-            "served publicly on the anonymous seating chart."
+            "compact JSON, max 6 nesting levels. The `transform`, `aisles` and `floor` keys "
+            "are served publicly on the anonymous seating chart and tier seats endpoint."
         ),
     )
 

--- a/src/events/service/seating/chart.py
+++ b/src/events/service/seating/chart.py
@@ -9,7 +9,6 @@ polls, and :func:`bump_chart_version` is the only writer of.
 """
 
 import datetime
-import typing as t
 import uuid
 
 from django.utils import timezone
@@ -21,20 +20,9 @@ from events.schema.seating import (
     ChartSeatSchema,
     ChartSectorSchema,
     VenueChartSchema,
+    project_chart_metadata,
 )
 from events.schema.venue import PriceCategorySchema
-
-
-def _project_metadata(metadata: dict[str, t.Any] | None, allowed: frozenset[str]) -> dict[str, t.Any] | None:
-    """Reduce organizer-written metadata to the chart's public whitelist (#761).
-
-    ``None`` stays ``None`` (the FE's one emptiness check); an object keeps only its
-    whitelisted keys, verbatim — possibly ``{}``. The whitelists live next to the chart
-    schemas in :mod:`events.schema.seating`.
-    """
-    if metadata is None:
-        return None
-    return {k: v for k, v in metadata.items() if k in allowed}
 
 
 def bump_chart_version(venue_id: uuid.UUID) -> datetime.datetime:
@@ -92,7 +80,7 @@ def build_chart(venue: Venue) -> VenueChartSchema:
                 shape=sector.shape,
                 capacity=sector.capacity,
                 display_order=sector.display_order,
-                metadata=_project_metadata(sector.metadata, CHART_SECTOR_METADATA_KEYS),
+                metadata=project_chart_metadata(sector.metadata, CHART_SECTOR_METADATA_KEYS),
                 seats=seat_schemas,
             )
         )
@@ -100,7 +88,7 @@ def build_chart(venue: Venue) -> VenueChartSchema:
         venue_id=venue.id,
         venue_name=venue.name,
         updated_at=venue.chart_version,
-        metadata=_project_metadata(venue.metadata, CHART_VENUE_METADATA_KEYS),
+        metadata=project_chart_metadata(venue.metadata, CHART_VENUE_METADATA_KEYS),
         price_categories=[PriceCategorySchema.from_orm(c) for c in categories],
         sectors=sector_schemas,
     )

--- a/src/events/service/venue_service.py
+++ b/src/events/service/venue_service.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
 from events import models, schema
+from events.schema.seating import CHART_SECTOR_METADATA_KEYS, project_chart_metadata
 from events.service.seating.chart import bump_chart_version
 from events.service.seating.paint_report import PriorPaint, build_report
 
@@ -847,7 +848,8 @@ def get_tier_seat_availability(
         shape=shape,
         capacity=sector.capacity,
         display_order=sector.display_order,
-        metadata=sector.metadata,
+        # Anonymous surface: serve the chart's whitelisted projection, never the verbatim blob (#769).
+        metadata=project_chart_metadata(sector.metadata, CHART_SECTOR_METADATA_KEYS),
         seats=seats,
         available_count=available_count,
         total_count=len(seats),

--- a/src/events/tests/test_controllers/test_seating_public.py
+++ b/src/events/tests/test_controllers/test_seating_public.py
@@ -72,32 +72,34 @@ def test_chart_projects_metadata_to_whitelisted_keys(
 ) -> None:
     """The anonymous chart serves a whitelisted projection, not the verbatim blob (#761).
 
-    Venue level keeps only ``stage``; sector level only ``transform``/``aisles`` —
-    exactly the keys the shipped buyer renderer reads. Whitelisted values pass
+    Venue level keeps only ``stage``/``floors``; sector level only
+    ``transform``/``aisles``/``floor`` — the keys the buyer renderer reads, including
+    the floors convention (letsrevel/revel-frontend#680). Whitelisted values pass
     through verbatim; everything else the designer wrote is stripped.
     """
     event, seats = seated_event
     venue = event.venue
     assert venue is not None
     stage = {"shape": [{"x": 0.0, "y": 0.0}, {"x": 10.0, "y": 0.0}], "label": "Stage"}
+    floors = [{"id": "ground", "name": "Ground", "order": 0}]
     venue.metadata = {
         "stage": stage,
-        "floors": [{"id": "ground", "name": "Ground", "order": 0}],
+        "floors": floors,
         "designer_note": "loading dock code 4711",
     }
     venue.save(update_fields=["metadata"])
     sector = seats[0].sector
     transform = {"x": 0.0, "y": 120.0, "rotation": 90.0}
     aisles = {"verticalAisles": [4], "horizontalAisles": [2], "invertRowOrder": False}
-    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground"}
+    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground", "scratch": "not for buyers"}
     sector.save(update_fields=["metadata"])
 
     resp = client.get(f"/api/events/{event.id}/seating/chart")
 
     assert resp.status_code == 200, resp.content
     body = resp.json()
-    assert body["metadata"] == {"stage": stage}
-    assert body["sectors"][0]["metadata"] == {"transform": transform, "aisles": aisles}
+    assert body["metadata"] == {"stage": stage, "floors": floors}
+    assert body["sectors"][0]["metadata"] == {"transform": transform, "aisles": aisles, "floor": "ground"}
 
 
 def test_chart_projects_non_whitelisted_metadata_to_empty_object(
@@ -110,7 +112,7 @@ def test_chart_projects_non_whitelisted_metadata_to_empty_object(
     venue.metadata = {"scratch": "not for buyers"}
     venue.save(update_fields=["metadata"])
     sector = seats[0].sector
-    sector.metadata = {"floor": "ground"}
+    sector.metadata = {"designer_note": "loading dock code 4711"}
     sector.save(update_fields=["metadata"])
 
     resp = client.get(f"/api/events/{event.id}/seating/chart")
@@ -148,6 +150,41 @@ def test_chart_query_count_is_unaffected_by_venue_metadata(
     venue.save(update_fields=["metadata"])
     with django_assert_num_queries(_CHART_QUERIES):
         assert client.get(f"/api/events/{event.id}/seating/chart").status_code == 200
+
+
+def test_tier_seats_projects_sector_metadata_to_whitelisted_keys(
+    client: Client, seated_event: tuple[Event, list[VenueSeat]]
+) -> None:
+    """The anonymous seats endpoint serves the chart's sector projection, not the verbatim blob (#769).
+
+    ``GET /events/{event_id}/tickets/{tier_id}/seats`` is the second anonymous surface
+    carrying sector metadata — same whitelist as the chart: ``transform``/``aisles``/``floor``.
+    """
+    event, seats = seated_event
+    tier = _seated_tier(event, seats)
+    sector = seats[0].sector
+    transform = {"x": 0.0, "y": 120.0, "rotation": 90.0}
+    aisles = {"verticalAisles": [4], "horizontalAisles": [2], "invertRowOrder": False}
+    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground", "designer_note": "dock code 4711"}
+    sector.save(update_fields=["metadata"])
+
+    resp = client.get(f"/api/events/{event.id}/tickets/{tier.id}/seats")
+
+    assert resp.status_code == 200, resp.content
+    assert resp.json()["metadata"] == {"transform": transform, "aisles": aisles, "floor": "ground"}
+
+
+def test_tier_seats_metadata_is_null_when_unset(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:
+    """No designer data serialises as ``null`` — the projection must not turn it into ``{}`` (#769)."""
+    event, seats = seated_event
+    tier = _seated_tier(event, seats)
+
+    resp = client.get(f"/api/events/{event.id}/tickets/{tier.id}/seats")
+
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert "metadata" in body
+    assert body["metadata"] is None
 
 
 def test_chart_404_when_event_has_no_venue(client: Client, event: Event) -> None:


### PR DESCRIPTION
## What

Two decided follow-ups to the #761 / PR #768 metadata projection, landed together on the `feature/venue-seating` integration branch.

### 1. Seats endpoint projection (#769)

`GET /events/{event_id}/tickets/{tier_id}/seats` — the second anonymous surface carrying sector metadata — served `VenueSector.metadata` **verbatim**. It now serves the same whitelisted projection the chart uses (`CHART_SECTOR_METADATA_KEYS`), so every anonymous surface serves the projection. `null` stays `null`; an object reduces to its whitelisted keys (possibly `{}`).

The projection helper was factored out of `build_chart` into `events.schema.seating.project_chart_metadata`, next to the whitelist constants, and is shared by both surfaces — no duplicated logic.

**Rationale**: consistency and bounded exposure; the shipped frontend reads no metadata from this endpoint, so nothing can break.

### 2. Floors whitelist extension (letsrevel/revel-frontend#680)

The agreed FE convention — `venue.metadata.floors = [{id, name, order}]`, `sector.metadata.floor = <floor id>` — is added to the public whitelists:

- `CHART_VENUE_METADATA_KEYS`: `{stage}` → `{stage, floors}`
- `CHART_SECTOR_METADATA_KEYS`: `{transform, aisles}` → `{transform, aisles, floor}`

**Rationale**: deliberate, maintainer-approved public-contract widening so FE #680 (multi-floor designer + buyer map) is not blocked by the projection.

Docs (`docs/guides/seating/venue-and-layout.md`) and the four write-schema `description` strings in `src/events/schema/venue.py` updated to keep the enumerated public keys accurate.

## Evidence

- **Probe (pre-fix)**: new seats-endpoint test failed with the response containing the non-whitelisted key — `Left contains 1 more item: {'designer_note': 'dock code 4711'}` — confirming verbatim serving; the chart test extended for `floors` failed with `Right contains 1 more item: {'floors': [...]}` — confirming floors were stripped.
- **Post-fix**: full `test_seating_public.py` — 20 passed; related suites (`test_venue_metadata_limits.py`, `test_chart_version.py`, `test_seat_availability.py`) — 56 passed.
- **New tests**: seats endpoint strips extra keys / preserves whitelisted keys incl. `floor` / `null` passthrough; chart passes `floors` + `floor` through; existing stripping tests still cover non-whitelisted keys.
- `make check` and `uv run mkdocs build --strict` green. No migrations (metadata columns unchanged). No catalog changes.

## OpenAPI diff verdict

Regenerated via `make dump-openapi`, diffed against a pre-change baseline with the known nondeterministic `operationId` noise filtered out: **only the four metadata `description` strings changed — zero name/type/structural changes.**

Refs #769
Frontend convention: letsrevel/revel-frontend#680

🤖 Generated with [Claude Code](https://claude.com/claude-code)