### PR TITLE
fix(events): point membership Checkout return URLs at the membership route (#838)

### DIFF
--- a/src/events/service/subscription_stripe_service.py
+++ b/src/events/service/subscription_stripe_service.py
@@ -135,12 +135,14 @@ def _checkout_session_urls(organization: Organization) -> dict[str, str]:
     """Success/cancel redirect URLs for a membership Checkout Session.
 
     Mirrors the ticket checkout convention (``stripe_service._create_stripe_session``):
-    redirect back to the org page with a query flag the frontend reads.
+    redirect back with a query flag the frontend reads. Points at the dedicated
+    membership route (``/org/<slug>/membership``, revel-frontend#720) — the org
+    landing page no longer renders the checkout outcome (#838).
     """
     frontend_base_url = SiteSettings.get_solo().frontend_base_url
     return {
-        "success_url": f"{frontend_base_url}/org/{organization.slug}?membership_success=true",
-        "cancel_url": f"{frontend_base_url}/org/{organization.slug}?membership_cancelled=true",
+        "success_url": f"{frontend_base_url}/org/{organization.slug}/membership?membership_success=true",
+        "cancel_url": f"{frontend_base_url}/org/{organization.slug}/membership?membership_cancelled=true",
     }
 
 

--- a/src/events/tests/test_service/test_subscription_stripe_service.py
+++ b/src/events/tests/test_service/test_subscription_stripe_service.py
@@ -286,8 +286,9 @@ class TestStartOnlineSubscription:
         assert kwargs["metadata"] == {"membership_subscription_id": str(subscription.pk)}
         assert kwargs["subscription_data"]["metadata"] == {"membership_subscription_id": str(subscription.pk)}
         assert kwargs["stripe_account"] == "acct_test_org"
-        assert "membership_success=true" in kwargs["success_url"]
-        assert "membership_cancelled=true" in kwargs["cancel_url"]
+        # Dedicated membership route, not the org landing page (#838).
+        assert f"/org/{stripe_org.slug}/membership?membership_success=true" in kwargs["success_url"]
+        assert f"/org/{stripe_org.slug}/membership?membership_cancelled=true" in kwargs["cancel_url"]
         assert isinstance(kwargs["expires_at"], int)
 
     def test_refuses_offline_plan(


### PR DESCRIPTION
Closes #838.

## What

Both Stripe Checkout return URLs in `_checkout_session_urls` now point at the dedicated membership route:

- `success_url` → `/org/{slug}/membership?membership_success=true`
- `cancel_url` → `/org/{slug}/membership?membership_cancelled=true`

The test now pins the full path, not just the query flags.

## Why

The frontend moved the membership surface (plan grid + `CheckoutReturnCard`) to `/org/{slug}/membership` (letsrevel/revel-frontend#720); the org landing page currently works around the backend-owned URL with a 303 redirect on every return from Stripe — an extra round trip right after paying.

## Checked while in here

Swept the module and notification code for other paths assuming the membership UI lives on the org landing page — none found. `subscription_notifications.py` deliberately uses `/account/memberships` (the global member surface, #815) and links the org page only for the inline contact form; both remain correct.

## Sequencing

Safe to merge and deploy in any order **as long as the frontend redirect stays** until this is deployed. The frontend redirect must be removed only afterwards — noting this on revel-frontend#720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDAqbf5rVnRc17gVWAnevg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Membership checkout success and cancellation redirects now return to the organization’s dedicated Membership page.
  * Existing organization details and status indicators are preserved in the redirect URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->