### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-07
+
+### Changed
+- Production and development dependencies refreshed across the board (`aiogram`, `django-ninja-extra`, `django-simple-history`, `django-unfold`, the OpenTelemetry stack, `pillow-heif`, `prometheus-client`, `uvicorn`, and the test toolchain). `requests` is now declared explicitly instead of relying on a transitive pull. `stripe` is pinned `<15` and `django-ninja-jwt` `<5.4.5` until their breaking changes are handled in dedicated migrations
+- Seeded organizations now get deterministic placeholder logos, so seeded and demo instances render with real imagery instead of blank avatars
+
+### Security
+- `h2` floor raised to 4.4.1 (CVE-2026-71554), patching the HTTP/2 client stack used for outbound requests
+
 ## [2.1.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.1.1] - 2026-08-07

### Changed
- Production and development dependencies refreshed across the board (`aiogram`, `django-ninja-extra`, `django-simple-history`, `django-unfold`, the OpenTelemetry stack, `pillow-heif`, `prometheus-client`, `uvicorn`, and the test toolchain). `requests` is now declared explicitly instead of relying on a transitive pull. `stripe` is pinned `<15` and `django-ninja-jwt` `<5.4.5` until their breaking changes are handled in dedicated migrations
- Seeded organizations now get deterministic placeholder logos, so seeded and demo instances render with real imagery instead of blank avatars

### Security
- `h2` floor raised to 4.4.1 (CVE-2026-71554), patching the HTTP/2 client stack used for outbound requests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic placeholder logos for seeded organizations, providing consistent visuals when no custom logo is available.
* **Bug Fixes**
  * Refreshed application dependencies for improved stability and compatibility.
* **Security**
  * Updated the HTTP/2 library to address a recently identified security vulnerability.
* **Release**
  * Updated the project version to 2.1.1, released August 7, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->