### PR TITLE
perf(permissions): invalidate the my-permissions snapshot on membership changes (#886)

### DIFF
--- a/src/events/service/organization_service/membership.py
+++ b/src/events/service/organization_service/membership.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
 # events/migrations/0001_initial.py (referenced as a field `default=`), so it
 # cannot be renamed without breaking historical migrations.
 from events.models.organization import _get_default_permissions
-from events.service import blacklist_service, permission_snapshot
+from events.service import blacklist_service
 from notifications.enums import NotificationType
 from notifications.signals import notification_requested
 
@@ -592,11 +592,8 @@ def add_staff(
 
     permission_data = permissions.model_dump(mode="json") if permissions else _get_default_permissions()
 
-    staff = OrganizationStaff.objects.create(organization=organization, user=user, permissions=permission_data)
-    # Staff grants are interactive ("try now") — the grantee's cached map must not
-    # outlive this grant (#884).
-    permission_snapshot.invalidate_my_permissions(user.id)
-    return staff
+    # Snapshot invalidation (#884) now happens in the OrganizationStaff signal receivers (#886).
+    return OrganizationStaff.objects.create(organization=organization, user=user, permissions=permission_data)
 
 
 def remove_staff(organization: Organization, user: RevelUser) -> None:
@@ -609,7 +606,4 @@ def update_staff_permissions(staff_member: OrganizationStaff, permissions: Permi
     """Update the permissions for a staff member."""
     staff_member.permissions = permissions.model_dump(mode="json")
     staff_member.save()
-    # Staff grants are interactive ("try now") — the grantee's cached map must not
-    # outlive this grant (#884).
-    permission_snapshot.invalidate_my_permissions(staff_member.user_id)
     return staff_member

--- a/src/events/signals.py
+++ b/src/events/signals.py
@@ -29,6 +29,7 @@ from events.models import (
     TicketTier,
 )
 from events.models.organization import MembershipTier
+from events.service import permission_snapshot
 from events.service.blacklist_service import apply_blacklist_consequences, link_blacklist_entries_for_user
 from events.service.follow_service import get_followers_for_new_event_notification
 from events.service.potluck_service import unclaim_user_potluck_items
@@ -273,6 +274,25 @@ def handle_membership_removed(sender: type[OrganizationMember], instance: Organi
         )
 
     transaction.on_commit(send_removal_notification)
+
+
+@receiver(post_save, sender=OrganizationMember)
+@receiver(post_delete, sender=OrganizationMember)
+@receiver(post_save, sender=OrganizationStaff)
+@receiver(post_delete, sender=OrganizationStaff)
+def invalidate_permission_snapshot(
+    sender: type[OrganizationMember | OrganizationStaff],
+    instance: OrganizationMember | OrganizationStaff,
+    **kwargs: t.Any,
+) -> None:
+    """Bust the user's cached my-permissions payload on any membership/staff write (#886).
+
+    Membership writes are scattered across services, Stripe sync, admin and signals, so
+    a receiver beats enumerating call sites. Note: ``bulk_create``/``bulk_update``
+    bypass signals — no such call sites exist for these models today; if one is added,
+    it must invalidate explicitly.
+    """
+    permission_snapshot.invalidate_my_permissions(instance.user_id)
 
 
 @receiver(post_save, sender=OrganizationStaff)

--- a/src/events/tests/test_controllers/test_permission_snapshot.py
+++ b/src/events/tests/test_controllers/test_permission_snapshot.py
@@ -1,8 +1,9 @@
 """Tests for the my-permissions payload cache (#880).
 
 Pins the contract of ``events.service.permission_snapshot``: short-TTL per-user cache,
-post-commit (never in-transaction) invalidation at the grant sites, rollback safety,
-and fail-open behavior when the cache backend errors.
+post-commit (never in-transaction) invalidation at the grant sites and via the
+membership/staff signal receivers (#886), rollback safety, and fail-open behavior
+when the cache backend errors.
 """
 
 import typing as t
@@ -14,7 +15,14 @@ from django.test.client import Client
 from django.urls import reverse
 
 from accounts.models import RevelUser
-from events.models import Organization, OrganizationStaff, OrganizationToken, PermissionMap, PermissionsSchema
+from events.models import (
+    Organization,
+    OrganizationMember,
+    OrganizationStaff,
+    OrganizationToken,
+    PermissionMap,
+    PermissionsSchema,
+)
 from events.service import permission_snapshot
 from events.service.organization_service import lifecycle, membership, tokens
 
@@ -124,6 +132,77 @@ def test_update_staff_permissions_invalidates_on_commit(
 
     payload = permission_snapshot.get_my_permissions_payload(user)
     assert payload["organization_permissions"][str(organization.id)]["default"]["create_event"] is True
+
+
+def test_membership_create_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Any OrganizationMember save busts the member's cached map after commit (#886)."""
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        OrganizationMember.objects.create(organization=organization, user=user)
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert str(organization.id) in payload["memberships"]
+
+
+def test_membership_status_change_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """A status update on an existing membership busts the cached map after commit (#886)."""
+    with django_capture_on_commit_callbacks(execute=True):
+        member = OrganizationMember.objects.create(organization=organization, user=user)
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        member.status = OrganizationMember.MembershipStatus.PAUSED
+        member.save()
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert payload["memberships"][str(organization.id)]["status"] == "paused"
+
+
+def test_membership_delete_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Deleting a membership busts the cached map after commit (#886)."""
+    with django_capture_on_commit_callbacks(execute=True):
+        member = OrganizationMember.objects.create(organization=organization, user=user)
+    key = permission_snapshot.get_cache_key(user.id)
+    permission_snapshot.get_my_permissions_payload(user)
+    assert cache.get(key) is not None
+
+    with django_capture_on_commit_callbacks(execute=True):
+        member.delete()
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert payload["memberships"] == {}
+
+
+def test_remove_staff_invalidates_on_commit(
+    user: RevelUser, organization: Organization, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Revoking staff status busts the ex-staffer's cached map after commit (#886)."""
+    with django_capture_on_commit_callbacks(execute=True):
+        OrganizationStaff.objects.create(organization=organization, user=user)
+    key = permission_snapshot.get_cache_key(user.id)
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert str(organization.id) in payload["organization_permissions"]
+
+    with django_capture_on_commit_callbacks(execute=True):
+        membership.remove_staff(organization, user)
+    assert cache.get(key) is None
+
+    payload = permission_snapshot.get_my_permissions_payload(user)
+    assert payload["organization_permissions"] == {}
 
 
 def test_rollback_leaves_cache_untouched(user: RevelUser) -> None:


### PR DESCRIPTION
Closes #886. Follow-up to #884 (#885), which shipped the staff half via explicit call sites.

## What

- **`events/signals.py`**: one receiver registered for `post_save` + `post_delete` on both `OrganizationMember` and `OrganizationStaff`, calling `invalidate_my_permissions(instance.user_id)` (already post-commit safe). A docstring notes the `bulk_create`/`bulk_update` blind spot — no such call sites exist for these models today.
- **`membership.py`**: removed #884's two explicit call sites (`add_staff`, `update_staff_permissions`) — now redundant.
- Kept the token-claim and org-creation call sites: the org-creation one covers owner permissions (derived from `Organization.owner`, which no receiver sees); the token-claim one is belt-and-braces.

## Why receivers, not call sites

Membership writes are spread across the membership manager, Stripe subscription sync, subscription mirroring in signals, org-admin endpoints, and the Django admin. Receivers cover all of them in one place — including queryset deletes (blacklist staff removal, a path #884 never covered) — and future write paths can't silently reintroduce the bug.

## Tests

New: membership create / status change / delete, and staff removal (previously uncovered) all bust the cache post-commit. Existing #884 staff tests pass unchanged through the receivers.

- `pytest src/events/tests/test_controllers/test_permission_snapshot.py` — 14 passed
- `test_organization_service.py` + signal test suites — 106 passed
- `test_organization_admin/` — 556 passed
- `make check` — clean (ruff, mypy --strict, migrations, i18n, task names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017x1LCUdzwpXo2upKb1R1zW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission changes now reliably refresh cached access information when memberships or staff assignments are created, updated, paused, or removed.
  * Updated permissions are reflected after database transactions complete.

* **Tests**
  * Added coverage for membership and staff changes to verify permission data is refreshed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->