### PR TITLE
feat(events): expose revival window and grace period on the public org schema

### DIFF
--- a/src/events/schema/organization.py
+++ b/src/events/schema/organization.py
@@ -165,10 +165,14 @@ class OrganizationRetrieveSchema(
     contact_method: Organization.ContactMethod
     contact_email: str | None = None
     # Member-facing subscription policy: shown to prospective subscribers before
-    # they request/pay for a membership (grace period stays admin-internal). Given a
-    # default so it's non-required in the public schema — narrower org payloads
-    # (list/minimal) that don't carry it stay structurally assignable.
+    # they request/pay for a membership. The two day counts joined the public payload
+    # in #809 (2026-07) — the pre-purchase billing disclosure needs the real numbers;
+    # they stay read-only here, writable only via the admin edit schema. Given
+    # defaults so they're non-required in the public schema — narrower org payloads
+    # (list/minimal) that don't carry them stay structurally assignable.
     membership_refund_policy: str = ""
+    membership_grace_period_days: int = 7
+    membership_subscription_revival_window_days: int = 30
 
     @staticmethod
     def resolve_contact_email(obj: Organization, context: t.Any) -> str | None:

--- a/src/events/tests/test_controllers/test_organization_controller.py
+++ b/src/events/tests/test_controllers/test_organization_controller.py
@@ -143,6 +143,35 @@ def test_get_organization_by_privileged_users(
     assert response.json()["name"] == organization.name
 
 
+def test_get_organization_exposes_membership_billing_policy(client: Client, organization: Organization) -> None:
+    """The public org payload carries the billing-disclosure numbers (issue #809).
+
+    The subscribe flow tells a prospective member how long the grace period is and how
+    long they can rejoin at the old price, so both day counts must be readable anonymously.
+    """
+    organization.visibility = Organization.Visibility.PUBLIC
+    organization.membership_grace_period_days = 14
+    organization.membership_subscription_revival_window_days = 45
+    organization.membership_refund_policy = "Full refund within 7 days."
+    organization.save(
+        update_fields=[
+            "visibility",
+            "membership_grace_period_days",
+            "membership_subscription_revival_window_days",
+            "membership_refund_policy",
+        ]
+    )
+    url = reverse("api:get_organization", kwargs={"slug": organization.slug})
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["membership_grace_period_days"] == 14
+    assert data["membership_subscription_revival_window_days"] == 45
+    assert data["membership_refund_policy"] == "Full refund within 7 days."
+
+
 class TestListMembershipPlans:
     """Public listing of an organization's active subscription plans.
 
@@ -346,6 +375,34 @@ class TestCreateOrganization:
         org = Organization.objects.get(name="Auto Verify Org", owner=nonmember_user)
         assert org.contact_email == "owner@example.com"
         assert org.contact_email_verified is True
+
+    def test_create_organization_ignores_membership_policy_fields(
+        self, nonmember_client: Client, nonmember_user: RevelUser
+    ) -> None:
+        """The day counts are readable on the public schema but writable only by admins (issue #809)."""
+        # Arrange
+        nonmember_user.email_verified = True
+        nonmember_user.save()
+
+        url = reverse("api:create_organization")
+        payload = {
+            "name": "Policy Smuggler",
+            "contact_email": "contact@smuggler.com",
+            "membership_grace_period_days": 999,
+            "membership_subscription_revival_window_days": 999,
+        }
+
+        # Act
+        response = nonmember_client.post(url, data=payload, content_type="application/json")
+
+        # Assert -- the create schema drops the unknown keys, so the model defaults survive.
+        assert response.status_code == 201
+        data = response.json()
+        assert data["membership_grace_period_days"] == 7
+        assert data["membership_subscription_revival_window_days"] == 30
+        org = Organization.objects.get(name="Policy Smuggler", owner=nonmember_user)
+        assert org.membership_grace_period_days == 7
+        assert org.membership_subscription_revival_window_days == 30
 
     def test_create_organization_without_verified_email_fails(
         self, nonmember_client: Client, nonmember_user: RevelUser


### PR DESCRIPTION
Closes #809.

## Decision

Expose **both** `membership_subscription_revival_window_days` **and** `membership_grace_period_days` on the public organization read schema, read-only.

The frontend's pre-purchase billing disclosure (letsrevel/revel-frontend#703) needs both numbers — "you keep access for a grace period of N days if a payment fails" and "you can rejoin within N days at the current price". Neither number reveals anything about other members or the org's finances, and the revival window in particular is a selling point we currently can't state. The issue's counter-argument (org policy surface area) loses to the member deciding whether to hand over money.

The comment in `organization.py` that declared the grace period admin-internal is updated to record the new call, citing #809.

## Which schemas

Only `OrganizationRetrieveSchema` — the org detail payload the subscribe flow reads. This matches exactly where `membership_refund_policy` already sits, so the detail/list split stays consistent: `MinimalOrganizationSchema` and `OrganizationInListSchema` remain lean (they exist to avoid N+1s on event/org lists and carry no membership policy at all). Both new fields are declared with their model defaults (`7` / `30`) for the same reason `membership_refund_policy` has `= ""`: it keeps them non-required in the OpenAPI schema so narrower org payloads stay structurally assignable on the frontend.

`OrganizationRetrieveSchema` is also the response for several org-admin endpoints, which already had these fields via `OrganizationAdminDetailSchema` — no behaviour change there.

No model change, so no migration. Plain scalar columns already loaded with the org row, so no extra queries.

## Write access unchanged

The fields remain writable only through `OrganizationEditSchema` (org-admin PUT), still gated by the `manage_subscriptions` permission via `_MEMBERSHIP_POLICY_FIELDS`. No new write path.

## Tests

- `test_get_organization_exposes_membership_billing_policy` — anonymous GET on a public org returns both day counts (14 / 45) plus the refund policy.
- `test_create_organization_ignores_membership_policy_fields` — the only public-facing org write path (POST /organizations/) drops the keys; the created org keeps the model defaults.

Results: `src/events/tests/test_controllers/test_organization_controller.py` 26 passed; `test_organization_admin/`, `test_organization_contact.py`, `test_dashboard_controller.py`, `test_token_endpoints.py` 576 passed; `src/api/tests/test_openapi_schema.py` 3 passed. `make check` green (ruff, mypy --strict, migration check, i18n, file length, task names).

## Frontend

`pnpm generate:api` needed — `OrganizationRetrieveSchema` gains two optional integer fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtpbeLss5QghtRPoTRVYV3