### PR TITLE
feat(wallet): stable image indirection URLs for Google Wallet passes

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -353,30 +353,36 @@ def _placeholder_png_bytes() -> bytes:
     return buffer.getvalue()
 
 
-def serve_image_or_placeholder(file_field: FieldFile | None) -> HttpResponse:
-    """Serve an image field's current bytes, or a neutral placeholder.
+def serve_image_or_placeholder(*file_fields: FieldFile | None) -> HttpResponse:
+    """Serve the first readable image field's bytes, or a neutral placeholder.
 
     Backs stable image URLs embedded in external artifacts (e.g. Google
     Wallet save links in old emails): uploads delete the replaced file from
-    storage, so these URLs must degrade to a placeholder — never an error —
-    when the file was replaced, removed, or never set.
+    storage, so these URLs must degrade — never error — when a file was
+    replaced, removed, or never set. Candidates are tried in order (e.g.
+    thumbnail, then original) so a broken optimized variant falls back to
+    the original rather than the placeholder (same contract as
+    ``wallet.apple.images.resolve_cover_art``, #358).
 
     Args:
-        file_field: A Django FileField/ImageField value, or None.
+        file_fields: Django FileField/ImageField values, best first; falsy
+            entries are skipped.
 
     Returns:
         A cacheable image response.
     """
     body = _placeholder_png_bytes()
     content_type = "image/png"
-    if file_field:
+    for file_field in file_fields:
+        if not file_field:
+            continue
         try:
             with file_field.open("rb") as f:
                 body = f.read()
             content_type = mimetypes.guess_type(file_field.name or "")[0] or "application/octet-stream"
+            break
         except OSError, ValueError:
-            body = _placeholder_png_bytes()
-            content_type = "image/png"
+            continue
     response = HttpResponse(body, content_type=content_type)
     response["Cache-Control"] = "public, max-age=3600"
     return response

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -1,4 +1,6 @@
+import functools
 import hashlib
+import mimetypes
 import sys
 import typing as t
 from io import BytesIO
@@ -9,6 +11,8 @@ from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import IntegrityError, models, transaction
+from django.db.models.fields.files import FieldFile
+from django.http import HttpResponse
 from PIL import Image
 from pydantic import BaseModel
 
@@ -339,3 +343,40 @@ def safe_save_uploaded_file(
         )
 
     return instance
+
+
+@functools.lru_cache(maxsize=1)
+def _placeholder_png_bytes() -> bytes:
+    """A neutral 150x150 solid-gray PNG, generated once per process."""
+    buffer = BytesIO()
+    Image.new("RGB", (150, 150), (203, 213, 225)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def serve_image_or_placeholder(file_field: FieldFile | None) -> HttpResponse:
+    """Serve an image field's current bytes, or a neutral placeholder.
+
+    Backs stable image URLs embedded in external artifacts (e.g. Google
+    Wallet save links in old emails): uploads delete the replaced file from
+    storage, so these URLs must degrade to a placeholder — never an error —
+    when the file was replaced, removed, or never set.
+
+    Args:
+        file_field: A Django FileField/ImageField value, or None.
+
+    Returns:
+        A cacheable image response.
+    """
+    body = _placeholder_png_bytes()
+    content_type = "image/png"
+    if file_field:
+        try:
+            with file_field.open("rb") as f:
+                body = f.read()
+            content_type = mimetypes.guess_type(file_field.name or "")[0] or "application/octet-stream"
+        except OSError, ValueError:
+            body = _placeholder_png_bytes()
+            content_type = "image/png"
+    response = HttpResponse(body, content_type=content_type)
+    response["Cache-Control"] = "public, max-age=3600"
+    return response

--- a/src/events/controllers/event_public/details.py
+++ b/src/events/controllers/event_public/details.py
@@ -2,6 +2,8 @@ import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
 from ninja import Query
 from ninja_extra import (
     api_controller,
@@ -12,6 +14,7 @@ from ninja_extra.searching import Searching, searching
 
 from accounts.models import RevelUser
 from common.authentication import I18nJWTAuth, OptionalAuth
+from common.utils import serve_image_or_placeholder
 from events import filters, models, schema
 from events.service import announcement_service, event_service
 
@@ -39,6 +42,19 @@ class EventPublicDetailsController(EventPublicBaseController):
         ticket tiers, and visibility settings. Use this to display the event detail page.
         """
         return self.get_one(event_id)
+
+    @route.get("/{uuid:event_id}/cover-art", url_name="event_cover_art", response={200: None, 404: None})
+    def get_event_cover_art(self, event_id: UUID) -> HttpResponse:
+        """Serve the event's current cover art, or a placeholder.
+
+        Stable URL embedded in Google Wallet save links: it must resolve to an
+        image for as long as the event exists, even after the cover art file is
+        replaced or removed (old links live in ticket emails forever).
+        Bypasses visibility filtering — Google's image fetcher is anonymous,
+        and cover art files are already served unauthenticated from /media.
+        """
+        event = get_object_or_404(models.Event, id=event_id)
+        return serve_image_or_placeholder(event.cover_art)
 
     @route.get(
         "/{uuid:event_id}/attendee-list",

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -193,7 +193,7 @@ class OrganizationController(UserAwareController):
         and logo files are already served unauthenticated from /media.
         """
         organization = get_object_or_404(models.Organization, id=organization_id)
-        return serve_image_or_placeholder(organization.logo_thumbnail or organization.logo)
+        return serve_image_or_placeholder(organization.logo_thumbnail, organization.logo)
 
     @route.get("/{slug}", url_name="get_organization", response=schema.OrganizationRetrieveSchema)
     def get_organization(self, slug: str) -> models.Organization:

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db.models import Prefetch, QuerySet
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from ninja import Query
@@ -22,6 +23,7 @@ from common.throttling import (
     UserRequestThrottle,
     WriteThrottle,
 )
+from common.utils import serve_image_or_placeholder
 from events import filters, models, schema
 from events.service import (
     announcement_service,
@@ -179,6 +181,19 @@ class OrganizationController(UserAwareController):
         Stripe checkout return URLs (#848) back to slug pages.
         """
         return self.get_one_by_id(organization_id)
+
+    @route.get("/{uuid:organization_id}/logo", url_name="organization_logo", response={200: None, 404: None})
+    def get_organization_logo(self, organization_id: UUID) -> HttpResponse:
+        """Serve the organization's current logo, or a placeholder.
+
+        Stable URL embedded in Google Wallet save links: it must resolve to an
+        image for as long as the organization exists, even after the logo file
+        is replaced or removed (old links live in ticket emails forever).
+        Bypasses visibility filtering — Google's image fetcher is anonymous,
+        and logo files are already served unauthenticated from /media.
+        """
+        organization = get_object_or_404(models.Organization, id=organization_id)
+        return serve_image_or_placeholder(organization.logo_thumbnail or organization.logo)
 
     @route.get("/{slug}", url_name="get_organization", response=schema.OrganizationRetrieveSchema)
     def get_organization(self, slug: str) -> models.Organization:

--- a/src/events/tests/test_controllers/test_public_asset_images.py
+++ b/src/events/tests/test_controllers/test_public_asset_images.py
@@ -67,6 +67,20 @@ class TestOrganizationLogo:
         assert response.status_code == 200
         assert response.content.startswith(PNG_MAGIC)
 
+    def test_falls_back_to_original_when_thumbnail_file_missing(
+        self, client: Client, organization: Organization, png_bytes: bytes
+    ) -> None:
+        """A broken thumbnail file falls back to the original logo, not the placeholder."""
+        organization.logo.save("logo.png", ContentFile(png_bytes), save=True)
+        organization.logo_thumbnail.save("logo_thumb.png", ContentFile(b"thumb-bytes"), save=True)
+        organization.logo_thumbnail.storage.delete(organization.logo_thumbnail.name)
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content == png_bytes
+
     def test_private_org_logo_still_served_anonymously(
         self, client: Client, organization: Organization, png_bytes: bytes
     ) -> None:

--- a/src/events/tests/test_controllers/test_public_asset_images.py
+++ b/src/events/tests/test_controllers/test_public_asset_images.py
@@ -1,0 +1,117 @@
+# src/events/tests/test_controllers/test_public_asset_images.py
+
+"""Tests for the public org-logo / event-cover-art image endpoints.
+
+These endpoints back the stable image URLs embedded in Google Wallet save
+links: they must keep resolving to *an* image (current file or placeholder)
+for any existing org/event, with no auth, forever — Google's image fetcher
+errors otherwise and the save link dies.
+"""
+
+import pytest
+from django.core.files.base import ContentFile
+from django.test.client import Client
+from django.urls import reverse
+
+from events.models import Event, Organization
+
+pytestmark = pytest.mark.django_db
+
+PNG_MAGIC = b"\x89PNG"
+
+
+class TestOrganizationLogo:
+    def test_serves_logo_bytes(self, client: Client, organization: Organization, png_bytes: bytes) -> None:
+        """The current logo file is served with cache headers."""
+        organization.logo.save("logo.png", ContentFile(png_bytes), save=True)
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert response.content == png_bytes
+        assert "public" in response["Cache-Control"]
+
+    def test_prefers_thumbnail_over_logo(self, client: Client, organization: Organization, png_bytes: bytes) -> None:
+        """logo_thumbnail wins over logo, mirroring the wallet builder."""
+        organization.logo.save("logo.png", ContentFile(b"original-logo-bytes"), save=True)
+        organization.logo_thumbnail.save("logo_thumb.png", ContentFile(png_bytes), save=True)
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content == png_bytes
+
+    def test_placeholder_when_no_logo(self, client: Client, organization: Organization) -> None:
+        """An org without a logo serves a placeholder image, not an error."""
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert response.content.startswith(PNG_MAGIC)
+
+    def test_placeholder_when_file_missing_from_storage(
+        self, client: Client, organization: Organization, png_bytes: bytes
+    ) -> None:
+        """A DB-referenced file deleted from storage degrades to the placeholder."""
+        organization.logo.save("logo.png", ContentFile(png_bytes), save=True)
+        organization.logo.storage.delete(organization.logo.name)
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content.startswith(PNG_MAGIC)
+
+    def test_private_org_logo_still_served_anonymously(
+        self, client: Client, organization: Organization, png_bytes: bytes
+    ) -> None:
+        """Visibility filtering is bypassed: Google's fetcher is anonymous."""
+        organization.visibility = Organization.Visibility.PRIVATE
+        organization.save(update_fields=["visibility"])
+        organization.logo.save("logo.png", ContentFile(png_bytes), save=True)
+        url = reverse("api:organization_logo", kwargs={"organization_id": organization.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content == png_bytes
+
+    def test_unknown_org_404s(self, client: Client) -> None:
+        url = reverse("api:organization_logo", kwargs={"organization_id": "00000000-0000-0000-0000-000000000000"})
+
+        response = client.get(url)
+
+        assert response.status_code == 404
+
+
+class TestEventCoverArt:
+    def test_serves_cover_art_bytes(self, client: Client, event: Event, png_bytes: bytes) -> None:
+        event.cover_art.save("cover.png", ContentFile(png_bytes), save=True)
+        url = reverse("api:event_cover_art", kwargs={"event_id": event.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert response.content == png_bytes
+        assert "public" in response["Cache-Control"]
+
+    def test_placeholder_when_no_cover_art(self, client: Client, event: Event) -> None:
+        url = reverse("api:event_cover_art", kwargs={"event_id": event.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content.startswith(PNG_MAGIC)
+
+    def test_unknown_event_404s(self, client: Client) -> None:
+        url = reverse("api:event_cover_art", kwargs={"event_id": "00000000-0000-0000-0000-000000000000"})
+
+        response = client.get(url)
+
+        assert response.status_code == 404

--- a/src/wallet/google/builder.py
+++ b/src/wallet/google/builder.py
@@ -13,10 +13,10 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
-from django.db.models.fields.files import FieldFile
+from django.urls import reverse
 from django.utils import timezone
 
-from events.models import HeldSeriesPass, Ticket
+from events.models import Event, HeldSeriesPass, Organization, Ticket
 from events.utils import get_event_timezone, get_organization_timezone
 from wallet.apple.formatting import format_iso_date, format_price, get_theme_hex_background
 from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD
@@ -33,11 +33,25 @@ def _localized(value: str) -> dict[str, t.Any]:
     return {"defaultValue": {"language": "en", "value": value}}
 
 
-def _absolute_media_url(file_field: FieldFile | None) -> str | None:
-    """Absolute public URL for a media file, or None when unset."""
-    if not file_field:
+def _org_logo_url(org: Organization) -> str | None:
+    """Stable indirection URL for the org logo, or None when unset.
+
+    Raw media URLs die when a logo is replaced (uploads delete the old file),
+    which would void every save link already sitting in ticket emails. The
+    API endpoint always serves the *current* logo or a placeholder.
+    """
+    if not (org.logo_thumbnail or org.logo):
         return None
-    return f"{settings.BASE_URL.rstrip('/')}{file_field.url}"
+    path = reverse("api:organization_logo", kwargs={"organization_id": org.id})
+    return f"{settings.BASE_URL.rstrip('/')}{path}"
+
+
+def _event_cover_url(event: Event) -> str | None:
+    """Stable indirection URL for the event cover art, or None when unset."""
+    if not event.cover_art:
+        return None
+    path = reverse("api:event_cover_art", kwargs={"event_id": event.id})
+    return f"{settings.BASE_URL.rstrip('/')}{path}"
 
 
 def _image(url: str | None) -> dict[str, t.Any] | None:
@@ -133,8 +147,8 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
         tz=tz,
         venue_name=venue_name,
         address=address,
-        logo_url=_absolute_media_url(org.logo_thumbnail or org.logo),
-        hero_url=_absolute_media_url(event.cover_art),
+        logo_url=_org_logo_url(org),
+        hero_url=_event_cover_url(event),
     )
 
     obj: dict[str, t.Any] = {
@@ -188,7 +202,7 @@ def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
         address = (venue.full_address() if venue else None) or representative.address or None
         tz = get_event_timezone(representative)
         event_start = representative.start
-        hero_url = _absolute_media_url(representative.cover_art)
+        hero_url = _event_cover_url(representative)
     else:
         venue_name = None
         address = None
@@ -207,7 +221,7 @@ def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
         tz=tz,
         venue_name=venue_name,
         address=address,
-        logo_url=_absolute_media_url(org.logo_thumbnail or org.logo),
+        logo_url=_org_logo_url(org),
         hero_url=hero_url,
     )
 

--- a/src/wallet/tests/test_google_builder.py
+++ b/src/wallet/tests/test_google_builder.py
@@ -136,7 +136,11 @@ def test_ticket_payload_venue_sector_seat(google_wallet_configured_settings: Non
 def test_ticket_payload_logo_and_hero_present_when_set(
     google_wallet_configured_settings: None, ticket: Ticket, png_bytes: bytes, settings: t.Any
 ) -> None:
-    """Org logo and event cover_art surface as BASE_URL-prefixed logo/heroImage."""
+    """Org logo and event cover_art surface as stable indirection URLs (not raw media paths).
+
+    Raw media URLs die when the file is replaced — uploads delete the old file
+    from storage — which would void save links already sitting in old emails.
+    """
     settings.BASE_URL = "https://letsrevel.io"
     organization = ticket.event.organization
     organization.logo.save("logo.png", ContentFile(png_bytes), save=True)
@@ -146,8 +150,8 @@ def test_ticket_payload_logo_and_hero_present_when_set(
     cls = payload["eventTicketClasses"][0]
 
     base_url = settings.BASE_URL.rstrip("/")
-    assert cls["logo"]["sourceUri"]["uri"] == f"{base_url}{organization.logo.url}"
-    assert cls["heroImage"]["sourceUri"]["uri"] == f"{base_url}{ticket.event.cover_art.url}"
+    assert cls["logo"]["sourceUri"]["uri"] == f"{base_url}/api/organizations/{organization.id}/logo"
+    assert cls["heroImage"]["sourceUri"]["uri"] == f"{base_url}/api/events/{ticket.event.id}/cover-art"
 
 
 def test_ticket_payload_images_omitted_for_non_https_base_url(


### PR DESCRIPTION
## Problem

Google Wallet save links are fat JWTs embedded in ticket emails that must never go stale — but their `logo`/`heroImage` fields embedded raw `/media` URLs. Uploads delete the replaced file from storage (`safe_save_uploaded_file`), so an org rebrand or cover-art change kills the image URL inside every save link already sitting in old emails. Google fetches those images at save time and rejects the pass with a generic "Something went wrong" — the save link is dead.

(Found while debugging the demo-instance wallet failure: unfetchable images void the save.)

## Solution

Embed **stable indirection URLs** instead of raw media paths:

- `GET /api/organizations/{id}/logo` — serves the current `logo_thumbnail or logo`
- `GET /api/events/{id}/cover-art` — serves the current `cover_art`

Both are anonymous (Google's image fetcher carries no auth; these files are already served unauthenticated from `/media`), bypass visibility filtering, send `Cache-Control: public, max-age=3600`, and degrade to a generated neutral placeholder PNG when the file is unset or missing from storage — never an error. Unknown IDs 404 (a deleted org's pass is moot).

Stale image in an old pass link is acceptable; a dead link is not. Passes saved later even pick up the *current* logo.

## Changes

- `common/utils.py`: `serve_image_or_placeholder()` + cached placeholder generation
- `events/controllers/organization.py` / `event_public/details.py`: the two routes
- `wallet/google/builder.py`: embeds `reverse()`-built indirection URLs for ticket and series-pass payloads; removes the now-unused `_absolute_media_url`

## Tests

- 9 new endpoint tests (bytes served, thumbnail preference, placeholder on missing/removed file, private-org anonymous access, 404 on unknown id)
- Builder tests updated to pin the new URL shape
- 626 tests green across wallet, common, and touched controllers; `make check` passes

## Note for #878

`feature/878-membership-passes` still calls the removed `_absolute_media_url` in its membership builder — switch it to `_org_logo_url(org)` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public image endpoints for event cover art and organization logos.
  * Added placeholder images when artwork is unavailable, inaccessible, or invalid.
  * Images now include appropriate content types and one-hour cache headers.
  * Google Wallet passes use stable image links that continue working when artwork is replaced.

* **Bug Fixes**
  * Improved fallback behavior for missing organization and event images.
  * Added clear 404 responses for unknown events and organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->