### PR TITLE
chore: trim derivable sections from CLAUDE.md; fix tos.md gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,7 @@ rendered_templates/
 .claude/agent-memory
 
 # Local drafting files (legal docs)
-toc.md
+tos.md
 privacy.md
 .research/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,19 +111,7 @@ This project uses a comprehensive Makefile.
 
 ## Project Architecture
 
-Revel is a Django-based event management & ticketing platform.
-
-### Core applications
-- **accounts/** — auth, registration, JWT, GDPR compliance.
-- **events/** — events, organizations, tickets, memberships, invitations.
-- **questionnaires/** — dynamic questionnaires with LLM-powered evaluation.
-- **notifications/** — multi-channel (in-app, email, Telegram) with preferences & digests.
-- **polls/** — Organization-managed polls
-- **wallet/** — Apple Wallet `.pkpass` generation.
-- **geo/** — geolocation, city data, IP-based location.
-- **telegram/** — Telegram bot with FSM conversation flows.
-- **api/** — global API config, exception handlers, rate limiting.
-- **common/** — shared utilities, auth, base models, admin customizations.
+Revel is a Django-based event management & ticketing platform (apps under `src/`).
 
 ### Key patterns
 - **Service layer** — business logic in `<app>/service/`. Hybrid: function-based for stateless
@@ -132,13 +120,6 @@ Revel is a Django-based event management & ticketing platform.
   consistent tags; `PageNumberPaginationExtra`; `@searching` for search.
 - **Permissions** — `events/controllers/permissions.py`; org roles (Owner/Staff/Member);
   event-level eligibility; JWT auth with optional anonymous access.
-
-### Stack
-Django 5+ / Django Ninja · PostgreSQL + PostGIS · Celery + Redis · JWT (custom user model) ·
-Docker Compose (Postgres, Redis, ClamAV). Python 3.14+. **UV** for deps (never pip).
-
-### Key config files
-`pyproject.toml` (deps + ruff/mypy/pytest), `Makefile`, `compose.yaml`, `src/revel/settings/`.
 
 ### Quality bar
 ruff (format + lint) · mypy `--strict` + Django plugin · Google-style docstrings ·
@@ -347,15 +328,6 @@ def list_items(self) -> QuerySet[Item]:
 
 ---
 
-## Dependency Management
-
-**UV only — never pip.**
-- Add: `uv add <package>` · dev: `uv add --dev <package>` · optional: `uv add --optional <group> <package>`.
-- Remove: `uv remove <package>` · Sync: `uv sync` (`--dev` to include dev deps).
-- Why: faster, deterministic resolution, managed venv, better conflict detection.
-
----
-
 ## Testing
 
 - Create test data via ORM and shared fixtures from `conftest.py`.
@@ -393,3 +365,4 @@ Non-negotiable, project-specific:
 - **Always discuss the approach before writing code for non-trivial changes** (Principle #1).
 - **UV, never pip.** **Models never import services.**
 - **Avoid circular dependencies.**
+- **Don't commit specs or plans from brainstorming sessions, they are gitignored**


### PR DESCRIPTION
## Summary
- Trim CLAUDE.md content a fresh session can re-derive from the codebase: core-applications list (`ls src/`), Stack + Key config files (`pyproject.toml`), and the Dependency Management section body (standard `uv` invocations — the "UV, never pip" rule remains in Hard Rules).
- Fix the legal-drafts `.gitignore` entry: the drafted file is `tos.md`, not `toc.md`.

Saves ~400 est. tokens of always-loaded context per session; no rules or gotchas removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the architecture overview and removed outdated dependency-management details.
  * Added guidance prohibiting brainstorming-session specifications or plans from being committed.
* **Chores**
  * Updated local legal-document ignore rules to exclude the correct draft file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->