### PR TITLE
fix(notifications): don't duplicate the Payment Instructions heading

### DIFF
--- a/src/common/templatetags/markdown_tags.py
+++ b/src/common/templatetags/markdown_tags.py
@@ -11,6 +11,8 @@ from common.fields import render_markdown
 
 register = template.Library()
 
+_LEADING_ATX_HEADING_RE = re.compile(r"\A\s*#{1,6}[ \t]+\S[^\n]*(?:\n|\Z)")
+
 
 @register.filter(is_safe=True)
 def markdown(value: str | None) -> str:
@@ -35,6 +37,27 @@ def markdown(value: str | None) -> str:
     # render_markdown calls nh3.clean() with a strict allowlist, so the output
     # is sanitized and safe to mark as such.
     return mark_safe(render_markdown(value))
+
+
+@register.filter
+def strip_leading_heading(value: str | None) -> str:
+    """Drop a leading markdown heading so it doesn't duplicate a template-provided title.
+
+    Organizer-authored markdown (e.g. manual payment instructions) is rendered inside
+    cards that already carry their own heading. When the author starts their text with
+    ``## Payment Instructions``, the heading shows up twice in a row. This filter removes
+    that first heading; anything else in the content is untouched.
+
+    Usage:
+        {% load markdown_tags %}
+        {{ context.manual_payment_instructions|strip_leading_heading|markdown }}
+    """
+    if not value:
+        return ""
+
+    # ponytail: only ATX headings ("## Title"). Setext ("Title\n====") is rare in
+    # organizer content; extend here if it shows up.
+    return _LEADING_ATX_HEADING_RE.sub("", value).lstrip()
 
 
 @register.filter

--- a/src/common/templatetags/markdown_tags.py
+++ b/src/common/templatetags/markdown_tags.py
@@ -11,7 +11,9 @@ from common.fields import render_markdown
 
 register = template.Library()
 
-_LEADING_ATX_HEADING_RE = re.compile(r"\A\s*#{1,6}[ \t]+\S[^\n]*(?:\n|\Z)")
+# A leading ATX heading plus the blank lines under it. The trailing `(?:[ \t]*\n)*`
+# stops at the first line with content, so that line's own indentation survives.
+_LEADING_ATX_HEADING_RE = re.compile(r"\A\s*#{1,6}[ \t]+\S[^\n]*(?:[ \t]*\n)*")
 
 
 @register.filter(is_safe=True)
@@ -48,6 +50,10 @@ def strip_leading_heading(value: str | None) -> str:
     ``## Payment Instructions``, the heading shows up twice in a row. This filter removes
     that first heading; anything else in the content is untouched.
 
+    Content that doesn't open with a heading is returned verbatim, and a heading that is
+    the *whole* content is kept — an organizer who wrote their instructions as a single
+    ``# ...`` line would otherwise see them vanish, leaving an empty card.
+
     Usage:
         {% load markdown_tags %}
         {{ context.manual_payment_instructions|strip_leading_heading|markdown }}
@@ -57,7 +63,11 @@ def strip_leading_heading(value: str | None) -> str:
 
     # ponytail: only ATX headings ("## Title"). Setext ("Title\n====") is rare in
     # organizer content; extend here if it shows up.
-    return _LEADING_ATX_HEADING_RE.sub("", value).lstrip()
+    match = _LEADING_ATX_HEADING_RE.match(value)
+    if not match:
+        return value
+
+    return value[match.end() :] or value
 
 
 @register.filter

--- a/src/common/tests/test_markdown_tags.py
+++ b/src/common/tests/test_markdown_tags.py
@@ -44,6 +44,27 @@ class TestStripLeadingHeading:
         value = "#1 rule: pay before the event."
         assert strip_leading_heading(value) == value
 
-    def test_heading_only_content_becomes_empty(self) -> None:
-        """Content that is nothing but a heading strips down to nothing."""
-        assert strip_leading_heading("## Payment Instructions") == ""
+    def test_heading_only_content_is_kept(self) -> None:
+        """Stripping never empties the content — an organizer's one-liner must survive.
+
+        Whoever writes their whole instructions as a single `# ...` line would otherwise
+        get an empty payment card: the templates gate on the raw value, so the heading
+        renders and the "contact the organizer" fallback never fires.
+        """
+        value = "# Please e-transfer to IBAN AT12 3456 7890"
+        assert strip_leading_heading(value) == value
+
+    def test_heading_only_content_with_trailing_blank_lines_is_kept(self) -> None:
+        """Trailing whitespace doesn't make heading-only content look strippable."""
+        value = "## Payment Instructions\n\n"
+        assert strip_leading_heading(value) == value
+
+    def test_preserves_indentation_of_content_without_heading(self) -> None:
+        """No heading means no rewriting — a 4-space code block keeps its indent."""
+        value = "    IBAN: AT12 3456 7890\n    BIC: REVELAT2X\n"
+        assert strip_leading_heading(value) == value
+
+    def test_preserves_indentation_of_content_below_a_heading(self) -> None:
+        """The blank lines under the heading go; the body's own indent stays."""
+        result = strip_leading_heading("## Payment Instructions\n\n    IBAN: AT12 3456 7890\n")
+        assert result == "    IBAN: AT12 3456 7890\n"

--- a/src/common/tests/test_markdown_tags.py
+++ b/src/common/tests/test_markdown_tags.py
@@ -1,0 +1,49 @@
+"""Tests for the markdown_tags template filters."""
+
+import pytest
+
+from common.templatetags.markdown_tags import strip_leading_heading
+
+
+class TestStripLeadingHeading:
+    """Tests for strip_leading_heading."""
+
+    @pytest.mark.parametrize("value", [None, "", "   \n\n  "])
+    def test_empty_input(self, value: str | None) -> None:
+        """Falsy or whitespace-only input renders as an empty string."""
+        assert strip_leading_heading(value).strip() == ""
+
+    @pytest.mark.parametrize("hashes", ["#", "##", "###", "####", "#####", "######"])
+    def test_strips_leading_atx_heading_at_any_level(self, hashes: str) -> None:
+        """A leading ATX heading of any level is removed."""
+        result = strip_leading_heading(f"{hashes} Payment Instructions\n\nTransfer to IBAN.")
+        assert result == "Transfer to IBAN."
+
+    def test_strips_heading_preceded_by_blank_lines(self) -> None:
+        """Leading whitespace before the heading doesn't prevent stripping."""
+        result = strip_leading_heading("\n\n  ## Payment Instructions\n\nTransfer to IBAN.")
+        assert result == "Transfer to IBAN."
+
+    def test_strips_only_the_first_heading(self) -> None:
+        """Later headings belong to the organizer's own structure and are preserved."""
+        result = strip_leading_heading("## Payment Instructions\n\nIntro.\n\n## Bank Details\n\nIBAN.")
+        assert result == "Intro.\n\n## Bank Details\n\nIBAN."
+
+    def test_leaves_content_without_leading_heading_untouched(self) -> None:
+        """Bare text keeps every character, including a mid-text '#'."""
+        value = "Please transfer to IBAN: XX1234567890\n\nRef #123"
+        assert strip_leading_heading(value) == value
+
+    def test_does_not_strip_heading_below_other_content(self) -> None:
+        """A heading that isn't first is not a duplicate of the template title."""
+        value = "Transfer to IBAN.\n\n## Payment Instructions"
+        assert strip_leading_heading(value) == value
+
+    def test_does_not_strip_hash_without_space(self) -> None:
+        """'#1 rule' is a hashtag, not a heading."""
+        value = "#1 rule: pay before the event."
+        assert strip_leading_heading(value) == value
+
+    def test_heading_only_content_becomes_empty(self) -> None:
+        """Content that is nothing but a heading strips down to nothing."""
+        assert strip_leading_heading("## Payment Instructions") == ""

--- a/src/notifications/templates/notifications/email/ticket_created.html
+++ b/src/notifications/templates/notifications/email/ticket_created.html
@@ -33,7 +33,7 @@
         <div class="card card--warning">
             <h3 style="margin-top: 0;">{% trans "Payment Instructions" %}</h3>
             {% if context.manual_payment_instructions %}
-                <div style="border-left: 3px solid #ddd; padding-left: 15px; margin: 10px 0; color: #666;">{{ context.manual_payment_instructions|markdown }}</div>
+                <div style="border-left: 3px solid #ddd; padding-left: 15px; margin: 10px 0; color: #666;">{{ context.manual_payment_instructions|strip_leading_heading|markdown }}</div>
             {% else %}
                 <p>{% trans "Please contact the organizer to complete the payment." %}</p>
             {% endif %}

--- a/src/notifications/templates/notifications/email/ticket_created.txt
+++ b/src/notifications/templates/notifications/email/ticket_created.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% trans "Hello" %} {{ user.display_name }},
+{% load i18n markdown_tags %}{% trans "Hello" %} {{ user.display_name }},
 
 {% if context.ticket_holder_name %}
 {% blocktranslate with holder=context.ticket_holder_name event=context.event_name %}{{ holder }} has registered for {{ event }}.{% endblocktranslate %}
@@ -21,7 +21,7 @@
 - {% trans "Ticket ID:" %} {{ context.ticket_id }}
 
 {% if context.manual_payment_instructions %}{% trans "Payment Instructions:" %}
-{{ context.manual_payment_instructions }}
+{{ context.manual_payment_instructions|strip_leading_heading }}
 {% else %}{% trans "Please contact the organizer to complete the payment." %}
 {% endif %}{% else %}{% blocktranslate with event=context.event_name %}Your ticket for {{ event }} is confirmed! 🎉{% endblocktranslate %}
 

--- a/src/notifications/templates/notifications/in_app/ticket_created.md
+++ b/src/notifications/templates/notifications/in_app/ticket_created.md
@@ -1,4 +1,4 @@
-{% load i18n %}{% if context.ticket_holder_name %}
+{% load i18n markdown_tags %}{% if context.ticket_holder_name %}
 {% blocktranslate with holder=context.ticket_holder_name event=context.event_name %}**{{ holder }}** has registered for **{{ event }}**.{% endblocktranslate %}
 
 **{% trans "Ticket Details:" %}**
@@ -19,7 +19,7 @@
 - {% trans "Ticket ID:" %} `{{ context.ticket_id }}`
 
 {% if context.manual_payment_instructions %}**{% trans "Payment Instructions:" %}**
-> {{ context.manual_payment_instructions }}
+> {{ context.manual_payment_instructions|strip_leading_heading }}
 {% else %}_{% trans "Please contact the organizer to complete the payment." %}_
 {% endif %}{% else %}{% blocktranslate with event=context.event_name %}Your ticket for **{{ event }}** is confirmed! 🎉{% endblocktranslate %}
 

--- a/src/notifications/templates/notifications/telegram/ticket_created.md
+++ b/src/notifications/templates/notifications/telegram/ticket_created.md
@@ -1,4 +1,4 @@
-{% load i18n %}{% if context.ticket_holder_name %}
+{% load i18n markdown_tags %}{% if context.ticket_holder_name %}
 {% blocktranslate with holder=context.ticket_holder_name event=context.event_name %}<b>{{ holder }}</b> has registered for <b>{{ event }}</b>.{% endblocktranslate %}
 
 <b>{% trans "Ticket Details:" %}</b>
@@ -18,7 +18,7 @@
 • {% trans "Status:" %} {% trans "Pending" %}
 
 {% if context.manual_payment_instructions %}<b>{% trans "Payment Instructions:" %}</b>
-<blockquote>{{ context.manual_payment_instructions }}</blockquote>
+<blockquote>{{ context.manual_payment_instructions|strip_leading_heading }}</blockquote>
 {% else %}<i>{% trans "Please contact the organizer to complete the payment." %}</i>
 {% endif %}{% else %}✅ {% blocktranslate with event=context.event_name %}Ticket Confirmed for <b>{{ event }}</b>{% endblocktranslate %}
 

--- a/src/notifications/tests/test_ticket_templates.py
+++ b/src/notifications/tests/test_ticket_templates.py
@@ -922,6 +922,17 @@ class TestPendingTicketPaymentInstructions:
         assert "Please transfer to IBAN: XX1234567890" in rendered
 
     @pytest.mark.parametrize("template", _TICKET_CREATED_CHANNELS)
+    def test_single_line_heading_instructions_are_not_swallowed(self, template: str) -> None:
+        """Instructions written as one heading line must still reach the recipient.
+
+        The templates gate on the raw value, so stripping this to nothing would render
+        a Payment Instructions label with an empty body and no fallback copy.
+        """
+        rendered = self._render(template, instructions="# Please e-transfer to IBAN AT12 3456 7890")
+
+        assert "Please e-transfer to IBAN AT12 3456 7890" in rendered
+
+    @pytest.mark.parametrize("template", _TICKET_CREATED_CHANNELS)
     def test_missing_instructions_fall_back_to_contact_copy(self, template: str) -> None:
         """Without instructions every channel shows the fallback copy."""
         rendered = self._render(template, instructions=None)

--- a/src/notifications/tests/test_ticket_templates.py
+++ b/src/notifications/tests/test_ticket_templates.py
@@ -871,3 +871,59 @@ class TestTicketCancelledTemplateBranching:
         rendered = self._render(template, source="")
         assert "has been cancelled" in rendered
         assert "You cancelled" not in rendered
+
+
+_TICKET_CREATED_CHANNELS: tuple[str, ...] = (
+    "notifications/in_app/ticket_created.md",
+    "notifications/email/ticket_created.html",
+    "notifications/email/ticket_created.txt",
+    "notifications/telegram/ticket_created.md",
+)
+
+
+class TestPendingTicketPaymentInstructions:
+    """Tests that organizer payment instructions don't duplicate the template's own heading."""
+
+    def _render(self, template: str, *, instructions: str | None) -> str:
+        """Render a pending-ticket notification with the given manual payment instructions."""
+        from django.template.loader import render_to_string
+
+        return render_to_string(
+            template,
+            {
+                "user": {"display_name": "Test User"},
+                "context": {
+                    "event_name": "Test Fest",
+                    "event_start_formatted": "TBD",
+                    "event_location": "",
+                    "tier_name": "GA",
+                    "ticket_id": "abc",
+                    "ticket_status": "pending",
+                    "event_url": "https://example.com",
+                    "manual_payment_instructions": instructions,
+                },
+            },
+        )
+
+    @pytest.mark.parametrize("template", _TICKET_CREATED_CHANNELS)
+    def test_leading_heading_in_instructions_is_not_duplicated(self, template: str) -> None:
+        """The template supplies the heading, so the organizer's leading one is dropped."""
+        rendered = self._render(template, instructions="## Payment Instructions\n\nTransfer to IBAN AT12.")
+
+        assert rendered.count("Payment Instructions") == 1
+        assert "Transfer to IBAN AT12." in rendered
+
+    @pytest.mark.parametrize("template", _TICKET_CREATED_CHANNELS)
+    def test_instructions_without_heading_are_preserved(self, template: str) -> None:
+        """Bare instructions still render under the template's heading."""
+        rendered = self._render(template, instructions="Please transfer to IBAN: XX1234567890")
+
+        assert "Payment Instructions" in rendered
+        assert "Please transfer to IBAN: XX1234567890" in rendered
+
+    @pytest.mark.parametrize("template", _TICKET_CREATED_CHANNELS)
+    def test_missing_instructions_fall_back_to_contact_copy(self, template: str) -> None:
+        """Without instructions every channel shows the fallback copy."""
+        rendered = self._render(template, instructions=None)
+
+        assert "contact the organizer" in rendered


### PR DESCRIPTION
Fixes #859.

## Problem

The pending-ticket notification renders its own **Payment Instructions** heading and then the organizer-supplied markdown, which commonly starts with its own `## Payment Instructions` (that's what the bootstrap seed does, and it's a natural pattern for organizers to copy) — so the heading appeared twice in a row.

## Fix

Neither of the issue's two sketches works alone:

- Dropping the template heading breaks orgs that write bare text with no heading of their own (e.g. the showcase seed's `"Please transfer to IBAN: XX1234567890"`) — the card would be unlabelled.
- Demoting the organizer's heading still leaves two "Payment Instructions" lines.

So: keep the template heading (it's the card label, consistent with the Event Details / Ticket Information cards) and strip a **leading** heading from the organizer content. The organizer's first heading is redundant by construction — it sits directly under our label — while any later headings, which are real structure, are preserved.

New `strip_leading_heading` filter in `common/templatetags/markdown_tags.py`, applied on all four `ticket_created` channels (email HTML, email text, in-app, Telegram) — the duplication was identical in each, and the issue's HTML repro is just where it was spotted.

Only ATX headings (`## Title`) are handled; setext (`Title\n====`) is left with a `# ponytail:` note.

## Tests

- `src/common/tests/test_markdown_tags.py` — new, covers the filter: every heading level, leading blank lines, only-the-first-heading, heading-only content, and the non-heading cases (`#1 rule`, mid-text `#`, heading below other content).
- `TestPendingTicketPaymentInstructions` in `test_ticket_templates.py` — parametrized over all four channels: leading heading not duplicated, bare instructions preserved under the heading, missing instructions still fall back to the contact-the-organizer copy.

```
27 passed  (new tests)
85 passed  (test_ticket_templates.py + test_ticket_templates_branding.py)
```

`make format` / `lint` / `mypy` / `i18n-check` all clean. No new translatable strings, so no `.po` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment instructions in ticket-created notifications by removing redundant leading Markdown headings.
  * Applied consistent formatting across email, in-app, and Telegram notifications.
  * Removed only the initial heading while preserving later headings, indentation, and headingless instructions.
  * Preserved fallback contact information when payment details are unavailable.

* **Tests**
  * Added coverage for heading levels, whitespace handling, heading-only content, hashtag-like text, and notification rendering across supported channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->