### PR TITLE
perf(api): remove DISTINCT planner bombs, cache openapi & my-permissions, fix admin inline N+1s (#880)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ DB_PASSWORD=db-password
 DB_NAME=revel
 DB_PORT=5432
 
+# REDIS (cache + Celery broker)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# Per-operation socket timeouts (seconds) for the Django cache client. Bound every
+# cache op so a hung Redis errors out instead of blocking requests indefinitely (#880).
+# REDIS_SOCKET_CONNECT_TIMEOUT=1.0
+# REDIS_SOCKET_TIMEOUT=1.0
+
 APPLE_TEAM_IDENTIFIER=FOOBAR
 
 # Apple Wallet Pass Configuration (optional)

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -197,6 +197,7 @@ Most external services have safe defaults for local development. Here's what act
 |---------|---------|---------|-------|
 | PostgreSQL | `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_PORT` | `revel`, `db-password`, `revel`, `5432` | Provided by Docker Compose (values from `.env.example`) |
 | Redis | `REDIS_HOST` | `localhost` | Provided by Docker Compose |
+| Redis timeouts | `REDIS_SOCKET_CONNECT_TIMEOUT`, `REDIS_SOCKET_TIMEOUT` | `1.0`, `1.0` | Seconds; bound every cache op so a hung Redis errors instead of blocking requests (#880) |
 
 ### Required for specific features
 

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,7 +1,10 @@
+import typing as t
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpRequest
 from django.utils.translation import gettext_lazy as _
+from ninja.openapi.schema import OpenAPISchema
 from ninja_extra import NinjaExtraAPI
 
 from accounts.controllers.account import AccountController
@@ -46,7 +49,37 @@ from wallet.controllers import TicketWalletController
 
 from .exception_handlers import handle_django_validation_error, handle_general_exception
 
-api = NinjaExtraAPI(
+
+class CachedSchemaNinjaExtraAPI(NinjaExtraAPI):
+    """NinjaExtraAPI whose OpenAPI schema is generated once per process.
+
+    ninja rebuilds the entire schema (~540 component schemas, ~850KB) on every
+    ``/openapi.json`` request — seconds of CPU per hit, on a public, unthrottled
+    view (#880). The schema depends only on the registered routes and the mount
+    ``path_prefix``, both fixed after startup, so it is safe to memoize.
+    """
+
+    _schema_cache: dict[str, OpenAPISchema]
+
+    def get_openapi_schema(
+        self,
+        *,
+        path_prefix: str | None = None,
+        path_params: dict[str, t.Any] | None = None,
+    ) -> OpenAPISchema:
+        """Return the (memoized) OpenAPI schema for this API."""
+        if path_prefix is None:
+            path_prefix = self.get_root_path(path_params or {})
+        cache = getattr(self, "_schema_cache", None)
+        if cache is None:
+            cache = self._schema_cache = {}
+        if path_prefix not in cache:
+            # Racing threads both build; the result is identical and idempotent.
+            cache[path_prefix] = super().get_openapi_schema(path_prefix=path_prefix)
+        return cache[path_prefix]
+
+
+api = CachedSchemaNinjaExtraAPI(
     title="REVEL Backend API",
     docs_url="/docs",
     # docs_decorator=staff_member_required if not settings.DEBUG else None,

--- a/src/api/tests/test_openapi_schema.py
+++ b/src/api/tests/test_openapi_schema.py
@@ -131,6 +131,8 @@ SUBSCRIPTION_PATH_MARKERS = (
 
 def _declared_error_schemas(status_filter: t.Callable[[str], bool]) -> dict[tuple[str, str, str], set[str]]:
     """Map each ``(path, method, status)`` matching ``status_filter`` to its component names."""
+    # Drop the process-level memo (#880) so the guard actually observes generation.
+    api._schema_cache = {}
     with schema_name_collision_guard():
         spec = api.get_openapi_schema()
 

--- a/src/api/tests/test_openapi_schema.py
+++ b/src/api/tests/test_openapi_schema.py
@@ -21,9 +21,19 @@ pytestmark = pytest.mark.django_db
 
 
 def _components() -> dict[str, t.Any]:
+    # Drop the process-level memo (#880) so the guard actually observes generation.
+    api._schema_cache = {}
     with schema_name_collision_guard():
         schema = api.get_openapi_schema()
     return t.cast(dict[str, t.Any], schema["components"]["schemas"])
+
+
+def test_openapi_schema_is_memoized() -> None:
+    """Repeat calls return the same object — the schema is built once per process (#880)."""
+    api._schema_cache = {}
+    first = api.get_openapi_schema()
+    second = api.get_openapi_schema()
+    assert first is second
 
 
 def test_schema_generation_has_no_component_name_collisions() -> None:

--- a/src/events/admin/base.py
+++ b/src/events/admin/base.py
@@ -210,12 +210,18 @@ class VenueSeatInline(TabularInline):  # type: ignore[misc]
 class TicketTierInline(TabularInline):  # type: ignore[misc]
     model = models.TicketTier
     extra = 1
+    # raw_id: plain <select>s here enumerate every venue/sector/membership-tier in the DB
+    # and fire one __str__ query per <option>, per row + empty form (#880).
+    raw_id_fields = ["venue", "sector", "restricted_to_membership_tiers"]
 
 
 class EventInvitationInline(TabularInline):  # type: ignore[misc]
     model = models.EventInvitation
     extra = 1
     autocomplete_fields = ["user"]
+    # raw_id: the tiers multi-select enumerates every TicketTier across all events,
+    # one Event __str__ query per <option> (#880).
+    raw_id_fields = ["tiers"]
 
 
 class EventRSVPInline(TabularInline):  # type: ignore[misc]
@@ -228,6 +234,10 @@ class TicketInline(TabularInline):  # type: ignore[misc]
     model = models.Ticket
     extra = 0
     autocomplete_fields = ["user", "tier", "checked_in_by"]
+    # raw_id: these rendered as plain <select>s over EVERY seat/venue/sector/discount
+    # code/held pass in the DB, with one __str__ query per <option>, per ticket row +
+    # empty form — thousands of queries on a seated event's change page (#880).
+    raw_id_fields = ["venue", "sector", "seat", "discount_code", "held_pass"]
     readonly_fields = ["id", "checked_in_at"]
     can_delete = False
 
@@ -245,6 +255,9 @@ class WaitlistOfferInline(TabularInline):  # type: ignore[misc]
     model = models.WaitlistOffer
     extra = 0
     fields = ("user", "status", "expires_at", "is_cutoff_batch", "batch_id", "created_at")
+    # Without this, `user` rendered as a <select> over every registered user, once per
+    # offer row + empty form (#880).
+    autocomplete_fields = ["user"]
     readonly_fields = ("created_at", "batch_id")
     show_change_link = True
 

--- a/src/events/controllers/dashboard.py
+++ b/src/events/controllers/dashboard.py
@@ -209,8 +209,10 @@ class DashboardController(UserAwareController):
         payment method. Results are ordered by newest first.
         """
         # Use full() manager which includes: event, organization, tier (with venue/sector/city), seat, payment
+        # No .distinct(): every filter/search field is a to-one join, and DISTINCT over the wide
+        # full() select costs ~600ms of Postgres *planning* time per request (#880).
         qs = models.Ticket.objects.full().filter(user=self.user()).order_by("-created_at")
-        return params.filter(qs).distinct()
+        return params.filter(qs)
 
     @route.patch(
         "/tickets/{ticket_id}/guest-name",
@@ -250,7 +252,8 @@ class DashboardController(UserAwareController):
         qs = models.EventInvitationRequest.objects.with_event_details().filter(user=self.user())
         if event_id:
             qs = qs.filter(event_id=event_id)
-        return params.filter(qs).distinct()
+        # No .distinct(): all filter/search fields are to-one joins (#880).
+        return params.filter(qs)
 
     @route.get(
         "/rsvps",
@@ -271,7 +274,8 @@ class DashboardController(UserAwareController):
         Supports filtering by status (yes/no/maybe). Results are ordered by newest first.
         """
         qs = models.EventRSVP.objects.with_event_details().filter(user=self.user()).order_by("-created_at")
-        return params.filter(qs).distinct()
+        # No .distinct(): all filter/search fields are to-one joins (#880).
+        return params.filter(qs)
 
     @route.get(
         "/invoices",

--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -42,8 +42,7 @@ TicketOrdering = t.Literal[
 # else the recorded price (offline/at-the-door PWYC, discounted, or category-priced),
 # else the tier list price. tier.price is non-nullable (defaults to 0), so the result is
 # never NULL — no NULLS FIRST/LAST handling needed. All three operands are already joined
-# via Ticket.objects.full(), but the COALESCE itself must be annotated so it appears in
-# the SELECT list (required for SELECT DISTINCT).
+# via Ticket.objects.full(); the COALESCE is annotated so it can be used in ORDER BY.
 #
 # KNOWN LIMITATION — category-priced tiers (spec §5.5). This is a DB-level expression used
 # to sort and display a list; it cannot walk seat → price category → the tier's
@@ -106,11 +105,11 @@ class EventAdminTicketsController(EventAdminBaseController):
     def list_ticket_tiers(self, event_id: UUID) -> QuerySet[models.TicketTier]:
         """List all ticket tiers for an event."""
         self.get_one(event_id)
+        # No .distinct(): all joins are to-one (#880).
         return (
             models.TicketTier.objects.with_venue_and_sector()
             .select_related("event__organization")
             .filter(event_id=event_id)
-            .distinct()
         )
 
     @route.post(
@@ -224,7 +223,9 @@ class EventAdminTicketsController(EventAdminBaseController):
             qs = qs.filter(held_pass__isnull=(source == "direct"))
         qs = params.filter(qs).annotate(effective_price_paid=EFFECTIVE_PRICE_PAID)
         # "-id" is a stable tiebreaker so pagination stays deterministic across equal sort keys.
-        return qs.distinct().order_by(TICKET_ORDER_FIELDS[order_by], "-id")
+        # No .distinct(): every filter/search/order field is a to-one join, and DISTINCT over
+        # the wide full() select costs ~600ms of Postgres *planning* time per request (#880).
+        return qs.order_by(TICKET_ORDER_FIELDS[order_by], "-id")
 
     @route.get(
         "/tickets/{ticket_id}",

--- a/src/events/controllers/permissions.py
+++ b/src/events/controllers/permissions.py
@@ -14,7 +14,7 @@ from accounts.models import RevelUser
 from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
 from events import models, schema
-from events.models import OrganizationMember
+from events.service import permission_snapshot
 
 
 class RootPermission(BasePermission):
@@ -231,26 +231,12 @@ class PermissionController(UserAwareController):
         url_name="my_permissions",
         response=schema.OrganizationPermissionsSchema,
     )
-    def my_permissions(self) -> schema.OrganizationPermissionsSchema:
-        """Get a user's permission map, per organization."""
-        user = self.user()
-        perms = models.OrganizationStaff.objects.select_related("organization").filter(user=user)
-        owner_perms = {
-            str(org_id): "owner"
-            for org_id in models.Organization.objects.filter(owner=user).all().values_list("id", flat=True)
-        }
-        staff_perms = {str(perm.organization.id): perm.permissions for perm in perms}
-        permissions = {**staff_perms, **owner_perms}
+    def my_permissions(self) -> dict[str, t.Any]:
+        """Get a user's permission map, per organization.
 
-        # Build memberships dict with minimal member info
-        memberships: dict[str, schema.MinimalOrganizationMemberSchema] = {}
-        members = (
-            models.OrganizationMember.objects.select_related("tier")
-            .filter(user=user)
-            .exclude(status=OrganizationMember.MembershipStatus.BANNED)
-        )
-        for member in members:
-            org_id_str = str(member.organization_id)
-            memberships[org_id_str] = schema.MinimalOrganizationMemberSchema.from_orm(member)
-
-        return schema.OrganizationPermissionsSchema(organization_permissions=permissions, memberships=memberships)
+        Served from a short-TTL per-user cache (#880) — see
+        ``events.service.permission_snapshot`` for the staleness/safety model.
+        The returned dict is re-validated against ``OrganizationPermissionsSchema``
+        by ninja, so a corrupt cache entry fails loudly rather than silently.
+        """
+        return permission_snapshot.get_my_permissions_payload(self.user())

--- a/src/events/service/organization_service/lifecycle.py
+++ b/src/events/service/organization_service/lifecycle.py
@@ -9,6 +9,7 @@ from accounts.models import RevelUser
 from events import schema
 from events.exceptions import MembershipPolicyManageSubscriptionsOnlyError, RevenueReportCadenceOwnerOnlyError
 from events.models import Organization
+from events.service import permission_snapshot
 from events.service.organization_service.contact import (
     create_and_send_contact_email_verification,
     validate_contact_method,
@@ -101,6 +102,10 @@ def create_organization(
     # Send verification email if contact email is not auto-verified
     if not contact_email_verified:
         create_and_send_contact_email_verification(organization, contact_email, owner)
+
+    # The FE navigates straight to the org admin layout, which 403s on a permission
+    # map that lacks the new org — the cached map must not outlive this grant (#880).
+    permission_snapshot.invalidate_my_permissions(owner.id)
 
     return organization
 

--- a/src/events/service/organization_service/tokens.py
+++ b/src/events/service/organization_service/tokens.py
@@ -25,7 +25,7 @@ from events.models import (
     OrganizationStaff,
     OrganizationToken,
 )
-from events.service import blacklist_service
+from events.service import blacklist_service, permission_snapshot
 
 # Canned messages for the organization-token guard exceptions. Co-located with
 # the service that raises them so the per-app exception handlers (and any caller)
@@ -305,4 +305,7 @@ def claim_invitation(user: RevelUser, token: str) -> Organization | None:
     if not created:
         return None
     OrganizationToken.objects.filter(pk=token).update(uses=F("uses") + 1)
+    # The claimer is mid-flow and about to load pages gated on the permission map —
+    # the cached map must not outlive this grant (#880).
+    permission_snapshot.invalidate_my_permissions(user.id)
     return organization_token.organization

--- a/src/events/service/permission_snapshot.py
+++ b/src/events/service/permission_snapshot.py
@@ -1,0 +1,107 @@
+"""Cached per-user snapshot of the my-permissions payload (#880).
+
+``GET /permissions/my-permissions`` is the third most-called API view (~147k req/week —
+the frontend auth store and five SSR loaders hit it on nearly every navigation), so the
+rendered payload is cached per user for a short TTL.
+
+Safety model: no server-side authorization ever reads this payload — every admin/staff/
+purchase endpoint re-checks ``has_org_permission``/``is_owner_or_staff``/membership
+against the DB per request — so a stale entry can only mis-render UI affordances for up
+to the TTL, never grant access. Explicit invalidation therefore exists only where a
+*grant* is part of an interactive flow (org creation, invitation-token claim) and a
+stale miss would 403 the very page the frontend navigates to next; every other mutation
+(staff/member changes, bans, subscription syncs, admin edits, cascades) deliberately
+rides the TTL.
+
+Cache ops fail open: a broken/unreachable Redis degrades to the plain DB build and never
+fails a request or a mutation.
+"""
+
+import typing as t
+from uuid import UUID
+
+import structlog
+from django.core.cache import cache
+from django.db import transaction
+
+from accounts.models import RevelUser
+from events import models, schema
+from events.models import OrganizationMember
+
+logger = structlog.get_logger(__name__)
+
+# Bump when the payload shape changes (OrganizationPermissionsSchema /
+# MinimalOrganizationMemberSchema / MembershipTierSchema) so a rolling deploy never
+# serves an old-shape entry to new code.
+CACHE_VERSION = "v1"
+CACHE_TTL_SECONDS = 60
+
+
+def get_cache_key(user_id: UUID | str) -> str:
+    """Cache key for a user's my-permissions payload."""
+    return f"my_permissions:{CACHE_VERSION}:{user_id}"
+
+
+def get_my_permissions_payload(user: RevelUser) -> dict[str, t.Any]:
+    """Return the my-permissions payload for ``user``, cached for CACHE_TTL_SECONDS."""
+    key = get_cache_key(user.id)
+    try:
+        cached = cache.get(key)
+    except Exception:
+        logger.warning("my_permissions_cache_get_failed", exc_info=True)
+        cached = None
+    if cached is not None:
+        return t.cast(dict[str, t.Any], cached)
+
+    payload = build_my_permissions_payload(user)
+    try:
+        cache.set(key, payload, timeout=CACHE_TTL_SECONDS)
+    except Exception:
+        logger.warning("my_permissions_cache_set_failed", exc_info=True)
+    return payload
+
+
+def build_my_permissions_payload(user: RevelUser) -> dict[str, t.Any]:
+    """Build the payload from the DB (no caching)."""
+    staff_perms: dict[str, t.Any] = {
+        str(org_id): perms
+        for org_id, perms in models.OrganizationStaff.objects.filter(user=user).values_list(
+            "organization_id", "permissions"
+        )
+    }
+    owner_perms = {
+        str(org_id): "owner" for org_id in models.Organization.objects.filter(owner=user).values_list("id", flat=True)
+    }
+    permissions = {**staff_perms, **owner_perms}
+
+    memberships: dict[str, schema.MinimalOrganizationMemberSchema] = {}
+    members = (
+        models.OrganizationMember.objects.select_related("tier")
+        .filter(user=user)
+        .exclude(status=OrganizationMember.MembershipStatus.BANNED)
+    )
+    for member in members:
+        memberships[str(member.organization_id)] = schema.MinimalOrganizationMemberSchema.from_orm(member)
+
+    return schema.OrganizationPermissionsSchema(
+        organization_permissions=permissions, memberships=memberships
+    ).model_dump(mode="json")
+
+
+def invalidate_my_permissions(*user_ids: UUID | str) -> None:
+    """Schedule a post-commit cache delete for the given users' payloads.
+
+    ``on_commit`` (not an in-transaction delete): under ``ATOMIC_REQUESTS`` a delete
+    issued before commit lets any concurrent request re-cache the *old* committed
+    state for the full TTL. Deleting after commit closes that race; on rollback the
+    callback is discarded, which is correct — the cached value is still true.
+    """
+    keys = [get_cache_key(user_id) for user_id in user_ids]
+
+    def _delete() -> None:
+        try:
+            cache.delete_many(keys)
+        except Exception:
+            logger.warning("my_permissions_cache_delete_failed", exc_info=True)
+
+    transaction.on_commit(_delete)

--- a/src/events/tests/test_controllers/test_event_admin/test_tickets/test_no_distinct_regression.py
+++ b/src/events/tests/test_controllers/test_event_admin/test_tickets/test_no_distinct_regression.py
@@ -1,0 +1,105 @@
+"""Regression guards for #880 on the admin ticket list: no DISTINCT, no duplicates.
+
+Same rationale as ``test_controllers/test_no_distinct_regression.py`` — DISTINCT over the
+wide ``full()`` join is pure planner cost and deduplicates nothing. These tests pin that
+under the would-be fan-out conditions: an M2M-restricted tier, a search term matching
+several ``user__*`` fields at once, the ``source`` filter, and ordering by the
+``effective_price_paid`` annotation.
+"""
+
+import typing as t
+
+import pytest
+from django.db import connection
+from django.test.client import Client
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from accounts.models import RevelUser
+from events.models import Event, MembershipTier, Ticket, TicketTier
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_checked(client: Client, url: str, params: dict[str, t.Any] | None = None) -> dict[str, t.Any]:
+    """GET the url asserting 200, no ticket/tier SELECT DISTINCT, and no duplicate ids.
+
+    The event-visibility gate (``Event.objects.for_user``) runs in the same request and
+    keeps a legitimately load-bearing DISTINCT (M2M staff/member joins), so the guard
+    targets only the wide ticket/tier list queries this fix touched.
+    """
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url, params or {})
+    assert response.status_code == 200
+    offenders = [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "SELECT DISTINCT" in q["sql"]
+        and ('FROM "events_ticket"' in q["sql"] or 'FROM "events_tickettier"' in q["sql"])
+    ]
+    assert not offenders, f"SELECT DISTINCT reintroduced (#880): {offenders[0][:200]}"
+    data: dict[str, t.Any] = response.json()
+    ids = [item["id"] for item in data["results"]]
+    assert len(ids) == len(set(ids)), f"duplicate rows in response: {ids}"
+    return data
+
+
+def test_admin_list_tickets_no_duplicates(
+    organization_owner_client: Client,
+    event: Event,
+    offline_tier: TicketTier,
+    pending_offline_ticket: Ticket,
+    public_user: RevelUser,
+) -> None:
+    """Tickets on an M2M-restricted tier, searched by a multi-field term, appear exactly once."""
+    # The M2M that would duplicate rows if it were joined instead of prefetched.
+    mt1 = MembershipTier.objects.create(organization=event.organization, name="Gold")
+    mt2 = MembershipTier.objects.create(organization=event.organization, name="Silver")
+    offline_tier.restricted_to_membership_tiers.add(mt1, mt2)
+
+    # A holder whose email, first AND last name all match one search term — the OR across
+    # several user__* joined fields is the would-be fan-out shape of the search decorator.
+    public_user.first_name = "Zaphod"
+    public_user.last_name = "Zaphodson"
+    public_user.email = "zaphod@example.com"
+    public_user.save(update_fields=["first_name", "last_name", "email"])
+    second_ticket = Ticket.objects.create(
+        guest_name="Second",
+        user=public_user,
+        event=event,
+        tier=offline_tier,
+        status=Ticket.TicketStatus.ACTIVE,
+    )
+
+    url = reverse("api:list_tickets", kwargs={"event_id": event.pk})
+
+    data = _get_checked(organization_owner_client, url)
+    assert data["count"] == 2
+
+    data = _get_checked(organization_owner_client, url, {"search": "zaphod"})
+    assert data["count"] == 2
+    assert {item["id"] for item in data["results"]} == {str(pending_offline_ticket.id), str(second_ticket.id)}
+
+    # Filters + annotation ordering combined still exact.
+    data = _get_checked(
+        organization_owner_client,
+        url,
+        {"search": "zaphod", "source": "direct", "order_by": "-price_paid", "tier__payment_method": "offline"},
+    )
+    assert data["count"] == 2
+
+
+def test_admin_list_ticket_tiers_no_duplicates_with_m2m(
+    organization_owner_client: Client,
+    event: Event,
+    offline_tier: TicketTier,
+) -> None:
+    """A tier restricted to two membership tiers is listed exactly once."""
+    mt1 = MembershipTier.objects.create(organization=event.organization, name="Gold")
+    mt2 = MembershipTier.objects.create(organization=event.organization, name="Silver")
+    offline_tier.restricted_to_membership_tiers.add(mt1, mt2)
+
+    url = reverse("api:list_ticket_tiers", kwargs={"event_id": event.pk})
+    data = _get_checked(organization_owner_client, url)
+    tier_ids = [item["id"] for item in data["results"]]
+    assert tier_ids.count(str(offline_tier.id)) == 1

--- a/src/events/tests/test_controllers/test_no_distinct_regression.py
+++ b/src/events/tests/test_controllers/test_no_distinct_regression.py
@@ -1,0 +1,124 @@
+"""Regression guards for #880: dropping ``.distinct()`` must not introduce duplicates.
+
+DISTINCT over the multi-join ``full()``/``with_event_details()`` selects costs hundreds of
+milliseconds of Postgres *planning* time per request while deduplicating nothing (every
+filter/search field on these endpoints is a to-one join). These tests pin both halves of
+that claim: the endpoints never emit SELECT DISTINCT, **and** the responses contain no
+duplicate rows even under the conditions that would fan out if any join were multi-valued —
+M2M membership-tier restrictions on the tier, a search term matching several joined fields
+at once, and multi-value status filters.
+"""
+
+import typing as t
+from datetime import timedelta
+
+import pytest
+from django.db import connection
+from django.test.client import Client
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events.models import Event, EventRSVP, MembershipTier, Ticket
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_checked(client: Client, url: str, params: dict[str, t.Any] | None = None) -> dict[str, t.Any]:
+    """GET the url asserting 200, no SELECT DISTINCT, and no duplicate result ids."""
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url, params or {})
+    assert response.status_code == 200
+    offenders = [q["sql"] for q in ctx.captured_queries if "SELECT DISTINCT" in q["sql"]]
+    assert not offenders, f"SELECT DISTINCT reintroduced (#880): {offenders[0][:200]}"
+    data: dict[str, t.Any] = response.json()
+    ids = [item["id"] for item in data["results"]]
+    assert len(ids) == len(set(ids)), f"duplicate rows in response: {ids}"
+    return data
+
+
+@pytest.fixture
+def fanout_event(dashboard_setup: dict[str, t.Any]) -> Event:
+    """An event whose name/description and tier name all match one search term,
+
+    and whose tier is restricted to TWO membership tiers — the M2M that would
+    duplicate rows if it were ever joined instead of prefetched.
+    """
+    org = dashboard_setup["orgs"]["ticket"]
+    event = Event.objects.create(
+        organization=org,
+        name="Gala Night",
+        slug="gala-night",
+        description="Gala Night is the event of the season",
+        status="open",
+        start=timezone.now() + timedelta(days=3),
+        end=timezone.now() + timedelta(days=4),
+    )
+    tier = event.ticket_tiers.first()
+    assert tier is not None
+    tier.name = "Gala Night Pass"
+    tier.save(update_fields=["name"])
+    mt1 = MembershipTier.objects.create(organization=org, name="Gold")
+    mt2 = MembershipTier.objects.create(organization=org, name="Silver")
+    tier.restricted_to_membership_tiers.add(mt1, mt2)
+    return event
+
+
+def test_dashboard_tickets_no_duplicates_with_m2m_and_search(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    fanout_event: Event,
+) -> None:
+    """Two tickets on an M2M-restricted tier come back exactly once each, searched or not."""
+    tier = fanout_event.ticket_tiers.first()
+    assert tier is not None
+    t1 = Ticket.objects.create(guest_name="G1", event=fanout_event, user=dashboard_user, tier=tier)
+    t2 = Ticket.objects.create(
+        guest_name="G2", event=fanout_event, user=dashboard_user, tier=tier, status=Ticket.TicketStatus.PENDING
+    )
+
+    url = reverse("api:dashboard_tickets")
+
+    data = _get_checked(dashboard_client, url)
+    ids = {item["id"] for item in data["results"]}
+    assert {str(t1.id), str(t2.id)} <= ids
+
+    # Search term matches event name, event description AND tier name simultaneously —
+    # the OR across three joined fields is the classic would-be fan-out shape.
+    data = _get_checked(dashboard_client, url, {"search": "Gala Night"})
+    assert data["count"] == 2
+    assert {item["id"] for item in data["results"]} == {str(t1.id), str(t2.id)}
+
+    # Filters + search combined still exact.
+    data = _get_checked(dashboard_client, url, {"search": "Gala Night", "status": "pending"})
+    assert data["count"] == 1
+    assert data["results"][0]["id"] == str(t2.id)
+
+
+def test_dashboard_tickets_no_distinct_baseline(dashboard_client: Client, dashboard_setup: dict[str, t.Any]) -> None:
+    """The seeded ticket serves a non-empty page with no DISTINCT and no duplicates."""
+    data = _get_checked(dashboard_client, reverse("api:dashboard_tickets"))
+    assert data["count"] >= 1  # non-empty: the wide query actually ran
+
+
+def test_dashboard_rsvps_no_duplicates_multi_status(
+    dashboard_client: Client,
+    dashboard_user: RevelUser,
+    fanout_event: Event,
+    dashboard_setup: dict[str, t.Any],
+) -> None:
+    """Multi-value status filter plus search returns each RSVP exactly once."""
+    EventRSVP.objects.create(event=fanout_event, user=dashboard_user, status="yes")
+
+    url = reverse("api:dashboard_rsvps")
+    data = _get_checked(dashboard_client, url)
+    assert data["count"] == 2  # setup's RSVP + this one
+
+    # status is a list filter (status__in) — the multi-VALUE (not multi-join) case.
+    data = _get_checked(dashboard_client, url, {"status": ["yes", "maybe"], "search": "Gala Night"})
+    assert data["count"] == 1
+
+
+def test_dashboard_invitation_requests_no_distinct(dashboard_client: Client, dashboard_setup: dict[str, t.Any]) -> None:
+    _get_checked(dashboard_client, reverse("api:dashboard_invitation_requests"))

--- a/src/events/tests/test_controllers/test_permission_snapshot.py
+++ b/src/events/tests/test_controllers/test_permission_snapshot.py
@@ -1,0 +1,142 @@
+"""Tests for the my-permissions payload cache (#880).
+
+Pins the contract of ``events.service.permission_snapshot``: short-TTL per-user cache,
+post-commit (never in-transaction) invalidation at the two grant sites, rollback safety,
+and fail-open behavior when the cache backend errors.
+"""
+
+import typing as t
+
+import pytest
+from django.core.cache import cache
+from django.db import transaction
+from django.test.client import Client
+from django.urls import reverse
+
+from accounts.models import RevelUser
+from events.models import Organization, OrganizationStaff, OrganizationToken
+from events.service import permission_snapshot
+from events.service.organization_service import lifecycle, tokens
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user(django_user_model: type[RevelUser]) -> RevelUser:
+    return django_user_model.objects.create_user(
+        username="snapshot-user", email="snapshot@example.com", password="p", email_verified=True
+    )
+
+
+def test_payload_is_cached_and_reused(user: RevelUser) -> None:
+    """The second call is served from the cache: later DB changes are not reflected."""
+    first = permission_snapshot.get_my_permissions_payload(user)
+    assert first["organization_permissions"] == {}
+
+    org = Organization.objects.create(name="Fresh Org", owner=RevelUser.objects.create_user("other-owner"))
+    OrganizationStaff.objects.create(organization=org, user=user)
+
+    second = permission_snapshot.get_my_permissions_payload(user)
+    assert second == first  # stale by design (60s TTL) — served from cache
+
+    cache.delete(permission_snapshot.get_cache_key(user.id))
+    third = permission_snapshot.get_my_permissions_payload(user)
+    assert str(org.id) in third["organization_permissions"]
+
+
+def test_cached_payload_matches_fresh_build(member_client: Client, member_user: RevelUser) -> None:
+    """First (miss) and second (hit) responses are byte-identical through the endpoint."""
+    url = reverse("api:my_permissions")
+    fresh = member_client.get(url)
+    cached = member_client.get(url)
+    assert fresh.status_code == cached.status_code == 200
+    assert fresh.json() == cached.json()
+
+
+def test_create_organization_invalidates_on_commit(user: RevelUser, django_capture_on_commit_callbacks: t.Any) -> None:
+    """The grant-site delete is deferred to commit — never issued inside the transaction."""
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)  # populate
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=False) as callbacks:
+        lifecycle.create_organization(owner=user, name="Snapshot Org", contact_email=user.email)
+        # Still cached: an in-transaction delete would reopen the repopulate race (#880).
+        assert cache.get(key) is not None
+
+    for callback in callbacks:
+        callback()
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert "owner" in payload["organization_permissions"].values()
+
+
+def test_claim_invitation_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Claiming a staff-granting token busts the claimer's cached map after commit."""
+    issuer = RevelUser.objects.create_user("token-issuer")
+    token = OrganizationToken.objects.create(
+        organization=organization, issuer=issuer, grants_staff_status=True, grants_membership=False
+    )
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        claimed = tokens.claim_invitation(user, str(token.pk))
+    assert claimed == organization
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert str(organization.id) in payload["organization_permissions"]
+
+
+def test_rollback_leaves_cache_untouched(user: RevelUser) -> None:
+    """A rolled-back mutation discards the on_commit delete — the cached value is still true."""
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+
+    class Boom(Exception):
+        pass
+
+    with pytest.raises(Boom), transaction.atomic():
+        permission_snapshot.invalidate_my_permissions(user.id)
+        raise Boom()
+
+    assert cache.get(key) is not None
+
+
+def test_endpoint_fails_open_when_cache_errors(
+    member_client: Client, member_user: RevelUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken cache backend degrades to the DB build — never a 500."""
+
+    def boom(*args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(permission_snapshot.cache, "get", boom)
+    monkeypatch.setattr(permission_snapshot.cache, "set", boom)
+
+    response = member_client.get(reverse("api:my_permissions"))
+    assert response.status_code == 200
+    assert str(Organization.objects.get(members=member_user).id) in response.json()["memberships"]
+
+
+def test_invalidation_delete_failure_does_not_raise(
+    user: RevelUser, monkeypatch: pytest.MonkeyPatch, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """A failed cache delete is swallowed — the mutation must never fail on Redis."""
+
+    def boom(*args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(permission_snapshot.cache, "delete_many", boom)
+    with django_capture_on_commit_callbacks(execute=True):
+        permission_snapshot.invalidate_my_permissions(user.id)  # must not raise
+
+
+def test_cache_key_is_versioned() -> None:
+    """The key embeds the bumpable version constant (rolling-deploy shape safety)."""
+    assert f":{permission_snapshot.CACHE_VERSION}:" in permission_snapshot.get_cache_key("abc")

--- a/src/events/tests/test_controllers/test_permission_snapshot.py
+++ b/src/events/tests/test_controllers/test_permission_snapshot.py
@@ -108,16 +108,29 @@ def test_rollback_leaves_cache_untouched(user: RevelUser) -> None:
     assert cache.get(key) is not None
 
 
+class _BrokenCache:
+    """Stand-in for a down Redis: every operation raises.
+
+    Swapped in for the *module binding* in ``permission_snapshot`` only — patching
+    methods on the shared Django cache proxy would also break the global throttles,
+    which 500 the request before it ever reaches the endpoint.
+    """
+
+    def get(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise ConnectionError("redis down")
+
+    def set(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise ConnectionError("redis down")
+
+    def delete_many(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise ConnectionError("redis down")
+
+
 def test_endpoint_fails_open_when_cache_errors(
     member_client: Client, member_user: RevelUser, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A broken cache backend degrades to the DB build — never a 500."""
-
-    def boom(*args: t.Any, **kwargs: t.Any) -> t.Any:
-        raise ConnectionError("redis down")
-
-    monkeypatch.setattr(permission_snapshot.cache, "get", boom)
-    monkeypatch.setattr(permission_snapshot.cache, "set", boom)
+    monkeypatch.setattr(permission_snapshot, "cache", _BrokenCache())
 
     response = member_client.get(reverse("api:my_permissions"))
     assert response.status_code == 200
@@ -128,11 +141,7 @@ def test_invalidation_delete_failure_does_not_raise(
     user: RevelUser, monkeypatch: pytest.MonkeyPatch, django_capture_on_commit_callbacks: t.Any
 ) -> None:
     """A failed cache delete is swallowed — the mutation must never fail on Redis."""
-
-    def boom(*args: t.Any, **kwargs: t.Any) -> t.Any:
-        raise ConnectionError("redis down")
-
-    monkeypatch.setattr(permission_snapshot.cache, "delete_many", boom)
+    monkeypatch.setattr(permission_snapshot, "cache", _BrokenCache())
     with django_capture_on_commit_callbacks(execute=True):
         permission_snapshot.invalidate_my_permissions(user.id)  # must not raise
 

--- a/src/revel/settings/base.py
+++ b/src/revel/settings/base.py
@@ -260,6 +260,15 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}",
+        # Bound every cache op: the default redis-py client has NO timeouts, so a hung
+        # (vs refused) Redis would block indefinitely — and the cache sits on every
+        # request's hot path via the global throttles (#880). A refused/timed-out op
+        # raises instead, which callers either surface (throttling) or absorb
+        # (fail-open caches like events.service.permission_snapshot).
+        "OPTIONS": {
+            "socket_connect_timeout": config("REDIS_SOCKET_CONNECT_TIMEOUT", cast=float, default=1.0),
+            "socket_timeout": config("REDIS_SOCKET_TIMEOUT", cast=float, default=1.0),
+        },
     }
 }
 


### PR DESCRIPTION
Implements all findings from #880 (endpoint performance umbrella). Root-cause analysis, measurements, and the invalidation spec live in that issue.

## Changes

### 1. Remove `.distinct()` from five list endpoints
`dashboard_tickets` / `dashboard_rsvps` / `dashboard_invitation_requests`, admin `list_tickets` / `list_ticket_tiers`.

`EXPLAIN ANALYZE` showed the DISTINCT over the wide `full()` select costs **~600ms–700ms of Postgres planning time per request** (execution: 1.5ms) — ~2.6s on demo hardware — while deduplicating nothing: every filter, search field, annotation, and ordering on these endpoints is a to-one join (verified exhaustively per field in #880). Git history confirms the `.distinct()` was never load-bearing here — the endpoints were born with it; the real duplicate-rows problem lived on the M2M-joining dashboard org/event endpoints and was fixed properly by the UNION-of-IDs refactor in #63.

**Regression tests** create the would-be fan-out conditions (tiers restricted to two membership tiers, search terms matching multiple joined fields simultaneously, multi-value status filters, `source` + annotation ordering) and assert exact counts, exact ID sets, no duplicate IDs, and no `SELECT DISTINCT` in the captured SQL. Measured locally: 615ms → **15ms**.

### 2. Memoize OpenAPI schema generation
django-ninja rebuilds the full schema (544 component schemas, 854KB) on every `/api/openapi.json` request — a public, unthrottled view (the API-level throttles don't apply to ninja's plain Django docs views), so each hit burned ~2.4s of CPU while pinning a gunicorn worker + PgBouncer connection. `CachedSchemaNinjaExtraAPI` builds it once per process; the schema depends only on registered routes and the mount prefix, both fixed after startup. The collision-guard tests reset the memo so they still observe real generation; `dump_openapi` is unaffected (single call, its monkeypatch active during the only build).

### 3. Fix admin Event-change-page inline widget N+1s (p95 4.2s)
The inlines rendered plain `<select>`s over entire tables — `seat` over every `VenueSeat` in the DB with one `__str__` query per option per row (+ the always-rendered empty form), `tiers` over every TicketTier, `user` over every registered user. Now `raw_id_fields` / `autocomplete_fields` on `TicketInline`, `TicketTierInline`, `EventInvitationInline`, `WaitlistOfferInline`.

### 4. Cache `my_permissions` (~147k req/week)
New `events/service/permission_snapshot.py`: per-user 60s-TTL cache of the rendered payload, versioned key (`my_permissions:v1:{user_id}`), plain `model_dump(mode="json")` dict (ninja re-validates on the way out, so a corrupt entry 500s loudly instead of serving plausible-but-wrong data), **fail-open on every cache op**.

Safety model (verified in #880): no server-side authorization ever reads this payload — every admin/staff/purchase endpoint re-checks the DB per request — so staleness is UI-only and bounded by the TTL. Explicit invalidation exists at exactly the two interactive grant sites where a stale miss would 403 the page the FE navigates to next (`create_organization`, `claim_invitation`), via `transaction.on_commit` — never in-transaction, which would reopen the invalidate-then-repopulate race under `ATOMIC_REQUESTS`. Tests pin the deferred-to-commit ordering, rollback safety, fail-open, and cache-hit/fresh-build equivalence.

Includes the free trim: `values_list` instead of hydrating full Organization rows for the staff map.

### 5. Bound Redis cache ops with socket timeouts
The built-in `RedisCache` client had no timeouts, so a hung (vs down) Redis would block the global throttle check on every request indefinitely. New `REDIS_SOCKET_CONNECT_TIMEOUT` / `REDIS_SOCKET_TIMEOUT` (default 1.0s), documented in `.env.example` and the troubleshooting env-var table.

## Not included (still open in #880)
- The two conditional per-row N+1s (`resolve_seat_pricing`, `resolve_total_available` → `staff_members`) — secondary, tens of ms.
- DB `lock_timeout` / `log_lock_waits` hardening for the 48s `confirm_ticket_payment` class — needs a value decision, separate change.

## Verification
- `mypy --strict` clean (1188 files); ruff format + lint clean; i18n / file-length / task-names gates pass.
- ~290 targeted tests pass: new regression suites, permissions, dashboard, admin tickets, org controller, error-response contracts, api tests.
- No migrations.

Closes nothing on its own — #880 stays open for the remaining items above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017x1LCUdzwpXo2upKb1R1zW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved permission loading with short-term caching and automatic updates after organization or invitation changes.
  * Prevented Redis operations from hanging indefinitely with configurable connection and socket timeouts.
  * Improved dashboard, ticket-list, and API schema performance while preserving unique results.

* **Admin Improvements**
  * Added faster ID selection and user autocomplete for large ticketing and waitlist forms.

* **Documentation**
  * Documented Redis timeout settings, defaults, and configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->