### PR TITLE
feat(events): dedicated reason code for exhausted questionnaire attempts

### DIFF
--- a/src/events/service/membership_manager/enums.py
+++ b/src/events/service/membership_manager/enums.py
@@ -42,6 +42,7 @@ class MembershipReasonCode(StrEnum):
     MEMBERSHIP_QUESTIONNAIRE_PENDING = "membership_questionnaire_pending"
     MEMBERSHIP_QUESTIONNAIRE_FAILED = "membership_questionnaire_failed"
     MEMBERSHIP_QUESTIONNAIRE_RETAKE_COOLDOWN = "membership_questionnaire_retake_cooldown"
+    MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED = "membership_questionnaire_attempts_exhausted"
     REQUIRES_APPROVAL = "requires_approval"
     TIER_REQUIRES_SUBSCRIPTION = "tier_requires_subscription"
     PLAN_NOT_ONLINE = "plan_not_online"
@@ -73,6 +74,9 @@ class Reasons(StrEnum):
     MEMBERSHIP_QUESTIONNAIRE_RETAKE_COOLDOWN = gettext_noop(
         "Membership questionnaire evaluation was insufficient. You can try again later."
     )
+    # Deliberately the same msgid the submit endpoint's 400 uses: the verdict and
+    # the refusal a user would hit by submitting anyway must read identically.
+    MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED = gettext_noop("You have reached the maximum number of attempts.")
     REQUIRES_APPROVAL = gettext_noop("Your application is awaiting staff approval.")
     TIER_REQUIRES_SUBSCRIPTION = gettext_noop("This tier requires a paid subscription. Subscribe to a plan to join.")
     PLAN_NOT_ONLINE = gettext_noop("This plan is not configured for online checkout.")

--- a/src/events/service/membership_manager/gates.py
+++ b/src/events/service/membership_manager/gates.py
@@ -318,7 +318,20 @@ class MembershipQuestionnaireGate(BaseMembershipEligibilityGate):
     def _handle_rejected(
         self, questionnaire: "Questionnaire", submission: QuestionnaireSubmission
     ) -> MembershipEligibility:
-        """Apply retake cooldown logic for a rejected evaluation."""
+        """Apply the attempts cap, then the retake cooldown, for a rejected evaluation.
+
+        Order mirrors ``_validate_resubmission`` in
+        :mod:`events.service.membership_questionnaire_service` exactly: the cap
+        outranks the retake policy there, so it must outrank it here too — a
+        gate that promised SUBMIT_QUESTIONNAIRE (or a cooldown that expires into
+        one) to a user at the cap would send them to a guaranteed 400.
+        """
+        if 0 < questionnaire.max_attempts <= self.handler.questionnaire_attempt_count:
+            return self._block(
+                Reasons.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED,
+                questionnaire_id=questionnaire.pk,
+            )
+
         if questionnaire.can_retake_after is not None and submission.submitted_at is not None:
             retry_on = submission.submitted_at + questionnaire.can_retake_after
             if retry_on > timezone.now():

--- a/src/events/service/membership_manager/service.py
+++ b/src/events/service/membership_manager/service.py
@@ -138,6 +138,26 @@ class MembershipEligibilityService:
         return self.applications_by_tier.get(self.tier.pk)
 
     @functools.cached_property
+    def questionnaire_attempt_count(self) -> int:
+        """How many READY submissions the user has made for the resolved membership questionnaire.
+
+        Counted lazily — only :class:`~.gates.MembershipQuestionnaireGate`'s
+        rejected branch needs it, so list views (where every row builds a
+        service) pay for this query only for users who actually failed an
+        evaluation. Mirrors the queryset
+        ``events.service.membership_questionnaire_service._validate_resubmission``
+        counts against, so the gate and the submit endpoint agree on when the
+        cap is hit.
+        """
+        if self.membership_questionnaire_oq is None:
+            return 0
+        return QuestionnaireSubmission.objects.filter(
+            user=self.user,
+            questionnaire_id=self.membership_questionnaire_oq.questionnaire_id,
+            status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        ).count()
+
+    @functools.cached_property
     def _blacklist_state(self) -> _BlacklistState:
         """Compute the user's blacklist/whitelist standing once, cache the result."""
         from events.service.blacklist_service import (
@@ -245,6 +265,9 @@ class MembershipEligibilityService:
 TERMINAL_REJECTION_CODES: t.Final[frozenset[MembershipReasonCode]] = frozenset(
     {
         MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_FAILED,
+        # A user at the attempts cap can never satisfy the questionnaire gate again,
+        # whatever the retake policy says — as terminal as an outright failure.
+        MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED,
     }
 )
 

--- a/src/events/service/membership_questionnaire_service.py
+++ b/src/events/service/membership_questionnaire_service.py
@@ -123,10 +123,10 @@ def _validate_resubmission(*, user: RevelUser, org_questionnaire: OrganizationQu
         raise HttpError(400, str(_("Your questionnaire has already been approved.")))
 
     # Rejected: apply the retake policy.
-    # ponytail: MembershipQuestionnaireGate does not surface exhausted attempts as a
-    # distinct verdict yet, so a user at the cap sees SUBMIT_QUESTIONNAIRE and learns
-    # about the cap from this 400. Enforcing it here is still required — without it an
-    # AUTOMATIC-mode membership questionnaire could be brute-forced.
+    # MembershipQuestionnaireGate blocks the cap ahead of the retake policy with
+    # MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED, so a user at the cap is never told to
+    # submit. Enforcing it here too is still required — the gate is advisory, and without
+    # this an AUTOMATIC-mode membership questionnaire could be brute-forced.
     if 0 < questionnaire.max_attempts <= len(submissions):
         raise HttpError(400, str(_("You have reached the maximum number of attempts.")))
 

--- a/src/events/tests/test_service/test_membership_manager/test_advance_application.py
+++ b/src/events/tests/test_service/test_membership_manager/test_advance_application.py
@@ -1,6 +1,7 @@
 """Tests for advance_application state-advance-on-read helper."""
 
 import typing as t
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone
@@ -222,6 +223,51 @@ def test_pending_with_paused_membership_stays_pending(
 
     assert result.status == OrganizationMembershipRequest.Status.PENDING
     assert eligibility.allowed is False
+
+
+def test_pending_with_exhausted_questionnaire_attempts_rejects(
+    user: RevelUser, organization: Organization, tier: MembershipTier
+) -> None:
+    """#810: the attempts cap is terminal too — the row must not linger PENDING.
+
+    Retakes are configured and the cooldown has elapsed, so before the dedicated
+    reason code this application stayed PENDING behind a SUBMIT_QUESTIONNAIRE
+    verdict the user could never satisfy.
+    """
+    q = Questionnaire.objects.create(
+        name="Q",
+        status=Questionnaire.QuestionnaireStatus.PUBLISHED,
+        can_retake_after=timedelta(hours=1),
+        max_attempts=1,
+    )
+    oq = OrganizationQuestionnaire.objects.create(
+        organization=organization,
+        questionnaire=q,
+        questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.MEMBERSHIP,
+    )
+    organization.default_membership_questionnaire = oq
+    organization.save(update_fields=["default_membership_questionnaire"])
+    submission = QuestionnaireSubmission.objects.create(
+        user=user,
+        questionnaire=q,
+        status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        submitted_at=timezone.now() - timedelta(days=1),
+    )
+    QuestionnaireEvaluation.objects.create(
+        submission=submission,
+        status=QuestionnaireEvaluation.QuestionnaireEvaluationStatus.REJECTED,
+    )
+    app = OrganizationMembershipRequest.objects.create(
+        organization=organization,
+        user=user,
+        tier=tier,
+        status=OrganizationMembershipRequest.Status.PENDING,
+    )
+
+    result, eligibility = advance_application(app)
+
+    assert result.status == OrganizationMembershipRequest.Status.REJECTED
+    assert eligibility.reason_code == MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED
 
 
 def test_pending_with_terminal_questionnaire_failure_rejects_and_notifies(

--- a/src/events/tests/test_service/test_membership_manager/test_gates_questionnaire.py
+++ b/src/events/tests/test_service/test_membership_manager/test_gates_questionnaire.py
@@ -1,6 +1,6 @@
 """Tests for MembershipQuestionnaireGate."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from django.utils import timezone
@@ -8,7 +8,7 @@ from django.utils import timezone
 from accounts.models import RevelUser
 from events.models import MembershipTier, Organization, OrganizationQuestionnaire
 from events.service.membership_manager import MembershipEligibilityService
-from events.service.membership_manager.enums import MembershipNextStep, Reasons
+from events.service.membership_manager.enums import MembershipNextStep, MembershipReasonCode, Reasons
 from questionnaires.models import Questionnaire, QuestionnaireEvaluation, QuestionnaireSubmission
 
 pytestmark = pytest.mark.django_db
@@ -140,6 +140,129 @@ def test_rejected_without_retake_returns_failed_terminal(
     assert result.allowed is False
     assert result.reason == str(Reasons.MEMBERSHIP_QUESTIONNAIRE_FAILED)
     assert result.next_step is None
+
+
+def _rejected_submission(
+    user: RevelUser, questionnaire: Questionnaire, submitted_at: datetime | None = None
+) -> QuestionnaireSubmission:
+    """Create a READY submission with a REJECTED evaluation."""
+    submission = QuestionnaireSubmission.objects.create(
+        user=user,
+        questionnaire=questionnaire,
+        status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        submitted_at=submitted_at or timezone.now(),
+    )
+    QuestionnaireEvaluation.objects.create(
+        submission=submission, status=QuestionnaireEvaluation.QuestionnaireEvaluationStatus.REJECTED
+    )
+    return submission
+
+
+def test_rejected_at_attempts_cap_returns_attempts_exhausted(
+    user: RevelUser, organization: Organization, tier: MembershipTier, org_questionnaire: OrganizationQuestionnaire
+) -> None:
+    """#810: at the cap the verdict is terminal, not an invitation to submit again.
+
+    Cooldown has elapsed, so before the dedicated code this returned
+    SUBMIT_QUESTIONNAIRE — and the submission it invited was guaranteed a 400.
+    """
+    _attach_to_org(organization, org_questionnaire)
+    q = org_questionnaire.questionnaire
+    q.can_retake_after = timedelta(hours=1)
+    q.max_attempts = 1
+    q.save(update_fields=["can_retake_after", "max_attempts"])
+    _rejected_submission(user, q, submitted_at=timezone.now() - timedelta(days=1))
+
+    result = MembershipEligibilityService(user=user, organization=organization, tier=tier).check_eligibility()
+
+    assert result.allowed is False
+    assert result.reason_code == MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED
+    assert result.reason == str(Reasons.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED)
+    assert result.next_step is None
+    assert result.questionnaire_id == q.pk
+
+
+def test_attempts_cap_outranks_an_unexpired_retake_cooldown(
+    user: RevelUser, organization: Organization, tier: MembershipTier, org_questionnaire: OrganizationQuestionnaire
+) -> None:
+    """Waiting out the cooldown would change nothing, so don't promise a retry."""
+    _attach_to_org(organization, org_questionnaire)
+    q = org_questionnaire.questionnaire
+    q.can_retake_after = timedelta(days=7)
+    q.max_attempts = 1
+    q.save(update_fields=["can_retake_after", "max_attempts"])
+    _rejected_submission(user, q)
+
+    result = MembershipEligibilityService(user=user, organization=organization, tier=tier).check_eligibility()
+
+    assert result.reason_code == MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED
+    assert result.next_step is None
+    assert result.retry_on is None
+
+
+def test_attempts_remaining_still_invites_a_new_submission(
+    user: RevelUser, organization: Organization, tier: MembershipTier, org_questionnaire: OrganizationQuestionnaire
+) -> None:
+    """0 < used < max: the CTA stays SUBMIT_QUESTIONNAIRE."""
+    _attach_to_org(organization, org_questionnaire)
+    q = org_questionnaire.questionnaire
+    q.can_retake_after = timedelta(hours=1)
+    q.max_attempts = 3
+    q.save(update_fields=["can_retake_after", "max_attempts"])
+    _rejected_submission(user, q, submitted_at=timezone.now() - timedelta(days=1))
+
+    result = MembershipEligibilityService(user=user, organization=organization, tier=tier).check_eligibility()
+
+    assert result.allowed is False
+    assert result.next_step == MembershipNextStep.SUBMIT_QUESTIONNAIRE
+    assert result.reason_code == MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_MISSING
+
+
+def test_unlimited_attempts_never_exhausts(
+    user: RevelUser, organization: Organization, tier: MembershipTier, org_questionnaire: OrganizationQuestionnaire
+) -> None:
+    """max_attempts=0 means unlimited — three rejections still resolve by retake policy."""
+    _attach_to_org(organization, org_questionnaire)
+    q = org_questionnaire.questionnaire
+    assert q.max_attempts == 0  # default: unlimited
+    for days_ago in (3, 2, 1):
+        _rejected_submission(user, q, submitted_at=timezone.now() - timedelta(days=days_ago))
+
+    result = MembershipEligibilityService(user=user, organization=organization, tier=tier).check_eligibility()
+
+    # can_retake_after is None → the pre-existing terminal FAILED verdict, unchanged.
+    assert result.reason_code == MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_FAILED
+
+
+def test_stale_approval_ignores_the_attempts_cap(
+    user: RevelUser, organization: Organization, tier: MembershipTier, org_questionnaire: OrganizationQuestionnaire
+) -> None:
+    """An aged-out APPROVED evaluation asks for a resubmission even at the cap.
+
+    Lockstep with ``_validate_resubmission``, which returns early (allowing the
+    submission) for a stale approval before it ever reaches the cap check.
+    """
+    org_questionnaire.max_submission_age = timedelta(days=30)
+    org_questionnaire.save(update_fields=["max_submission_age"])
+    _attach_to_org(organization, org_questionnaire)
+    q = org_questionnaire.questionnaire
+    q.max_attempts = 1
+    q.save(update_fields=["max_attempts"])
+
+    submission = QuestionnaireSubmission.objects.create(
+        user=user,
+        questionnaire=q,
+        status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        submitted_at=timezone.now() - timedelta(days=90),
+    )
+    evaluation = QuestionnaireEvaluation.objects.create(
+        submission=submission, status=QuestionnaireEvaluation.QuestionnaireEvaluationStatus.APPROVED
+    )
+    QuestionnaireEvaluation.objects.filter(pk=evaluation.pk).update(updated_at=timezone.now() - timedelta(days=90))
+
+    result = MembershipEligibilityService(user=user, organization=organization, tier=tier).check_eligibility()
+
+    assert result.next_step == MembershipNextStep.SUBMIT_QUESTIONNAIRE
 
 
 def test_members_exempt_skips_gate_for_existing_active_member(


### PR DESCRIPTION
Closes #810

## What

A member who has burned through a membership questionnaire's `max_attempts` still got `next_step=submit_questionnaire` from `MembershipQuestionnaireGate`. They filled the questionnaire, submitted, and only then hit the 400 that `_validate_resubmission` raises for the cap. The last thing they did before being refused was exactly what the API told them to do.

`MembershipQuestionnaireGate`'s rejected branch now checks the cap **first** and returns a terminal refusal:

- **New reason code:** `MembershipReasonCode.MEMBERSHIP_QUESTIONNAIRE_ATTEMPTS_EXHAUSTED` → wire value `"membership_questionnaire_attempts_exhausted"`
- `next_step` is `None`, `questionnaire_id` is still populated, `retry_on` is not — a structurally distinguishable refusal, same shape as the activation-pending code from #806.

## Why the ordering matters

`_validate_resubmission` checks the cap *before* the retake policy, so the gate must too. Checking it after would leave a user with `can_retake_after` set seeing `wait_to_retake_questionnaire` and then, once the cooldown expired, `submit_questionnaire` — a countdown to a guaranteed 400. The gate counts attempts against the identical queryset (all `READY` submissions for `(user, questionnaire)`), so the two can never disagree about when the cap is hit.

The count is a lazy `functools.cached_property` on `MembershipEligibilityService`: only users whose latest evaluation was REJECTED trigger the extra query, so list views (which build one service per row) pay nothing in the common case.

## Behavior changes worth flagging

The new code joins `TERMINAL_REJECTION_CODES`, so a PENDING `OrganizationMembershipRequest` at the cap auto-rejects on read (and notifies) rather than lingering:

- **Preserves** the existing auto-reject for the no-retake case, which used to arrive here via `MEMBERSHIP_QUESTIONNAIRE_FAILED`. That case now reports the more precise `..._ATTEMPTS_EXHAUSTED` instead — an FE-visible relabel, but only when `max_attempts > 0` (the default `0` = unlimited is untouched).
- **Extends** it to capped-with-retakes applications, which previously stayed PENDING behind a verdict the user could never satisfy.

## i18n

The reason reuses the submit endpoint's existing msgid — *"You have reached the maximum number of attempts."* — so the verdict and the 400 a user would hit by submitting anyway read identically, and the `de`/`fr`/`it` catalogs need no new entries. `make i18n-check` is green.

No migration: `MembershipReasonCode` is a Python `StrEnum`, not a DB choices field.

## Tests

`src/events/tests/test_service/test_membership_manager/test_gates_questionnaire.py` (5 new):

- at the cap with the cooldown elapsed → new code, `next_step is None` (the #810 regression)
- at the cap with the cooldown *active* → cap outranks it, no `retry_on`
- `0 < used < max` → still `submit_questionnaire` / `..._MISSING`
- `max_attempts=0` with 3 rejections → unlimited semantics unchanged (`..._FAILED`)
- stale APPROVED evaluation at the cap → still `submit_questionnaire`, lockstep with `_validate_resubmission`'s early return

`test_advance_application.py` (1 new): PENDING row at the cap auto-rejects with the new code.

The submit path's 400 is untouched and already covered by `test_me_membership_questionnaire.py`.

**Results:** `make check` green (ruff, mypy --strict, migration-check, i18n-check, file-length, task-names). `src/events/tests/test_service/test_membership_manager/` 83 passed; `test_me_membership_questionnaire.py` + `test_me_applications*.py` 69 passed. Verified `membership_questionnaire_attempts_exhausted` appears in the dumped OpenAPI schema.

**FE:** `pnpm generate:api` needed to pick up the new enum member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtpbeLss5QghtRPoTRVYV3