### PR TITLE
chore(release): v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-08-12
+
+### Changed
+
+- Membership card PDF redesigned onto the ticket PDF's design system: rounded card on lavender paper, cover banner with gradient fallback, member identity row (logo, name, tier, member-since), enlarged centered QR sticker with scan instruction, and the standard legal/"Powered by revel." footer
+- Apple and Google Wallet passes (tickets, series passes, and membership cards) now carry a "Powered by Revel" attribution — an Apple back field and a Google links entry pointing at https://letsrevel.io
+
 ## [2.3.0] - 2026-08-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.3.0"
+version = "2.3.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.3.1] - 2026-08-12

### Changed

- Membership card PDF redesigned onto the ticket PDF's design system: rounded card on lavender paper, cover banner with gradient fallback, member identity row (logo, name, tier, member-since), enlarged centered QR sticker with scan instruction, and the standard legal/"Powered by revel." footer
- Apple and Google Wallet passes (tickets, series passes, and membership cards) now carry a "Powered by Revel" attribution — an Apple back field and a Google links entry pointing at https://letsrevel.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned membership card PDFs.
  * Added Revel attribution to Apple and Google Wallet passes for tickets, series passes, and membership cards.

* **Chores**
  * Updated the application version to 2.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->