### PR TITLE
feat(events): allow clearing cancel_at_period_end on a live subscription

### DIFF
--- a/src/events/controllers/me_subscriptions.py
+++ b/src/events/controllers/me_subscriptions.py
@@ -17,7 +17,7 @@ from common.schema import ErrorDetail, ResponseMessage
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import schema
 from events.models import MembershipSubscription, MembershipSubscriptionPlan, Organization, OrganizationMember
-from events.service import subscription_service, subscription_stripe_service
+from events.service import subscription_service, subscription_stripe_service, subscription_uncancel
 
 
 @api_controller("/me", auth=I18nJWTAuth(), tags=["Me - Subscriptions"], throttle=UserDefaultThrottle())
@@ -159,6 +159,33 @@ class MeSubscriptionsController(UserAwareController):
         )
         subscription = get_object_or_404(qs)
         return subscription_service.cancel_subscription(subscription, immediate=payload.immediate)
+
+    @route.post(
+        "/organizations/{org_id}/subscription/uncancel",
+        url_name="uncancel_my_membership_subscription",
+        response={
+            200: schema.MySubscriptionSchema,
+            400: ResponseMessage,
+            404: ResponseMessage,
+            502: ResponseMessage,
+        },
+        throttle=WriteThrottle(),
+    )
+    def uncancel_subscription(self, org_id: UUID) -> MembershipSubscription:
+        """Undo a scheduled cancellation on the caller's subscription.
+
+        Clears ``cancel_at_period_end`` so the subscription keeps renewing; for
+        ONLINE plans the same flag is cleared on Stripe. Refuses once the row is
+        terminal, or if the plan has since been archived.
+        """
+        qs = (
+            MembershipSubscription.objects.filter(user=self.user(), organization_id=org_id)
+            .exclude(status__in=MembershipSubscription.TERMINAL_STATUSES)
+            .select_related("plan", "plan__tier", "organization")
+            .order_by("-created_at")
+        )
+        subscription = get_object_or_404(qs)
+        return subscription_uncancel.uncancel_subscription(subscription)
 
     @route.post(
         "/organizations/{org_id}/subscription/change-plan",

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -19,7 +19,12 @@ from common.schema import ResponseMessage
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from events import models, schema
 from events.controllers.permissions import OrganizationPermission
-from events.service import subscription_refunds, subscription_reporting, subscription_service
+from events.service import (
+    subscription_refunds,
+    subscription_reporting,
+    subscription_service,
+    subscription_uncancel,
+)
 from events.service.subscription_service import InitialPayment
 
 from .base import OrganizationAdminBaseController
@@ -383,6 +388,21 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
             organization=organization,
         )
         return subscription_service.cancel_subscription(subscription, immediate=payload.immediate)
+
+    @route.post(
+        "/subscriptions/{sub_id}/uncancel",
+        url_name="uncancel_subscription",
+        response={200: schema.SubscriptionSchema, 400: ResponseMessage, 404: ResponseMessage, 502: ResponseMessage},
+    )
+    def uncancel_subscription(self, slug: str, sub_id: UUID) -> models.MembershipSubscription:
+        """Undo a scheduled cancellation, so the subscription keeps renewing."""
+        organization = self.get_one(slug)
+        subscription = get_object_or_404(
+            models.MembershipSubscription.objects.select_related("plan", "plan__tier", "user"),
+            pk=sub_id,
+            organization=organization,
+        )
+        return subscription_uncancel.uncancel_subscription(subscription)
 
     @route.post(
         "/subscriptions/{sub_id}/pause",

--- a/src/events/service/subscription_uncancel.py
+++ b/src/events/service/subscription_uncancel.py
@@ -1,0 +1,93 @@
+"""Undo a scheduled cancellation on a membership subscription.
+
+Split out of :mod:`events.service.subscription_service` and
+:mod:`events.service.subscription_stripe_service` (both at the 1000-line
+file-length cap). Holds the exact inverse of
+``cancel_subscription(immediate=False)``: clearing ``cancel_at_period_end`` so
+the subscription keeps renewing.
+
+Nothing else moves — status, period and payment history are untouched — so this
+is only ever a way *back* from a scheduled cancel, never a way to resurrect a
+terminalized row (that is what revival is for).
+"""
+
+import stripe
+import structlog
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+from ninja.errors import HttpError
+
+from events.models import MembershipSubscription, MembershipSubscriptionPlan
+from events.service.subscription_stripe_payloads import _stripe_account_kwargs
+
+logger = structlog.get_logger(__name__)
+
+
+def _uncancel_on_stripe(subscription: MembershipSubscription, stripe_subscription_id: str) -> None:
+    """Clear ``cancel_at_period_end`` on the linked Stripe subscription.
+
+    Mirrors :func:`subscription_stripe_service.pause_online_subscription`'s
+    failure handling: any Stripe error surfaces as the module-wide retryable
+    502 and leaves local state untouched, so we never record a renewal Stripe
+    never accepted.
+    """
+    try:
+        stripe.Subscription.modify(
+            stripe_subscription_id,
+            cancel_at_period_end=False,
+            **_stripe_account_kwargs(subscription.organization),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "subscription_stripe_uncancel_failed",
+            subscription_id=str(subscription.pk),
+            stripe_subscription_id=stripe_subscription_id,
+            error=str(exc),
+        )
+        raise HttpError(502, str(_("Payment processing failed. Please try again later."))) from exc
+
+
+@transaction.atomic
+def uncancel_subscription(subscription: MembershipSubscription) -> MembershipSubscription:
+    """Clear ``cancel_at_period_end`` so the subscription renews again.
+
+    Refuses a terminal row — the cancellation already happened, so there is
+    nothing left to undo — and a row whose plan has since been archived, with
+    the same reason a fresh subscribe would give. A row that is not scheduled to
+    cancel is already in the requested state and returns unchanged, mirroring
+    :func:`subscription_service.pause_subscription`'s already-PAUSED no-op.
+
+    For ONLINE (Stripe-managed) subscriptions the flag is cleared on Stripe
+    first; the ``customer.subscription.updated`` webhook then re-settles local
+    state. As in ``cancel_online_subscription`` the flag is also mirrored
+    locally right away so the caller need not wait for the webhook round-trip.
+    An ONLINE row with no Stripe link yet (cancelled while its first checkout
+    was still pending) takes the local path, exactly as the cancel side does.
+    """
+    # Same lock protocol as cancel/pause/resume: reload under a row lock that is
+    # held across the Stripe call, which serializes this mutation against echo
+    # webhooks (see docs/engineering-notes.md).
+    subscription = (
+        MembershipSubscription.objects.select_for_update(of=("self",))
+        .select_related("plan", "plan__tier", "organization")
+        .get(pk=subscription.pk)
+    )
+    if subscription.is_terminal:
+        raise HttpError(400, str(_("Cannot resume renewal on a cancelled or expired subscription.")))
+    if not subscription.cancel_at_period_end:
+        return subscription
+    if not subscription.plan.is_active:
+        # Same refusal as ``create_subscription`` / ``_validate_revivable``:
+        # keeping the renewal alive would go on billing a retired plan.
+        raise HttpError(400, str(_("This plan is archived and no longer accepts new subscriptions.")))
+
+    if (
+        subscription.plan.payment_method == MembershipSubscriptionPlan.PaymentMethod.ONLINE
+        and subscription.stripe_subscription_id
+    ):
+        _uncancel_on_stripe(subscription, subscription.stripe_subscription_id)
+
+    subscription.cancel_at_period_end = False
+    subscription.save(update_fields=["cancel_at_period_end", "updated_at"])
+    logger.info("subscription_uncancelled", subscription_id=str(subscription.pk))
+    return subscription

--- a/src/events/tests/test_controllers/test_subscription_uncancel.py
+++ b/src/events/tests/test_controllers/test_subscription_uncancel.py
@@ -1,0 +1,372 @@
+"""Tests for clearing a scheduled cancellation (issue #808).
+
+Covers the member-facing and staff-facing ``uncancel`` endpoints plus the
+shared service guards.
+"""
+
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+import stripe
+from django.test.client import Client
+from django.urls import reverse
+from ninja.errors import HttpError
+from ninja_jwt.tokens import RefreshToken
+
+from accounts.models import RevelUser
+from events.models import (
+    MembershipSubscription,
+    MembershipSubscriptionPlan,
+    MembershipTier,
+    Organization,
+)
+from events.service import subscription_service, subscription_uncancel
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tier(organization: Organization) -> MembershipTier:
+    return MembershipTier.objects.get(organization=organization, name="General membership")
+
+
+@pytest.fixture
+def plan(tier: MembershipTier) -> MembershipSubscriptionPlan:
+    return subscription_service.create_plan(
+        tier, name="Monthly", price=Decimal("10.00"), currency="EUR", period_unit="month"
+    )
+
+
+@pytest.fixture
+def online_plan(organization: Organization, tier: MembershipTier) -> MembershipSubscriptionPlan:
+    organization.stripe_account_id = "acct_test_org"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.save(
+        update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"],
+    )
+    return MembershipSubscriptionPlan.objects.create(
+        tier=tier,
+        name="Monthly Online",
+        price=Decimal("10.00"),
+        currency="EUR",
+        period_unit="month",
+        payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+        stripe_product_id="prod_uncancel",
+        stripe_price_id="price_uncancel",
+    )
+
+
+@pytest.fixture
+def subscriber_user(django_user_model: type[RevelUser]) -> RevelUser:
+    return django_user_model.objects.create_user(
+        username="uncancel_sub", email="uncancel-sub@example.com", password="pass"
+    )
+
+
+@pytest.fixture
+def subscriber_client(subscriber_user: RevelUser) -> Client:
+    refresh = RefreshToken.for_user(subscriber_user)
+    return Client(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")  # type: ignore[attr-defined]
+
+
+def _scheduled_cancel(
+    plan: MembershipSubscriptionPlan,
+    user: RevelUser,
+    organization: Organization,
+    *,
+    stripe_subscription_id: str = "",
+) -> MembershipSubscription:
+    """An ACTIVE subscription already scheduled to cancel at period end."""
+    subscription = MembershipSubscription.objects.create(
+        user=user,
+        plan=plan,
+        organization=organization,
+        status=MembershipSubscription.SubscriptionStatus.ACTIVE,
+        cancel_at_period_end=True,
+        stripe_subscription_id=stripe_subscription_id,
+    )
+    return subscription
+
+
+def _member_url(organization: Organization) -> str:
+    return reverse("api:uncancel_my_membership_subscription", kwargs={"org_id": organization.id})
+
+
+def _admin_url(organization: Organization, subscription: MembershipSubscription) -> str:
+    return reverse("api:uncancel_subscription", kwargs={"slug": organization.slug, "sub_id": subscription.id})
+
+
+class TestMemberUncancel:
+    def test_member_clears_scheduled_cancellation(
+        self,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 200, response.content
+        assert response.json()["cancel_at_period_end"] is False
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is False
+        assert subscription.status == MembershipSubscription.SubscriptionStatus.ACTIVE
+
+    @mock.patch("events.service.subscription_uncancel.stripe.Subscription.modify")
+    def test_online_clears_the_flag_on_stripe(
+        self,
+        mock_modify: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(
+            online_plan, subscriber_user, organization, stripe_subscription_id="sub_to_uncancel"
+        )
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 200, response.content
+        mock_modify.assert_called_once()
+        assert mock_modify.call_args.args[0] == "sub_to_uncancel"
+        assert mock_modify.call_args.kwargs["cancel_at_period_end"] is False
+        assert mock_modify.call_args.kwargs["stripe_account"] == "acct_test_org"
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is False
+
+    @mock.patch("events.service.subscription_uncancel.stripe.Subscription.modify")
+    def test_stripe_failure_leaves_the_flag_set(
+        self,
+        mock_modify: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        """A refused Stripe modify must not record a renewal Stripe never accepted."""
+        mock_modify.side_effect = stripe.error.APIConnectionError("boom")
+        subscription = _scheduled_cancel(online_plan, subscriber_user, organization, stripe_subscription_id="sub_flaky")
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 502, response.content
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is True
+
+    @mock.patch("events.service.subscription_uncancel.stripe.Subscription.modify")
+    def test_online_without_stripe_link_stays_local(
+        self,
+        mock_modify: mock.Mock,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        online_plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        """An ONLINE row cancelled before its first checkout has no Stripe record to update."""
+        subscription = _scheduled_cancel(online_plan, subscriber_user, organization)
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 200, response.content
+        mock_modify.assert_not_called()
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is False
+
+    def test_not_scheduled_is_a_no_op(
+        self,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = subscription_service.create_subscription(plan, subscriber_user)
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 200, response.content
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is False
+
+    def test_archived_plan_is_refused(
+        self,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+        subscription_service.archive_plan(plan)
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 400, response.content
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is True
+
+    def test_terminal_subscription_is_invisible_to_the_member(
+        self,
+        subscriber_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        """A cancelled row is excluded by the member's non-terminal lookup — 404, not 400."""
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+        subscription.status = MembershipSubscription.SubscriptionStatus.CANCELLED
+        subscription.save(update_fields=["status"])
+
+        response = subscriber_client.post(_member_url(organization))
+
+        assert response.status_code == 404, response.content
+
+    def test_member_cannot_touch_someone_elses_subscription(
+        self,
+        nonmember_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+
+        response = nonmember_client.post(_member_url(organization))
+
+        assert response.status_code == 404, response.content
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is True
+
+
+class TestStaffUncancel:
+    def test_staff_clears_a_members_scheduled_cancellation(
+        self,
+        organization_owner_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+
+        response = organization_owner_client.post(_admin_url(organization, subscription))
+
+        assert response.status_code == 200, response.content
+        assert response.json()["cancel_at_period_end"] is False
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is False
+
+    def test_terminal_subscription_is_refused(
+        self,
+        organization_owner_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+        subscription.status = MembershipSubscription.SubscriptionStatus.EXPIRED
+        subscription.save(update_fields=["status"])
+
+        response = organization_owner_client.post(_admin_url(organization, subscription))
+
+        assert response.status_code == 400, response.content
+
+    def test_non_staff_is_refused(
+        self,
+        member_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+
+        response = member_client.post(_admin_url(organization, subscription))
+
+        assert response.status_code == 403, response.content
+        subscription.refresh_from_db()
+        assert subscription.cancel_at_period_end is True
+
+    def test_other_organization_subscription_is_not_found(
+        self,
+        organization_owner_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+        organization_owner_user: RevelUser,
+    ) -> None:
+        other_org = Organization.objects.create(name="Other", slug="other", owner=organization_owner_user)
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+
+        url = reverse("api:uncancel_subscription", kwargs={"slug": other_org.slug, "sub_id": subscription.id})
+        response = organization_owner_client.post(url)
+
+        assert response.status_code == 404, response.content
+
+
+class TestStuckStateResolved:
+    def test_pause_works_again_after_uncancel(
+        self,
+        organization_owner_client: Client,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        """The exact deadlock from #808: a scheduled cancel could be neither paused nor undone."""
+        subscription = subscription_service.create_subscription(plan, subscriber_user)
+        subscription_service.cancel_subscription(subscription, immediate=False)
+
+        pause_url = reverse("api:pause_subscription", kwargs={"slug": organization.slug, "sub_id": subscription.id})
+        assert organization_owner_client.post(pause_url).status_code == 400
+
+        assert organization_owner_client.post(_admin_url(organization, subscription)).status_code == 200
+
+        assert organization_owner_client.post(pause_url).status_code == 200
+        subscription.refresh_from_db()
+        assert subscription.status == MembershipSubscription.SubscriptionStatus.PAUSED
+        assert subscription.cancel_at_period_end is False
+
+
+class TestServiceGuards:
+    def test_terminal_row_raises_400(
+        self,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+        subscription.status = MembershipSubscription.SubscriptionStatus.CANCELLED
+        subscription.save(update_fields=["status"])
+
+        with pytest.raises(HttpError) as exc_info:
+            subscription_uncancel.uncancel_subscription(subscription)
+
+        assert exc_info.value.status_code == 400
+
+    def test_archived_plan_raises_400(
+        self,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        subscription = _scheduled_cancel(plan, subscriber_user, organization)
+        subscription_service.archive_plan(plan)
+
+        with pytest.raises(HttpError) as exc_info:
+            subscription_uncancel.uncancel_subscription(subscription)
+
+        assert exc_info.value.status_code == 400
+
+    def test_archived_plan_does_not_block_an_unscheduled_row(
+        self,
+        subscriber_user: RevelUser,
+        plan: MembershipSubscriptionPlan,
+        organization: Organization,
+    ) -> None:
+        """Nothing to undo means nothing to refuse — the row is already in the requested state."""
+        subscription = subscription_service.create_subscription(plan, subscriber_user)
+        subscription_service.archive_plan(plan)
+
+        result = subscription_uncancel.uncancel_subscription(subscription)
+
+        assert result.cancel_at_period_end is False

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -5020,3 +5020,6 @@ msgstr "Gesperrtes Telegram-Konto verbunden"
 
 msgid "Django site admin"
 msgstr "Django-Website-Admin"
+
+msgid "Cannot resume renewal on a cancelled or expired subscription."
+msgstr "Die Verlängerung eines gekündigten oder abgelaufenen Abos kannst Du nicht wieder aktivieren."

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -5011,3 +5011,6 @@ msgstr "Compte Telegram banni connecté"
 
 msgid "Django site admin"
 msgstr "Administration du site Django"
+
+msgid "Cannot resume renewal on a cancelled or expired subscription."
+msgstr "Tu ne peux pas réactiver le renouvellement d'un abonnement annulé ou expiré."

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -4978,3 +4978,6 @@ msgstr "Account Telegram bloccato collegato"
 
 msgid "Django site admin"
 msgstr "Amministrazione del sito Django"
+
+msgid "Cannot resume renewal on a cancelled or expired subscription."
+msgstr "Non puoi riattivare il rinnovo di un abbonamento annullato o scaduto."


### PR DESCRIPTION
Closes #808.

## Why

A scheduled cancellation was a one-way door. Once `cancel_at_period_end` was set, nothing in the API could clear it:

- A member who cancelled by mistake could only let the subscription lapse — losing their price if the plan changed, and losing the revival path entirely (a `cancel_at_period_end` row terminalizes as CANCELLED with `expired_at` unset, so the rejoin window never opens).
- The organizer had no remedy either. `pause_subscription` refuses a row scheduled to cancel, so the row was stuck until it lapsed — neither pausable nor undoable.

## What

New service `events.service.subscription_uncancel.uncancel_subscription()` — the exact inverse of `cancel_subscription(immediate=False)`. It lives in its own module because both `subscription_service.py` (995 lines) and `subscription_stripe_service.py` (985) are at the 1000-line cap; the module docstring says so, matching the existing `subscription_sales` / `subscription_refunds` split pattern.

It reloads the row under the same `select_for_update(of=("self",))` lock the other subscription mutations hold across the Stripe call (the echo-webhook serialization documented in `docs/engineering-notes.md`), then clears the flag. Status, period and payment history are untouched — this is a way *back* from a scheduled cancel, never a way to resurrect a terminalized row.

Guards, mirroring the neighbouring functions:

| Case | Behaviour |
|---|---|
| Terminal row | 400 — the cancellation already happened |
| Plan archived since | 400, reusing the exact refusal a fresh subscribe gives |
| Not scheduled to cancel | Unchanged no-op (like `pause_subscription`'s already-PAUSED return) |

ONLINE rows call `stripe.Subscription.modify(sub_id, cancel_at_period_end=False, **account_kwargs)` first. Any `StripeError` surfaces as the module's retryable 502 and leaves the local flag set — mirroring `pause_online_subscription` / `resume_online_subscription` — so we never record a renewal Stripe did not accept. An ONLINE row with no Stripe link yet (cancelled while its first checkout was still pending) takes the local path, exactly as the cancel side does.

## Endpoints added

| Method | Path | Audience | Responses |
|---|---|---|---|
| POST | `/api/me/organizations/{org_id}/subscription/uncancel` | member (own sub) | 200 `MySubscriptionSchema`, 400, 404, 502 |
| POST | `/api/organization-admin/{slug}/subscriptions/{sub_id}/uncancel` | staff (`manage_subscriptions`) | 200 `SubscriptionSchema`, 400, 404, 502 |

Thin controllers, no try/except, existing response schemas reused — no new schemas and **no migration** (only an existing boolean flag is cleared).

## Notifications

None added. No existing `NotificationType` fits an "un-cancelled" event, and per the repo's rules new notification plumbing is out of scope here. Worth a follow-up if organizers ask for it.

## i18n

One new string (`"Cannot resume renewal on a cancelled or expired subscription."`), hand-appended to de/fr/it with informal address, zero fuzzy. The archived-plan refusal reuses an existing msgid. `make i18n-check` green.

## Tests

`src/events/tests/test_controllers/test_subscription_uncancel.py` — 16 tests, all passing:

- Member clears a scheduled cancel (OFFLINE + ONLINE); ONLINE asserts `modify` called once with `cancel_at_period_end=False` and the right `stripe_account`
- Stripe failure → 502 with the flag still set
- ONLINE without a Stripe link stays local (`modify` not called)
- Not-scheduled no-op; archived plan refused; archived plan does *not* block an unscheduled row
- Terminal row → 404 for the member (excluded by the non-terminal lookup), 400 for staff
- Someone else's subscription → 404; other org's subscription → 404; non-staff on the admin route → 403
- **`test_pause_works_again_after_uncancel`** — reproduces the issue's deadlock end to end: pause is refused (400), uncancel succeeds (200), pause then works (200)

`make check` fully green (ruff, mypy --strict, migrations, i18n, file-length, task-names). Neighbouring suites re-run green: `test_subscription_service.py`, `test_me_subscriptions.py`, `test_organization_admin/test_subscriptions.py`, `test_subscription_uncancel.py` (153 passed), plus subscription notifications/signals/sales-controls/revival (79 passed) and `test_openapi_schema.py` (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtpbeLss5QghtRPoTRVYV3