### PR TITLE
fix(telegram): close the bot HTTP session in get_bot_name

### DIFF
--- a/src/telegram/service.py
+++ b/src/telegram/service.py
@@ -101,6 +101,16 @@ def disconnect_account(user: RevelUser) -> None:
         )
 
 
+async def _fetch_bot_username() -> str:
+    """Fetch the bot username from the Telegram API, closing the HTTP session."""
+    bot = get_bot()
+    try:
+        bot_user = await bot.get_me()
+        return bot_user.username or ""
+    finally:
+        await bot.session.close()
+
+
 def get_bot_name() -> str:
     """Get the bot name with caching.
 
@@ -116,10 +126,7 @@ def get_bot_name() -> str:
     if cached_name is not None:
         return str(cached_name)
 
-    # Fetch from Telegram API
-    bot = get_bot()
-    bot_name_obj = async_to_sync(bot.get_me)()
-    bot_name: str = bot_name_obj.username or ""
+    bot_name = async_to_sync(_fetch_bot_username)()
 
     # Cache for 24 hours
     cache.set(cache_key, bot_name, timeout=86400)

--- a/src/telegram/tests/test_service_bot_name.py
+++ b/src/telegram/tests/test_service_bot_name.py
@@ -1,0 +1,56 @@
+# src/telegram/tests/test_service_bot_name.py
+"""Tests for telegram.service.get_bot_name."""
+
+import typing as t
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from django.core.cache import cache
+
+from telegram import service
+
+CACHE_KEY = "telegram:bot_name"
+
+
+@pytest.fixture
+def mock_bot(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """A fake aiogram Bot whose get_me returns a user and whose session tracks close()."""
+    bot = MagicMock()
+    bot.get_me = AsyncMock(return_value=MagicMock(username="revel_test_bot"))
+    bot.session.close = AsyncMock()
+    monkeypatch.setattr(service, "get_bot", lambda: bot)
+    return bot
+
+
+@pytest.fixture(autouse=True)
+def clear_bot_name_cache() -> t.Iterator[None]:
+    """Isolate the bot-name cache key between tests."""
+    cache.delete(CACHE_KEY)
+    yield
+    cache.delete(CACHE_KEY)
+
+
+def test_get_bot_name_fetches_and_closes_session(mock_bot: MagicMock) -> None:
+    assert service.get_bot_name() == "revel_test_bot"
+    mock_bot.get_me.assert_awaited_once()
+    mock_bot.session.close.assert_awaited_once()
+
+
+def test_get_bot_name_closes_session_when_get_me_fails(mock_bot: MagicMock) -> None:
+    mock_bot.get_me = AsyncMock(side_effect=RuntimeError("telegram down"))
+    with pytest.raises(RuntimeError, match="telegram down"):
+        service.get_bot_name()
+    mock_bot.session.close.assert_awaited_once()
+    assert cache.get(CACHE_KEY) is None
+
+
+def test_get_bot_name_uses_cache_on_second_call(mock_bot: MagicMock) -> None:
+    assert service.get_bot_name() == "revel_test_bot"
+    assert service.get_bot_name() == "revel_test_bot"
+    mock_bot.get_me.assert_awaited_once()
+    assert cache.get(CACHE_KEY) == "revel_test_bot"
+
+
+def test_get_bot_name_empty_username_falls_back_to_empty_string(mock_bot: MagicMock) -> None:
+    mock_bot.get_me = AsyncMock(return_value=MagicMock(username=None))
+    assert service.get_bot_name() == ""


### PR DESCRIPTION
## Summary

`GET /api/telegram/botname` has been leaking an aiohttp `ClientSession` on every bot-name cache miss. `service.get_bot_name()` created an aiogram `Bot` (which owns its own `ClientSession`) and called `async_to_sync(bot.get_me)()` without ever closing `bot.session`, so when `async_to_sync` tore down its temporary event loop the session was left to the garbage collector — producing the paired **"Unclosed client session" / "Unclosed connector"** errors visible in prod logs (once per 24h cache expiry: Jul 25, 26, 27).

`send_telegram_message` in `telegram/utils.py` already closes its session; this was the one deviant `get_bot()` call site.

## Fix

Fetch the username inside a single async wrapper (`_fetch_bot_username`) that closes the session in a `finally` block, so cleanup happens inside the same event loop even when `get_me()` raises.

## Tests

New `src/telegram/tests/test_service_bot_name.py`:
- fetches the name and closes the session
- closes the session even when `get_me()` raises (and caches nothing)
- serves the cached value without re-fetching
- falls back to `""` when the bot has no username

`pytest src/telegram/tests` → 78 passed. `make format lint mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving the Telegram bot name by ensuring network sessions are properly closed.
  * Preserved existing 24-hour caching behavior.
  * Added fallback handling when no bot username is available.

* **Tests**
  * Added coverage for successful retrieval, caching, error handling, cleanup, and missing usernames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->