### PR TITLE
chore(ci): make codecov patch status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# Codecov configuration
+#
+# Patch status is informational only: chore/deps commits that touch a single
+# uncovered line (e.g. adding a type-ignore comment) were turning main red
+# with "0.00% of diff hit" while every real CI gate was green. The enforced
+# coverage bar remains the "Combined coverage gate" job in test.yaml (90%+).
+coverage:
+  status:
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Why

Main showed a red X after #854: the `codecov/patch` commit status failed with "0.00% of diff hit (target 96.97%)". The only coverable line in that diff was adding a `# type: ignore[no-untyped-call]` comment to `src/common/observability/tracing.py` — a line inside `init_tracing()` that only runs in production with OTEL enabled, so tests have never covered it. Every real CI gate was green.

## What

Add a `codecov.yml` setting the default patch status to `informational: true`. Codecov still reports patch coverage on PRs, but can no longer produce a red X for it. The enforced coverage bar remains the "Combined coverage gate" job in `test.yaml` (90%+ branch coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage reporting settings so patch coverage status is informational.
  * Existing CI coverage checks continue to enforce coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->