### PR TITLE
feat(subscriptions): expose membership policy fields and revival window via API (#777, #778)

### DIFF
--- a/src/events/controllers/organization_admin/members.py
+++ b/src/events/controllers/organization_admin/members.py
@@ -17,7 +17,7 @@ from common.schema import TagSchema
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import filters, models, schema
 from events.controllers.permissions import IsOrganizationOwner, IsOrganizationStaff, OrganizationPermission
-from events.service import organization_service, update_db_instance
+from events.service import organization_service
 
 from .base import OrganizationAdminBaseController
 
@@ -132,7 +132,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
     @route.get(
         "/membership-tiers",
         url_name="list_membership_tiers",
-        response=list[schema.MembershipTierSchema],
+        response=list[schema.MembershipTierAdminSchema],
         permissions=[IsOrganizationStaff()],
         throttle=UserDefaultThrottle(),
     )
@@ -144,7 +144,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
     @route.post(
         "/membership-tiers",
         url_name="create_membership_tier",
-        response={201: schema.MembershipTierSchema},
+        response={201: schema.MembershipTierAdminSchema},
     )
     def create_membership_tier(
         self, slug: str, payload: schema.MembershipTierCreateSchema
@@ -168,7 +168,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
     @route.put(
         "/membership-tiers/{tier_id}",
         url_name="update_membership_tier",
-        response=schema.MembershipTierSchema,
+        response=schema.MembershipTierAdminSchema,
     )
     def update_membership_tier(
         self, slug: str, tier_id: UUID, payload: schema.MembershipTierUpdateSchema
@@ -176,7 +176,7 @@ class OrganizationAdminMembersController(OrganizationAdminBaseController):
         """Update a membership tier."""
         organization = self.get_one(slug)
         tier = get_object_or_404(models.MembershipTier, pk=tier_id, organization=organization)
-        return update_db_instance(tier, payload)
+        return organization_service.update_membership_tier(tier, payload)
 
     @route.delete(
         "/membership-tiers/{tier_id}",

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -196,7 +196,7 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         organization = self.get_one(slug)
         return (
             models.MembershipSubscription.objects.filter(organization=organization)
-            .select_related("user", "plan", "plan__tier")
+            .select_related("user", "plan", "plan__tier", "organization")
             .order_by("-created_at")
         )
 
@@ -210,7 +210,7 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         """Get a single subscription by id."""
         organization = self.get_one(slug)
         return get_object_or_404(
-            models.MembershipSubscription.objects.select_related("user", "plan", "plan__tier"),
+            models.MembershipSubscription.objects.select_related("user", "plan", "plan__tier", "organization"),
             pk=sub_id,
             organization=organization,
         )

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -155,6 +155,7 @@ from .mixins import (
 from .organization import (
     ApproveMembershipRequestSchema,
     MemberAddSchema,
+    MembershipTierAdminSchema,
     MembershipTierCreateSchema,
     MembershipTierSchema,
     MembershipTierUpdateSchema,
@@ -547,6 +548,7 @@ __all__ = [
     "MembershipApplicationSchema",
     "MembershipEligibilitySchema",
     "MembershipPaymentSchema",
+    "MembershipTierAdminSchema",
     "MembershipTierCreateSchema",
     "MembershipTierSchema",
     "MembershipTierUpdateSchema",

--- a/src/events/schema/organization.py
+++ b/src/events/schema/organization.py
@@ -58,7 +58,12 @@ class OrganizationEditSchema(CityEditMixin, SocialMediaSchemaEditMixin):
     contact_method: Organization.ContactMethod = Organization.ContactMethod.NONE
     revenue_report_cadence: Organization.RevenueReportCadence = Organization.RevenueReportCadence.NONE
     membership_grace_period_days: t.Annotated[int, Field(ge=0)] = 7
+    membership_subscription_revival_window_days: t.Annotated[int, Field(ge=0)] = 30
     membership_refund_policy: StrippedString = ""
+    # Membership eligibility policy defaults (overridable per tier). The questionnaire id
+    # is validated (org-scoped, MEMBERSHIP type) in the service layer before persisting.
+    default_membership_questionnaire_id: UUID | None = None
+    default_requires_membership_approval: bool = False
 
 
 class OrganizationBillingInfoSchema(Schema):
@@ -205,7 +210,11 @@ class OrganizationAdminDetailSchema(
     revenue_report_cadence: OrganizationModel.RevenueReportCadence
     # Membership subscription policy
     membership_grace_period_days: int
+    membership_subscription_revival_window_days: int
     membership_refund_policy: str
+    # Membership eligibility policy defaults
+    default_membership_questionnaire_id: UUID | None = None
+    default_requires_membership_approval: bool
 
 
 class OrganizationPermissionsSchema(Schema):
@@ -266,14 +275,30 @@ class MembershipTierSchema(ModelSchema):
         fields = ["id", "name", "description", "display_order"]
 
 
+class MembershipTierAdminSchema(MembershipTierSchema):
+    """Admin-facing tier view exposing the eligibility-policy overrides for form prefill.
+
+    ``requires_membership_approval`` is tri-state: ``None`` means "inherit the org default".
+    Kept separate from the member-facing ``MembershipTierSchema`` so these policy fields
+    don't leak into nested member/subscription/ticket-tier serializations.
+    """
+
+    membership_questionnaire_id: UUID | None = None
+    requires_membership_approval: bool | None = None
+
+
 class MembershipTierCreateSchema(Schema):
     name: OneToOneFiftyString
     description: str | None = None
+    membership_questionnaire_id: UUID | None = None
+    requires_membership_approval: bool | None = None
 
 
 class MembershipTierUpdateSchema(Schema):
     name: OneToOneFiftyString | None = None
     description: str | None = None
+    membership_questionnaire_id: UUID | None = None
+    requires_membership_approval: bool | None = None
 
 
 class MinimalOrganizationMemberSchema(ModelSchema):

--- a/src/events/schema/subscription.py
+++ b/src/events/schema/subscription.py
@@ -1,5 +1,6 @@
 """Subscription, plan, and payment schemas (Phase 1)."""
 
+from datetime import datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -210,6 +211,8 @@ class _BaseSubscriptionSchema(ModelSchema):
     current_period_end: AwareDatetime | None = None
     cancelled_at: AwareDatetime | None = None
     pending_plan_id: UUID | None = None
+    expired_at: AwareDatetime | None = None
+    revival_deadline: AwareDatetime | None = None
 
     class Meta:
         model = MembershipSubscription
@@ -219,6 +222,22 @@ class _BaseSubscriptionSchema(ModelSchema):
             "created_at",
             "updated_at",
         ]
+
+    @staticmethod
+    def resolve_revival_deadline(obj: MembershipSubscription) -> datetime | None:
+        """Deadline to revive an EXPIRED subscription in place.
+
+        ``expired_at + org.membership_subscription_revival_window_days``. Returns ``None``
+        unless the subscription is EXPIRED, has an ``expired_at`` timestamp, and the org's
+        revival window is greater than zero — mirroring ``_validate_revivable`` in
+        ``subscription_service`` so the surfaced deadline matches what revival enforces.
+        """
+        if obj.status != MembershipSubscription.SubscriptionStatus.EXPIRED or obj.expired_at is None:
+            return None
+        window = obj.organization.membership_subscription_revival_window_days
+        if window <= 0:
+            return None
+        return obj.expired_at + timedelta(days=window)
 
 
 class MySubscriptionSchema(_BaseSubscriptionSchema):

--- a/src/events/service/organization_service/__init__.py
+++ b/src/events/service/organization_service/__init__.py
@@ -30,7 +30,9 @@ from events.service.organization_service.membership import (
     remove_staff,
     reorder_membership_tiers,
     update_member,
+    update_membership_tier,
     update_staff_permissions,
+    validate_membership_questionnaire,
 )
 from events.service.organization_service.tokens import (
     GRANT_INVARIANT_MESSAGE,
@@ -73,9 +75,11 @@ __all__ = [
     "reorder_membership_tiers",
     "update_contact_email",
     "update_member",
+    "update_membership_tier",
     "update_organization",
     "update_organization_token",
     "update_staff_permissions",
     "validate_contact_method",
+    "validate_membership_questionnaire",
     "verify_contact_email",
 ]

--- a/src/events/service/organization_service/lifecycle.py
+++ b/src/events/service/organization_service/lifecycle.py
@@ -28,7 +28,11 @@ MEMBERSHIP_POLICY_MANAGE_SUBSCRIPTIONS_MESSAGE = _(
 )
 
 # Subscription-policy fields on ``OrganizationEditSchema`` guarded by ``manage_subscriptions``.
-_MEMBERSHIP_POLICY_FIELDS = ("membership_grace_period_days", "membership_refund_policy")
+_MEMBERSHIP_POLICY_FIELDS = (
+    "membership_grace_period_days",
+    "membership_subscription_revival_window_days",
+    "membership_refund_policy",
+)
 
 
 @transaction.atomic
@@ -123,10 +127,16 @@ def update_organization(
     bypass that permission. The owner implicitly holds every permission.
     """
     from events.service import update_db_instance
+    from events.service.organization_service.membership import validate_membership_questionnaire
 
     data = payload.model_dump(exclude_unset=True)
     if "contact_method" in data:
         validate_contact_method(organization, Organization.ContactMethod(data["contact_method"]))
+
+    # Validate the default membership questionnaire before save so a bad id yields a clean 400
+    # (the model's clean() would otherwise 500 dereferencing a non-existent FK). NULL clears it.
+    if data.get("default_membership_questionnaire_id"):
+        validate_membership_questionnaire(organization, data["default_membership_questionnaire_id"])
 
     if (
         "revenue_report_cadence" in data

--- a/src/events/service/organization_service/membership.py
+++ b/src/events/service/organization_service/membership.py
@@ -23,7 +23,7 @@ from events.models import (
 )
 
 if t.TYPE_CHECKING:
-    from events.schema import MembershipTierCreateSchema
+    from events.schema import MembershipTierCreateSchema, MembershipTierUpdateSchema
 
 # Intentional cross-module use of a private helper: the name is pinned by
 # events/migrations/0001_initial.py (referenced as a field `default=`), so it
@@ -224,6 +224,32 @@ def update_member(
     return member
 
 
+def validate_membership_questionnaire(organization: Organization, questionnaire_id: UUID) -> None:
+    """Ensure ``questionnaire_id`` names a MEMBERSHIP questionnaire owned by ``organization``.
+
+    Mirrors the model-level ``clean()`` rules (org-scoped, MEMBERSHIP type) but runs before
+    ``save()`` so callers get a clean 400 for a cross-org, wrong-type, or non-existent id —
+    the model ``clean()`` would 500 on the last case when it dereferences the FK.
+
+    Args:
+        organization: The organization the questionnaire must belong to.
+        questionnaire_id: The candidate ``OrganizationQuestionnaire`` id.
+
+    Raises:
+        HttpError 400: If no matching MEMBERSHIP questionnaire exists for the organization.
+    """
+    exists = models.OrganizationQuestionnaire.objects.filter(
+        pk=questionnaire_id,
+        organization=organization,
+        questionnaire_type=models.OrganizationQuestionnaire.QuestionnaireType.MEMBERSHIP,
+    ).exists()
+    if not exists:
+        raise HttpError(
+            400,
+            str(_("The membership questionnaire must belong to this organization and be of type MEMBERSHIP.")),
+        )
+
+
 @transaction.atomic
 def create_membership_tier(organization: Organization, payload: "MembershipTierCreateSchema") -> MembershipTier:
     """Create a membership tier, appending it at the bottom of the organization's ordering.
@@ -240,10 +266,39 @@ def create_membership_tier(organization: Organization, payload: "MembershipTierC
     Returns:
         The created ``MembershipTier``, appended after any existing tiers.
     """
+    if payload.membership_questionnaire_id:
+        validate_membership_questionnaire(organization, payload.membership_questionnaire_id)
     Organization.objects.select_for_update().filter(pk=organization.pk).first()
     current_max = MembershipTier.objects.filter(organization=organization).aggregate(m=Max("display_order"))["m"]
     display_order = 0 if current_max is None else current_max + 1
     return MembershipTier.objects.create(organization=organization, display_order=display_order, **payload.model_dump())
+
+
+@transaction.atomic
+def update_membership_tier(tier: MembershipTier, payload: "MembershipTierUpdateSchema") -> MembershipTier:
+    """Update a membership tier, validating any membership-questionnaire override first.
+
+    The tier-level questionnaire (when set) must belong to the tier's organization and be of
+    type MEMBERSHIP; a NULL override clears it (inherit the org default). Delegates the field
+    write to ``update_db_instance`` (locked, ``exclude_unset`` so tri-state fields keep their
+    "not provided vs explicit null" distinction).
+
+    Args:
+        tier: The tier to update.
+        payload: The validated ``MembershipTierUpdateSchema`` payload.
+
+    Returns:
+        The updated ``MembershipTier``.
+
+    Raises:
+        HttpError 400: If ``membership_questionnaire_id`` is not a MEMBERSHIP questionnaire for the org.
+    """
+    from events.service import update_db_instance
+
+    data = payload.model_dump(exclude_unset=True)
+    if data.get("membership_questionnaire_id"):
+        validate_membership_questionnaire(tier.organization, data["membership_questionnaire_id"])
+    return update_db_instance(tier, payload)
 
 
 @transaction.atomic

--- a/src/events/tests/test_controllers/test_me_subscriptions.py
+++ b/src/events/tests/test_controllers/test_me_subscriptions.py
@@ -1,5 +1,7 @@
 """Tests for the member-facing /me subscription endpoints."""
 
+import typing as t
+from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest import mock
 
@@ -7,6 +9,7 @@ import pytest
 import stripe
 from django.test.client import Client
 from django.urls import reverse
+from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
 
 from accounts.models import RevelUser
@@ -586,3 +589,63 @@ class TestBillingPortalEndpoint:
         url = reverse("api:create_billing_portal_session", kwargs={"org_id": organization.id})
         response = subscriber_client.post(url, data={}, content_type="application/json")
         assert response.status_code == 400
+
+
+class TestRevivalDeadlineExposure:
+    """expired_at + computed revival_deadline on the member-facing subscription schema (issue #778)."""
+
+    @staticmethod
+    def _expire(sub: MembershipSubscription) -> MembershipSubscription:
+        sub.status = MembershipSubscription.SubscriptionStatus.EXPIRED
+        sub.expired_at = timezone.now() - timedelta(days=1)
+        sub.save(update_fields=["status", "expired_at"])
+        return sub
+
+    def _list_item(self, client: Client) -> dict[str, t.Any]:
+        response = client.get(reverse("api:list_my_membership_subscriptions"))
+        assert response.status_code == 200
+        return response.json()["results"][0]  # type: ignore[no-any-return]
+
+    def test_expired_subscription_exposes_deadline(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+        organization: Organization,
+    ) -> None:
+        organization.membership_subscription_revival_window_days = 30
+        organization.save(update_fields=["membership_subscription_revival_window_days"])
+        self._expire(their_subscription)
+
+        item = self._list_item(subscriber_client)
+
+        assert item["expired_at"] is not None
+        assert item["revival_deadline"] is not None
+        expired_at = datetime.fromisoformat(item["expired_at"])
+        deadline = datetime.fromisoformat(item["revival_deadline"])
+        assert deadline - expired_at == timedelta(days=30)
+
+    def test_window_zero_yields_no_deadline(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+        organization: Organization,
+    ) -> None:
+        organization.membership_subscription_revival_window_days = 0
+        organization.save(update_fields=["membership_subscription_revival_window_days"])
+        self._expire(their_subscription)
+
+        item = self._list_item(subscriber_client)
+
+        assert item["expired_at"] is not None
+        assert item["revival_deadline"] is None
+
+    def test_non_expired_subscription_has_no_deadline(
+        self,
+        subscriber_client: Client,
+        their_subscription: MembershipSubscription,
+    ) -> None:
+        # ``their_subscription`` is active/pending, never EXPIRED.
+        item = self._list_item(subscriber_client)
+
+        assert item["expired_at"] is None
+        assert item["revival_deadline"] is None

--- a/src/events/tests/test_controllers/test_organization_admin/test_core.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_core.py
@@ -15,9 +15,20 @@ from accounts.jwt import create_token
 from accounts.models import RevelUser
 from common.utils import assert_image_equal
 from events import schema
-from events.models import Organization, OrganizationStaff
+from events.models import Organization, OrganizationQuestionnaire, OrganizationStaff
+from questionnaires.models import Questionnaire
 
 pytestmark = pytest.mark.django_db
+
+
+def _make_org_questionnaire(
+    org: Organization,
+    questionnaire_type: str = OrganizationQuestionnaire.QuestionnaireType.MEMBERSHIP,
+) -> OrganizationQuestionnaire:
+    q = Questionnaire.objects.create(name="Q", status=Questionnaire.QuestionnaireStatus.PUBLISHED)
+    return OrganizationQuestionnaire.objects.create(
+        organization=org, questionnaire=q, questionnaire_type=questionnaire_type
+    )
 
 
 # --- Tests for PUT /organization-admin/{slug} ---
@@ -88,6 +99,75 @@ def test_update_membership_grace_period_rejects_negative(
     assert response.status_code == 422
     organization.refresh_from_db()
     assert organization.membership_grace_period_days == 7
+
+
+def test_update_revival_window_and_eligibility_policy(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """Revival window (issue #778) and membership-eligibility defaults (issue #777) are writable via PUT."""
+    oq = _make_org_questionnaire(organization)
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {
+        "visibility": "public",
+        "membership_subscription_revival_window_days": 45,
+        "default_membership_questionnaire_id": str(oq.id),
+        "default_requires_membership_approval": True,
+    }
+
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["membership_subscription_revival_window_days"] == 45
+    assert data["default_membership_questionnaire_id"] == str(oq.id)
+    assert data["default_requires_membership_approval"] is True
+    organization.refresh_from_db()
+    assert organization.membership_subscription_revival_window_days == 45
+    assert organization.default_membership_questionnaire_id == oq.id
+    assert organization.default_requires_membership_approval is True
+
+
+def test_update_revival_window_rejects_negative(organization_owner_client: Client, organization: Organization) -> None:
+    """A negative revival window is rejected at the schema boundary (ge=0)."""
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public", "membership_subscription_revival_window_days": -1}
+
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 422
+
+
+def test_update_default_questionnaire_rejects_cross_org(
+    organization_owner_client: Client, organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """A default questionnaire belonging to another org is rejected with 400."""
+    other_org = Organization.objects.create(name="Other Org", slug="other-org", owner=organization_owner_user)
+    other_oq = _make_org_questionnaire(other_org)
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public", "default_membership_questionnaire_id": str(other_oq.id)}
+
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 400
+    organization.refresh_from_db()
+    assert organization.default_membership_questionnaire_id is None
+
+
+def test_update_default_questionnaire_rejects_wrong_type(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """A non-MEMBERSHIP questionnaire is rejected with 400."""
+    feedback_oq = _make_org_questionnaire(
+        organization, questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.FEEDBACK
+    )
+    url = reverse("api:edit_organization", kwargs={"slug": organization.slug})
+    payload = {"visibility": "public", "default_membership_questionnaire_id": str(feedback_oq.id)}
+
+    response = organization_owner_client.put(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 400
+    organization.refresh_from_db()
+    assert organization.default_membership_questionnaire_id is None
 
 
 def test_upload_organization_logo_by_owner(

--- a/src/events/tests/test_controllers/test_organization_admin/test_members.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_members.py
@@ -9,9 +9,23 @@ from django.test.client import Client
 from django.urls import reverse
 
 from accounts.models import RevelUser
-from events.models import MembershipTier, Organization, OrganizationMember, OrganizationStaff
+from events.models import (
+    MembershipTier,
+    Organization,
+    OrganizationMember,
+    OrganizationQuestionnaire,
+    OrganizationStaff,
+)
+from questionnaires.models import Questionnaire
 
 pytestmark = pytest.mark.django_db
+
+
+def _membership_questionnaire(org: Organization) -> OrganizationQuestionnaire:
+    q = Questionnaire.objects.create(name="Q", status=Questionnaire.QuestionnaireStatus.PUBLISHED)
+    return OrganizationQuestionnaire.objects.create(
+        organization=org, questionnaire=q, questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.MEMBERSHIP
+    )
 
 
 class TestManageMembersAndStaff:
@@ -363,6 +377,105 @@ def test_update_membership_tier_by_owner(organization_owner_client: Client, orga
 
     tier.refresh_from_db()
     assert tier.name == "New Name"
+
+
+def test_create_membership_tier_with_eligibility_overrides(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """A tier can be created with a questionnaire override and requires_membership_approval (issue #777)."""
+    oq = _membership_questionnaire(organization)
+    url = reverse("api:create_membership_tier", kwargs={"slug": organization.slug})
+    payload = {
+        "name": "Gated",
+        "membership_questionnaire_id": str(oq.id),
+        "requires_membership_approval": True,
+    }
+
+    response = organization_owner_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["membership_questionnaire_id"] == str(oq.id)
+    assert data["requires_membership_approval"] is True
+    tier = MembershipTier.objects.get(organization=organization, name="Gated")
+    assert tier.membership_questionnaire_id == oq.id
+    assert tier.requires_membership_approval is True
+
+
+def test_create_membership_tier_rejects_cross_org_questionnaire(
+    organization_owner_client: Client, organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """A tier questionnaire from another org is rejected with 400."""
+    other_org = Organization.objects.create(name="Other Org", slug="other-org", owner=organization_owner_user)
+    other_oq = _membership_questionnaire(other_org)
+    url = reverse("api:create_membership_tier", kwargs={"slug": organization.slug})
+    payload = {"name": "Bad", "membership_questionnaire_id": str(other_oq.id)}
+
+    response = organization_owner_client.post(url, data=orjson.dumps(payload), content_type="application/json")
+
+    assert response.status_code == 400
+    assert not MembershipTier.objects.filter(organization=organization, name="Bad").exists()
+
+
+def test_update_membership_tier_approval_tristate_set_then_inherit(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """requires_membership_approval is tri-state: settable to True, then back to null (inherit org default)."""
+    tier = MembershipTier.objects.create(organization=organization, name="Tri")
+    url = reverse("api:update_membership_tier", kwargs={"slug": organization.slug, "tier_id": tier.id})
+
+    # Set the override explicitly.
+    response = organization_owner_client.put(
+        url, data=orjson.dumps({"requires_membership_approval": True}), content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json()["requires_membership_approval"] is True
+    tier.refresh_from_db()
+    assert tier.requires_membership_approval is True
+
+    # Explicit null clears the override (inherit the org default).
+    response = organization_owner_client.put(
+        url, data=orjson.dumps({"requires_membership_approval": None}), content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json()["requires_membership_approval"] is None
+    tier.refresh_from_db()
+    assert tier.requires_membership_approval is None
+
+
+def test_update_membership_tier_omitting_approval_leaves_it_unchanged(
+    organization_owner_client: Client, organization: Organization
+) -> None:
+    """Omitting requires_membership_approval on update does not reset the existing override."""
+    tier = MembershipTier.objects.create(organization=organization, name="Keep", requires_membership_approval=True)
+    url = reverse("api:update_membership_tier", kwargs={"slug": organization.slug, "tier_id": tier.id})
+
+    response = organization_owner_client.put(
+        url, data=orjson.dumps({"name": "Keep Renamed"}), content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    tier.refresh_from_db()
+    assert tier.name == "Keep Renamed"
+    assert tier.requires_membership_approval is True
+
+
+def test_update_membership_tier_rejects_cross_org_questionnaire(
+    organization_owner_client: Client, organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """Updating a tier with a questionnaire from another org is rejected with 400."""
+    other_org = Organization.objects.create(name="Other Org", slug="other-org", owner=organization_owner_user)
+    other_oq = _membership_questionnaire(other_org)
+    tier = MembershipTier.objects.create(organization=organization, name="ToGate")
+    url = reverse("api:update_membership_tier", kwargs={"slug": organization.slug, "tier_id": tier.id})
+
+    response = organization_owner_client.put(
+        url, data=orjson.dumps({"membership_questionnaire_id": str(other_oq.id)}), content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    tier.refresh_from_db()
+    assert tier.membership_questionnaire_id is None
 
 
 def test_update_membership_tier_by_staff_with_permission(

--- a/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
+++ b/src/events/tests/test_controllers/test_organization_admin/test_subscriptions.py
@@ -336,6 +336,29 @@ class TestSubscriptionEndpoints:
         assert response.status_code == 200
         assert response.json()["id"] == str(sub.id)
 
+    def test_expired_subscription_exposes_revival_deadline(
+        self,
+        organization_owner_client: Client,
+        organization: Organization,
+        plan: MembershipSubscriptionPlan,
+        subscriber: RevelUser,
+    ) -> None:
+        """The staff SubscriptionSchema surfaces expired_at + computed revival_deadline (issue #778)."""
+        organization.membership_subscription_revival_window_days = 30
+        organization.save(update_fields=["membership_subscription_revival_window_days"])
+        sub = subscription_service.create_subscription(plan, subscriber)
+        sub.status = MembershipSubscription.SubscriptionStatus.EXPIRED
+        sub.expired_at = timezone.now() - datetime.timedelta(days=1)
+        sub.save(update_fields=["status", "expired_at"])
+
+        url = reverse("api:get_subscription", kwargs={"slug": organization.slug, "sub_id": sub.id})
+        response = organization_owner_client.get(url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["expired_at"] is not None
+        assert data["revival_deadline"] is not None
+
     def test_create_subscription_with_initial_payment(
         self,
         organization_owner_client: Client,


### PR DESCRIPTION
Part of #777 / #778. Base is `feature/subscriptions-integration`, so these issues won't auto-close on merge — that's intended.

Pure API-exposure work: the model fields already exist on the subscriptions-integration branch, so **no migrations**.

## #777 — Membership eligibility fields (org defaults + tier overrides)
- `OrganizationEditSchema` + `OrganizationAdminDetailSchema`: added `default_membership_questionnaire_id: UUID | None` and `default_requires_membership_approval: bool`.
- `MembershipTierCreateSchema` / `MembershipTierUpdateSchema`: added `membership_questionnaire_id: UUID | None` and tri-state `requires_membership_approval: bool | None` (`None` = inherit org default; `exclude_unset` preserves "not provided" vs "explicit null").
- New `MembershipTierAdminSchema(MembershipTierSchema)` used as the response for the admin tier list/create/update endpoints so the FE can prefill. Kept **separate** from the shared `MembershipTierSchema` because that one is nested into member-facing / subscription / ticket-tier payloads and would otherwise leak the policy fields.
- New service helper `validate_membership_questionnaire(org, questionnaire_id)` returns a clean **400** for cross-org, wrong-type, **and non-existent** ids. This is load-bearing: relying on the model `clean()` alone would return a **500** for a non-existent id (its `clean()` dereferences the FK → `DoesNotExist`, which `full_clean` does not catch). Wired into `update_organization` (org default), `create_membership_tier`, and a new thin `update_membership_tier` service fn (controller now delegates instead of calling `update_db_instance` directly).

## #778 — Revival window + `expired_at` / `revival_deadline`
- `OrganizationEditSchema` (`ge=0`, default 30) + `OrganizationAdminDetailSchema`: added `membership_subscription_revival_window_days`, next to `membership_grace_period_days`.
- Added `expired_at` and a computed `revival_deadline` to `_BaseSubscriptionSchema`, so **both** `MySubscriptionSchema` and `SubscriptionSchema` (staff drawer) inherit them via one resolver. `revival_deadline = expired_at + timedelta(days=window)` only when status is EXPIRED, `expired_at` is set, and window > 0 — mirroring `_validate_revivable` in `subscription_service`.
- N+1 guard: `select_related("organization")` added to the org-admin `list_subscriptions` and `get_subscription` querysets (the `/me` endpoints already select it).

## Gating decision
`membership_subscription_revival_window_days` is a subscription-policy field, so it's added to `_MEMBERSHIP_POLICY_FIELDS` and gated by `manage_subscriptions` (like `membership_grace_period_days` / `membership_refund_policy`). The two #777 eligibility fields are join-eligibility, not subscription billing, so they stay under `edit_organization`.

## #777 item 3 — questionnaire-list finding
No new endpoint/filter added. The existing org-admin list endpoint (`list_org_questionnaires`) already exposes `questionnaire_type` on every row via `OrganizationQuestionnaireInListSchema`, so the FE can identify MEMBERSHIP-type questionnaires client-side. `QuestionnaireFilterSchema` has no server-side `questionnaire_type` filter, but since the type is visible per-row, per the issue's "only add if genuinely not filterable/visible" I did not add one.

## Notes
- `.artifacts/openapi.json` regeneration is **deliberately deferred** to the integration branch (coordinator regenerates once after integration).
- Did not touch `SubscribeResponseSchema` / `RevivalResponseSchema` or any checkout/client_secret code (parallel lane).

## Tests
Extended the existing test files (`test_core.py`, `test_members.py`, `test_me_subscriptions.py`, org-admin `test_subscriptions.py`): org PATCH happy path, revival-window set + negative rejection, cross-org and wrong-type questionnaire rejection (org + tier), tier tri-state set→inherit + omit-leaves-unchanged, and `revival_deadline` computation (EXPIRED-with-window, window=0, non-expired). `make format` / `make lint` / `make mypy` clean; 177 passed across the four files, `test_organization_service.py` (48) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)