### PR TITLE
fix(events): scope the seeder's global sweeps to its own objects (#840)

### DIFF
--- a/src/events/management/commands/seeder/interactions.py
+++ b/src/events/management/commands/seeder/interactions.py
@@ -376,8 +376,12 @@ class InteractionSeeder(BaseSeeder):
 
         requests_to_create: list[WhitelistRequest] = []
 
-        # Get blacklist entries with fuzzy matches (name-based)
-        name_blacklist_entries = Blacklist.objects.filter(first_name__isnull=False).select_related("organization")[:100]
+        # Get blacklist entries with fuzzy matches (name-based), scoped to this
+        # run's organizations so pre-existing fixtures are left alone (#840).
+        name_blacklist_entries = Blacklist.objects.filter(
+            organization_id__in=self.state.organization_ids,
+            first_name__isnull=False,
+        ).select_related("organization")[:100]
 
         for entry in name_blacklist_entries:
             if not self.random_bool(0.3):

--- a/src/events/management/commands/seeder/questionnaires.py
+++ b/src/events/management/commands/seeder/questionnaires.py
@@ -292,8 +292,10 @@ class QuestionnaireSeeder(BaseSeeder):
 
         evaluations_to_create: list[QuestionnaireEvaluation] = []
 
-        # Get ready submissions that don't already have evaluations
+        # Get ready submissions that don't already have evaluations, scoped to
+        # this run's questionnaires so pre-existing fixtures keep their state (#840).
         ready_submissions = QuestionnaireSubmission.objects.filter(
+            questionnaire__in=self.state.questionnaires,
             status="ready",
             evaluation__isnull=True,
         )

--- a/src/events/management/commands/seeder/state.py
+++ b/src/events/management/commands/seeder/state.py
@@ -67,6 +67,16 @@ class SeederState:
     non_ticketed_events: list["Event"] = field(default_factory=list)
     private_events: list["Event"] = field(default_factory=list)
 
+    @property
+    def organization_ids(self) -> list[UUID]:
+        """IDs of the organizations created by this seeder run.
+
+        Every entity the seeder creates hangs off one of these, so this is the
+        scoping key for any query that would otherwise sweep the whole database
+        and mutate pre-existing fixtures (#840).
+        """
+        return [org.id for org in self.organizations]
+
     def get_random_user(self, rand: random.Random) -> "RevelUser":
         """Get a random user from all users."""
         return rand.choice(self.users)

--- a/src/events/management/commands/seeder/tickets.py
+++ b/src/events/management/commands/seeder/tickets.py
@@ -257,9 +257,12 @@ class TicketSeeder(BaseSeeder):
 
         from django.db.models import Count
 
-        # Get ticket counts per tier (excluding cancelled)
+        # Get ticket counts per tier (excluding cancelled), scoped to this run (#840)
         tier_counts = (
-            Ticket.objects.exclude(status=Ticket.TicketStatus.CANCELLED).values("tier_id").annotate(count=Count("id"))
+            Ticket.objects.filter(event__organization_id__in=self.state.organization_ids)
+            .exclude(status=Ticket.TicketStatus.CANCELLED)
+            .values("tier_id")
+            .annotate(count=Count("id"))
         )
 
         tier_count_map = {tc["tier_id"]: tc["count"] for tc in tier_counts}
@@ -285,7 +288,10 @@ class TicketSeeder(BaseSeeder):
         refunded_tickets: list[Ticket] = []
         tier_refund_counts: dict[UUID, int] = {}
 
+        # Scoped to this run's organizations: an unscoped sweep cancels tickets and
+        # decrements quantity_sold on pre-existing fixtures too (#840).
         online_tickets = Ticket.objects.filter(
+            event__organization_id__in=self.state.organization_ids,
             tier__payment_method=TicketTier.PaymentMethod.ONLINE,
             payment__isnull=True,
         ).select_related("tier", "user")

--- a/src/events/tests/test_management/test_seeder_payments.py
+++ b/src/events/tests/test_management/test_seeder_payments.py
@@ -41,11 +41,13 @@ def online_ticket(db: t.Any) -> Ticket:
     )
 
 
-def _run_payments(weights: dict[str, float]) -> TicketSeeder:
-    """Run only the _create_payments pass with the given status weights."""
+def _run_payments(weights: dict[str, float], organizations: list[Organization]) -> TicketSeeder:
+    """Run only the _create_payments pass, scoped to the given organizations."""
     config = SeederConfig(seed=1234)
     config.payment_status_weights = weights
-    seeder = TicketSeeder(config=config, state=SeederState(), stdout=io.StringIO())
+    state = SeederState()
+    state.organizations = organizations
+    seeder = TicketSeeder(config=config, state=state, stdout=io.StringIO())
     seeder._create_payments()
     return seeder
 
@@ -53,7 +55,10 @@ def _run_payments(weights: dict[str, float]) -> TicketSeeder:
 @pytest.mark.django_db
 def test_refunded_payment_is_internally_consistent(online_ticket: Ticket) -> None:
     """A seeded REFUNDED payment records the refund and cancels the ticket (#550)."""
-    _run_payments({"succeeded": 0.0, "pending": 0.0, "failed": 0.0, "refunded": 1.0})
+    _run_payments(
+        {"succeeded": 0.0, "pending": 0.0, "failed": 0.0, "refunded": 1.0},
+        [online_ticket.event.organization],
+    )
 
     payment = Payment.objects.get(ticket=online_ticket)
     assert payment.status == Payment.PaymentStatus.REFUNDED
@@ -74,7 +79,10 @@ def test_refunded_payment_is_internally_consistent(online_ticket: Ticket) -> Non
 @pytest.mark.django_db
 def test_succeeded_payment_leaves_ticket_active(online_ticket: Ticket) -> None:
     """A non-refunded payment must not touch the ticket or refund fields."""
-    _run_payments({"succeeded": 1.0, "pending": 0.0, "failed": 0.0, "refunded": 0.0})
+    _run_payments(
+        {"succeeded": 1.0, "pending": 0.0, "failed": 0.0, "refunded": 0.0},
+        [online_ticket.event.organization],
+    )
 
     payment = Payment.objects.get(ticket=online_ticket)
     assert payment.status == Payment.PaymentStatus.SUCCEEDED

--- a/src/events/tests/test_management/test_seeder_scoping.py
+++ b/src/events/tests/test_management/test_seeder_scoping.py
@@ -1,0 +1,119 @@
+"""Tests that the seeder's sweeps stay scoped to the objects it created (#840).
+
+The seeder used to run global ``Model.objects.filter(...)`` sweeps with no run
+scoping. Against a database that already contained ``bootstrap_test_events``
+fixtures, that silently corrupted them — most visibly by refunding (and thus
+cancelling) tickets on ``test-sold-out-event`` and decrementing its tier's
+``quantity_sold``, so the event was no longer sold out.
+"""
+
+import io
+import typing as t
+
+import pytest
+from django.contrib.gis.geos import Point
+from django.core.management import call_command
+
+from accounts.models import RevelUser
+from events.management.commands.seeder.config import SeederConfig
+from events.management.commands.seeder.interactions import InteractionSeeder
+from events.management.commands.seeder.questionnaires import QuestionnaireSeeder
+from events.management.commands.seeder.state import SeederState
+from events.management.commands.seeder.tickets import TicketSeeder
+from events.models import Blacklist, Organization, Payment, Ticket, TicketTier, WhitelistRequest
+from geo.models import City
+from questionnaires.models import Questionnaire, QuestionnaireEvaluation, QuestionnaireSubmission
+
+pytestmark = pytest.mark.django_db
+
+ALWAYS_REFUND = {"succeeded": 0.0, "pending": 0.0, "failed": 0.0, "refunded": 1.0}
+
+
+def _state(organizations: list[Organization]) -> SeederState:
+    """A seeder state whose run "created" the given organizations."""
+    state = SeederState()
+    state.organizations = organizations
+    return state
+
+
+def _seeder_org() -> Organization:
+    """An organization standing in for one the seeder created this run."""
+    owner = RevelUser.objects.create_user(username="seeded.owner", email="seeded.owner@example.com", password="x")
+    return Organization.objects.create(name="Seeded Org", slug="seeded-org", owner=owner)
+
+
+@pytest.fixture
+def vienna(db: t.Any) -> City:
+    """The city ``bootstrap_test_events`` looks up (already present via geo fixtures)."""
+    city, _ = City.objects.get_or_create(
+        name="Vienna",
+        country="Austria",
+        defaults={
+            "ascii_name": "Vienna",
+            "iso2": "AT",
+            "iso3": "AUT",
+            "city_id": 1,
+            "location": Point(16.3738, 48.2082),
+        },
+    )
+    return city
+
+
+def test_bootstrap_sold_out_fixture_survives_a_seed_run(vienna: City) -> None:
+    """``bootstrap`` → ``seed`` must leave ``test-sold-out-event`` sold out (#840).
+
+    Both halves of the old damage are asserted: the ``Ticket`` rows *and* the
+    tier's denormalized ``quantity_sold`` counter.
+    """
+    call_command("bootstrap_test_events")
+    tier = TicketTier.objects.get(event__slug="test-sold-out-event", name="General Admission")
+    assert tier.payment_method == TicketTier.PaymentMethod.ONLINE
+    assert tier.quantity_sold == 5
+
+    config = SeederConfig(seed=1234)
+    config.payment_status_weights = ALWAYS_REFUND  # the outcome that used to corrupt the fixture
+    TicketSeeder(config=config, state=_state([_seeder_org()]), stdout=io.StringIO())._create_payments()
+
+    tier.refresh_from_db()
+    assert tier.quantity_sold == 5
+    assert Ticket.objects.filter(tier=tier, status=Ticket.TicketStatus.ACTIVE).count() == 5
+    assert not Ticket.objects.filter(tier=tier).exclude(status=Ticket.TicketStatus.ACTIVE).exists()
+    assert not Payment.objects.filter(ticket__tier=tier).exists()
+
+
+def test_payments_are_created_for_the_run_s_own_tickets(vienna: City) -> None:
+    """Scoping must not stop the seeder from paying for its own tickets."""
+    call_command("bootstrap_test_events")
+    foreign_tier = TicketTier.objects.get(event__slug="test-sold-out-event", name="General Admission")
+    org = foreign_tier.event.organization
+
+    TicketSeeder(config=SeederConfig(seed=1234), state=_state([org]), stdout=io.StringIO())._create_payments()
+
+    assert Payment.objects.filter(ticket__tier=foreign_tier).count() == 5
+
+
+def test_evaluations_are_scoped_to_the_run_s_questionnaires() -> None:
+    """A ready submission on a foreign questionnaire must not be auto-evaluated."""
+    user = RevelUser.objects.create_user(username="submitter", email="submitter@example.com", password="x")
+    foreign = Questionnaire.objects.create(name="Foreign questionnaire")
+    QuestionnaireSubmission.objects.create(
+        questionnaire=foreign, user=user, status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY
+    )
+
+    seeder = QuestionnaireSeeder(config=SeederConfig(seed=1234), state=SeederState(), stdout=io.StringIO())
+    seeder._create_evaluations()
+
+    assert not QuestionnaireEvaluation.objects.exists()
+
+
+def test_whitelist_requests_are_scoped_to_the_run_s_organizations() -> None:
+    """A foreign organization's blacklist must not sprout seeded whitelist requests."""
+    owner = RevelUser.objects.create_user(username="foreign.owner", email="foreign.owner@example.com", password="x")
+    foreign_org = Organization.objects.create(name="Foreign Org", slug="foreign-org", owner=owner)
+    Blacklist.objects.create(organization=foreign_org, first_name="Banned", reason="test", created_by=owner)
+
+    state = _state([_seeder_org()])
+    state.regular_users = [owner]
+    InteractionSeeder(config=SeederConfig(seed=1234), state=state, stdout=io.StringIO())._create_whitelist_requests()
+
+    assert not WhitelistRequest.objects.exists()


### PR DESCRIPTION
Closes #840

## Problem

`TicketSeeder._create_payments` swept **every** ticket in the database, not just the ones the
seeder created. Run `make seed` on a database that already contains `bootstrap_test_events`
fixtures and it rolled a random payment status per ticket; each `REFUNDED` outcome set
`status=CANCELLED` and decremented the tier's denormalized `quantity_sold`. `test-sold-out-event`
(ONLINE tier, `quantity_sold=5`, five ACTIVE tickets, no `Payment` rows) matches that shape exactly,
so seeding silently un-sold-out the fixture — with the damage split across two independent halves
(the `Ticket` rows *and* the counter), which is what made it hard to diagnose.

## Fix

Option 1 from the issue: scope to the seeder's own objects. New `SeederState.organization_ids`
gives the run a single scoping key — everything the seeder creates hangs off one of its own
organizations.

Applied to all four unscoped sweeps found in the audit:

| Sweep | Was | Now |
|---|---|---|
| `TicketSeeder._create_payments` | every ONLINE ticket without a payment | …within this run's orgs |
| `TicketSeeder._update_tier_quantities` | global per-tier ticket count | …within this run's orgs |
| `QuestionnaireSeeder._create_evaluations` | every ready submission without an evaluation | …on this run's questionnaires |
| `InteractionSeeder._create_whitelist_requests` | every name-matched blacklist entry | …within this run's orgs |

Only the first was actively destructive; the second is a no-op change in outcome (it already wrote
only to state-tracked tiers) and is scoped for correctness-by-construction. The last two were
additively corrupting — they attached seeded evaluations / whitelist requests to foreign fixtures.

The scoping is fail-closed: an empty `organization_ids` selects nothing rather than everything.

## Tests

New `src/events/tests/test_management/test_seeder_scoping.py`:

- **Regression (AC 1–3):** runs the real `bootstrap_test_events` command, then a payments pass
  forced to 100% REFUNDED with a *different* org in seeder state, and asserts `test-sold-out-event`
  still has `quantity_sold=5`, 5 ACTIVE tickets, and no `Payment` rows. Verified it fails
  (`assert 0 == 5`) with the scoping removed.
- Scoping doesn't break the happy path — payments *are* created when the fixture's org is the
  run's own.
- Evaluation and whitelist-request scoping each get a test.

`test_seeder_payments.py` updated to put its org in seeder state (it previously relied on the
global sweep).

`make format lint mypy` clean; `src/events/tests/test_management/` — 21 passed.

## Note

`revel-frontend/tests/e2e/README.md` still prescribes the `reset_events && make seed &&
make bootstrap-tests` ordering workaround. That's a separate repo; with this merged the ordering
constraint is no longer load-bearing and the README can be relaxed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDAqbf5rVnRc17gVWAnevg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Seeder operations now affect only organizations and records created during the current run.
  * Prevented updates to pre-existing tickets, payment records, questionnaire evaluations, and whitelist requests.
  * Preserved existing ticket availability and sales counters when seeding additional data.

* **Tests**
  * Added regression coverage to verify correct seeding isolation across payments, tickets, questionnaires, and whitelist requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->