### PR TITLE
feat(wallet): membership card PDF restyle + platform attribution on wallet passes

### DIFF
--- a/src/events/templates/events/membership_card.html
+++ b/src/events/templates/events/membership_card.html
@@ -8,285 +8,142 @@
         /* Brand tokens from docs/brand-style-guide.md (hexes are the contract):
            paper #F3EFFA · ink #0D1E1C · Hearty Purple #8C3CDD · Light Crimson #E6332A.
            Brand gradient is linear VERTICAL, Hearty Purple (top) -> Light Crimson (bottom). */
-        @page {
-            size: A4;
-            margin: 0;
-        }
+        @page { size: A4; margin: 0; }
+        html, body { margin: 0; padding: 0; }
         body {
             font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             font-weight: 300;
             color: #0D1E1C;
-            margin: 0;
-            padding: 0;
+            background: #F3EFFA;
         }
-        .card-container {
-            width: 100%;
+        .page {
+            width: 210mm; height: 296mm;
+            padding: 10mm;
+            box-sizing: border-box;
+        }
+        .card {
+            background: #FFFFFF;
+            border-radius: 18px;
+            overflow: hidden;
             height: 100%;
-            display: flex;
-            flex-direction: column;
-            page-break-inside: avoid;
+            display: flex; flex-direction: column;
+            border: 1px solid #D6CBE6;
         }
 
-        /* Cover Banner */
-        .cover-banner {
-            width: 100%;
-            height: 180px;
-            background: linear-gradient(to bottom, #8C3CDD 0%, #E6332A 100%);
-            position: relative;
-            overflow: hidden;
-        }
-        .cover-banner img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
-        .cover-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: linear-gradient(to top, rgba(13,30,28,0.82) 0%, rgba(13,30,28,0) 100%);
-            padding: 20px 30px;
+        /* Cover banner */
+        .banner { height: 46mm; position: relative; overflow: hidden; background: linear-gradient(to bottom, #8C3CDD, #E6332A); }
+        .banner img.cover { width: 100%; height: 100%; object-fit: cover; }
+        .banner-overlay {
+            position: absolute; left: 0; right: 0; bottom: 0;
+            padding: 6mm 9mm 5mm;
+            background: linear-gradient(to top, rgba(13,30,28,0.82), rgba(13,30,28,0));
             color: #FFFFFF;
         }
-        .cover-overlay .eyebrow {
-            margin: 0;
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 1.6px;
-            text-transform: uppercase;
-            opacity: 0.92;
+        .banner-overlay .eyebrow {
+            margin: 0 0 1.2mm; font-size: 6.5pt; font-weight: 600;
+            letter-spacing: 1.6px; text-transform: uppercase; opacity: 0.92;
         }
-        .cover-overlay h1 {
-            margin: 4px 0 0 0;
-            font-size: 24px;
-            font-weight: 600;
-        }
+        .banner-overlay h1 { margin: 0; font-size: 21pt; font-weight: 600; letter-spacing: 0.2px; }
 
-        /* Logo Section */
-        .logo-section {
-            display: flex;
-            align-items: center;
-            padding: 25px 30px;
-            background: #FFFFFF;
-            border-bottom: 2px solid #EDE7F6;
+        /* Member identity row */
+        .identity {
+            display: flex; align-items: center;
+            padding: 7mm 9mm;
+            border-bottom: 1px solid #EDE7F6;
         }
-        .logo-container {
-            width: 60px;
-            height: 60px;
-            border-radius: 8px;
-            flex-shrink: 0;
-            overflow: hidden;
-            margin-right: 15px;
+        .logo {
+            width: 16mm; height: 16mm; border-radius: 10px;
+            overflow: hidden; flex-shrink: 0; margin-right: 5mm;
+            border: 1px solid #EDE7F6;
         }
-        .logo-container img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
-        .member-name {
-            flex: 1;
-        }
-        .member-name .name {
-            font-size: 18px;
-            font-weight: 600;
-            color: #0D1E1C;
-            margin: 0;
-        }
-        .member-name .since {
-            font-size: 12px;
-            color: #46405E;
-            margin: 3px 0 0 0;
-        }
+        .logo img { width: 100%; height: 100%; object-fit: cover; }
+        .identity .who { flex: 1; }
+        .identity .name { margin: 0; font-size: 15pt; font-weight: 600; }
+        .identity .since { margin: 1.2mm 0 0; font-size: 9pt; color: #46405E; }
         .tier-badge {
             display: inline-block;
-            background: #8C3CDD;
-            color: #FFFFFF;
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 0.4px;
+            background: #8C3CDD; color: #FFFFFF;
+            font-size: 7.5pt; font-weight: 600; letter-spacing: 0.8px;
             text-transform: uppercase;
-            padding: 5px 12px;
-            border-radius: 999px;
-            margin-left: 10px;
+            padding: 1.6mm 4mm; border-radius: 999px;
+            margin-left: 4mm; vertical-align: middle;
         }
 
-        /* Content Section */
-        .content-section {
-            padding: 25px 30px;
-            background: #FFFFFF;
+        /* QR centerpiece */
+        .qr-zone {
             flex: 1;
-        }
-        .info-card {
-            background: #F8F5FC;
-            border-left: 4px solid #8C3CDD;
-            padding: 15px;
-            border-radius: 4px;
-        }
-        .info-row {
-            display: flex;
-            margin: 8px 0;
-            font-size: 13px;
-        }
-        .info-label {
-            font-weight: 600;
-            color: #46405E;
-            min-width: 110px;
-        }
-        .info-value {
-            color: #0D1E1C;
-            flex: 1;
-        }
-
-        /* QR Code Section */
-        .qr-section {
+            display: flex; flex-direction: column;
+            align-items: center; justify-content: center;
             text-align: center;
-            padding: 20px 30px;
-            background: #FFFFFF;
-            border-top: 1px solid #EDE7F6;
+            padding: 8mm 9mm;
         }
-        .qr-code-container {
-            display: inline-block;
-            padding: 15px;
-            background: #FFFFFF;
-            border: 2px solid #8C3CDD;
-            border-radius: 8px;
+        .qr-zone .eyebrow {
+            font-size: 6.5pt; font-weight: 600; letter-spacing: 1.6px;
+            text-transform: uppercase; color: #8C3CDD; margin: 0 0 3mm;
         }
-        .qr-code-container img {
-            display: block;
+        .qr-sticker {
+            background: #FFFFFF; border: 1px solid #D6CBE6; border-radius: 14px;
+            padding: 5mm; margin: 0 0 5mm;
         }
-        .qr-instruction {
-            margin-top: 12px;
-            font-size: 11px;
-            color: #8C3CDD;
-        }
-        .member-id-short {
-            margin-top: 6px;
-            font-family: monospace;
-            font-size: 11px;
-            color: #46405E;
-        }
+        .qr-sticker img { display: block; width: 48mm; height: 48mm; }
+        .instruction { font-size: 9pt; color: #46405E; margin: 0; line-height: 1.5; }
+        .mid { font-family: monospace; font-size: 8pt; color: #8C3CDD; margin: 4mm 0 0; }
 
-        /* Footer Section */
-        .footer-section {
-            padding: 16px 30px;
-            background: #F8F5FC;
+        /* Footer */
+        .footer {
             border-top: 1px solid #EDE7F6;
-            text-align: center;
+            padding: 4mm 9mm; display: flex; align-items: center; justify-content: space-between;
         }
-        .footer-section p {
-            margin: 4px 0;
-            font-size: 10px;
-            color: #8A82A6;
-        }
-        .member-id {
-            font-family: monospace;
-            color: #46405E;
-        }
-
-        /* Powered by revel. footer */
-        .brand-footer {
-            padding: 10px 30px 14px;
-            background: #F8F5FC;
-            text-align: center;
-            border-top: 1px solid #EDE7F6;
-        }
-        .brand-footer-inner {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-        }
-        .brand-footer img {
-            width: 4.2mm;
-            height: 4.8mm;
-        }
-        .brand-footer-text {
-            font-size: 9px;
-            color: #8A82A6;
-            letter-spacing: 0.2px;
-        }
-        .brand-footer .wordmark {
-            font-size: 9.5px;
-            font-weight: 600;
-            letter-spacing: 0.06em;
-        }
-
-        /* Decorative accent bar */
-        .accent-bar {
-            height: 4px;
-            background: linear-gradient(to right, #8C3CDD, #E6332A);
-        }
+        .legal { font-size: 7pt; color: #8A82A6; margin: 0; }
+        /* "Powered by revel." lockup — mirrors the FE RevelWordmark: "revel" SemiBold in the
+           brand gradient (per-letter #8C3CDD → #E6332A: WeasyPrint has no background-clip:text),
+           period in ink, tracking 0.06em on the wordmark. */
+        .powered { display: flex; align-items: center; gap: 1.8mm; white-space: nowrap; }
+        .powered img { width: 4.2mm; height: 4.8mm; }
+        .powered .by { font-size: 8pt; font-weight: 300; color: #46405E; }
+        .powered .wordmark { font-size: 8.5pt; font-weight: 600; letter-spacing: 0.06em; }
+        .powered .dot { color: #0D1E1C; }
     </style>
 </head>
 <body>
-    <div class="card-container">
-        <!-- Cover Banner -->
-        <div class="cover-banner">
-            {% if cover_art_url %}
-            <img src="{{ cover_art_url }}" alt="">
-            {% endif %}
-            <div class="cover-overlay">
+<div class="page">
+    <div class="card">
+        <div class="banner">
+            {% if cover_art_url %}<img class="cover" src="{{ cover_art_url }}" alt="">{% endif %}
+            <div class="banner-overlay">
                 <p class="eyebrow">Membership</p>
                 <h1>{{ organization_name }}</h1>
             </div>
         </div>
 
-        <div class="accent-bar"></div>
-
-        <!-- Logo and Member Name -->
-        <div class="logo-section">
+        <div class="identity">
             {% if logo_url %}
-            <div class="logo-container">
-                <img src="{{ logo_url }}" alt="">
-            </div>
+            <div class="logo"><img src="{{ logo_url }}" alt=""></div>
             {% endif %}
-            <div class="member-name">
+            <div class="who">
                 <p class="name">{{ member_name }}{% if tier_name %}<span class="tier-badge">{{ tier_name }}</span>{% endif %}</p>
                 <p class="since">Member since {{ member_since }}</p>
             </div>
         </div>
 
-        <!-- Details -->
-        <div class="content-section">
-            <div class="info-card">
-                <div class="info-row">
-                    <span class="info-label">Organization</span>
-                    <span class="info-value">{{ organization_name }}</span>
-                </div>
-                {% if tier_name %}
-                <div class="info-row">
-                    <span class="info-label">Tier</span>
-                    <span class="info-value">{{ tier_name }}</span>
-                </div>
-                {% endif %}
+        <div class="qr-zone">
+            <p class="eyebrow">Member</p>
+            <div class="qr-sticker">
+                <img src="data:image/png;base64,{{ qr_code_base64 }}" alt="Membership Card QR Code">
             </div>
+            <p class="instruction">Present this QR code to verify your membership.</p>
+            <p class="mid">{{ member_id_short }}</p>
         </div>
 
-        <!-- QR Code -->
-        <div class="qr-section">
-            <div class="qr-code-container">
-                <img src="data:image/png;base64,{{ qr_code_base64 }}" alt="Membership Card QR Code" width="140" height="140">
-            </div>
-            <p class="qr-instruction">Present this QR code to verify your membership</p>
-            <p class="member-id-short">{{ member_id_short }}</p>
-        </div>
-
-        <!-- Footer -->
-        <div class="footer-section">
-            <p>This card identifies its holder as a member; status is confirmed at scan time. Event entry requires a valid ticket.</p>
-            <p class="member-id">{{ member_id }}</p>
-        </div>
-
-        <!-- Powered by revel. -->
-        <div class="brand-footer">
-            <div class="brand-footer-inner">
-                {% if brand_mark %}
+        <div class="footer">
+            <p class="legal">Status is confirmed at scan time &middot; Event entry requires a valid ticket &middot; {{ member_id }}</p>
+            <div class="powered">
                 <img src="file://{{ brand_mark }}" alt="">
-                {% endif %}
-                <span class="brand-footer-text">Powered by</span>
-                <span class="wordmark"><span style="color:#8C3CDD">r</span><span style="color:#A33AB0">e</span><span style="color:#B93884">v</span><span style="color:#D03557">e</span><span style="color:#E6332A">l</span><span style="color:#0D1E1C">.</span></span>
+                <span class="by">Powered by</span>
+                <span class="wordmark"><span style="color:#8C3CDD">r</span><span style="color:#A33AB0">e</span><span style="color:#B93884">v</span><span style="color:#D03557">e</span><span style="color:#E6332A">l</span><span class="dot">.</span></span>
             </div>
         </div>
     </div>
+</div>
 </body>
 </html>

--- a/src/wallet/apple/generator.py
+++ b/src/wallet/apple/generator.py
@@ -52,6 +52,14 @@ logger = structlog.get_logger(__name__)
 # Gives attendees time after the event officially ends (e.g. encores, delays).
 PASS_EXPIRATION_GRACE_PERIOD = timedelta(hours=12)
 
+# Platform attribution on the back of every pass — the wallet equivalent of the
+# PDF footer's "Powered by revel." lockup. Product URL, not the instance URL:
+# attribution points at the project even on self-hosted deployments. Also used
+# by the Google rail (linksModuleData) so both rails stay in sync.
+POWERED_BY_LABEL = "Powered by"
+POWERED_BY_VALUE = "Revel — https://letsrevel.io"
+POWERED_BY_URL = "https://letsrevel.io"
+
 
 @dataclass
 class PassData:
@@ -264,6 +272,7 @@ class ApplePassGenerator:
                 "backFields": [
                     {"key": "member_id", "label": "Member ID", "value": data.serial_number},
                     {"key": "org", "label": "Organization", "value": data.organization_name},
+                    {"key": "powered_by", "label": POWERED_BY_LABEL, "value": POWERED_BY_VALUE},
                 ],
             },
         }
@@ -588,6 +597,8 @@ class ApplePassGenerator:
                     "value": "\n".join(seating_parts),
                 }
             )
+
+        fields.append({"key": "powered_by", "label": POWERED_BY_LABEL, "value": POWERED_BY_VALUE})
 
         return fields
 

--- a/src/wallet/google/builder.py
+++ b/src/wallet/google/builder.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from events.models import Event, HeldSeriesPass, Organization, OrganizationMember, Ticket
 from events.utils import get_event_timezone, get_organization_timezone
 from wallet.apple.formatting import format_iso_date, format_price, get_theme_hex_background
-from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD
+from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD, POWERED_BY_URL
 from wallet.pricing import resolve_ticket_price
 
 
@@ -31,6 +31,11 @@ def _pass_id(kind: str, entity_id: t.Any) -> str:
 def _localized(value: str) -> dict[str, t.Any]:
     """Wrap a string in Google's LocalizedString shape."""
     return {"defaultValue": {"language": "en", "value": value}}
+
+
+def _powered_by_links() -> dict[str, t.Any]:
+    """Platform attribution link — mirrors the Apple rail's powered_by back field."""
+    return {"uris": [{"id": "powered_by", "uri": POWERED_BY_URL, "description": "Powered by Revel"}]}
 
 
 def _org_logo_url(org: Organization) -> str | None:
@@ -159,6 +164,7 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
         "ticketType": _localized(ticket.tier.name),
         "validTimeInterval": {"end": {"date": format_iso_date(event.end + PASS_EXPIRATION_GRACE_PERIOD, tz=tz)}},
         "textModulesData": [{"id": "price", "header": "Price", "body": format_price(price, currency)}],
+        "linksModuleData": _powered_by_links(),
     }
     if ticket.guest_name:
         obj["ticketHolderName"] = ticket.guest_name
@@ -235,6 +241,7 @@ def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
         "textModulesData": [
             {"id": "price", "header": "Price", "body": format_price(held_pass.price_paid, series_pass.currency)}
         ],
+        "linksModuleData": _powered_by_links(),
     }
     return {"eventTicketClasses": [cls], "eventTicketObjects": [obj]}
 
@@ -281,6 +288,7 @@ def build_membership_payload(member: OrganizationMember) -> dict[str, t.Any]:
                 "body": "Your newest membership card supersedes any older ones.",
             },
         ],
+        "linksModuleData": _powered_by_links(),
     }
     if member.tier:
         obj["subheader"] = _localized(member.tier.name)

--- a/src/wallet/tests/test_generator.py
+++ b/src/wallet/tests/test_generator.py
@@ -922,3 +922,16 @@ class TestPassJsonFieldLayout:
         secondary = pass_dict["eventTicket"]["secondaryFields"]
 
         assert all(f["key"] not in ("venue", "address") for f in secondary)
+
+    def test_back_fields_end_with_powered_by(self, settings: t.Any, mock_signer: MagicMock) -> None:
+        """Every pass carries the platform attribution as the last back field."""
+        settings.APPLE_WALLET_PASS_TYPE_ID = "pass.com.test"
+        settings.APPLE_WALLET_TEAM_ID = "TEAM123"
+        generator = ApplePassGenerator(signer=mock_signer)
+
+        pass_dict = self._build_and_parse(generator)
+        back = pass_dict["eventTicket"]["backFields"]
+
+        assert back[-1]["key"] == "powered_by"
+        assert back[-1]["label"] == "Powered by"
+        assert "https://letsrevel.io" in back[-1]["value"]

--- a/src/wallet/tests/test_generator.py
+++ b/src/wallet/tests/test_generator.py
@@ -932,6 +932,8 @@ class TestPassJsonFieldLayout:
         pass_dict = self._build_and_parse(generator)
         back = pass_dict["eventTicket"]["backFields"]
 
-        assert back[-1]["key"] == "powered_by"
-        assert back[-1]["label"] == "Powered by"
-        assert "https://letsrevel.io" in back[-1]["value"]
+        assert back[-1] == {
+            "key": "powered_by",
+            "label": "Powered by",
+            "value": "Revel — https://letsrevel.io",
+        }

--- a/src/wallet/tests/test_generator_membership.py
+++ b/src/wallet/tests/test_generator_membership.py
@@ -67,8 +67,11 @@ def test_membership_pass_back_fields_carry_powered_by(
     """The membership card carries the platform attribution back field."""
     pass_json = _extract_pass_json(generator.generate_membership_pass(member))
     back = pass_json["generic"]["backFields"]
-    assert back[-1]["key"] == "powered_by"
-    assert "https://letsrevel.io" in back[-1]["value"]
+    assert back[-1] == {
+        "key": "powered_by",
+        "label": "Powered by",
+        "value": "Revel — https://letsrevel.io",
+    }
 
 
 @pytest.mark.django_db

--- a/src/wallet/tests/test_generator_membership.py
+++ b/src/wallet/tests/test_generator_membership.py
@@ -61,6 +61,17 @@ def test_membership_pass_tier_shown_and_omitted(
 
 
 @pytest.mark.django_db
+def test_membership_pass_back_fields_carry_powered_by(
+    generator: ApplePassGenerator, member: OrganizationMember
+) -> None:
+    """The membership card carries the platform attribution back field."""
+    pass_json = _extract_pass_json(generator.generate_membership_pass(member))
+    back = pass_json["generic"]["backFields"]
+    assert back[-1]["key"] == "powered_by"
+    assert "https://letsrevel.io" in back[-1]["value"]
+
+
+@pytest.mark.django_db
 def test_membership_pass_raises_on_signer_error(member: OrganizationMember) -> None:
     """ApplePassSignerError must propagate unchanged (mirrors the ticket generator contract)."""
     mock_signer = MagicMock()

--- a/src/wallet/tests/test_google_builder.py
+++ b/src/wallet/tests/test_google_builder.py
@@ -352,3 +352,17 @@ def test_series_pass_no_covered_events_falls_back_to_created_at(
 
     assert cls["dateTime"]["start"].startswith(str(held.created_at.year))
     assert "heroImage" not in cls
+
+
+def test_payload_objects_carry_powered_by_link(
+    google_wallet_configured_settings: None,
+    ticket: Ticket,
+    held_series_pass: t.Any,
+    google_covered_events: list[Event],
+) -> None:
+    """Ticket and series-pass objects carry the platform attribution link (mirrors the Apple back field)."""
+    from wallet.google.builder import build_series_pass_payload
+
+    expected = {"uris": [{"id": "powered_by", "uri": "https://letsrevel.io", "description": "Powered by Revel"}]}
+    assert build_ticket_payload(ticket)["eventTicketObjects"][0]["linksModuleData"] == expected
+    assert build_series_pass_payload(held_series_pass)["eventTicketObjects"][0]["linksModuleData"] == expected

--- a/src/wallet/tests/test_google_builder_membership.py
+++ b/src/wallet/tests/test_google_builder_membership.py
@@ -44,6 +44,18 @@ def test_membership_object_id_base_when_tierless(member: OrganizationMember, set
 
 
 @pytest.mark.django_db
+def test_membership_object_carries_powered_by_link(member: OrganizationMember, settings: t.Any) -> None:
+    """The membership card object carries the platform attribution link."""
+    settings.GOOGLE_WALLET_ISSUER_ID = "1234"
+    settings.GOOGLE_WALLET_CLASS_PREFIX = "revel"
+
+    obj = build_membership_payload(member)["genericObjects"][0]
+    assert obj["linksModuleData"] == {
+        "uris": [{"id": "powered_by", "uri": "https://letsrevel.io", "description": "Powered by Revel"}]
+    }
+
+
+@pytest.mark.django_db
 def test_membership_logo_uses_stable_indirection_url(
     member: OrganizationMember, png_bytes: bytes, settings: t.Any
 ) -> None:


### PR DESCRIPTION
Two related branding changes to member/attendee-facing artifacts:

## Membership card PDF restyle

The membership card PDF predated the 2026 rebrand of the ticket PDF and diverged badly (px-based, full-bleed, small purple-boxed QR). This reworks it onto the ticket template's design system while keeping the QR centered as the centerpiece:

- Lavender paper page + rounded white card shell (ticket `.page`/`.card`)
- 46mm cover banner with gradient fallback and overlay (eyebrow + org name)
- Member identity row: logo, name, tier pill, member-since
- QR in the ticket-style white sticker, enlarged to 48mm, centered, with scan instruction and short member ID
- Ticket-style footer: legal line + 'Powered by revel.' lockup

Template-only change; `create_membership_pdf` context keys unchanged.

## Platform attribution on Apple/Google wallet passes

The wallet equivalent of the PDF footer lockup. Neither platform has a footer slot on the pass face, and the front is the organizer's brand surface — so attribution goes on the back/details:

- **Apple**: `powered_by` back field ('Powered by · Revel — https://letsrevel.io', auto-linked by data detectors) on tickets, series passes, and membership cards
- **Google**: `linksModuleData` entry ('Powered by Revel' → https://letsrevel.io) on ticket, series-pass, and membership objects

Product URL by design (not the instance URL): attribution points at the project even on self-hosted deployments.

## Tests

- `src/events/tests/test_membership_card_pdf.py` — 4 passed
- `src/wallet/tests/` — 253 passed (5 new: Apple back-field ×2, Google links ×3)
- `make format lint mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned membership cards with a cleaner A4 layout and rounded borders.
  * Improved visual hierarchy for the cover banner, member identity, QR code, legal text, and footer.
  * Updated spacing, typography, colors, and branding presentation for a more polished printable card.

* **New Features**
  * Added “Powered by Revel” attribution to Apple Wallet and Google Wallet membership, ticket, and series passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->