### PR TITLE
feat(wallet): rebrand passes to the brand gradient (Hearty Purple → Light Crimson)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ Revel is a Django-based event management & ticketing platform (apps under `src/`
   consistent tags; `PageNumberPaginationExtra`; `@searching` for search.
 - **Permissions** — `events/controllers/permissions.py`; org roles (Owner/Staff/Member);
   event-level eligibility; JWT auth with optional anonymous access.
+- **Brand tokens** — colors, gradient (vertical, Hearty Purple → Light Crimson), and
+  typography from the official style guide are recorded in
+  [`docs/brand-style-guide.md`](docs/brand-style-guide.md); use those exact hex/RGB
+  values, never re-derive them from HSL.
 
 ### Quality bar
 ruff (format + lint) · mypy `--strict` + Django plugin · Google-style docstrings ·

--- a/docs/brand-style-guide.md
+++ b/docs/brand-style-guide.md
@@ -1,0 +1,70 @@
+# Revel Brand Style Guide — Technical Tokens
+
+Source of truth: **Revel Digital Brand Styleguide** (Isabella Radich, 2026; InDesign
+source + PDF kept locally in `local_stuff/Revel_Digital-Styleguide/`, not committed).
+An earlier deck (*Branding + Social Media Design*, Acid Hairs, 2026-06-24) shows the
+same palette. This file records the technical values so code never has to rediscover
+them.
+
+## Colors
+
+| Role      | Name          | Hex       | RGB             |
+| --------- | ------------- | --------- | --------------- |
+| Primary   | Hearty Purple | `#8C3CDD` | `140, 60, 221`  |
+| Primary   | Light Crimson | `#E6332A` | `230, 51, 42`   |
+| Secondary | Lavender      | `#AB82DB` | `171, 130, 219` |
+| Secondary | Periwinkle    | `#9AB2FF` | `154, 178, 255` |
+| Highlight | Amber         | `#F9B233` | `249, 178, 51`  |
+| Text      | Ink           | `#0D1E1C` | `13, 30, 28`    |
+| Text      | White         | `#FFFFFF` | `255, 255, 255` |
+
+**The hex values are the contract.** The style-guide PDF's printed RGB lines contain
+typos (it prints "230, 52, 42" for Light Crimson and "1171, 130, 219" for Lavender);
+the hexes and the InDesign swatches agree on the values in the table above. Don't
+re-derive these colors from HSL tokens either — HSL→RGB truncation lands one unit off
+(e.g. `#8C3BDC` instead of `#8C3CDD`).
+
+## Brand gradient
+
+**Linear, vertical: Hearty Purple (top) → Light Crimson (bottom), midpoint at 50%**
+("Logo Gradient" page; the InDesign gradient swatch "Verlauf" runs Violett→Rot with
+these exact stops). This is the gradient of the RevelMark logo and the guide's cover.
+The older branding deck showed a diagonal-looking swatch — vertical is correct.
+
+## Logo
+
+- RevelMark "R" with heart counter, filled with the brand gradient; wordmark
+  "let's revel." underneath (Nata Sans: "let's" Light, "revel" Semibold, tracking 60).
+- Safe zone: ½× on all sides, where × is the height of the heart counter.
+- Don't crowd the logo against edges or other elements (see the guide's do/don't pages).
+
+## Typography
+
+- **Nata Sans** — main brand font, used universally (web + social). All family styles
+  allowed. Tracking 0 everywhere except the logo wordmark (60).
+- **BBH Bartle** — additional display font for social media designs, upper and
+  lowercase, tracking 0.
+- Both are open-source Google Fonts.
+
+## Picture style
+
+- **Do:** colourful, warm image language; closeness and a sense of community;
+  "real"-looking portraits.
+- **Don't:** classic stock imagery; people who feel like actors or models; cold,
+  distanced shots; corporate casual.
+
+## Where these tokens live in code
+
+- Backend wallet passes: `src/wallet/apple/formatting.py`
+  (`_HEARTY_PURPLE_RGB`, `_LIGHT_CRIMSON_RGB`; gradient endpoints via
+  `get_gradient_rgb()`, Google-rail hex via `get_theme_hex_background()`); vertical
+  gradient rendering in `src/wallet/apple/images.py` (`generate_gradient_background`).
+- Frontend: `revel-frontend/src/app.css` (`--logo-from`/`--logo-to`,
+  `--poster-purple`, `--poster-crimson`, `--poster-lavender`, `--poster-periwinkle`,
+  `--poster-amber`, `--poster-ink`). The frontend derives colors from HSL tokens, so
+  some render one RGB unit off the table above; there the HSL tokens are the contract,
+  and AA-contrast variants exist deliberately (e.g. `--poster-crimson-deep`
+  `hsl(3 79% 50%)` for white text panels).
+- Accessibility floor: white text on Hearty Purple ≈ 5.5:1 (AA for normal text);
+  white on raw Light Crimson ≈ 4.3:1 (fails AA normal text — use a deepened variant
+  behind white copy, as the frontend does).

--- a/src/wallet/apple/formatting.py
+++ b/src/wallet/apple/formatting.py
@@ -38,34 +38,36 @@ def _hsl_to_rgb_string(hue: float, saturation: float, lightness: float) -> str:
     return f"rgb({int(rgb[0] * 255)}, {int(rgb[1] * 255)}, {int(rgb[2] * 255)})"
 
 
-# HSL tokens shared by both wallet rails (see the theme comment below).
-_CRIMSON_DEEP_HSL = (3, 0.79, 0.50)
+# Brand tokens. The two primaries use the digital style guide's exact values
+# (Revel Digital Brand Styleguide, "Colours"): the hexes are the contract —
+# HSL->RGB truncation would land one unit off (#8C3BDC != #8C3CDD), and the
+# guide PDF's printed RGB for Light Crimson (230, 52, 42) is itself a typo
+# for hex E6332A. The label keeps the frontend's lavender-paper HSL token
+# (--background light: 268 60% 96%, rendering as #F4EEFA — one RGB unit
+# off the ticket PDF's paper #F3EFFA; the HSL token is the contract there).
+_HEARTY_PURPLE_RGB = (140, 60, 221)  # #8C3CDD, frontend --logo-from / --poster-purple
+_LIGHT_CRIMSON_RGB = (230, 51, 42)  # #E6332A, frontend --logo-to / --poster-crimson
 _LAVENDER_PAPER_HSL = (268, 0.60, 0.96)
 
 
-def _hsl_to_hex_string(hue: float, saturation: float, lightness: float) -> str:
-    """Convert HSL values to an uppercase #RRGGBB hex string.
+def _rgb_string(rgb: tuple[int, int, int]) -> str:
+    """Format an RGB tuple as Apple's expected "rgb(r, g, b)" string.
 
     Args:
-        hue: Hue in degrees (0-360).
-        saturation: Saturation (0-1).
-        lightness: Lightness (0-1).
+        rgb: (r, g, b) channel values, 0-255.
 
     Returns:
-        Uppercase hex color string in format "#RRGGBB".
+        Color string in format "rgb(r, g, b)".
     """
-    # colorsys uses HLS order (hue, lightness, saturation)
-    rgb = colorsys.hls_to_rgb(hue / 360, lightness, saturation)
-    return "#{:02X}{:02X}{:02X}".format(int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
+    return f"rgb({rgb[0]}, {rgb[1]}, {rgb[2]})"
 
 
-# Revel 2026 "crimson pop" theme (HSL tokens from frontend app.css):
-# crimson-deep panel (--poster-crimson-deep: 3 79% 50%, the AA-vs-white
-# variant of Light Crimson #E6332A), white text, lavender-paper labels
-# (--background light: 268 60% 96%, rendering as #F4EEFA — one RGB unit
-# off the ticket PDF's paper #F3EFFA; the HSL token is the contract).
+# Revel brand theme (2026 gradient rebrand): Hearty Purple panel (white text
+# measures ~5.5:1, AA pass), lavender-paper labels. The Apple rail layers the
+# vertical purple->crimson gradient background.png on top of this
+# backgroundColor; the Google rail can only render the solid hex.
 REVEL_THEME = PassColors(
-    background=_hsl_to_rgb_string(*_CRIMSON_DEEP_HSL),
+    background=_rgb_string(_HEARTY_PURPLE_RGB),
     foreground="rgb(255, 255, 255)",
     label=_hsl_to_rgb_string(*_LAVENDER_PAPER_HSL),
 )
@@ -75,19 +77,28 @@ def get_theme_colors() -> PassColors:
     """Get the Revel theme colors for passes.
 
     Returns:
-        PassColors with the Revel dark theme.
+        PassColors with the Revel brand theme.
     """
     return REVEL_THEME
 
 
-def get_theme_hex_background() -> str:
-    """Get the crimson-deep background as hex, for the Google Wallet rail.
+def get_gradient_rgb() -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Get the brand gradient endpoints for image generation.
 
     Returns:
-        Uppercase #RRGGBB string derived from the same HSL token as
+        (start, end) RGB tuples: Hearty Purple -> Light Crimson.
+    """
+    return _HEARTY_PURPLE_RGB, _LIGHT_CRIMSON_RGB
+
+
+def get_theme_hex_background() -> str:
+    """Get the Hearty Purple background as hex, for the Google Wallet rail.
+
+    Returns:
+        Uppercase #RRGGBB string for the same RGB token as
         ``REVEL_THEME.background``.
     """
-    return _hsl_to_hex_string(*_CRIMSON_DEEP_HSL)
+    return "#{:02X}{:02X}{:02X}".format(*_HEARTY_PURPLE_RGB)
 
 
 def format_iso_date(dt: datetime, tz: ZoneInfo | None = None) -> str:

--- a/src/wallet/apple/generator.py
+++ b/src/wallet/apple/generator.py
@@ -31,10 +31,12 @@ from wallet.apple.formatting import (
     get_theme_colors,
 )
 from wallet.apple.images import (
+    BACKGROUND_SIZES,
     ICON_SIZES,
     LOGO_SIZES,
     generate_colored_icon,
     generate_fallback_logo,
+    generate_gradient_background,
     parse_rgb_color,
     resize_image,
     resolve_cover_art,
@@ -299,6 +301,10 @@ class ApplePassGenerator:
         # Logos
         for filename, size in LOGO_SIZES.items():
             files[filename] = resize_image(pass_data.logo_image, size)
+
+        # Vertical brand-gradient background (iOS blurs it behind the pass)
+        for filename, size in BACKGROUND_SIZES.items():
+            files[filename] = generate_gradient_background(size)
 
         return files
 

--- a/src/wallet/apple/images.py
+++ b/src/wallet/apple/images.py
@@ -5,11 +5,14 @@ including creating placeholder logos, resizing images, and generating icons.
 """
 
 import colorsys
+import functools
 import io
 import typing as t
 
 import structlog
 from PIL import Image, ImageDraw, ImageFont
+
+from wallet.apple.formatting import get_gradient_rgb
 
 logger = structlog.get_logger(__name__)
 
@@ -27,6 +30,13 @@ LOGO_SIZES: dict[str, tuple[int, int]] = {
     "logo@3x.png": (480, 150),
 }
 
+# Apple background image: 180x220 points, blurred by iOS behind the pass front.
+BACKGROUND_SIZES: dict[str, tuple[int, int]] = {
+    "background.png": (180, 220),
+    "background@2x.png": (360, 440),
+    "background@3x.png": (540, 660),
+}
+
 
 def generate_colored_icon(size: tuple[int, int], color: tuple[int, int, int]) -> bytes:
     """Generate a simple colored square icon.
@@ -39,6 +49,30 @@ def generate_colored_icon(size: tuple[int, int], color: tuple[int, int, int]) ->
         PNG image as bytes.
     """
     img = Image.new("RGB", size, color)
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@functools.lru_cache(maxsize=len(BACKGROUND_SIZES))
+def generate_gradient_background(size: tuple[int, int]) -> bytes:
+    """Generate the vertical brand-gradient background PNG.
+
+    Bilinear upscaling of a 1x2 image renders an exact linear gradient from
+    the top color to the bottom one (digital style guide "Logo Gradient":
+    Hearty Purple -> Light Crimson). Cached per size: the gradient only
+    depends on the brand tokens, so each size renders once per process.
+
+    Args:
+        size: (width, height) of the output image in pixels.
+
+    Returns:
+        PNG image bytes.
+    """
+    start, end = get_gradient_rgb()
+    endpoints = Image.new("RGB", (1, 2))
+    endpoints.putdata([start, end])
+    img = endpoints.resize(size, Image.Resampling.BILINEAR)
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")
     return buffer.getvalue()

--- a/src/wallet/tests/test_formatting.py
+++ b/src/wallet/tests/test_formatting.py
@@ -15,6 +15,7 @@ from wallet.apple.formatting import (
     format_date_full,
     format_iso_date,
     format_price,
+    get_gradient_rgb,
     get_theme_colors,
     get_theme_hex_background,
 )
@@ -79,13 +80,13 @@ class TestGetThemeColors:
         colors = get_theme_colors()
         assert colors is REVEL_THEME
 
-    def test_theme_has_crimson_background(self) -> None:
-        """The theme background is the brand crimson-deep panel (3 79% 50%)."""
+    def test_theme_has_hearty_purple_background(self) -> None:
+        """The theme background is the brand primary Hearty Purple (#8C3CDD)."""
         colors = get_theme_colors()
-        assert colors.background == "rgb(228, 36, 26)"
+        assert colors.background == "rgb(140, 60, 221)"
 
     def test_theme_has_white_foreground(self) -> None:
-        """The theme foreground is white (AA on the crimson-deep panel)."""
+        """The theme foreground is white (AA on Hearty Purple, ~5.5:1)."""
         colors = get_theme_colors()
         assert colors.foreground == "rgb(255, 255, 255)"
 
@@ -248,10 +249,22 @@ class TestFormatPrice:
 
 
 def test_theme_hex_background_matches_rgb_theme() -> None:
-    """The Google-rail hex color must be the same crimson as the Apple rail."""
+    """The Google-rail hex color must be the same color as the Apple rail."""
     hex_color = get_theme_hex_background()
     match = re.fullmatch(r"rgb\((\d+), (\d+), (\d+)\)", REVEL_THEME.background)
     assert match is not None
     expected = "#{:02X}{:02X}{:02X}".format(*(int(g) for g in match.groups()))
     assert hex_color == expected
     assert re.fullmatch(r"#[0-9A-F]{6}", hex_color)
+
+
+def test_theme_hex_background_is_hearty_purple() -> None:
+    """The Google-rail hex is the exact style-guide Hearty Purple."""
+    assert get_theme_hex_background() == "#8C3CDD"
+
+
+def test_gradient_endpoints_match_style_guide() -> None:
+    """Gradient runs Hearty Purple -> Light Crimson (digital style guide hexes)."""
+    start, end = get_gradient_rgb()
+    assert start == (140, 60, 221)  # #8C3CDD
+    assert end == (230, 51, 42)  # #E6332A

--- a/src/wallet/tests/test_generator.py
+++ b/src/wallet/tests/test_generator.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.utils import timezone
+from PIL import Image
 
 from accounts.models import RevelUser
 from events.models import Event, Ticket, TicketTier
@@ -17,7 +18,7 @@ from events.models.ticket import Payment
 from events.models.venue import Venue
 from wallet.apple.formatting import PassColors
 from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD, ApplePassGenerator, ApplePassGeneratorError, PassData
-from wallet.apple.images import ICON_SIZES, LOGO_SIZES
+from wallet.apple.images import BACKGROUND_SIZES, ICON_SIZES, LOGO_SIZES
 from wallet.apple.signer import ApplePassSignerError
 
 pytestmark = pytest.mark.django_db
@@ -481,6 +482,39 @@ class TestApplePassGeneratorGenerateFiles:
         for logo_name in LOGO_SIZES:
             assert logo_name in files
 
+    def test_generates_gradient_backgrounds(
+        self, settings: t.Any, mock_signer: MagicMock, sample_logo_bytes: bytes
+    ) -> None:
+        """Should generate the brand-gradient background at all scales."""
+        settings.APPLE_WALLET_PASS_TYPE_ID = "pass.com.test"
+        settings.APPLE_WALLET_TEAM_ID = "TEAM123"
+
+        generator = ApplePassGenerator(signer=mock_signer)
+        now = timezone.now()
+        colors = PassColors(background="rgb(0,0,0)", foreground="rgb(255,255,255)", label="rgb(128,128,128)")
+
+        data = PassData(
+            serial_number="serial",
+            description="Test",
+            organization_name="Org",
+            event_name="Event",
+            event_start=now,
+            event_end=now + timedelta(hours=1),
+            address=None,
+            ticket_tier="Tier",
+            ticket_price="Free",
+            colors=colors,
+            logo_image=sample_logo_bytes,
+        )
+
+        files = generator._generate_files(data)
+
+        for background_name, expected_size in BACKGROUND_SIZES.items():
+            assert background_name in files
+            assert files[background_name][:8] == b"\x89PNG\r\n\x1a\n"
+            image = Image.open(io.BytesIO(files[background_name]))
+            assert image.size == expected_size
+
 
 class TestApplePassGeneratorCreateArchive:
     """Tests for _create_archive method."""
@@ -567,6 +601,11 @@ class TestApplePassGeneratorGeneratePass:
             # Should contain logos
             assert "logo.png" in namelist
             assert "logo@2x.png" in namelist
+
+            # Should contain gradient backgrounds
+            assert "background.png" in namelist
+            assert "background@2x.png" in namelist
+            assert "background@3x.png" in namelist
 
     def test_raises_on_signer_error(
         self,

--- a/src/wallet/tests/test_google_builder.py
+++ b/src/wallet/tests/test_google_builder.py
@@ -42,6 +42,7 @@ def test_ticket_payload_shape(google_wallet_configured_settings: None, ticket: T
     assert cls["eventName"]["defaultValue"]["value"] == event.name
     assert cls["reviewStatus"] == "UNDER_REVIEW"
     assert cls["hexBackgroundColor"] == get_theme_hex_background()
+    assert cls["hexBackgroundColor"] == "#8C3CDD"
     assert cls["dateTime"]["start"].startswith(str(event.start.year))
 
     assert obj["id"] == f"3388000000012345678.test.ticket.{ticket.id}"

--- a/src/wallet/tests/test_images.py
+++ b/src/wallet/tests/test_images.py
@@ -1,16 +1,19 @@
 """Tests for wallet/apple/images.py."""
 
 import io
+import typing as t
 from unittest.mock import MagicMock
 from uuid import UUID
 
 from PIL import Image
 
 from wallet.apple.images import (
+    BACKGROUND_SIZES,
     ICON_SIZES,
     LOGO_SIZES,
     generate_colored_icon,
     generate_fallback_logo,
+    generate_gradient_background,
     generate_text_logo,
     parse_rgb_color,
     resize_image,
@@ -379,3 +382,51 @@ class TestParseRgbColor:
         """Should parse white color."""
         result = parse_rgb_color("rgb(255, 255, 255)")
         assert result == (255, 255, 255)
+
+
+class TestGenerateGradientBackground:
+    """Tests for generate_gradient_background."""
+
+    def test_background_sizes_are_apple_spec(self) -> None:
+        """background.png is 180x220 points at 1x/2x/3x scales."""
+        assert BACKGROUND_SIZES == {
+            "background.png": (180, 220),
+            "background@2x.png": (360, 440),
+            "background@3x.png": (540, 660),
+        }
+
+    def test_generates_valid_png_at_each_size(self) -> None:
+        """Every declared size renders a PNG with exactly those dimensions."""
+        for size in BACKGROUND_SIZES.values():
+            png_bytes = generate_gradient_background(size)
+            img = Image.open(io.BytesIO(png_bytes))
+            assert img.format == "PNG"
+            assert img.size == size
+            assert img.mode == "RGB"
+
+    def test_gradient_runs_purple_to_crimson_vertically(self) -> None:
+        """Top edge is Hearty Purple, bottom edge is Light Crimson."""
+        png_bytes = generate_gradient_background((180, 220))
+        img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+        top = t.cast(tuple[int, int, int], img.getpixel((90, 0)))
+        bottom = t.cast(tuple[int, int, int], img.getpixel((90, 219)))
+        for channel, expected in zip(top, (140, 60, 221)):
+            assert abs(channel - expected) <= 3
+        for channel, expected in zip(bottom, (230, 51, 42)):
+            assert abs(channel - expected) <= 3
+
+    def test_gradient_is_horizontally_uniform(self) -> None:
+        """A vertical gradient has identical pixels across each row."""
+        png_bytes = generate_gradient_background((180, 220))
+        img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+        for y in (0, 110, 219):
+            assert img.getpixel((0, y)) == img.getpixel((90, y)) == img.getpixel((179, y))
+
+    def test_gradient_midpoint_blends_endpoints(self) -> None:
+        """The center pixel sits between the endpoints (a real gradient, not a fill)."""
+        png_bytes = generate_gradient_background((180, 220))
+        img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+        center = t.cast(tuple[int, int, int], img.getpixel((90, 110)))
+        for channel, start, end in zip(center, (140, 60, 221), (230, 51, 42)):
+            low, high = min(start, end), max(start, end)
+            assert low < channel < high


### PR DESCRIPTION
## Summary

Rebrands both wallet rails from the solid crimson-deep theme to the official brand identity, per the **Revel Digital Brand Styleguide**:

- **Apple**: real vertical gradient — `background.png`/`@2x`/`@3x` (Hearty Purple top → Light Crimson bottom) generated at runtime from the brand tokens (`lru_cache`d, no committed assets to drift) and bundled into every `.pkpass` (event tickets and series passes). `backgroundColor` and the notification icon become solid Hearty Purple.
- **Google**: `hexBackgroundColor` → `#8C3CDD` (the card can't render gradients — solid primary instead), flowing through the existing `get_theme_hex_background()` with zero builder changes.
- **Docs**: new `docs/brand-style-guide.md` codifies the guide's technical values, with a `CLAUDE.md` pointer.

Notable: the style-guide PDF's printed RGB values are typos (hex `E6332A` = `230, 51, 42`, not "230, 52, 42") — verified against the InDesign swatches. The hexes are the documented contract, and tokens are exact RGB (no HSL derivation, which lands one unit off).

## Test plan

- [x] 209 wallet tests pass (8 new: gradient sizes/direction/uniformity, bundle contents, token literals)
- [x] `make format` / `make lint` / `make mypy` clean
- [x] Signed sample `.pkpass` generated and pixel-checked (top row `140, 60, 221`, bottom row `230, 51, 42`)
- [ ] Device check: verify iOS renders the blurred gradient and the eventTicket front layout doesn't switch to the thumbnail variant (fallback if it does: drop the background images, keep solid purple)
- [ ] Google Wallet: save a pass and confirm the `#8C3CDD` card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017x1LCUdzwpXo2upKb1R1zW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added official Revel brand color, gradient, typography, logo, imagery, and accessibility guidance.
  - Updated Apple Wallet passes with the Hearty Purple theme and vertical purple-to-crimson gradient backgrounds.
  - Added correctly sized gradient background assets for Apple Wallet displays.

- **Bug Fixes**
  - Aligned wallet and Google Wallet background colors with the official brand value: `#8C3CDD`.

- **Documentation**
  - Added contributor guidance for using exact brand style tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->