### PR TITLE
perf(permissions): invalidate the my-permissions snapshot on staff grants

### DIFF
--- a/src/events/service/organization_service/membership.py
+++ b/src/events/service/organization_service/membership.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
 # events/migrations/0001_initial.py (referenced as a field `default=`), so it
 # cannot be renamed without breaking historical migrations.
 from events.models.organization import _get_default_permissions
-from events.service import blacklist_service
+from events.service import blacklist_service, permission_snapshot
 from notifications.enums import NotificationType
 from notifications.signals import notification_requested
 
@@ -592,7 +592,11 @@ def add_staff(
 
     permission_data = permissions.model_dump(mode="json") if permissions else _get_default_permissions()
 
-    return OrganizationStaff.objects.create(organization=organization, user=user, permissions=permission_data)
+    staff = OrganizationStaff.objects.create(organization=organization, user=user, permissions=permission_data)
+    # Staff grants are interactive ("try now") — the grantee's cached map must not
+    # outlive this grant (#884).
+    permission_snapshot.invalidate_my_permissions(user.id)
+    return staff
 
 
 def remove_staff(organization: Organization, user: RevelUser) -> None:
@@ -605,4 +609,7 @@ def update_staff_permissions(staff_member: OrganizationStaff, permissions: Permi
     """Update the permissions for a staff member."""
     staff_member.permissions = permissions.model_dump(mode="json")
     staff_member.save()
+    # Staff grants are interactive ("try now") — the grantee's cached map must not
+    # outlive this grant (#884).
+    permission_snapshot.invalidate_my_permissions(staff_member.user_id)
     return staff_member

--- a/src/events/service/permission_snapshot.py
+++ b/src/events/service/permission_snapshot.py
@@ -8,10 +8,11 @@ Safety model: no server-side authorization ever reads this payload — every adm
 purchase endpoint re-checks ``has_org_permission``/``is_owner_or_staff``/membership
 against the DB per request — so a stale entry can only mis-render UI affordances for up
 to the TTL, never grant access. Explicit invalidation therefore exists only where a
-*grant* is part of an interactive flow (org creation, invitation-token claim) and a
-stale miss would 403 the very page the frontend navigates to next; every other mutation
-(staff/member changes, bans, subscription syncs, admin edits, cascades) deliberately
-rides the TTL.
+*grant* is part of an interactive flow and a stale entry would 403 or blank the very
+surface the grant was made for: org creation, invitation-token claim, and staff grants
+(add_staff, update_staff_permissions — #884). Every other mutation (staff/member
+removals, bans, subscription syncs, admin edits, cascades) deliberately rides the TTL —
+narrowing directions can only mis-render dead affordances, never leak access.
 
 Cache ops fail open: a broken/unreachable Redis degrades to the plain DB build and never
 fails a request or a mutation.

--- a/src/events/tests/test_controllers/test_permission_snapshot.py
+++ b/src/events/tests/test_controllers/test_permission_snapshot.py
@@ -1,7 +1,7 @@
 """Tests for the my-permissions payload cache (#880).
 
 Pins the contract of ``events.service.permission_snapshot``: short-TTL per-user cache,
-post-commit (never in-transaction) invalidation at the two grant sites, rollback safety,
+post-commit (never in-transaction) invalidation at the grant sites, rollback safety,
 and fail-open behavior when the cache backend errors.
 """
 
@@ -14,9 +14,9 @@ from django.test.client import Client
 from django.urls import reverse
 
 from accounts.models import RevelUser
-from events.models import Organization, OrganizationStaff, OrganizationToken
+from events.models import Organization, OrganizationStaff, OrganizationToken, PermissionMap, PermissionsSchema
 from events.service import permission_snapshot
-from events.service.organization_service import lifecycle, tokens
+from events.service.organization_service import lifecycle, membership, tokens
 
 pytestmark = pytest.mark.django_db
 
@@ -91,6 +91,39 @@ def test_claim_invitation_invalidates_on_commit(
 
     payload = permission_snapshot.get_my_permissions_payload(user)
     assert str(organization.id) in payload["organization_permissions"]
+
+
+def test_add_staff_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Granting staff status busts the grantee's cached map after commit (#884)."""
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        membership.add_staff(organization, user)
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert str(organization.id) in payload["organization_permissions"]
+
+
+def test_update_staff_permissions_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Changing a staff member's permission map busts their cached map after commit (#884)."""
+    staff = OrganizationStaff.objects.create(organization=organization, user=user)
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        membership.update_staff_permissions(staff, PermissionsSchema(default=PermissionMap(create_event=True)))
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert payload["organization_permissions"][str(organization.id)]["default"]["create_event"] is True
 
 
 def test_rollback_leaves_cache_untouched(user: RevelUser) -> None:


### PR DESCRIPTION
Closes #884. Follow-up to #880 / #882.

## What

Adds post-commit invalidation of the my-permissions snapshot at the two **staff-grant** mutations in `events/service/organization_service/membership.py`:

- `add_staff` — promoting a member to staff (`POST /staff/{user_id}`)
- `update_staff_permissions` — changing a staff member's permission map (`PUT /staff/{user_id}/permissions`)

Both mirror the existing grant-site pattern (`lifecycle.py` org creation, `tokens.py` token claim): a couple of lines calling `permission_snapshot.invalidate_my_permissions(user.id)`, which is already post-commit safe and fail-open.

Also updates the documented invalidation rule in `permission_snapshot.py`'s module docstring — staff grants now belong to the invalidate-explicitly bucket, and the "rides the TTL" list is restated as the narrowing directions only.

## Why

Staff grants meet the same criterion as the existing invalidation sites: they are interactive (the owner grants while the colleague waits to "try now"), and a stale entry silently withholds the exact surface the grant was made for, for up to 60s, with no remedy available to the frontend — it cannot bust a server-side cache. Not a security issue: server-side authorization never reads this payload.

`remove_staff` deliberately stays on the TTL per the issue's scoping — the narrowing direction cannot leak access.

## Cost

Negligible: staff-permission writes are orders of magnitude rarer than the ~147k req/week the cache absorbs.

## Tests

Two new on-commit invalidation tests in `test_permission_snapshot.py`, written TDD (watched both fail against the old behaviour, for the right reason):

- `test_add_staff_invalidates_on_commit`
- `test_update_staff_permissions_invalidates_on_commit`

Verified: `test_permission_snapshot.py` 10 passed · `test_organization_admin/test_members.py` 56 passed · `test_service/test_organization_service.py` 53 passed · `make check` fully green (ruff, mypy strict, migrations, i18n, file lengths, task names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017x1LCUdzwpXo2upKb1R1zW