### PR TITLE
feat(wallet): rebrand Apple Wallet passes — crimson-pop theme

### DIFF
--- a/src/wallet/apple/formatting.py
+++ b/src/wallet/apple/formatting.py
@@ -38,14 +38,14 @@ def _hsl_to_rgb_string(hue: float, saturation: float, lightness: float) -> str:
     return f"rgb({int(rgb[0] * 255)}, {int(rgb[1] * 255)}, {int(rgb[2] * 255)})"
 
 
-# Revel dark theme colors (HSL from frontend app.css)
-# --background: 270 30% 8%
-# --foreground: 270 10% 95%
-# --muted-foreground: 270 10% 65%
+# Revel 2026 "crimson pop" theme (HSL tokens from frontend app.css):
+# crimson-deep panel (--poster-crimson-deep: 3 79% 50%, the AA-vs-white
+# variant of Light Crimson #E6332A), white text, lavender-paper labels
+# (--background light: 268 60% 96%, the paper #F3EFFA of the ticket PDF).
 REVEL_THEME = PassColors(
-    background=_hsl_to_rgb_string(270, 0.30, 0.08),
-    foreground=_hsl_to_rgb_string(270, 0.10, 0.95),
-    label=_hsl_to_rgb_string(270, 0.10, 0.65),
+    background=_hsl_to_rgb_string(3, 0.79, 0.50),
+    foreground="rgb(255, 255, 255)",
+    label=_hsl_to_rgb_string(268, 0.60, 0.96),
 )
 
 

--- a/src/wallet/apple/formatting.py
+++ b/src/wallet/apple/formatting.py
@@ -41,7 +41,8 @@ def _hsl_to_rgb_string(hue: float, saturation: float, lightness: float) -> str:
 # Revel 2026 "crimson pop" theme (HSL tokens from frontend app.css):
 # crimson-deep panel (--poster-crimson-deep: 3 79% 50%, the AA-vs-white
 # variant of Light Crimson #E6332A), white text, lavender-paper labels
-# (--background light: 268 60% 96%, the paper #F3EFFA of the ticket PDF).
+# (--background light: 268 60% 96%, rendering as #F4EEFA — one RGB unit
+# off the ticket PDF's paper #F3EFFA; the HSL token is the contract).
 REVEL_THEME = PassColors(
     background=_hsl_to_rgb_string(3, 0.79, 0.50),
     foreground="rgb(255, 255, 255)",

--- a/src/wallet/tests/test_formatting.py
+++ b/src/wallet/tests/test_formatting.py
@@ -77,18 +77,16 @@ class TestGetThemeColors:
         colors = get_theme_colors()
         assert colors is REVEL_THEME
 
-    def test_theme_has_dark_background(self) -> None:
-        """The theme should have a dark background (low lightness)."""
+    def test_theme_has_crimson_background(self) -> None:
+        """The theme background is the brand crimson-deep panel (3 79% 50%)."""
         colors = get_theme_colors()
-        # Parse RGB values from background
-        # "rgb(r, g, b)" format
         rgb_str = colors.background
         parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
         r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
-        # Dark background means low RGB values
-        assert r < 50
-        assert g < 50
-        assert b < 50
+        # Red-dominant: red channel high, green/blue low
+        assert r > 200
+        assert g < 60
+        assert b < 60
 
     def test_theme_has_light_foreground(self) -> None:
         """The theme should have a light foreground (high lightness)."""
@@ -97,6 +95,16 @@ class TestGetThemeColors:
         parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
         r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
         # Light foreground means high RGB values
+        assert r > 200
+        assert g > 200
+        assert b > 200
+
+    def test_theme_has_light_label(self) -> None:
+        """The label color is the light lavender paper (readable on crimson)."""
+        colors = get_theme_colors()
+        rgb_str = colors.label
+        parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
+        r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
         assert r > 200
         assert g > 200
         assert b > 200

--- a/src/wallet/tests/test_formatting.py
+++ b/src/wallet/tests/test_formatting.py
@@ -80,34 +80,17 @@ class TestGetThemeColors:
     def test_theme_has_crimson_background(self) -> None:
         """The theme background is the brand crimson-deep panel (3 79% 50%)."""
         colors = get_theme_colors()
-        rgb_str = colors.background
-        parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
-        r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
-        # Red-dominant: red channel high, green/blue low
-        assert r > 200
-        assert g < 60
-        assert b < 60
+        assert colors.background == "rgb(228, 36, 26)"
 
-    def test_theme_has_light_foreground(self) -> None:
-        """The theme should have a light foreground (high lightness)."""
+    def test_theme_has_white_foreground(self) -> None:
+        """The theme foreground is white (AA on the crimson-deep panel)."""
         colors = get_theme_colors()
-        rgb_str = colors.foreground
-        parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
-        r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
-        # Light foreground means high RGB values
-        assert r > 200
-        assert g > 200
-        assert b > 200
+        assert colors.foreground == "rgb(255, 255, 255)"
 
-    def test_theme_has_light_label(self) -> None:
-        """The label color is the light lavender paper (readable on crimson)."""
+    def test_theme_has_paper_label(self) -> None:
+        """The label color is the light lavender paper (268 60% 96%)."""
         colors = get_theme_colors()
-        rgb_str = colors.label
-        parts = rgb_str.replace("rgb(", "").replace(")", "").split(",")
-        r, g, b = int(parts[0].strip()), int(parts[1].strip()), int(parts[2].strip())
-        assert r > 200
-        assert g > 200
-        assert b > 200
+        assert colors.label == "rgb(244, 238, 250)"
 
 
 class TestFormatIsoDate:


### PR DESCRIPTION
## Summary

Follow-up to the ticket PDF rebrand (#874): brings Apple Wallet passes onto the 2026 Bubble brand palette. Six on-brand variations were generated with the real `ApplePassGenerator` + signer and previewed on-device; the winner is **crimson pop**:

- **Background**: crimson-deep (`--poster-crimson-deep: 3 79% 50%` → `rgb(228, 36, 26)`) — the AA-vs-white poster variant of Light Crimson `#E6332A`, not the raw brand red
- **Foreground**: white
- **Labels**: lavender paper (`268 60% 96%` → `rgb(244, 238, 250)`), the paper of the rebranded ticket PDF

Pass icons follow automatically since they're a solid square of the background color.

Not in scope (possible follow-up): replacing the solid-square icon with the gradient R mark (`src/assets/brand/revel-mark.svg`) rasterized to the icon sizes.

## Test plan

- [x] `pytest src/wallet/tests/` — 168 passed; theme contract repinned (crimson-dominant bg, light fg, light label)
- [x] ruff + mypy clean on changed files
- [x] Signed `.pkpass` generated through the untouched production `generate_pass()` path and verified on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the wallet’s visual theme to the Revel 2026 “crimson pop” palette.
  * Introduced a crimson background, white foreground, and light lavender labels for improved visual contrast.
  * Refreshed wallet screens with a brighter, more distinctive appearance while maintaining clear text and label readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->