### PR TITLE
fix(accounts): referral Stripe verify no longer 500s on inaccessible connected account

### DIFF
--- a/src/accounts/admin/user.py
+++ b/src/accounts/admin/user.py
@@ -257,7 +257,37 @@ class RevelUserAdmin(UserAdmin, ModelAdmin):  # type: ignore[type-arg,misc]
     autocomplete_fields = ["groups"]
 
     # Actions
-    actions = ["send_verification_email", "send_password_reset_email", "ban_selected_users"]
+    actions = [
+        "send_verification_email",
+        "send_password_reset_email",
+        "ban_selected_users",
+        "clear_stripe_connect_account",
+    ]
+
+    @admin.action(description="Clear stale Stripe Connect account (superuser only)")
+    def clear_stripe_connect_account(self, request: HttpRequest, queryset: QuerySet[RevelUser]) -> None:
+        """Detach a stale Connect account so the referrer can re-onboard from scratch.
+
+        Nothing is deleted at Stripe — this only drops the local link. Account
+        status sync deliberately flags rather than clears the id (a misconfigured
+        platform key would otherwise wipe every live connection), so an account
+        that is genuinely gone at Stripe is unlinked here by a human.
+        """
+        if not request.user.is_superuser:
+            self.message_user(request, "Superuser required.", level=messages.ERROR)
+            return
+        cleared = 0
+        for target_user in queryset.exclude(stripe_account_id__isnull=True):
+            target_user.stripe_account_id = None
+            target_user.stripe_charges_enabled = False
+            target_user.stripe_details_submitted = False
+            target_user.save(
+                update_fields=target_user._stripe_update_fields(
+                    "stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"
+                )
+            )
+            cleared += 1
+        self.message_user(request, f"Cleared the Stripe Connect account of {cleared} user(s).")
 
     @admin.action(description="Send verification email")
     def send_verification_email(self, request: HttpRequest, queryset: QuerySet[RevelUser]) -> None:

--- a/src/accounts/tests/test_admin_stripe_connect.py
+++ b/src/accounts/tests/test_admin_stripe_connect.py
@@ -1,0 +1,64 @@
+"""Tests for the RevelUser admin's Stripe Connect actions."""
+
+import typing as t
+
+import pytest
+from django.contrib.admin.sites import site
+from django.contrib.messages.storage.fallback import FallbackStorage
+
+from accounts.models import RevelUser
+
+pytestmark = pytest.mark.django_db
+
+
+def _admin() -> t.Any:
+    return site._registry[RevelUser]
+
+
+def _request_with_messages(rf: t.Any, request_user: RevelUser) -> t.Any:
+    request = rf.post("/")
+    request.user = request_user
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+@pytest.fixture
+def connected_user(user: RevelUser) -> RevelUser:
+    user.stripe_account_id = "acct_stale"
+    user.stripe_charges_enabled = True
+    user.stripe_details_submitted = True
+    user.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+    return user
+
+
+def test_clear_stripe_connect_account_unlinks_stale_account(
+    rf: t.Any, connected_user: RevelUser, superuser: RevelUser
+) -> None:
+    """A superuser can unlink an account that is gone at Stripe, enabling re-onboarding."""
+    request = _request_with_messages(rf, superuser)
+
+    _admin().clear_stripe_connect_account(request, RevelUser.objects.filter(pk=connected_user.pk))
+
+    # Re-fetch: mypy narrows stripe_account_id to str after the fixture assignment,
+    # so asserting None on the same instance reads as unreachable.
+    fresh = RevelUser.objects.get(pk=connected_user.pk)
+    assert fresh.stripe_account_id is None
+    assert fresh.stripe_charges_enabled is False
+    assert fresh.stripe_details_submitted is False
+
+
+def test_clear_stripe_connect_account_requires_superuser(
+    rf: t.Any, connected_user: RevelUser, django_user_model: t.Type[RevelUser]
+) -> None:
+    """Non-superusers cannot unlink an account, even with admin access."""
+    staff_user = django_user_model.objects.create_user(
+        username="staff@example.com", email="staff@example.com", password="strong-password-123!", is_staff=True
+    )
+    request = _request_with_messages(rf, staff_user)
+
+    _admin().clear_stripe_connect_account(request, RevelUser.objects.filter(pk=connected_user.pk))
+
+    connected_user.refresh_from_db()
+    assert connected_user.stripe_account_id == "acct_stale"
+    assert connected_user.stripe_charges_enabled is True

--- a/src/accounts/tests/test_controllers/test_referral_stripe_controller.py
+++ b/src/accounts/tests/test_controllers/test_referral_stripe_controller.py
@@ -4,6 +4,7 @@ import typing as t
 from unittest.mock import Mock, patch
 
 import pytest
+import stripe
 from django.test.client import Client
 from django.urls import reverse
 from ninja_jwt.tokens import RefreshToken
@@ -175,3 +176,42 @@ class TestReferralStripeVerify:
     ) -> None:
         response = referrer_client.get(self.url)
         assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            stripe.error.PermissionError("The provided key 'sk_test_…' does not have access to account 'acct_stale'"),
+            stripe.error.InvalidRequestError("No such account: 'acct_stale'", param="account"),
+        ],
+        ids=["permission_error", "invalid_request_error"],
+    )
+    @patch("common.service.stripe_connect_service.stripe.Account.retrieve")
+    def test_inaccessible_account_reports_not_connected_instead_of_500(
+        self,
+        mock_retrieve: Mock,
+        error: stripe.error.StripeError,
+        referrer_client: Client,
+        referral_code: ReferralCode,
+        referrer: RevelUser,
+    ) -> None:
+        """A deleted/revoked/stale connected account must not 500 (see #694)."""
+        referrer.stripe_account_id = "acct_stale"
+        referrer.stripe_charges_enabled = True
+        referrer.stripe_details_submitted = True
+        referrer.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+
+        mock_retrieve.side_effect = error
+
+        response = referrer_client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "is_connected": False,
+            "charges_enabled": False,
+            "details_submitted": False,
+        }
+
+        referrer.refresh_from_db()
+        assert referrer.stripe_charges_enabled is False
+        assert referrer.stripe_details_submitted is False
+        assert referrer.is_stripe_connected is False

--- a/src/common/service/stripe_connect_service.py
+++ b/src/common/service/stripe_connect_service.py
@@ -96,12 +96,14 @@ def sync_account_status(connectable: StripeConnectMixin) -> stripe.Account | Non
     except (stripe.error.PermissionError, stripe.error.InvalidRequestError) as exc:
         # ponytail: we flag rather than clear ``stripe_account_id``. Clearing would be
         # irreversible and a misconfigured platform key (e.g. a test key in production)
-        # would wipe every live connection on the first verify call. Genuinely deleted
-        # accounts are cleared by a staff member from the Django admin.
+        # would wipe every live connection on the first verify call. An account that is
+        # genuinely gone at Stripe is unlinked by a superuser with the
+        # "Clear stale Stripe Connect account" admin action (user & organization admin).
+        # The message is not logged: Stripe embeds a truncated API key in it.
         logger.warning(
             "stripe_connect_account_inaccessible",
             stripe_account_id=connectable.stripe_account_id,
-            error=str(exc),
+            error_type=type(exc).__name__,
         )
         connectable.stripe_charges_enabled = False
         connectable.stripe_details_submitted = False

--- a/src/common/service/stripe_connect_service.py
+++ b/src/common/service/stripe_connect_service.py
@@ -8,12 +8,15 @@ autofill, URL construction) stays in each app's own service module.
 import typing as t
 
 import stripe
+import structlog
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 from pydantic import EmailStr
 
 from common.models import StripeConnectMixin
+
+logger = structlog.get_logger(__name__)
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
 stripe.api_version = settings.STRIPE_API_VERSION
@@ -68,19 +71,44 @@ def create_account_link(account_id: str, refresh_url: str, return_url: str) -> s
     return t.cast(str, account_link.url)
 
 
-def sync_account_status(connectable: StripeConnectMixin) -> stripe.Account:
+def sync_account_status(connectable: StripeConnectMixin) -> stripe.Account | None:
     """Fetch the latest status from Stripe and update *connectable* in place.
 
     Updates ``stripe_charges_enabled`` and ``stripe_details_submitted``, then
     returns the raw ``stripe.Account`` so callers can inspect additional fields
     (e.g. billing details) without a second API call.
 
+    If the stored account is not reachable with the platform key — deleted at
+    Stripe, access revoked, or a stale/seeded ID — the connectable is flagged as
+    not connected (both booleans reset) and ``None`` is returned, so callers
+    report "needs re-onboarding" instead of blowing up with a 500.
+
+    Returns:
+        The ``stripe.Account``, or ``None`` if it is not accessible.
+
     Raises:
         HttpError 400: If the connectable has no ``stripe_account_id``.
     """
     if connectable.stripe_account_id is None:
         raise HttpError(400, str(_("You must connect your Stripe account first.")))
-    account = get_account_details(connectable.stripe_account_id)
+    try:
+        account = get_account_details(connectable.stripe_account_id)
+    except (stripe.error.PermissionError, stripe.error.InvalidRequestError) as exc:
+        # ponytail: we flag rather than clear ``stripe_account_id``. Clearing would be
+        # irreversible and a misconfigured platform key (e.g. a test key in production)
+        # would wipe every live connection on the first verify call. Genuinely deleted
+        # accounts are cleared by a staff member from the Django admin.
+        logger.warning(
+            "stripe_connect_account_inaccessible",
+            stripe_account_id=connectable.stripe_account_id,
+            error=str(exc),
+        )
+        connectable.stripe_charges_enabled = False
+        connectable.stripe_details_submitted = False
+        connectable.save(
+            update_fields=connectable._stripe_update_fields("stripe_charges_enabled", "stripe_details_submitted"),
+        )
+        return None
     connectable.stripe_charges_enabled = account.charges_enabled
     connectable.stripe_details_submitted = account.details_submitted
     connectable.save(

--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -64,7 +64,7 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
     search_fields = ["name", "slug", "owner__username"]
     autocomplete_fields = ["owner", "city", "staff_members", "members"]
     prepopulated_fields = {"slug": ("name",)}
-    actions = ["bind_platform_stripe_account", "unbind_platform_stripe_account"]
+    actions = ["bind_platform_stripe_account", "unbind_platform_stripe_account", "clear_stripe_connect_account"]
 
     tabs = [
         ("Settings", ["Settings", "Social"]),
@@ -190,6 +190,31 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
                 )
             )
             self.message_user(request, f"{org.slug} unbound from platform Stripe account.", level=messages.SUCCESS)
+
+    @admin.action(description="Clear stale Stripe Connect account (superuser only)")
+    def clear_stripe_connect_account(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> None:
+        """Detach a stale Connect account so the org can re-onboard from scratch.
+
+        Nothing is deleted at Stripe — this only drops the local link. Account
+        status sync deliberately flags rather than clears the id (a misconfigured
+        platform key would otherwise wipe every live connection), so an account
+        that is genuinely gone at Stripe is unlinked here by a human.
+        """
+        if not request.user.is_superuser:
+            self.message_user(request, "Superuser required.", level=messages.ERROR)
+            return
+        cleared = 0
+        for org in queryset.exclude(stripe_account_id__isnull=True):
+            org.stripe_account_id = None
+            org.stripe_charges_enabled = False
+            org.stripe_details_submitted = False
+            org.save(
+                update_fields=org._stripe_update_fields(
+                    "stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"
+                )
+            )
+            cleared += 1
+        self.message_user(request, f"Cleared the Stripe Connect account of {cleared} organization(s).")
 
     def get_queryset(self, request: HttpRequest) -> QuerySet[models.Organization]:
         qs: QuerySet[models.Organization] = super().get_queryset(request)

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -103,6 +103,8 @@ def stripe_verify_account(organization: Organization) -> Organization:
     details if they are currently empty (fallback for orgs without a VAT ID).
     """
     account = sync_account_status(organization)
+    if account is None:  # account not accessible: already flagged as not connected
+        return organization
 
     # Organization-specific: auto-fill billing details from Stripe
     update_fields: list[str] = []

--- a/src/events/tests/test_admin/test_organization_platform_binding.py
+++ b/src/events/tests/test_admin/test_organization_platform_binding.py
@@ -1,4 +1,4 @@
-"""Tests for binding an Organization to the platform Stripe account."""
+"""Tests for the Organization admin's Stripe Connect actions."""
 
 import typing as t
 
@@ -136,4 +136,40 @@ def test_unbind_refuses_real_connect_binding(
 
     organization.refresh_from_db()
     assert organization.stripe_account_id == "acct_real_connect"  # untouched
+    assert organization.stripe_charges_enabled is True
+
+
+def test_clear_stripe_connect_account_unlinks_stale_account(
+    rf: t.Any, organization: Organization, superuser: RevelUser
+) -> None:
+    """A superuser can unlink an account that is gone at Stripe, enabling re-onboarding."""
+    organization.stripe_account_id = "acct_stale"
+    organization.stripe_charges_enabled = True
+    organization.stripe_details_submitted = True
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted"])
+    admin_instance = _admin()
+    request = _request_with_messages(rf, superuser)
+
+    admin_instance.clear_stripe_connect_account(request, Organization.objects.filter(pk=organization.pk))
+
+    fresh = Organization.objects.get(pk=organization.pk)
+    assert fresh.stripe_account_id is None
+    assert fresh.stripe_charges_enabled is False
+    assert fresh.stripe_details_submitted is False
+
+
+def test_clear_stripe_connect_account_requires_superuser(
+    rf: t.Any, organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """Non-superusers cannot unlink an account, even with admin access."""
+    organization.stripe_account_id = "acct_stale"
+    organization.stripe_charges_enabled = True
+    organization.save(update_fields=["stripe_account_id", "stripe_charges_enabled"])
+    admin_instance = _admin()
+    request = _request_with_messages(rf, organization_owner_user)
+
+    admin_instance.clear_stripe_connect_account(request, Organization.objects.filter(pk=organization.pk))
+
+    organization.refresh_from_db()
+    assert organization.stripe_account_id == "acct_stale"
     assert organization.stripe_charges_enabled is True

--- a/src/events/tests/test_service/test_stripe_service/test_connect_account.py
+++ b/src/events/tests/test_service/test_stripe_service/test_connect_account.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 import stripe
 
+from common.service.stripe_connect_service import sync_account_status
 from events.models import Organization
 from events.service import stripe_service
 
@@ -129,3 +130,81 @@ class TestGetAccountDetails:
         # Act & Assert
         with pytest.raises(stripe.error.APIError):
             stripe_service.get_account_details(account_id)
+
+
+class TestSyncAccountStatusInaccessibleAccount:
+    """``sync_account_status`` must not blow up when the stored account is unreachable."""
+
+    @pytest.fixture
+    def connected_organization(self, organization: Organization) -> Organization:
+        organization.stripe_account_id = "acct_gone"
+        organization.stripe_charges_enabled = True
+        organization.stripe_details_submitted = True
+        organization.save(
+            update_fields=["stripe_account_id", "stripe_charges_enabled", "stripe_details_submitted", "updated_at"]
+        )
+        return organization
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            stripe.error.PermissionError("The provided key does not have access to account 'acct_gone'"),
+            stripe.error.InvalidRequestError("No such account: 'acct_gone'", param="account"),
+        ],
+        ids=["permission_error", "invalid_request_error"],
+    )
+    @patch("stripe.Account.retrieve")
+    def test_flags_account_as_not_connected(
+        self,
+        mock_stripe_retrieve: Mock,
+        error: stripe.error.StripeError,
+        connected_organization: Organization,
+    ) -> None:
+        """An inaccessible account returns ``None`` and resets the connection flags."""
+        # Arrange
+        mock_stripe_retrieve.side_effect = error
+
+        # Act
+        result = sync_account_status(connected_organization)
+
+        # Assert
+        assert result is None
+        connected_organization.refresh_from_db()
+        assert connected_organization.stripe_charges_enabled is False
+        assert connected_organization.stripe_details_submitted is False
+        assert connected_organization.is_stripe_connected is False
+        # The ID is kept: clearing it would be irreversible if the platform key is misconfigured.
+        assert connected_organization.stripe_account_id == "acct_gone"
+
+    @patch("stripe.Account.retrieve")
+    def test_verify_account_returns_organization_without_billing_autofill(
+        self,
+        mock_stripe_retrieve: Mock,
+        connected_organization: Organization,
+    ) -> None:
+        """``stripe_verify_account`` degrades gracefully instead of raising."""
+        # Arrange
+        mock_stripe_retrieve.side_effect = stripe.error.PermissionError("no access")
+
+        # Act
+        result = stripe_service.stripe_verify_account(connected_organization)
+
+        # Assert
+        assert result is connected_organization
+        assert result.stripe_charges_enabled is False
+        assert result.stripe_details_submitted is False
+        assert result.billing_address == ""
+
+    @patch("stripe.Account.retrieve")
+    def test_other_stripe_errors_still_propagate(
+        self,
+        mock_stripe_retrieve: Mock,
+        connected_organization: Organization,
+    ) -> None:
+        """Unexpected Stripe failures must not be swallowed."""
+        # Arrange
+        mock_stripe_retrieve.side_effect = stripe.error.APIError("boom")
+
+        # Act & Assert
+        with pytest.raises(stripe.error.APIError):
+            sync_account_status(connected_organization)

--- a/src/events/tests/test_service/test_stripe_service/test_connect_account.py
+++ b/src/events/tests/test_service/test_stripe_service/test_connect_account.py
@@ -173,7 +173,8 @@ class TestSyncAccountStatusInaccessibleAccount:
         assert connected_organization.stripe_charges_enabled is False
         assert connected_organization.stripe_details_submitted is False
         assert connected_organization.is_stripe_connected is False
-        # The ID is kept: clearing it would be irreversible if the platform key is misconfigured.
+        # The ID is kept: clearing it would be irreversible if the platform key is
+        # misconfigured — a superuser unlinks it from the admin instead.
         assert connected_organization.stripe_account_id == "acct_gone"
 
     @patch("stripe.Account.retrieve")


### PR DESCRIPTION
## Problem

`GET /api/account/referral/stripe/verify` raised an unhandled `stripe._error.PermissionError` → **500** whenever the stored `stripe_account_id` was not accessible with the configured key:

```
stripe._error.PermissionError: The provided key 'sk_test_…' does not have access to
account 'acct_bootstrap_b2b' (or that account does not exist).
```

Path: `referral_stripe.verify` → `stripe_connect_service.sync_account_status()` → `get_account_details()` → `stripe.Account.retrieve()`.

Two flavours, both from #694: dev/E2E noise from the bootstrap-seeded fake ids (`acct_bootstrap_b2b`), and the real-world case of an account deleted at Stripe or platform access revoked.

## Fix

`sync_account_status` (service layer — the controller stays free of try/except) now catches `stripe.error.PermissionError` and `stripe.error.InvalidRequestError`, logs a `stripe_connect_account_inaccessible` warning, resets `stripe_charges_enabled` / `stripe_details_submitted` and returns `None`. The verify endpoint therefore returns `200 {"is_connected": false, "charges_enabled": false, "details_submitted": false}` — the "needs re-onboarding" state — instead of a 500. Other Stripe errors still propagate. The log records `error_type` rather than the Stripe message, which embeds a truncated API key prefix.

The same code path serves organizations, so `events.stripe_service.stripe_verify_account` gained a one-line early return (its billing autofill can't run without an account object). Its return type is unchanged.

**Deliberate choice: the stale `stripe_account_id` is flagged, not cleared.** Clearing automatically is irreversible, and a misconfigured platform key (e.g. a test key deployed against live accounts) would wipe every organization's/referrer's connection on the first verify call.

The unlink therefore stays a human decision — and this PR makes that decision possible, which it previously wasn't: `stripe_account_id` is `readonly_fields` on `RevelUserAdmin` and is in no editable fieldset on `OrganizationAdmin`, whose bind/unbind actions refuse to touch real Connect accounts. Both admins now expose a superuser-only **"Clear stale Stripe Connect account"** action that drops the local link (id + both flags) so `POST /connect` mints a fresh account. Nothing is deleted at Stripe.

## Tests

The service/endpoint tests fail on `main` and pass here (verified by stashing the service changes: 5 failed / 16 passed → 21 passed).

- `src/events/tests/test_service/test_stripe_service/test_connect_account.py::TestSyncAccountStatusInaccessibleAccount` — service level, parametrized over `PermissionError` / `InvalidRequestError`: returns `None`, flags reset, `is_stripe_connected` false, id retained; `stripe_verify_account` degrades gracefully; other `StripeError`s still propagate.
- `src/accounts/tests/test_controllers/test_referral_stripe_controller.py::TestReferralStripeVerify::test_inaccessible_account_reports_not_connected_instead_of_500` — endpoint level, same parametrization, asserts 200 + not-connected payload + persisted flags.
- `src/accounts/tests/test_admin_stripe_connect.py` and `src/events/tests/test_admin/test_organization_platform_binding.py` — the new admin action clears the link for a superuser and is a no-op for a non-superuser, on both models.

```
uv run pytest src/accounts/tests/test_admin_formatters.py src/accounts/tests/test_bootstrap_admin.py \
  src/accounts/tests/test_admin_notifications.py src/accounts/tests/test_admin_stripe_connect.py \
  src/events/tests/test_admin/ src/accounts/tests/test_controllers/test_referral_stripe_controller.py \
  src/events/tests/test_service/test_stripe_service/ \
  src/events/tests/test_controllers/test_organization_admin_stripe.py -q
# 168 passed

make check   # format, lint, mypy --strict, migrations, i18n, file-length, task-names — all pass
```

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)