### PR TITLE
feat(stripe): minimal payloads — generic labels, UUID return URLs, catalog scrub

### DIFF
--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -103,6 +103,16 @@ class OrganizationController(UserAwareController):
                     self._raise_if_token_gone(organization_id=org_id)
             raise
 
+    def get_one_by_id(self, organization_id: UUID) -> models.Organization:
+        """Get one organization by id, honoring the 410 dead-token upgrade like ``get_one``."""
+        try:
+            return self.get_object_or_exception(self.get_queryset(), id=organization_id)  # type: ignore[no-any-return]
+        except NotFound:
+            # _raise_if_token_gone only fires when the rejected token belongs to
+            # this organization, so unknown ids and unrelated tokens stay 404.
+            self._raise_if_token_gone(organization_id=organization_id)
+            raise
+
     @route.get("/", url_name="list_organizations", response=PaginatedResponseSchema[schema.OrganizationInListSchema])
     @paginate(PageNumberPaginationExtra, page_size=20)
     @searching(DistinctSearching, search_fields=["name", "description", "tags__tag__name"])
@@ -168,13 +178,7 @@ class OrganizationController(UserAwareController):
         expired/used-up org tokens. Used by the frontend to resolve the UUID-based
         Stripe checkout return URLs (#848) back to slug pages.
         """
-        try:
-            return self.get_object_or_exception(self.get_queryset(), id=organization_id)  # type: ignore[no-any-return]
-        except NotFound:
-            # _raise_if_token_gone only fires when the rejected token belongs to
-            # this organization, so unknown ids and unrelated tokens stay 404.
-            self._raise_if_token_gone(organization_id=organization_id)
-            raise
+        return self.get_one_by_id(organization_id)
 
     @route.get("/{slug}", url_name="get_organization", response=schema.OrganizationRetrieveSchema)
     def get_organization(self, slug: str) -> models.Organization:

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -164,10 +164,17 @@ class OrganizationController(UserAwareController):
     def get_organization_by_id(self, organization_id: UUID) -> models.Organization:
         """Retrieve organization details by ID.
 
-        Same visibility rules and payload as the slug route. Used by the frontend to
-        resolve the UUID-based Stripe checkout return URLs (#848) back to slug pages.
+        Same visibility rules and payload as the slug route, including the 410 for
+        expired/used-up org tokens. Used by the frontend to resolve the UUID-based
+        Stripe checkout return URLs (#848) back to slug pages.
         """
-        return self.get_object_or_exception(self.get_queryset(), id=organization_id)  # type: ignore[no-any-return]
+        try:
+            return self.get_object_or_exception(self.get_queryset(), id=organization_id)  # type: ignore[no-any-return]
+        except NotFound:
+            # _raise_if_token_gone only fires when the rejected token belongs to
+            # this organization, so unknown ids and unrelated tokens stay 404.
+            self._raise_if_token_gone(organization_id=organization_id)
+            raise
 
     @route.get("/{slug}", url_name="get_organization", response=schema.OrganizationRetrieveSchema)
     def get_organization(self, slug: str) -> models.Organization:

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -158,6 +158,17 @@ class OrganizationController(UserAwareController):
         organization = organization_service.create_organization(owner=user, **payload.model_dump())
         return 201, organization
 
+    # Declaration order is registration order: this must come before the /{slug}
+    # route, which would otherwise also match UUID-shaped strings.
+    @route.get("/{uuid:organization_id}", url_name="get_organization_by_id", response=schema.OrganizationRetrieveSchema)
+    def get_organization_by_id(self, organization_id: UUID) -> models.Organization:
+        """Retrieve organization details by ID.
+
+        Same visibility rules and payload as the slug route. Used by the frontend to
+        resolve the UUID-based Stripe checkout return URLs (#848) back to slug pages.
+        """
+        return self.get_object_or_exception(self.get_queryset(), id=organization_id)  # type: ignore[no-any-return]
+
     @route.get("/{slug}", url_name="get_organization", response=schema.OrganizationRetrieveSchema)
     def get_organization(self, slug: str) -> models.Organization:
         """Retrieve organization details using its unique slug.

--- a/src/events/management/commands/scrub_stripe_products.py
+++ b/src/events/management/commands/scrub_stripe_products.py
@@ -1,0 +1,114 @@
+"""``python manage.py scrub_stripe_products [--dry-run]``.
+
+One-off backfill for #848: outbound Stripe payloads no longer carry
+organizer-authored content, but Products already persisted in Stripe catalogs
+still do. This command scrubs them in place:
+
+1. **Plan products** — every ``MembershipSubscriptionPlan`` with a
+   ``stripe_product_id`` is renamed to the generic ``"Membership"`` and its
+   description emptied.
+2. **Catalog sweep** — for each distinct connected account (platform account
+   included once, with no ``stripe_account`` header), the ad-hoc Products that
+   Stripe materialized from past inline ``price_data`` are renamed:
+   ``"Ticket: …"`` → ``"Ticket"``, ``"Season pass: …"`` → ``"Season pass"``.
+
+Idempotent: already-generic names don't match a prefix and are skipped; plan
+products are re-modified unconditionally (a server-side no-op). Per-account
+Stripe errors are logged and skipped so one dead account can't abort the sweep.
+"""
+
+import typing as t
+
+import stripe
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+
+from events.models import MembershipSubscriptionPlan, Organization
+from events.service.subscription_stripe_payloads import _stripe_account_kwargs
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+stripe.api_version = settings.STRIPE_API_VERSION
+
+# Prefixes of the legacy organizer-authored product names → generic replacement.
+_PREFIX_TO_GENERIC: dict[str, str] = {
+    "Ticket: ": "Ticket",
+    "Season pass: ": "Season pass",
+}
+
+
+class Command(BaseCommand):
+    """Scrub organizer-authored names/descriptions out of existing Stripe Products (#848)."""
+
+    help = (
+        "Rename organizer-authored Stripe Products to generic labels: plan products "
+        "become 'Membership' (description cleared), and catalog products created from "
+        "past inline price_data lose their 'Ticket: …' / 'Season pass: …' names."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Wire the ``--dry-run`` flag."""
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Log every would-be modification without calling Stripe's modify API.",
+        )
+
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
+        """Scrub plan products, then sweep every Stripe account's product catalog."""
+        dry_run: bool = options["dry_run"]
+        plans_scrubbed = products_renamed = accounts_swept = errors = 0
+
+        plans = MembershipSubscriptionPlan.objects.exclude(stripe_product_id="").select_related("tier__organization")
+        for plan in plans:
+            account_kwargs = _stripe_account_kwargs(plan.tier.organization)
+            if dry_run:
+                self.stdout.write(f"[dry-run] would scrub plan product {plan.stripe_product_id} (plan {plan.pk})")
+                plans_scrubbed += 1
+                continue
+            try:
+                stripe.Product.modify(plan.stripe_product_id, name="Membership", description="", **account_kwargs)
+            except stripe.error.StripeError as exc:
+                self.stderr.write(f"Failed to scrub plan product {plan.stripe_product_id}: {exc}")
+                errors += 1
+                continue
+            plans_scrubbed += 1
+
+        account_ids = (
+            Organization.objects.exclude(stripe_account_id=None)
+            .exclude(stripe_account_id="")
+            .values_list("stripe_account_id", flat=True)
+            .distinct()
+        )
+        for account_id in (t.cast(str, aid) for aid in account_ids):  # exclude() above rules out None
+            # An org sharing the platform's own account is swept without the
+            # Connect header; ``distinct()`` guarantees it appears only once.
+            account_kwargs = {} if account_id == settings.STRIPE_ACCOUNT else {"stripe_account": account_id}
+            try:
+                for product in stripe.Product.list(limit=100, **account_kwargs).auto_paging_iter():
+                    generic = next(
+                        (new for prefix, new in _PREFIX_TO_GENERIC.items() if product["name"].startswith(prefix)),
+                        None,
+                    )
+                    if generic is None:
+                        continue
+                    if dry_run:
+                        self.stdout.write(f"[dry-run] would rename product {product['id']} to {generic!r}")
+                        products_renamed += 1
+                        continue
+                    try:
+                        stripe.Product.modify(product["id"], name=generic, **account_kwargs)
+                    except stripe.error.StripeError as exc:
+                        self.stderr.write(f"Failed to rename product {product['id']} on {account_id}: {exc}")
+                        errors += 1
+                        continue
+                    products_renamed += 1
+            except stripe.error.StripeError as exc:
+                self.stderr.write(f"Failed to sweep account {account_id}: {exc}")
+                errors += 1
+                continue
+            accounts_swept += 1
+
+        self.stdout.write(
+            f"Done: {plans_scrubbed} plan product(s) scrubbed, {products_renamed} product(s) renamed, "
+            f"{accounts_swept} account(s) swept, {errors} error(s)."
+        )

--- a/src/events/management/commands/scrub_stripe_products.py
+++ b/src/events/management/commands/scrub_stripe_products.py
@@ -7,10 +7,10 @@ still do. This command scrubs them in place:
 1. **Plan products** — every ``MembershipSubscriptionPlan`` with a
    ``stripe_product_id`` is renamed to the generic ``"Membership"`` and its
    description emptied.
-2. **Catalog sweep** — for each distinct connected account (platform account
-   included once, with no ``stripe_account`` header), the ad-hoc Products that
-   Stripe materialized from past inline ``price_data`` are renamed:
-   ``"Ticket: …"`` → ``"Ticket"``, ``"Season pass: …"`` → ``"Season pass"``.
+2. **Catalog sweep** — for each distinct connected account plus, always, the
+   platform's own account (swept once, with no ``stripe_account`` header), the
+   ad-hoc Products that Stripe materialized from past inline ``price_data`` are
+   renamed: ``"Ticket: …"`` → ``"Ticket"``, ``"Season pass: …"`` → ``"Season pass"``.
 
 Idempotent: already-generic names don't match a prefix and are skipped; plan
 products are re-modified unconditionally (a server-side no-op). Per-account
@@ -73,15 +73,18 @@ class Command(BaseCommand):
                 continue
             plans_scrubbed += 1
 
-        account_ids = (
+        org_account_ids = (
             Organization.objects.exclude(stripe_account_id=None)
             .exclude(stripe_account_id="")
             .values_list("stripe_account_id", flat=True)
             .distinct()
         )
-        for account_id in (t.cast(str, aid) for aid in account_ids):  # exclude() above rules out None
-            # An org sharing the platform's own account is swept without the
-            # Connect header; ``distinct()`` guarantees it appears only once.
+        # The platform's own catalog is always swept: orgs that once used the
+        # platform account (bootstrap data, or since migrated to their own
+        # Connect account, or deleted) left ad-hoc Products there that no org
+        # row references anymore. The set dedupes it against org-held ids.
+        account_ids = {settings.STRIPE_ACCOUNT, *(t.cast(str, aid) for aid in org_account_ids)}
+        for account_id in sorted(account_ids):
             account_kwargs = {} if account_id == settings.STRIPE_ACCOUNT else {"stripe_account": account_id}
             try:
                 for product in stripe.Product.list(limit=100, **account_kwargs).auto_paging_iter():

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -283,7 +283,6 @@ class StripeLineItem(t.TypedDict):
 
 def _build_line_items(
     payments: list[Payment],
-    event: Event,
     tier: TicketTier,
 ) -> list[StripeLineItem]:
     """Build Stripe line items — one per ``Payment`` row, at that row's own amount.
@@ -628,7 +627,7 @@ def create_batch_session(*, reservation_id: UUID) -> str:
     # Per-row line items, then the total invariant — both derived from the Payment
     # rows themselves, so a mixed-price cart (#739) bills each ticket at its own
     # amount regardless of the order this later request read them back in.
-    line_items = _build_line_items(payments, event, tier)
+    line_items = _build_line_items(payments, tier)
     _reconcile_line_items(line_items, payments, tier.currency)
 
     # Already per-row: the batch's platform fee is the sum of each Payment's own

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -281,20 +281,6 @@ class StripeLineItem(t.TypedDict):
     quantity: int
 
 
-def _product_data(payment: Payment, event: Event, tier: TicketTier) -> dict[str, str]:
-    """Name + description Stripe shows the buyer for one ticket row.
-
-    A blank holder name is a legal ticket state since #845 (email-only guests on an
-    event with ``require_ticket_names=False``), so the holder clause is dropped
-    entirely rather than rendered as a dangling "Ticket for ".
-    """
-    product_data = {"name": f"Ticket: {event.name} ({tier.name})"}
-    guest_name = payment.ticket.guest_name.strip()
-    if guest_name:
-        product_data["description"] = f"Ticket for {guest_name}"
-    return product_data
-
-
 def _build_line_items(
     payments: list[Payment],
     event: Event,
@@ -305,19 +291,19 @@ def _build_line_items(
     Derived per row rather than from a scalar unit price: since #739 a batch's
     Payment rows can legitimately hold different amounts (a mixed seat-category
     cart), and this runs in a *later request* than the reservation, where the row
-    order is unspecified. Taking both the amount and the guest name off the same
-    row makes ordering irrelevant. A ``0.00`` row (a fixed-amount discount floored
-    a ticket to zero) still gets its own line item — the ticket↔Payment pairing is
-    1:1 and the refund matcher depends on it.
+    order is unspecified. Taking the amount off the row itself makes ordering
+    irrelevant. A ``0.00`` row (a fixed-amount discount floored a ticket to zero)
+    still gets its own line item — the ticket↔Payment pairing is 1:1 and the
+    refund matcher depends on it.
 
-    ``payments`` must carry ``ticket`` (the caller's ``select_related``) — this
-    walks ``p.ticket`` per row and would otherwise be an N+1.
+    Product data is the generic constant ``"Ticket"`` — event/tier/guest names
+    never reach Stripe (#848).
     """
     return [
         StripeLineItem(
             price_data={
                 "currency": tier.currency.lower(),
-                "product_data": _product_data(payment, event, tier),
+                "product_data": {"name": "Ticket"},
                 "unit_amount": to_stripe_amount(payment.amount, tier.currency),
             },
             quantity=1,
@@ -402,8 +388,8 @@ def _create_stripe_session(
         customer_email=user.email,
         line_items=line_items,
         mode="payment",
-        success_url=f"{frontend_base_url}/events/{event.organization.slug}/{event.slug}?payment_success=true",
-        cancel_url=f"{frontend_base_url}/events/{event.organization.slug}/{event.slug}?payment_cancelled=true",
+        success_url=f"{frontend_base_url}/events/{event.organization.id}/{event.id}?payment_success=true",
+        cancel_url=f"{frontend_base_url}/events/{event.organization.id}/{event.id}?payment_cancelled=true",
         payment_intent_data={
             "application_fee_amount": application_fee_amount,
         },
@@ -703,7 +689,7 @@ def _create_series_pass_stripe_session(
     ticket_ids = ",".join(str(ticket.id) for ticket in tickets)
 
     frontend_base_url = site.frontend_base_url
-    series_url = f"{frontend_base_url}/events/{org.slug}/series/{series.slug}"
+    series_url = f"{frontend_base_url}/events/{org.id}/series/{series.id}"
     session_data = dict(  # noqa: C408
         customer_email=user.email,
         line_items=[
@@ -711,7 +697,7 @@ def _create_series_pass_stripe_session(
                 "price_data": {
                     "currency": series_pass.currency.lower(),
                     "product_data": {
-                        "name": f"Season pass: {series_pass.name} — {series.name}",
+                        "name": "Season pass",
                     },
                     "unit_amount": to_stripe_amount(total, series_pass.currency),
                 },

--- a/src/events/service/subscription_stripe_base.py
+++ b/src/events/service/subscription_stripe_base.py
@@ -69,8 +69,8 @@ def ensure_stripe_price(plan: MembershipSubscriptionPlan) -> MembershipSubscript
     try:
         if not plan.stripe_product_id:
             product = stripe.Product.create(
-                name=f"{plan.tier.name} — {plan.name}",
-                description=plan.description or None,
+                # Generic label only — tier/plan names and descriptions never reach Stripe (#848).
+                name="Membership",
                 metadata={"revel_plan_id": str(plan.pk)},
                 **kwargs,
             )

--- a/src/events/service/subscription_stripe_service.py
+++ b/src/events/service/subscription_stripe_service.py
@@ -68,8 +68,8 @@ def ensure_customer_profile(user: RevelUser, organization: Organization) -> Cust
 
     try:
         customer = stripe.Customer.create(
+            # No `name`: the user's display name stays out of Stripe payloads (#848).
             email=user.email,
-            name=user.get_display_name() or None,
             metadata={"revel_user_id": str(user.pk), "revel_org_id": str(organization.pk)},
             # Deterministic key keeps concurrent first-time subscribes from
             # creating duplicate Stripe Customers on the same Connect account.
@@ -136,13 +136,14 @@ def _checkout_session_urls(organization: Organization) -> dict[str, str]:
 
     Mirrors the ticket checkout convention (``stripe_service._create_stripe_session``):
     redirect back with a query flag the frontend reads. Points at the dedicated
-    membership route (``/org/<slug>/membership``, revel-frontend#720) — the org
-    landing page no longer renders the checkout outcome (#838).
+    membership route (``/org/<id>/membership``, revel-frontend#720) — the org
+    landing page no longer renders the checkout outcome (#838). UUID-based so the
+    org slug never reaches Stripe; the FE resolves UUIDs (#848 / revel-frontend#756).
     """
     frontend_base_url = SiteSettings.get_solo().frontend_base_url
     return {
-        "success_url": f"{frontend_base_url}/org/{organization.slug}/membership?membership_success=true",
-        "cancel_url": f"{frontend_base_url}/org/{organization.slug}/membership?membership_cancelled=true",
+        "success_url": f"{frontend_base_url}/org/{organization.id}/membership?membership_success=true",
+        "cancel_url": f"{frontend_base_url}/org/{organization.id}/membership?membership_cancelled=true",
     }
 
 

--- a/src/events/tests/test_controllers/test_organization_controller.py
+++ b/src/events/tests/test_controllers/test_organization_controller.py
@@ -1,4 +1,5 @@
 import typing as t
+import uuid
 from datetime import timedelta
 from decimal import Decimal
 
@@ -438,6 +439,67 @@ def test_get_organization_not_found(client: Client) -> None:
     """Test that a 404 is returned for a non-existent organization slug."""
     url = reverse("api:get_organization", kwargs={"slug": "non-existent-slug"})
     response = client.get(url)
+    assert response.status_code == 404
+
+
+# --- Tests for GET /organizations/{organization_id} (UUID lookup, #848) ---
+
+
+def test_get_organization_by_id(client: Client, organization: Organization) -> None:
+    """UUID lookup returns the same payload shape as the slug route (#848)."""
+    organization.visibility = Organization.Visibility.PUBLIC
+    organization.save(update_fields=["visibility"])
+    url = reverse("api:get_organization_by_id", kwargs={"organization_id": organization.id})
+    response = client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["slug"] == organization.slug
+    assert data["name"] == organization.name
+
+
+def test_get_organization_by_id_not_found(client: Client) -> None:
+    url = reverse("api:get_organization_by_id", kwargs={"organization_id": uuid.uuid4()})
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+def test_get_organization_by_id_respects_visibility(
+    client: Client, member_client: Client, organization: Organization
+) -> None:
+    """Same visibility rules as the slug route: private orgs are 404 for outsiders."""
+    # `organization` is private by default.
+    url = reverse("api:get_organization_by_id", kwargs={"organization_id": organization.id})
+    assert client.get(url).status_code == 404
+    assert member_client.get(url).status_code == 200
+
+
+def test_get_organization_by_slug_still_works(client: Client, organization: Organization) -> None:
+    """Route-ordering guard: UUID route must not shadow slug lookups."""
+    organization.visibility = Organization.Visibility.PUBLIC
+    organization.save(update_fields=["visibility"])
+    response = client.get(reverse("api:get_organization", kwargs={"slug": organization.slug}))
+    assert response.status_code == 200
+    assert response.json()["slug"] == organization.slug
+
+
+@pytest.mark.parametrize(
+    "path_segment",
+    [
+        "not-a-uuid-slug",
+        "1234-abcd",  # hyphenated numeric prefix — flirts with UUID shape
+        "ABCDEF12-3456-7890-ABCD-EF1234567890",  # UUID-shaped but uppercase; the uuid converter is lowercase-only
+        "12345678-1234-1234-1234-12345678901",  # one hex digit short of a UUID
+    ],
+)
+def test_non_uuid_segments_never_422(client: Client, path_segment: str) -> None:
+    """Anything that isn't a lowercase UUID must fall through to the slug route (#848).
+
+    The ``{uuid:...}`` converter filters at URL resolution, so a non-UUID segment
+    never reaches the by-id operation's validation — it resolves as a slug and
+    404s on the lookup. A 422 here would mean the uuid route started swallowing
+    slug-shaped requests.
+    """
+    response = client.get(reverse("api:get_organization", kwargs={"slug": path_segment}))
     assert response.status_code == 404
 
 

--- a/src/events/tests/test_controllers/test_organization_controller.py
+++ b/src/events/tests/test_controllers/test_organization_controller.py
@@ -482,6 +482,37 @@ def test_get_organization_by_slug_still_works(client: Client, organization: Orga
     assert response.json()["slug"] == organization.slug
 
 
+def test_get_organization_by_id_expired_token_returns_410(
+    client: Client, organization: Organization, organization_owner_user: RevelUser
+) -> None:
+    """The by-id route mirrors the slug route's 410 for dead org tokens (#333/#682).
+
+    An unrelated or unknown id still 404s — ``_raise_if_token_gone`` only fires
+    when the rejected token belongs to the requested organization.
+    """
+    # Arrange
+    organization.visibility = Organization.Visibility.PRIVATE
+    organization.save()
+    token = OrganizationToken.objects.create(
+        organization=organization,
+        issuer=organization_owner_user,
+        grants_membership=False,
+        expires_at=timezone.now() - timedelta(hours=1),
+    )
+    url = reverse("api:get_organization_by_id", kwargs={"organization_id": organization.id})
+
+    # Act
+    response = client.get(url, HTTP_X_ORG_TOKEN=token.pk)
+
+    # Assert
+    assert response.status_code == 410
+    assert "expired" in response.json()["detail"].lower()
+
+    # Unknown id with the same dead token: guard keeps it a plain 404.
+    other_url = reverse("api:get_organization_by_id", kwargs={"organization_id": uuid.uuid4()})
+    assert client.get(other_url, HTTP_X_ORG_TOKEN=token.pk).status_code == 404
+
+
 @pytest.mark.parametrize(
     "path_segment",
     [

--- a/src/events/tests/test_management/test_scrub_stripe_products_command.py
+++ b/src/events/tests/test_management/test_scrub_stripe_products_command.py
@@ -1,0 +1,170 @@
+"""Tests for the ``scrub_stripe_products`` management command."""
+
+import typing as t
+from decimal import Decimal
+from io import StringIO
+from unittest import mock
+
+import pytest
+import stripe
+from django.core.management import call_command
+
+from accounts.models import RevelUser
+from events.models import MembershipSubscriptionPlan, MembershipTier, Organization
+
+pytestmark = pytest.mark.django_db
+
+_CMD = "events.management.commands.scrub_stripe_products"
+
+
+@pytest.fixture
+def stripe_org(organization: Organization) -> Organization:
+    organization.stripe_account_id = "acct_scrub_org"
+    organization.save(update_fields=["stripe_account_id"])
+    return organization
+
+
+@pytest.fixture
+def online_plan(stripe_org: Organization) -> MembershipSubscriptionPlan:
+    tier = MembershipTier.objects.create(organization=stripe_org, name="Gold")
+    return MembershipSubscriptionPlan.objects.create(
+        tier=tier,
+        name="Monthly",
+        price=Decimal("10.00"),
+        currency="EUR",
+        period_unit="month",
+        period_count=1,
+        payment_method=MembershipSubscriptionPlan.PaymentMethod.ONLINE,
+        stripe_product_id="prod_plan",
+        stripe_price_id="price_plan",
+    )
+
+
+def _run(*args: str) -> str:
+    out = StringIO()
+    call_command("scrub_stripe_products", *args, stdout=out)
+    return out.getvalue()
+
+
+def _list_result(products: list[dict[str, str]]) -> mock.Mock:
+    """Build a ``stripe.Product.list`` return value whose pages yield ``products``."""
+    result = mock.Mock()
+    result.auto_paging_iter.return_value = iter(products)
+    return result
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_scrubs_plan_products(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    online_plan: MembershipSubscriptionPlan,
+) -> None:
+    """A plan with a Stripe product gets a generic name and an emptied description."""
+    mock_list.return_value = _list_result([])
+
+    output = _run()
+
+    assert mock_modify.call_count == 1
+    assert mock_modify.call_args.args == ("prod_plan",)
+    assert mock_modify.call_args.kwargs == {
+        "name": "Membership",
+        "description": "",
+        "stripe_account": "acct_scrub_org",
+    }
+    assert "1 plan product(s) scrubbed" in output
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_sweep_renames_prefixed_products(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    stripe_org: Organization,
+) -> None:
+    """Ad-hoc catalog products with organizer-authored prefixes are renamed."""
+    mock_list.return_value = _list_result(
+        [
+            {"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"},
+            {"id": "prod_2", "name": "Season pass: Autumn 2026"},
+        ]
+    )
+
+    output = _run()
+
+    mock_list.assert_called_once_with(limit=100, stripe_account="acct_scrub_org")
+    assert mock_modify.call_args_list == [
+        mock.call("prod_1", name="Ticket", stripe_account="acct_scrub_org"),
+        mock.call("prod_2", name="Season pass", stripe_account="acct_scrub_org"),
+    ]
+    assert "2 product(s) renamed" in output
+    assert "1 account(s) swept" in output
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_sweep_skips_generic_names(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    stripe_org: Organization,
+) -> None:
+    """Already-generic or unrelated product names are left untouched."""
+    mock_list.return_value = _list_result(
+        [
+            {"id": "prod_1", "name": "Ticket"},
+            {"id": "prod_2", "name": "Season pass"},
+            {"id": "prod_3", "name": "Merch bundle"},
+        ]
+    )
+
+    output = _run()
+
+    mock_modify.assert_not_called()
+    assert "0 product(s) renamed" in output
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_dry_run_makes_no_calls(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    online_plan: MembershipSubscriptionPlan,
+) -> None:
+    """``--dry-run`` lists every intended modification without calling ``modify``."""
+    mock_list.return_value = _list_result([{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}])
+
+    output = _run("--dry-run")
+
+    mock_modify.assert_not_called()
+    assert "prod_plan" in output
+    assert "prod_1" in output
+    assert "[dry-run]" in output
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_stripe_error_continues(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    stripe_org: Organization,
+) -> None:
+    """A dead account is logged and skipped; the sweep still reaches the others."""
+    owner = RevelUser.objects.create_user(username="scrub_owner2", email="scrub2@example.com", password="pass")
+    Organization.objects.create(name="Org Two", slug="org-two", owner=owner, stripe_account_id="acct_scrub_dead")
+
+    def _list_side_effect(**kwargs: t.Any) -> mock.Mock:
+        if kwargs.get("stripe_account") == "acct_scrub_dead":
+            raise stripe.error.APIError("boom")
+        return _list_result([{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}])
+
+    mock_list.side_effect = _list_side_effect
+    err = StringIO()
+    out = StringIO()
+
+    call_command("scrub_stripe_products", stdout=out, stderr=err)
+    output = out.getvalue()
+
+    mock_modify.assert_called_once_with("prod_1", name="Ticket", stripe_account="acct_scrub_org")
+    assert "acct_scrub_dead" in err.getvalue()
+    assert "1 account(s) swept" in output
+    assert "1 error(s)" in output

--- a/src/events/tests/test_management/test_scrub_stripe_products_command.py
+++ b/src/events/tests/test_management/test_scrub_stripe_products_command.py
@@ -53,6 +53,20 @@ def _list_result(products: list[dict[str, str]]) -> mock.Mock:
     return result
 
 
+def _catalog(per_account: dict[str | None, list[dict[str, str]]]) -> t.Callable[..., mock.Mock]:
+    """Side effect for ``stripe.Product.list``: per-account product pages.
+
+    Keys are ``stripe_account`` kwarg values; ``None`` is the platform account
+    (no Connect header). Accounts not listed yield an empty catalog. A fresh
+    iterator is built per call — the sweep visits several accounts.
+    """
+
+    def _side_effect(**kwargs: t.Any) -> mock.Mock:
+        return _list_result(per_account.get(kwargs.get("stripe_account"), []))
+
+    return _side_effect
+
+
 @mock.patch(f"{_CMD}.stripe.Product.list")
 @mock.patch(f"{_CMD}.stripe.Product.modify")
 def test_scrubs_plan_products(
@@ -61,7 +75,7 @@ def test_scrubs_plan_products(
     online_plan: MembershipSubscriptionPlan,
 ) -> None:
     """A plan with a Stripe product gets a generic name and an emptied description."""
-    mock_list.return_value = _list_result([])
+    mock_list.side_effect = _catalog({})
 
     output = _run()
 
@@ -83,22 +97,47 @@ def test_sweep_renames_prefixed_products(
     stripe_org: Organization,
 ) -> None:
     """Ad-hoc catalog products with organizer-authored prefixes are renamed."""
-    mock_list.return_value = _list_result(
-        [
-            {"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"},
-            {"id": "prod_2", "name": "Season pass: Autumn 2026"},
-        ]
+    mock_list.side_effect = _catalog(
+        {
+            "acct_scrub_org": [
+                {"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"},
+                {"id": "prod_2", "name": "Season pass: Autumn 2026"},
+            ]
+        }
     )
 
     output = _run()
 
-    mock_list.assert_called_once_with(limit=100, stripe_account="acct_scrub_org")
+    assert mock.call(limit=100, stripe_account="acct_scrub_org") in mock_list.call_args_list
     assert mock_modify.call_args_list == [
         mock.call("prod_1", name="Ticket", stripe_account="acct_scrub_org"),
         mock.call("prod_2", name="Season pass", stripe_account="acct_scrub_org"),
     ]
     assert "2 product(s) renamed" in output
-    assert "1 account(s) swept" in output
+    assert "2 account(s) swept" in output  # the org account + the platform account
+
+
+@mock.patch(f"{_CMD}.stripe.Product.list")
+@mock.patch(f"{_CMD}.stripe.Product.modify")
+def test_platform_catalog_always_swept(
+    mock_modify: mock.Mock,
+    mock_list: mock.Mock,
+    stripe_org: Organization,
+) -> None:
+    """The platform's own catalog is swept even when no org row references it.
+
+    Orgs that once used the platform account (bootstrap data, later migrated or
+    deleted) left ad-hoc Products there; the sweep must not depend on an org row
+    still carrying ``settings.STRIPE_ACCOUNT``.
+    """
+    mock_list.side_effect = _catalog({None: [{"id": "prod_platform", "name": "Ticket: Orphaned Event"}]})
+
+    output = _run()
+
+    assert mock.call(limit=100) in mock_list.call_args_list  # no stripe_account header
+    assert mock.call("prod_platform", name="Ticket") in mock_modify.call_args_list
+    assert "1 product(s) renamed" in output
+    assert "2 account(s) swept" in output
 
 
 @mock.patch(f"{_CMD}.stripe.Product.list")
@@ -109,12 +148,14 @@ def test_sweep_skips_generic_names(
     stripe_org: Organization,
 ) -> None:
     """Already-generic or unrelated product names are left untouched."""
-    mock_list.return_value = _list_result(
-        [
-            {"id": "prod_1", "name": "Ticket"},
-            {"id": "prod_2", "name": "Season pass"},
-            {"id": "prod_3", "name": "Merch bundle"},
-        ]
+    mock_list.side_effect = _catalog(
+        {
+            "acct_scrub_org": [
+                {"id": "prod_1", "name": "Ticket"},
+                {"id": "prod_2", "name": "Season pass"},
+                {"id": "prod_3", "name": "Merch bundle"},
+            ]
+        }
     )
 
     output = _run()
@@ -131,7 +172,7 @@ def test_dry_run_makes_no_calls(
     online_plan: MembershipSubscriptionPlan,
 ) -> None:
     """``--dry-run`` lists every intended modification without calling ``modify``."""
-    mock_list.return_value = _list_result([{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}])
+    mock_list.side_effect = _catalog({"acct_scrub_org": [{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}]})
 
     output = _run("--dry-run")
 
@@ -155,7 +196,7 @@ def test_stripe_error_continues(
     def _list_side_effect(**kwargs: t.Any) -> mock.Mock:
         if kwargs.get("stripe_account") == "acct_scrub_dead":
             raise stripe.error.APIError("boom")
-        return _list_result([{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}])
+        return _catalog({"acct_scrub_org": [{"id": "prod_1", "name": "Ticket: Kinky Party (VIP)"}]})(**kwargs)
 
     mock_list.side_effect = _list_side_effect
     err = StringIO()
@@ -166,5 +207,5 @@ def test_stripe_error_continues(
 
     mock_modify.assert_called_once_with("prod_1", name="Ticket", stripe_account="acct_scrub_org")
     assert "acct_scrub_dead" in err.getvalue()
-    assert "1 account(s) swept" in output
+    assert "2 account(s) swept" in output  # the live org account + the platform account
     assert "1 error(s)" in output

--- a/src/events/tests/test_series_pass/test_stripe.py
+++ b/src/events/tests/test_series_pass/test_stripe.py
@@ -260,10 +260,10 @@ class TestCreateSeriesPassSession:
         line_item = call_args[1]["line_items"][0]
         assert line_item["price_data"]["unit_amount"] == 3333
         series = online_series_pass.event_series
-        expected_name = f"Season pass: {online_series_pass.name} — {series.name}"
-        assert line_item["price_data"]["product_data"]["name"] == expected_name
+        # No pass/series names in the Stripe payload — generic label only (#848).
+        assert line_item["price_data"]["product_data"] == {"name": "Season pass"}
 
-        series_base_url = f"{settings.FRONTEND_BASE_URL}/events/{series.organization.slug}/series/{series.slug}"
+        series_base_url = f"{settings.FRONTEND_BASE_URL}/events/{series.organization.id}/series/{series.id}"
         assert call_args[1]["success_url"] == f"{series_base_url}?payment_success=true"
         assert call_args[1]["cancel_url"] == f"{series_base_url}?payment_cancelled=true"
 

--- a/src/events/tests/test_service/test_stripe_service/test_batch_reserve_and_session.py
+++ b/src/events/tests/test_service/test_stripe_service/test_batch_reserve_and_session.py
@@ -6,6 +6,7 @@ from unittest import mock
 from uuid import UUID, uuid4
 
 import pytest
+from django.conf import settings
 from django.utils import timezone
 from ninja.errors import HttpError
 
@@ -390,34 +391,37 @@ class TestCreateBatchSessionDoubleSubmit:
         assert resume.call_args.args[0] == str(stamped.id)
 
 
-class TestBlankHolderNameLineItems:
-    """A blank holder name is legal since #845 — Stripe must never show "Ticket for "."""
+class TestMinimalStripePayload:
+    """Stripe payloads carry no organizer-authored content (#848)."""
 
-    def _product_data(self, event: Event, tier: TicketTier, user: RevelUser, guest_name: str) -> dict[str, t.Any]:
+    def _session_kwargs(self, event: Event, tier: TicketTier, user: RevelUser, guest_name: str) -> dict[str, t.Any]:
         tickets = [_make_ticket(event, tier, user, guest_name=guest_name)]
         rid = uuid4()
         stripe_service.reserve_batch_payments(event=event, tier=tier, user=user, tickets=tickets, reservation_id=rid)
-        fake = mock.Mock(id="cs_blank", url="https://checkout.stripe.com/c/cs_blank")
+        fake = mock.Mock(id="cs_minimal", url="https://checkout.stripe.com/c/cs_minimal")
         with mock.patch("stripe.checkout.Session.create", return_value=fake) as create:
             stripe_service.create_batch_session(reservation_id=rid)
-        line_item = create.call_args.kwargs["line_items"][0]
-        return t.cast(dict[str, t.Any], line_item["price_data"]["product_data"])
+        return t.cast(dict[str, t.Any], create.call_args.kwargs)
 
-    def test_blank_name_drops_the_holder_clause(
+    @pytest.mark.parametrize("guest_name", ["", "Jane Doe"])
+    def test_product_data_is_generic_and_has_no_description(
+        self, event: Event, paid_ticket_tier: TicketTier, organization_owner_user: RevelUser, guest_name: str
+    ) -> None:
+        """Stripe must not receive event/tier names or guest names (#848)."""
+        kwargs = self._session_kwargs(event, paid_ticket_tier, organization_owner_user, guest_name)
+        product_data = kwargs["line_items"][0]["price_data"]["product_data"]
+
+        assert product_data == {"name": "Ticket"}
+
+    def test_return_urls_use_uuids_not_slugs(
         self, event: Event, paid_ticket_tier: TicketTier, organization_owner_user: RevelUser
     ) -> None:
-        """No description at all beats a dangling preposition on the buyer's receipt."""
-        product_data = self._product_data(event, paid_ticket_tier, organization_owner_user, "")
+        """Return URLs must not leak org/event slugs to Stripe (#848); the FE resolves UUIDs."""
+        kwargs = self._session_kwargs(event, paid_ticket_tier, organization_owner_user, "Jane Doe")
+        event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.organization.id}/{event.id}"
 
-        assert "description" not in product_data
-        assert product_data["name"] == f"Ticket: {event.name} ({paid_ticket_tier.name})"
-
-    def test_named_holder_still_gets_the_holder_clause(
-        self, event: Event, paid_ticket_tier: TicketTier, organization_owner_user: RevelUser
-    ) -> None:
-        product_data = self._product_data(event, paid_ticket_tier, organization_owner_user, "Jane Doe")
-
-        assert product_data["description"] == "Ticket for Jane Doe"
+        assert kwargs["success_url"] == f"{event_url}?payment_success=true"
+        assert kwargs["cancel_url"] == f"{event_url}?payment_cancelled=true"
 
 
 class TestClaimReservationHoldExtendOnly:

--- a/src/events/tests/test_service/test_stripe_service/test_mixed_price_session.py
+++ b/src/events/tests/test_service/test_stripe_service/test_mixed_price_session.py
@@ -84,15 +84,15 @@ def _reserve_mixed(
     return rid
 
 
-def _line_items_by_guest(line_items: list[dict[str, t.Any]]) -> dict[str, int]:
-    """Map each line item's guest name to the unit amount Stripe would charge."""
-    out: dict[str, int] = {}
+def _line_item_amounts(line_items: list[dict[str, t.Any]]) -> list[int]:
+    """Each line item's charged amount, sorted; also pins the generic product data (#848).
+
+    Amounts (not guest names) identify the line items: the payload must not carry
+    guest names, and the mixed-cart fixtures use distinct amounts by construction.
+    """
     for item in line_items:
-        description = item["price_data"]["product_data"]["description"]
-        guest = description.removeprefix("Ticket for ")
-        assert guest not in out, "one line item per ticket expected"
-        out[guest] = item["price_data"]["unit_amount"] * item["quantity"]
-    return out
+        assert item["price_data"]["product_data"] == {"name": "Ticket"}, "no organizer/guest content for Stripe (#848)"
+    return sorted(item["price_data"]["unit_amount"] * item["quantity"] for item in line_items)
 
 
 class TestMixedPriceLineItems:
@@ -110,7 +110,7 @@ class TestMixedPriceLineItems:
             stripe_service.create_batch_session(reservation_id=rid)
         line_items = create.call_args.kwargs["line_items"]
 
-        assert _line_items_by_guest(line_items) == {"Premium Guest": 5000, "Standard Guest": 3000}
+        assert _line_item_amounts(line_items) == [3000, 5000]
 
     def test_session_total_equals_sum_of_payment_amounts(
         self, event: Event, paid_ticket_tier: TicketTier, organization_owner_user: RevelUser
@@ -142,7 +142,7 @@ class TestMixedPriceLineItems:
             stripe_service.create_batch_session(reservation_id=rid)
         line_items = create.call_args.kwargs["line_items"]
 
-        assert _line_items_by_guest(line_items) == {"Paid": 5000, "Freebie": 0}
+        assert _line_item_amounts(line_items) == [0, 5000]
         assert Payment.objects.get(reservation_id=rid, ticket__guest_name="Freebie").amount == Decimal("0.00")
 
 

--- a/src/events/tests/test_service/test_stripe_service/test_mixed_price_session.py
+++ b/src/events/tests/test_service/test_stripe_service/test_mixed_price_session.py
@@ -157,8 +157,8 @@ class TestSessionTotalReconciliation:
 
         build = stripe_service._build_line_items
 
-        def drop_a_row(payments: list[Payment], ev: Event, tier: TicketTier) -> list[t.Any]:
-            return list(build(payments, ev, tier))[:1]
+        def drop_a_row(payments: list[Payment], tier: TicketTier) -> list[t.Any]:
+            return list(build(payments, tier))[:1]
 
         with mock.patch.object(stripe_service, "_build_line_items", side_effect=drop_a_row):
             with mock.patch("stripe.checkout.Session.create") as create:
@@ -315,8 +315,8 @@ class TestMismatchIsImpossibleToMiss:
         before = _counter(MISMATCH_METRIC, {"call_site": "preflight"})
         build = stripe_service._build_line_items
 
-        def drop_a_row(payments: list[Payment], ev: Event, tier: TicketTier) -> list[t.Any]:
-            return list(build(payments, ev, tier))[:1]
+        def drop_a_row(payments: list[Payment], tier: TicketTier) -> list[t.Any]:
+            return list(build(payments, tier))[:1]
 
         with mock.patch.object(stripe_service, "_build_line_items", side_effect=drop_a_row):
             with mock.patch("stripe.checkout.Session.create"):

--- a/src/events/tests/test_service/test_subscription_stripe_service.py
+++ b/src/events/tests/test_service/test_subscription_stripe_service.py
@@ -106,6 +106,8 @@ class TestEnsureCustomerProfile:
         kwargs = mock_create.call_args.kwargs
         assert kwargs["stripe_account"] == "acct_test_org"
         assert kwargs["email"] == subscriber.email
+        # No personal name in the Stripe payload (#848).
+        assert "name" not in kwargs
 
     @mock.patch("events.service.subscription_stripe_service.stripe.Customer.create")
     def test_reuses_existing_profile(
@@ -181,6 +183,9 @@ class TestEnsureStripePrice:
         assert result.stripe_product_id == "prod_new"
         assert result.stripe_price_id == "price_new"
         mock_product.assert_called_once()
+        # Generic product name, no tier/plan names or description in the Stripe payload (#848).
+        assert mock_product.call_args.kwargs["name"] == "Membership"
+        assert "description" not in mock_product.call_args.kwargs
         mock_price.assert_called_once()
         assert mock_price.call_args.kwargs["unit_amount"] == 10000  # 100.00 EUR
         assert mock_price.call_args.kwargs["currency"] == "eur"
@@ -286,9 +291,9 @@ class TestStartOnlineSubscription:
         assert kwargs["metadata"] == {"membership_subscription_id": str(subscription.pk)}
         assert kwargs["subscription_data"]["metadata"] == {"membership_subscription_id": str(subscription.pk)}
         assert kwargs["stripe_account"] == "acct_test_org"
-        # Dedicated membership route, not the org landing page (#838).
-        assert f"/org/{stripe_org.slug}/membership?membership_success=true" in kwargs["success_url"]
-        assert f"/org/{stripe_org.slug}/membership?membership_cancelled=true" in kwargs["cancel_url"]
+        # Dedicated membership route (#838), UUID-based so no slug leaks to Stripe (#848).
+        assert f"/org/{stripe_org.id}/membership?membership_success=true" in kwargs["success_url"]
+        assert f"/org/{stripe_org.id}/membership?membership_cancelled=true" in kwargs["cancel_url"]
         assert isinstance(kwargs["expires_at"], int)
 
     def test_refuses_offline_plan(


### PR DESCRIPTION
Closes #848. FE companion: letsrevel/revel-frontend#756.

## What

Uniform data minimization for everything we send Stripe — no organizer-authored content in any outbound payload, for **all** organizers (deliberately not keyword-conditional):

- **Checkout line items**: constant `"Ticket"` / `"Season pass"` labels; no event/tier/series names, no `Ticket for {guest_name}` description. (`_product_data` deleted, constant inlined.)
- **Membership**: `Product.create(name="Membership")`, no description; `Customer.create` drops the member's display name (email kept for receipts).
- **Return URLs**: `success_url`/`cancel_url` now carry UUIDs, not slugs — `/events/{org_id}/{event_id}`, `/events/{org_id}/series/{series_id}`, `/org/{org_id}/membership`. Slug URLs stay canonical; the FE resolves and 303s (revel-frontend#756).
- **New endpoint**: public `GET /api/organizations/{uuid}` (same visibility rules and payload as the slug route). Declared ahead of `/{slug}` — route order is load-bearing; a regression test pins that non-UUID segments (incl. uppercase-UUID and almost-UUID shapes) fall through to the slug route and never 422.
- **Backfill**: `scrub_stripe_products` management command (`--dry-run` supported) — renames existing plan Products and sweeps every connected account's catalog for old `Ticket: ` / `Season pass: ` ad-hoc Products materialized by past inline `price_data`.

## Why

Stripe has started ToS-flagging sex-positive events. Under direct charges the *organizer's* connected account is what Stripe's content review sees. Stripe needs amounts, currency, fees, email, and our join UUIDs — it does not need event content. See #848 for the full audit.

## Not in this PR

- FE UUID-param handling (revel-frontend#756).
- Organizer-side Stripe business profile / statement descriptors (their own onboarding).
- Our PDF invoices/credit notes keep real names (our data).

## Deploy sequencing

⚠️ **Deploy the frontend (revel-frontend#756) to production before this** — otherwise new checkouts return to slug routes fed with UUIDs and 404. Merge order is the reverse: this PR first, so the FE can regen the API client. Old sessions carry slug URLs, which keep working — no wait window.

## Testing

- 196 tests across the affected files (payload contracts rewritten tests-first, org-by-id + route-ordering/no-422 guards, scrub command incl. dry-run and StripeError-continuation).
- `make check` clean (format, lint, mypy strict, migration-check — no migrations, i18n, file-length, task-names).
- Webhook flows untouched: all session↔ticket/subscription joins are metadata-based (verified by audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organizations can now be retrieved directly using their UUID.
  - Stripe checkout links now use stable organization, event, and series IDs.

- **Privacy Improvements**
  - Stripe product names and descriptions no longer expose event, pass, membership, guest, or organizer details.
  - Stripe customer creation no longer includes display names.

- **Maintenance**
  - Added tooling to scrub previously exposed details from existing Stripe products, including a dry-run option.

- **Bug Fixes**
  - Improved routing so UUID- and slug-based organization links continue to work correctly.
  - Preserved appropriate handling for expired organization access tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->