### PR TITLE
fix(deps): bump pymdown-extensions to 11.0.1 to resolve CVE-2026-61632

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3157,15 +3157,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Nightly `pip-audit` (#773) flagged `pymdown-extensions==10.21.3` for CVE-2026-61632 (GHSA-9xwg-3r6f-jcx2, medium), fixed in 11.0.0.
- The advisory is a path traversal in the `pymdownx.b64` extension: `<img src="../…">` (or an absolute path) escapes the configured `base_path` and gets inlined as a base64 data URI, disclosing file contents.
- **Not exploitable here** — `pymdown-extensions` is a dev/docs-only transitive dep (`mkdocs-material` → `pymdown-extensions`, `[dependency-groups].dev`), `pymdownx.b64` is not among the extensions enabled in `mkdocs.yml`, and the only Markdown rendered is our own trusted docs at build time. Bumping anyway per the runbook's "fix exists → bump" preference.
- Applied `uv lock --upgrade-package pymdown-extensions` (`docs/runbooks/dependency-audit.md`). Lockfile-only diff; no `pyproject.toml` constraint change needed (`mkdocs-material>=9.7.6` accepts the 11.x line).

## Test plan
- [x] `make audit` — was "Found 1 known vulnerability in 1 package", now "No known vulnerabilities found"
- [x] `uv sync --locked --group dev` succeeds with the updated lockfile
- [x] `uv run mkdocs build --strict` succeeds — verifies the 10.x → 11.x major bump doesn't break the docs build

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)