### PR TITLE
fix: empty billing payload (#861) + MinimalEventSchema timezone (#862)

### DIFF
--- a/src/accounts/controllers/billing.py
+++ b/src/accounts/controllers/billing.py
@@ -25,10 +25,10 @@ from common.throttling import UserDefaultThrottle, WriteThrottle
 class UserBillingController(UserAwareController):
     """CRUD endpoints for user billing profile."""
 
-    @route.get("", url_name="get_billing_profile", response=UserBillingProfileSchema)
-    def get_billing_profile(self) -> UserBillingProfile:
-        """Get the authenticated user's billing profile."""
-        return get_object_or_404(UserBillingProfile, user=self.user())
+    @route.get("", url_name="get_billing_profile", response=UserBillingProfileSchema | None)
+    def get_billing_profile(self) -> UserBillingProfile | None:
+        """Get the authenticated user's billing profile, or null if none is saved yet."""
+        return UserBillingProfile.objects.filter(user=self.user()).first()
 
     @route.post(
         "", url_name="create_billing_profile", response={201: UserBillingProfileSchema}, throttle=WriteThrottle()

--- a/src/accounts/tests/test_controllers/test_billing_controller.py
+++ b/src/accounts/tests/test_controllers/test_billing_controller.py
@@ -42,12 +42,13 @@ class TestGetBillingProfile:
         assert data["vat_country_code"] == "IT"
         assert data["billing_email"] == "billing@example.com"
 
-    def test_returns_404_when_no_profile(self, auth_client: Client) -> None:
-        """Returns 404 when user has no billing profile."""
+    def test_returns_null_when_no_profile(self, auth_client: Client) -> None:
+        """Returns 200 with a null payload when user has no billing profile."""
         url = reverse("api:get_billing_profile")
         response = auth_client.get(url)
 
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert response.json() is None
 
     def test_unauthenticated_returns_401(self, client: Client) -> None:
         """Unauthenticated request returns 401."""

--- a/src/events/models/questionnaire.py
+++ b/src/events/models/questionnaire.py
@@ -22,7 +22,7 @@ class OrganizationQuestionnaireQueryset(models.QuerySet["OrganizationQuestionnai
         # Annotate with absolute time difference from now, order future first (ascending), past second (descending)
         event_qs = (
             Event.objects.exclude_templates()
-            .only("id", "name", "slug", "start")
+            .select_related("city", "venue", "venue__city")
             .annotate(
                 is_future=models.Case(
                     models.When(start__gte=current_time, then=True),

--- a/src/events/models/rsvp.py
+++ b/src/events/models/rsvp.py
@@ -18,8 +18,8 @@ class EventRSVPQuerySet(models.QuerySet["EventRSVP"]):
         return self.select_related("user")
 
     def with_event_details(self) -> t.Self:
-        """Prefetch event with venue for MinimalEventSchema."""
-        return self.select_related("event", "event__venue")
+        """Prefetch event with venue and city for MinimalEventSchema."""
+        return self.select_related("event", "event__venue", "event__city")
 
     def with_org_membership(self, organization_id: UUID) -> t.Self:
         """Prefetch user's membership for a specific organization."""

--- a/src/events/models/ticket.py
+++ b/src/events/models/ticket.py
@@ -589,6 +589,7 @@ class TicketQuerySet(models.QuerySet["Ticket"]):
         return self.select_related(
             "event",
             "event__organization",
+            "event__city",
             "event__venue",
             "event__venue__city",
             "tier",

--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -324,9 +324,17 @@ class MinimalEventSchema(LogoCoverArtThumbnailMixin):
     start: AwareDatetime
     end: AwareDatetime
     is_open_ended: bool = False
+    timezone: str
     logo: str | None = None
     cover_art: str | None = None
     venue: VenueSchema | None = None
+
+    @staticmethod
+    def resolve_timezone(obj: "Event") -> str:
+        """Expose the event's IANA timezone (see ``EventSchema.resolve_timezone``)."""
+        from events.utils import get_event_timezone
+
+        return str(get_event_timezone(obj))
 
 
 class TagUpdateSchema(BaseModel):

--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -330,11 +330,20 @@ class MinimalEventSchema(LogoCoverArtThumbnailMixin):
     venue: VenueSchema | None = None
 
     @staticmethod
-    def resolve_timezone(obj: "Event") -> str:
-        """Expose the event's IANA timezone (see ``EventSchema.resolve_timezone``)."""
+    def resolve_timezone(obj: t.Any) -> str:
+        """Expose the event's IANA timezone (see ``EventSchema.resolve_timezone``).
+
+        Resolvers run on every validation pass, including re-validation of an
+        already-serialized ``MinimalEventSchema`` embedded in an explicitly
+        constructed response schema (e.g. ``EventUserStatusResponse``), so keep
+        the already-resolved value when ``obj`` is not an ``Event``.
+        """
         from events.utils import get_event_timezone
 
-        return str(get_event_timezone(obj))
+        if isinstance(obj, Event):
+            return str(get_event_timezone(obj))
+        value = obj.get("timezone") if isinstance(obj, dict) else getattr(obj, "timezone", None)
+        return str(value) if value else "UTC"
 
 
 class TagUpdateSchema(BaseModel):

--- a/src/events/tests/test_controllers/test_minimal_event_timezone.py
+++ b/src/events/tests/test_controllers/test_minimal_event_timezone.py
@@ -1,0 +1,94 @@
+"""Tests for the ``timezone`` field on MinimalEventSchema (BE #862).
+
+Dashboard lists (``/api/dashboard/tickets``, ``/api/dashboard/rsvps``) serialize
+events as ``MinimalEventSchema``; exposing the resolved IANA timezone lets the
+frontend render event-local times consistently with the event detail page.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.gis.geos import Point
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events.models import Event, EventRSVP, Organization, Ticket
+from geo.models import City
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def vienna_event(organization: Organization) -> Event:
+    """An upcoming event located in Vienna (city timezone auto-derived)."""
+    city = City.objects.create(
+        name="Vienna",
+        ascii_name="Vienna",
+        country="AT",
+        city_id=99001,
+        location=Point(16.3738, 48.2082),
+    )
+    assert city.timezone == "Europe/Vienna"
+    return Event.objects.create(
+        organization=organization,
+        name="Vienna Event",
+        slug="vienna-event",
+        status="open",
+        city=city,
+        start=timezone.now() + timedelta(days=3),
+        end=timezone.now() + timedelta(days=4),
+    )
+
+
+def test_dashboard_tickets_expose_event_timezone(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    vienna_event: Event,
+) -> None:
+    """Ticket list events report the event city's IANA timezone."""
+    tier = vienna_event.ticket_tiers.first()
+    assert tier is not None
+    Ticket.objects.create(guest_name="Test Guest", event=vienna_event, user=dashboard_user, tier=tier)
+
+    response = dashboard_client.get(reverse("api:dashboard_tickets"))
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["event"]["timezone"] == "Europe/Vienna"
+
+
+def test_dashboard_rsvps_expose_event_timezone(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    vienna_event: Event,
+) -> None:
+    """RSVP list events report the event city's IANA timezone."""
+    EventRSVP.objects.create(event=vienna_event, user=dashboard_user, status=EventRSVP.RsvpStatus.YES)
+
+    response = dashboard_client.get(reverse("api:dashboard_rsvps"))
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["event"]["timezone"] == "Europe/Vienna"
+
+
+def test_dashboard_rsvps_timezone_falls_back_to_utc(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    organization: Organization,
+) -> None:
+    """Events without a city report the UTC fallback."""
+    event = Event.objects.create(
+        organization=organization,
+        name="No City Event",
+        slug="no-city-event",
+        status="open",
+        start=timezone.now() + timedelta(days=3),
+        end=timezone.now() + timedelta(days=4),
+    )
+    EventRSVP.objects.create(event=event, user=dashboard_user, status=EventRSVP.RsvpStatus.YES)
+
+    response = dashboard_client.get(reverse("api:dashboard_rsvps"))
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["event"]["timezone"] == "UTC"

--- a/src/events/tests/test_controllers/test_minimal_event_timezone.py
+++ b/src/events/tests/test_controllers/test_minimal_event_timezone.py
@@ -42,6 +42,22 @@ def vienna_event(organization: Organization) -> Event:
     )
 
 
+def test_minimal_event_schema_revalidation_preserves_timezone(vienna_event: Event) -> None:
+    """Re-validating an already-serialized schema keeps the resolved timezone.
+
+    Ninja resolvers run on every validation pass; endpoints like ``my-status``
+    embed pre-built ``UserTicketSchema``/``MinimalEventSchema`` instances in an
+    explicitly constructed response schema, which re-validates them.
+    """
+    from events.schema import MinimalEventSchema
+
+    instance = MinimalEventSchema.from_orm(vienna_event)
+    assert instance.timezone == "Europe/Vienna"
+
+    revalidated = MinimalEventSchema.model_validate(instance)
+    assert revalidated.timezone == "Europe/Vienna"
+
+
 def test_dashboard_tickets_expose_event_timezone(
     dashboard_client: Client,
     dashboard_user: RevelUser,


### PR DESCRIPTION
Addresses #861 and #862 in one PR, as both are small FE-driven API contract fixes.

## #861 — `GET /api/me/billing` returns 200 + `null` instead of 404

"No billing profile saved yet" is an empty state, not an error. The endpoint now uses a nullable response schema (`UserBillingProfileSchema | None`) and returns `null` with status 200 when no profile exists, so the browser stops logging a spurious `Failed to load resource: 404`. The FE already handles both shapes (404→null), so deploy order doesn't matter.

## #862 — add `timezone` to `MinimalEventSchema`

Purely additive: exposes the same resolved IANA timezone as `EventSchema` (`get_event_timezone`, UTC fallback) so dashboard ticket/RSVP lists can render event-local times. N+1 guards for the resolver's `event.city` access:

- `event__city` added to `Ticket.full()` and `EventRSVP.with_event_details()`
- the `OrganizationQuestionnaire` events prefetch drops its `.only("id", "name", "slug", "start")` — which was already deferred-loading the `end`/`logo`/`cover_art`/`venue` fields `MinimalEventSchema` serializes, one query per field per event — in favor of `select_related("city", "venue", "venue__city")`

## Tests

- Billing: 404 test updated to expect 200 + `null` (also confirms Ninja serializes the nullable response)
- New `test_minimal_event_timezone.py`: dashboard tickets/RSVPs report `Europe/Vienna` for a Vienna event, UTC fallback without a city
- `make check` green; billing, dashboard, questionnaire, series-pass, and ticket-cancellation suites pass (188 tests)

Closes #861
Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Minimal event details now include the event’s timezone.
  - Events without a city default to the UTC timezone.
  - Timezone information is preserved across dashboard ticket and RSVP responses.

- **Bug Fixes**
  - Billing-profile requests now return HTTP 200 with `null` when no profile exists, instead of a not-found error.
  - Dashboard event responses now consistently include location-related details and timezone information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->