### PR TITLE
feat(seed): deterministic poster-palette logos for all seeded organizations

### DIFF
--- a/src/events/management/commands/bootstrap_events.py
+++ b/src/events/management/commands/bootstrap_events.py
@@ -14,6 +14,7 @@ from django.core.management.base import BaseCommand
 from .bootstrap_helpers import (
     BootstrapState,
     attach_cover_art,
+    attach_org_logos,
     configure_organization_billing,
     configure_platform_billing,
     create_dietary_data,
@@ -78,6 +79,9 @@ class Command(BaseCommand):
 
         # Attach bundled cover art to orgs and events (cached in storage, no upload pipeline)
         attach_cover_art(state)
+
+        # Draw placeholder logos for the orgs so the frontend's branding accents render
+        attach_org_logos(state)
 
         # Create ticket tiers
         create_ticket_tiers(state)

--- a/src/events/management/commands/bootstrap_helpers/__init__.py
+++ b/src/events/management/commands/bootstrap_helpers/__init__.py
@@ -11,6 +11,7 @@ from .billing import (
 from .cover_art import attach_cover_art
 from .dietary import create_dietary_data
 from .events import create_event_series, create_events
+from .logos import attach_org_logos
 from .organizations import create_organizations
 from .potluck import create_potluck_items
 from .questionnaires import create_questionnaires
@@ -23,6 +24,7 @@ from .venues import create_venues
 __all__ = [
     "BootstrapState",
     "attach_cover_art",
+    "attach_org_logos",
     "configure_organization_billing",
     "configure_platform_billing",
     "create_dietary_data",

--- a/src/events/management/commands/bootstrap_helpers/logos.py
+++ b/src/events/management/commands/bootstrap_helpers/logos.py
@@ -1,0 +1,151 @@
+# src/events/management/commands/bootstrap_helpers/logos.py
+"""Deterministic placeholder logos for seeded organizations (frontend #782).
+
+The frontend renders an organization's ``logo_thumbnail`` (falling back to
+``logo``) as a branding accent, or *nothing at all* when neither is set. No
+seeded organization had a logo, so dev / e2e / demo environments always took the
+empty branch.
+
+Rather than committing an image per fixture organization, the mark is drawn at
+seed time with Pillow: a filled geometric shape in one of the brand's poster
+palette colours, carrying the organization's initials in whichever of ink/paper
+reads better on it. Shape and colour are derived from a BLAKE2b digest of the
+storage key, so a given organization always gets the same mark and a reseed
+writes byte-identical files to the same path — nothing accumulates. No Revel
+mark, wordmark, or external asset is involved.
+
+Lives next to ``cover_art.py`` because it does the same job: attach a trusted,
+locally-produced image plus its thumbnails straight onto the model, deliberately
+bypassing the upload pipeline (no file audit, no malware scan, no Celery). It is
+shared by ``bootstrap_events``, ``bootstrap_test_events`` and the ``seed``
+command.
+"""
+
+import hashlib
+import typing as t
+from io import BytesIO
+
+import structlog
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.db import models
+from PIL import Image, ImageDraw, ImageFont
+
+from common.thumbnails.config import THUMBNAIL_CONFIGS
+from common.thumbnails.service import generate_and_save_thumbnails, get_thumbnail_path
+from events.utils import _get_logo_initials  # reused: same initials the PDF/wallet fallbacks use
+
+from .base import BootstrapState
+
+logger = structlog.get_logger(__name__)
+
+STORAGE_PREFIX = "logos/seed"
+
+CANVAS = 512
+MARGIN = 56
+CORNER_RADIUS = 96
+
+# ACIDHAIRS poster palette (Hearty Purple, Light Crimson, Lavender, Periwinkle, Amber, Ink).
+PALETTE: tuple[str, ...] = ("#8C3CDD", "#E6332A", "#AB82DB", "#9AB2FF", "#F9B233", "#0D1E1C")
+SHAPES: tuple[str, ...] = ("circle", "rounded_square", "triangle")
+
+INK = "#0D1E1C"
+PAPER = "#FFFFFF"
+
+FONT_PATH = "NataSans-SemiBold.ttf"
+
+
+def _relative_luminance(hex_color: str) -> float:
+    """WCAG relative luminance of a ``#rrggbb`` colour."""
+    srgb = [int(hex_color[i : i + 2], 16) / 255 for i in (1, 3, 5)]
+    linear = [c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4 for c in srgb]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(first: str, second: str) -> float:
+    """WCAG contrast ratio between two ``#rrggbb`` colours."""
+    luminances = sorted((_relative_luminance(first), _relative_luminance(second)))
+    return (luminances[1] + 0.05) / (luminances[0] + 0.05)
+
+
+def _readable_on(background: str) -> str:
+    """Return whichever of paper/ink reads better on ``background``."""
+    return PAPER if _contrast_ratio(PAPER, background) >= _contrast_ratio(INK, background) else INK
+
+
+def generate_logo_png(key: str, name: str) -> bytes:
+    """Draw a deterministic geometric placeholder logo.
+
+    Args:
+        key: Stable identifier (an organization slug) driving shape and colour.
+        name: Display name the initials are taken from.
+
+    Returns:
+        PNG bytes of a ``CANVAS``-square logo.
+    """
+    digest = int.from_bytes(hashlib.blake2b(key.encode("utf-8"), digest_size=8).digest(), "big")
+    color = PALETTE[digest % len(PALETTE)]
+    shape = SHAPES[digest // len(PALETTE) % len(SHAPES)]
+
+    image = Image.new("RGB", (CANVAS, CANVAS), PAPER)
+    draw = ImageDraw.Draw(image)
+    box = (MARGIN, MARGIN, CANVAS - MARGIN, CANVAS - MARGIN)
+
+    center = (CANVAS // 2, CANVAS // 2)
+    font_size = 200
+    if shape == "circle":
+        draw.ellipse(box, fill=color)
+    elif shape == "rounded_square":
+        draw.rounded_rectangle(box, radius=CORNER_RADIUS, fill=color)
+    else:
+        # A triangle's optical centre sits low, and its width there is tighter.
+        draw.polygon(
+            [(CANVAS // 2, MARGIN), (CANVAS - MARGIN, CANVAS - MARGIN), (MARGIN, CANVAS - MARGIN)],
+            fill=color,
+        )
+        center = (CANVAS // 2, int(CANVAS * 0.62))
+        font_size = 140
+
+    font = ImageFont.truetype(str(settings.BASE_DIR / "fonts" / FONT_PATH), font_size)
+    draw.text(center, _get_logo_initials(name), font=font, fill=_readable_on(color), anchor="mm")
+
+    buffer = BytesIO()
+    image.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue()
+
+
+def attach_logo(instance: models.Model, *, key: str, name: str) -> None:
+    """Link a generated placeholder logo (and its thumbnails) onto ``instance``.
+
+    The image and its thumbnails live at deterministic storage paths; when they
+    already exist they are reused and only the model fields are updated (via
+    ``queryset.update()``, so no model ``save()`` side effects run).
+    """
+    if getattr(instance, "logo"):
+        return  # already set — keep reseeds idempotent
+
+    target = f"{STORAGE_PREFIX}/{key}.png"
+    if not default_storage.exists(target):
+        default_storage.save(target, ContentFile(generate_logo_png(key, name)))
+
+    config_key = (instance._meta.app_label, t.cast(str, instance._meta.model_name), "logo")
+    config = THUMBNAIL_CONFIGS[config_key]
+    thumbs = {spec.field_name: get_thumbnail_path(target, spec.field_name) for spec in config.specs}
+    if not all(default_storage.exists(path) for path in thumbs.values()):
+        result = generate_and_save_thumbnails(target, config)
+        thumbs = result.thumbnails
+        if result.has_failures:
+            logger.warning("Placeholder logo thumbnail generation failed", key=key, failures=result.failures)
+
+    updates: dict[str, str] = {"logo": target, **thumbs}
+    type(instance)._default_manager.filter(pk=instance.pk).update(**updates)
+    for field_name, path in updates.items():
+        setattr(instance, field_name, path)
+
+
+def attach_org_logos(state: BootstrapState) -> None:
+    """Give every bootstrap organization a deterministic placeholder logo."""
+    for org in state.orgs.values():
+        attach_logo(org, key=org.slug, name=org.name)
+    logger.info("Attached placeholder logos", orgs=len(state.orgs))

--- a/src/events/management/commands/bootstrap_test_events.py
+++ b/src/events/management/commands/bootstrap_test_events.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from accounts.models import RevelUser
 from common.models import Tag
 from events import models as events_models
+from events.management.commands.bootstrap_helpers.logos import attach_logo
 from geo.models import City
 from questionnaires import models as questionnaires_models
 
@@ -153,6 +154,9 @@ and access control scenario in the Revel platform. Perfect for frontend testing!
         self.org.contact_email = "test@eligibility.example.com"
         self.org.contact_email_verified = True
         self.org.save()
+
+        # Give it a placeholder logo so the frontend's branding accents render
+        attach_logo(self.org, key=self.org.slug, name=self.org.name)
 
         logger.info(f"Created organization: {self.org.name}")
 

--- a/src/events/management/commands/seeder/organizations.py
+++ b/src/events/management/commands/seeder/organizations.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from events.management.commands.bootstrap_helpers.logos import attach_logo
 from events.management.commands.seeder.base import BaseSeeder
 from events.models import (
     MembershipTier,
@@ -26,6 +27,7 @@ class OrganizationSeeder(BaseSeeder):
     def seed(self) -> None:
         """Seed organizations and related entities."""
         self._create_organizations()
+        self._attach_logos()
         self._create_membership_tiers()
         self._create_staff()
         self._create_members()
@@ -71,6 +73,15 @@ class OrganizationSeeder(BaseSeeder):
 
         self.state.organizations = self.batch_create(Organization, orgs_to_create, desc="Creating organizations")
         self.log(f"  Created {len(self.state.organizations)} organizations")
+
+    def _attach_logos(self) -> None:
+        """Give every seeded organization a deterministic placeholder logo."""
+        self.log("Attaching organization logos...")
+
+        for org in self.state.organizations:
+            attach_logo(org, key=org.slug, name=org.name)
+
+        self.log(f"  Attached {len(self.state.organizations)} organization logos")
 
     def _create_membership_tiers(self) -> None:
         """Create 2-4 membership tiers per organization."""

--- a/src/events/tests/test_management/test_seed_logos.py
+++ b/src/events/tests/test_management/test_seed_logos.py
@@ -1,0 +1,166 @@
+"""Tests for the deterministic placeholder logos seeded organizations get (frontend #782).
+
+The frontend renders an organization's ``logo_thumbnail`` (falling back to
+``logo``) or nothing at all, so every seeded organization needs both fields
+populated for the branding accents to show up in dev / e2e / demo.
+"""
+
+import io
+import typing as t
+from uuid import uuid4
+
+import pytest
+from django.core.files.storage import default_storage
+from PIL import Image
+
+from accounts.models import RevelUser
+from events.management.commands.bootstrap_helpers.base import BootstrapState
+from events.management.commands.bootstrap_helpers.logos import (
+    CANVAS,
+    INK,
+    PALETTE,
+    PAPER,
+    STORAGE_PREFIX,
+    _contrast_ratio,
+    _readable_on,
+    attach_logo,
+    attach_org_logos,
+    generate_logo_png,
+)
+from events.management.commands.seeder.config import SeederConfig
+from events.management.commands.seeder.organizations import OrganizationSeeder
+from events.management.commands.seeder.state import SeederState
+from events.models import Organization
+from events.schema import MinimalOrganizationSchema
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_media(settings: t.Any, tmp_path: t.Any) -> None:
+    """Keep generated logos out of the repo's media directory."""
+    settings.MEDIA_ROOT = tmp_path
+
+
+def _org(slug: str = "seeded-org", name: str = "Seeded Org") -> Organization:
+    """An organization standing in for one the seeders created."""
+    handle = f"{slug}.owner.{uuid4().hex[:8]}"
+    owner = RevelUser.objects.create_user(username=handle, email=f"{handle}@example.com", password="x")
+    return Organization.objects.create(name=name, slug=slug, owner=owner)
+
+
+def _stored_logos() -> list[str]:
+    """The generated logo files (thumbnails land in the same directory)."""
+    _, files = default_storage.listdir(STORAGE_PREFIX)
+    return sorted(name for name in files if name.endswith(".png"))
+
+
+def test_generated_logo_is_a_valid_square_png() -> None:
+    """The mark is a Pillow-readable PNG at the documented canvas size."""
+    with Image.open(io.BytesIO(generate_logo_png("seeded-org", "Seeded Org"))) as image:
+        assert image.format == "PNG"
+        assert image.size == (CANVAS, CANVAS)
+
+
+def test_generated_logo_is_deterministic_per_key() -> None:
+    """A reseed must produce byte-identical files, and distinct orgs distinct marks."""
+    assert generate_logo_png("seeded-org", "Seeded Org") == generate_logo_png("seeded-org", "Seeded Org")
+    assert generate_logo_png("seeded-org", "Seeded Org") != generate_logo_png("other-org", "Other Org")
+
+
+def test_generated_logo_uses_only_palette_and_neutral_colors() -> None:
+    """No hue outside the poster palette (plus ink/paper) may leak into the mark.
+
+    Anti-aliasing blends the shape into the field, so this checks the *dominant*
+    colors rather than every pixel.
+    """
+    allowed = {tuple(int(c[i : i + 2], 16) for i in (1, 3, 5)) for c in (*PALETTE, INK, PAPER)}
+    with Image.open(io.BytesIO(generate_logo_png("seeded-org", "Seeded Org"))) as image:
+        counted = image.convert("RGB").getcolors(maxcolors=1 << 20)
+    assert counted is not None, "the mark has more distinct colors than getcolors() would count"
+    dominant = {color for count, color in counted if count > 1000}
+    assert dominant, "expected at least one dominant color"
+    assert dominant <= allowed
+
+
+def test_initials_contrast_against_every_palette_color() -> None:
+    """The initials must stay legible on whichever palette color is drawn.
+
+    3:1 is WCAG's large-text / non-text threshold, and these initials are set at
+    140-200px. (Light Crimson tops out at 4.31:1 against paper, the palette's
+    worst pairing.)
+    """
+    for color in PALETTE:
+        assert _contrast_ratio(_readable_on(color), color) >= 3.0
+
+
+def test_attach_logo_populates_logo_and_thumbnail() -> None:
+    """Both fields the frontend reads are set, and the files really exist."""
+    org = _org()
+
+    attach_logo(org, key=org.slug, name=org.name)
+
+    org.refresh_from_db()
+    assert org.logo.name == f"{STORAGE_PREFIX}/{org.slug}.png"
+    assert org.logo_thumbnail.name
+    assert default_storage.exists(org.logo.name)
+    assert default_storage.exists(org.logo_thumbnail.name)
+
+
+def test_attached_logo_reaches_the_field_the_frontend_reads() -> None:
+    """``logo_thumbnail_url`` is what the frontend's LogoChip actually consumes."""
+    org = _org()
+
+    attach_logo(org, key=org.slug, name=org.name)
+
+    serialized = MinimalOrganizationSchema.from_orm(org)
+    assert serialized.logo_thumbnail_url is not None
+
+
+def test_attach_logo_is_idempotent() -> None:
+    """Reseeding must not error or pile up duplicate files."""
+    org = _org()
+    attach_logo(org, key=org.slug, name=org.name)
+    original_logo, original_thumb = org.logo.name, org.logo_thumbnail.name
+
+    attach_logo(org, key=org.slug, name=org.name)
+
+    org.refresh_from_db()
+    assert (org.logo.name, org.logo_thumbnail.name) == (original_logo, original_thumb)
+    assert _stored_logos() == [f"{org.slug}.png"]
+
+
+def test_attach_logo_reuses_an_existing_file_for_a_fresh_org() -> None:
+    """A wiped-and-reseeded org relinks the cached file instead of writing a new one."""
+    attach_logo(_org(), key="seeded-org", name="Seeded Org")
+    Organization.objects.all().delete()
+
+    attach_logo(_org(), key="seeded-org", name="Seeded Org")
+
+    assert _stored_logos() == ["seeded-org.png"]
+
+
+def test_attach_org_logos_covers_every_bootstrap_org() -> None:
+    """``bootstrap_events`` orgs — Org Alpha included — all come out with a logo."""
+    state = BootstrapState()
+    state.orgs["alpha"] = _org(slug="revel-events-collective", name="Revel Events Collective")
+    state.orgs["beta"] = _org(slug="tech-innovators-network", name="Tech Innovators Network")
+
+    attach_org_logos(state)
+
+    for org in Organization.objects.all():
+        assert org.logo, f"{org.slug} has no logo"
+        assert org.logo_thumbnail, f"{org.slug} has no logo thumbnail"
+
+
+def test_organization_seeder_gives_every_org_a_logo() -> None:
+    """The bulk ``seed`` command's organizations get logos too."""
+    state = SeederState()
+    state.organizations = [_org(slug=f"org-{i}", name=f"Seeded Org {i}") for i in range(3)]
+    seeder = OrganizationSeeder(SeederConfig(seed=999), state, io.StringIO())
+
+    seeder._attach_logos()
+
+    for org in Organization.objects.all():
+        assert org.logo, f"{org.slug} has no logo"
+        assert org.logo_thumbnail, f"{org.slug} has no logo thumbnail"


### PR DESCRIPTION
Addresses letsrevel/revel-frontend#782: the frontend rebrand's `LogoChip` shows an org's logo or nothing — and no seeded org had one, so dev/e2e/demo never render the accent.

## What

New `bootstrap_helpers/logos.py`, wired into **all three** org-creating commands (`bootstrap_events`, `bootstrap_test_events`, `seed`):

- 512×512 PNG per org: filled circle/rounded-square/triangle in one of the six poster-palette colors on a paper field, org initials in ink or paper (contrast computed, not eyeballed), Nata Sans SemiBold. No Revel branding.
- Shape+color derive from a BLAKE2b digest of the slug (not per-process-salted `hash()`) so reseeds are byte-deterministic.
- Thumbnails generated **inline** (the normal path is a Celery task on upload, which never fires at seed) so `logo_thumbnail_url` — the field LogoChip reads — actually resolves; verified through `MinimalOrganizationSchema` in tests.
- Idempotent three ways (early return when set, deterministic storage path with exists-check relink, deterministic bytes), each guard covered by a test. 10 new tests in `test_seed_logos.py`; `MEDIA_ROOT` redirected to tmp in tests.

## Notes for review

- `seeder/organizations.py` and `bootstrap_test_events.py` now import from `bootstrap_helpers.logos` — a new cross-package import; alternatives were duplication or seed-only code in production `events/utils/`. Easy to relocate if you prefer.
- `eligibility-test-org` now has a logo: any frontend e2e assertion or screenshot baseline relying on logo *absence* could shift — worth a frontend e2e run before merging.
- Existing dev/demo DBs keep empty logos until reseeded (`make nuke-db && make bootstrap && make seed`). No schema/API change, no deploy-ordering constraint.

`make check` green (ruff, mypy --strict); targeted suites 10/36/52 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic placeholder logos for organizations created during event bootstrapping and seeding.
  * Logos include organization initials, accessible contrast, and matching thumbnail images.
  * Existing logo files are reused to keep repeated seeding consistent.

* **Tests**
  * Added coverage for logo generation, display fields, accessibility, idempotency, and seeded organization coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->