### PR TITLE
docs(financials): label membership revenue as gross, excluded from taxable turnover

### DIFF
--- a/src/events/schema/financials.py
+++ b/src/events/schema/financials.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from ninja import Schema
-from pydantic import AwareDatetime
+from pydantic import AwareDatetime, Field
 
 
 class RateBucketSchema(Schema):
@@ -18,11 +18,25 @@ class RateBucketSchema(Schema):
 
 
 class CurrencyFinancialsSchema(Schema):
+    """Ticket money for one currency. Ticket scope only — membership revenue is not included here.
+
+    Every figure below is derived from ticket payments; membership subscription money is
+    reported separately in ``MembershipFinancialsSchema`` and is never folded into these totals.
+    """
+
     currency: str
     gross: Decimal
     refunds: Decimal
     net: Decimal
-    net_taxable: Decimal
+    net_taxable: Decimal = Field(
+        ...,
+        description=(
+            "VAT taxable base for TICKET revenue only, in this currency. Membership revenue is "
+            "excluded: subscription plans carry no VAT rate, so no VAT treatment is applied to "
+            "membership money and it cannot be added to this figure. Do not use this value as a "
+            "total taxable turnover without consulting your tax advisor."
+        ),
+    )
     vat: Decimal
     sold_count: int
     refunded_count: int
@@ -37,10 +51,15 @@ class EventFinancialsSchema(Schema):
 
 
 class MembershipFinancialsSchema(Schema):
-    """Membership subscription money for one currency.
+    """Membership subscription money for one currency, reported GROSS with no VAT treatment.
 
     ``net`` is gross minus refunds (the platform fee is reported, not deducted),
     matching the ticket-side convention so the two are addable.
+
+    VAT caveat: subscription plans carry no VAT rate, so none of these amounts are
+    VAT-decomposed — ``gross``/``net`` are gross-of-VAT figures. Consequently membership
+    revenue is excluded from ``CurrencyFinancialsSchema.net_taxable``, which is ticket
+    scope only. Do not present these numbers as a taxable base.
     """
 
     currency: str
@@ -52,7 +71,12 @@ class MembershipFinancialsSchema(Schema):
 
 
 class CombinedTotalsSchema(Schema):
-    """Grand total for one currency: ticket net plus membership net."""
+    """Grand total for one currency: ticket net plus membership net.
+
+    This is a cash-flow total, not a tax figure: ``memberships_net`` is gross of VAT (see
+    ``MembershipFinancialsSchema``), so ``net`` mixes a VAT-decomposed ticket component with
+    an untreated membership one and must not be filed as taxable turnover.
+    """
 
     currency: str
     tickets_net: Decimal

--- a/src/events/service/revenue_report_service.py
+++ b/src/events/service/revenue_report_service.py
@@ -114,6 +114,16 @@ _MEMBERSHIP_TXN_HEADERS = [
 ]
 
 
+# Membership plans carry no VAT rate, so nothing on this sheet is VAT-decomposed and the money
+# is deliberately absent from the ticket-scope "Net taxable turnover" totals on Summary. Say so
+# on the sheet itself: an organizer pasting these amounts into a VAT return would under-report.
+_MEMBERSHIP_VAT_NOTE = (
+    "Note: membership revenue is reported gross — no VAT treatment is applied. These amounts are "
+    "excluded from the Net taxable turnover figures on the Summary sheet, which cover ticket "
+    "revenue only. Consult your tax advisor."
+)
+
+
 def report_filename(scope: ReportScope, ext: str = "zip") -> str:
     """Return a canonical filename for the report bundle or one of its parts."""
     return f"revel-revenue-{scope.org.slug}-{scope.date_from}_{scope.date_to}.{ext}"
@@ -201,6 +211,10 @@ def build_xlsx(data: RevenueReportData) -> bytes:
     style_header_row(memberships)
     auto_fit_columns(memberships)
     memberships.freeze_panes = "A2"
+    # Appended after styling on purpose: the note must not widen column A, join the autofilter
+    # range, or shift the header/data rows that machine parsers key off.
+    memberships.append([])
+    memberships.append([_MEMBERSHIP_VAT_NOTE])
 
     buf = io.BytesIO()
     wb.save(buf)

--- a/src/events/tests/test_service/test_revenue_report_bundle.py
+++ b/src/events/tests/test_service/test_revenue_report_bundle.py
@@ -172,6 +172,29 @@ def test_membership_sheet_carries_the_reconciliation_columns(
 
 
 @pytest.mark.django_db
+def test_membership_sheet_labels_revenue_as_gross_and_out_of_scope(
+    membership_report_data: svc.RevenueReportData,
+) -> None:
+    """The sheet says membership money is gross and excluded from taxable turnover."""
+    wb = load_workbook(io.BytesIO(svc.build_xlsx(membership_report_data)))
+    sheet = wb["Membership payments"]
+    notes = [
+        str(row[0].value)
+        for row in sheet.iter_rows(min_row=2, max_col=1)
+        if row[0].value and "membership revenue is reported gross" in str(row[0].value)
+    ]
+    assert len(notes) == 1, "membership VAT note missing from the sheet"
+    assert "no VAT treatment is applied" in notes[0]
+    assert "excluded from the Net taxable turnover figures" in notes[0]
+    assert "tax advisor" in notes[0]
+    # The note sits below the data block: headers and the first payment row are untouched,
+    # so machine parsers keyed off row 1 / row 2 keep working.
+    assert sheet["A1"].value == "date"
+    assert sheet["B2"].value == "member@example.com"
+    assert sheet["A2"].value == membership_report_data.membership_payments[0].date.isoformat()
+
+
+@pytest.mark.django_db
 def test_membership_only_org_still_produces_a_report(membership_report_data: svc.RevenueReportData) -> None:
     """No tickets at all: the ticket sections are empty but the ledger is not."""
     assert membership_report_data.sections == []
@@ -195,11 +218,27 @@ def test_pdf_shows_membership_summary_instead_of_no_revenue(
 
 
 @pytest.mark.django_db
+def test_pdf_labels_membership_revenue_as_gross_and_out_of_scope(
+    membership_report_data: svc.RevenueReportData,
+) -> None:
+    """The membership table carries the gross / not-taxable-turnover caveat."""
+    html = render_to_string(
+        "reports/revenue_vat_report.html",
+        {"data": membership_report_data, "org": membership_report_data.scope.org},
+    )
+    assert "Membership revenue is reported gross" in html
+    assert "no VAT treatment is applied" in html
+    assert "excluded from the net taxable turnover figures" in html
+    assert "Consult your tax advisor." in html
+
+
+@pytest.mark.django_db
 def test_pdf_omits_the_membership_table_without_memberships(report_data: svc.RevenueReportData) -> None:
-    """Ticket-only orgs see the report exactly as before."""
+    """Ticket-only orgs see the report exactly as before: no membership table, no membership caveat."""
     html = render_to_string("reports/revenue_vat_report.html", {"data": report_data, "org": report_data.scope.org})
     assert "Memberships" not in html
     assert "No revenue in this period" not in html
+    assert "Membership revenue is reported gross" not in html
 
 
 @pytest.mark.django_db

--- a/src/templates/reports/revenue_vat_report.html
+++ b/src/templates/reports/revenue_vat_report.html
@@ -83,6 +83,7 @@
       {% endfor %}
     </tbody>
   </table>
+  <p class="foot"><strong>Membership revenue is reported gross — no VAT treatment is applied</strong>, and it is excluded from the net taxable turnover figures above, which cover ticket revenue only. Consult your tax advisor.</p>
   <p class="foot">Membership subscription revenue, per currency. Net is gross minus refunds; the platform fee is shown for information and is billed separately. Per-payment detail is in the "Membership payments" sheet of the XLSX.</p>
   {% endif %}
 


### PR DESCRIPTION
## What

Labels membership revenue as VAT-untreated everywhere organizers consume it, closing an under-reporting trap: the financials `net_taxable` figure is ticket-scope only, and nothing previously said that membership money was excluded from it. An organizer pasting the taxable-turnover figure into a VAT return would silently under-report.

Three surfaces, labeling only — no math changes, no new fields, no migrations:

- **Schema/OpenAPI** (`events/schema/financials.py`): `MembershipFinancialsSchema`, `CombinedTotalsSchema`, and the `net_taxable` field now state that membership figures are gross with no VAT treatment, `net_taxable` covers ticket revenue only, and `combined_totals.net` is a cash-flow figure, not a tax figure.
- **Revenue report PDF**: caption under the Memberships table (inside the conditional — ticket-only orgs unaffected, test-asserted).
- **Revenue report XLSX**: note rows appended below the data on the "Membership payments" sheet, after styling/autofilter/freeze-pane setup so header/data ranges stay parser-stable (test-asserted cell-by-cell).

## Why not real VAT figures

Membership-fee VAT treatment genuinely varies by org (exempt, standard-rated, out of scope); plans carry no VAT rate, so any figure we computed would be confidently wrong for someone. Full parity (plan-level VAT rates + bucket decomposition, mirroring tickets) is deliberately deferred — see the follow-up issue filed alongside this PR.

`make check` green; 42 tests across the bundle/branding/financials/aggregation/scheduled-report suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtpbeLss5QghtRPoTRVYV3
