### PR TITLE
fix(branding): align emails and invoices with style guide, extract shared pass CSS

### DIFF
--- a/src/common/templates/emails/base.html
+++ b/src/common/templates/emails/base.html
@@ -6,7 +6,7 @@
   <style>
     body { margin:0; padding:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; color:#0D1E1C; }
     .container { max-width:600px; margin:0 auto; background:#fff; }
-    .header { background:linear-gradient(135deg,#8C3CDD 0%,#E6332A 100%); padding:28px 20px; text-align:center; }
+    .header { background:linear-gradient(180deg,#8C3CDD 0%,#E6332A 100%); padding:28px 20px; text-align:center; }
     .content { padding:30px 20px; }
     .card { background:#f6f2fb; border-left:4px solid #8C3CDD; padding:20px; margin:20px 0; border-radius:4px; }
     .card--danger { background:#fdeceb; border-left-color:#E6332A; }
@@ -14,8 +14,8 @@
     .card--info { background:#eef1ff; border-left-color:#9AB2FF; }
     .info-row { margin:10px 0; }
     a { color:#8C3CDD; }
-    .button { display:inline-block; padding:14px 28px; background:linear-gradient(135deg,#8C3CDD 0%,#E6332A 100%); color:#fff !important; text-decoration:none; border-radius:6px; margin:20px 0; font-weight:600; }
-    .button--danger { background:#E6332A; }
+    .button { display:inline-block; padding:14px 28px; background:linear-gradient(180deg,#8C3CDD 0%,#E6332A 100%); color:#fff !important; text-decoration:none; border-radius:6px; margin:20px 0; font-weight:600; }
+    .button--danger { background:#E4251B; } /* deepened AA crimson behind white copy (style-guide accessibility floor) */
     .footer { background:#f6f2fb; padding:20px; text-align:center; color:#666; font-size:14px; }
     {% block extra_styles %}{% endblock %}
   </style>

--- a/src/events/templates/events/_pass_base_styles.html
+++ b/src/events/templates/events/_pass_base_styles.html
@@ -1,0 +1,61 @@
+{# Shared A4 print chrome for the pass/ticket PDFs (ticket.html, membership_card.html). #}
+{# Include via: {% include "events/_pass_base_styles.html" %}, then add a per-template   #}
+{# <style> block for page-specific rules.                                               #}
+{# Brand tokens from docs/brand-style-guide.md (hexes are the contract):                #}
+{#   paper #F3EFFA · ink #0D1E1C · Hearty Purple #8C3CDD · Light Crimson #E6332A.       #}
+{#   Brand gradient is linear VERTICAL, Hearty Purple (top) -> Light Crimson (bottom).  #}
+{% include "_fonts.html" %}
+<style>
+    @page { size: A4; margin: 0; }
+    html, body { margin: 0; padding: 0; }
+    body {
+        font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        font-weight: 300;
+        color: #0D1E1C;
+        background: #F3EFFA;
+    }
+    .page {
+        width: 210mm; height: 296mm;
+        padding: 10mm;
+        box-sizing: border-box;
+    }
+    .card {
+        background: #FFFFFF;
+        border-radius: 18px;
+        overflow: hidden;
+        height: 100%;
+        display: flex; flex-direction: column;
+        border: 1px solid #D6CBE6;
+    }
+
+    /* Cover banner */
+    .banner { height: 46mm; position: relative; overflow: hidden; background: linear-gradient(to bottom, #8C3CDD, #E6332A); }
+    .banner img.cover { width: 100%; height: 100%; object-fit: cover; }
+    .banner-overlay {
+        position: absolute; left: 0; right: 0; bottom: 0;
+        padding: 6mm 9mm 5mm;
+        background: linear-gradient(to top, rgba(13,30,28,0.82), rgba(13,30,28,0));
+        color: #FFFFFF;
+    }
+    .banner-overlay h1 { margin: 0; font-size: 21pt; font-weight: 600; letter-spacing: 0.2px; }
+
+    /* QR sticker frame (padding, margin and img size are set per template) */
+    .qr-sticker {
+        background: #FFFFFF; border: 1px solid #D6CBE6; border-radius: 14px;
+    }
+
+    /* Footer */
+    .footer {
+        border-top: 1px solid #EDE7F6;
+        padding: 4mm 9mm; display: flex; align-items: center; justify-content: space-between;
+    }
+    .legal { font-size: 7pt; color: #8A82A6; margin: 0; }
+    /* "Powered by revel." lockup — mirrors the FE RevelWordmark: "revel" SemiBold in the
+       brand gradient (per-letter #8C3CDD → #E6332A: WeasyPrint has no background-clip:text),
+       period in ink, tracking 0.06em on the wordmark. */
+    .powered { display: flex; align-items: center; gap: 1.8mm; white-space: nowrap; }
+    .powered img { width: 4.2mm; height: 4.8mm; }
+    .powered .by { font-size: 8pt; font-weight: 300; color: #46405E; }
+    .powered .wordmark { font-size: 8.5pt; font-weight: 600; letter-spacing: 0.06em; }
+    .powered .dot { color: #0D1E1C; }
+</style>

--- a/src/events/templates/events/membership_card.html
+++ b/src/events/templates/events/membership_card.html
@@ -3,47 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <title>Membership Card - {{ organization_name }}</title>
-    {% include "_fonts.html" %}
+    {% include "events/_pass_base_styles.html" %}
     <style>
-        /* Brand tokens from docs/brand-style-guide.md (hexes are the contract):
-           paper #F3EFFA · ink #0D1E1C · Hearty Purple #8C3CDD · Light Crimson #E6332A.
-           Brand gradient is linear VERTICAL, Hearty Purple (top) -> Light Crimson (bottom). */
-        @page { size: A4; margin: 0; }
-        html, body { margin: 0; padding: 0; }
-        body {
-            font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            font-weight: 300;
-            color: #0D1E1C;
-            background: #F3EFFA;
-        }
-        .page {
-            width: 210mm; height: 296mm;
-            padding: 10mm;
-            box-sizing: border-box;
-        }
-        .card {
-            background: #FFFFFF;
-            border-radius: 18px;
-            overflow: hidden;
-            height: 100%;
-            display: flex; flex-direction: column;
-            border: 1px solid #D6CBE6;
-        }
-
-        /* Cover banner */
-        .banner { height: 46mm; position: relative; overflow: hidden; background: linear-gradient(to bottom, #8C3CDD, #E6332A); }
-        .banner img.cover { width: 100%; height: 100%; object-fit: cover; }
-        .banner-overlay {
-            position: absolute; left: 0; right: 0; bottom: 0;
-            padding: 6mm 9mm 5mm;
-            background: linear-gradient(to top, rgba(13,30,28,0.82), rgba(13,30,28,0));
-            color: #FFFFFF;
-        }
         .banner-overlay .eyebrow {
             margin: 0 0 1.2mm; font-size: 6.5pt; font-weight: 600;
             letter-spacing: 1.6px; text-transform: uppercase; opacity: 0.92;
         }
-        .banner-overlay h1 { margin: 0; font-size: 21pt; font-weight: 600; letter-spacing: 0.2px; }
 
         /* Member identity row */
         .identity {
@@ -81,28 +46,10 @@
             font-size: 6.5pt; font-weight: 600; letter-spacing: 1.6px;
             text-transform: uppercase; color: #8C3CDD; margin: 0 0 3mm;
         }
-        .qr-sticker {
-            background: #FFFFFF; border: 1px solid #D6CBE6; border-radius: 14px;
-            padding: 5mm; margin: 0 0 5mm;
-        }
+        .qr-sticker { padding: 5mm; margin: 0 0 5mm; }
         .qr-sticker img { display: block; width: 48mm; height: 48mm; }
         .instruction { font-size: 9pt; color: #46405E; margin: 0; line-height: 1.5; }
         .mid { font-family: monospace; font-size: 8pt; color: #8C3CDD; margin: 4mm 0 0; }
-
-        /* Footer */
-        .footer {
-            border-top: 1px solid #EDE7F6;
-            padding: 4mm 9mm; display: flex; align-items: center; justify-content: space-between;
-        }
-        .legal { font-size: 7pt; color: #8A82A6; margin: 0; }
-        /* "Powered by revel." lockup — mirrors the FE RevelWordmark: "revel" SemiBold in the
-           brand gradient (per-letter #8C3CDD → #E6332A: WeasyPrint has no background-clip:text),
-           period in ink, tracking 0.06em on the wordmark. */
-        .powered { display: flex; align-items: center; gap: 1.8mm; white-space: nowrap; }
-        .powered img { width: 4.2mm; height: 4.8mm; }
-        .powered .by { font-size: 8pt; font-weight: 300; color: #46405E; }
-        .powered .wordmark { font-size: 8.5pt; font-weight: 600; letter-spacing: 0.06em; }
-        .powered .dot { color: #0D1E1C; }
     </style>
 </head>
 <body>

--- a/src/events/templates/events/ticket.html
+++ b/src/events/templates/events/ticket.html
@@ -3,43 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Ticket - {{ event_name }}</title>
-    {% include "_fonts.html" %}
+    {% include "events/_pass_base_styles.html" %}
     <style>
-        /* Brand tokens from docs/brand-style-guide.md (hexes are the contract):
-           paper #F3EFFA · ink #0D1E1C · Hearty Purple #8C3CDD · Light Crimson #E6332A.
-           Brand gradient is linear VERTICAL, Hearty Purple (top) -> Light Crimson (bottom). */
-        @page { size: A4; margin: 0; }
-        html, body { margin: 0; padding: 0; }
-        body {
-            font-family: 'Nata Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            font-weight: 300;
-            color: #0D1E1C;
-            background: #F3EFFA;
-        }
-        .page {
-            width: 210mm; height: 296mm;
-            padding: 10mm;
-            box-sizing: border-box;
-        }
-        .card {
-            background: #FFFFFF;
-            border-radius: 18px;
-            overflow: hidden;
-            height: 100%;
-            display: flex; flex-direction: column;
-            border: 1px solid #D6CBE6;
-        }
-
-        /* Cover banner */
-        .banner { height: 46mm; position: relative; overflow: hidden; background: linear-gradient(to bottom, #8C3CDD, #E6332A); }
-        .banner img.cover { width: 100%; height: 100%; object-fit: cover; }
-        .banner-overlay {
-            position: absolute; left: 0; right: 0; bottom: 0;
-            padding: 6mm 9mm 5mm;
-            background: linear-gradient(to top, rgba(13,30,28,0.82), rgba(13,30,28,0));
-            color: #FFFFFF;
-        }
-        .banner-overlay h1 { margin: 0; font-size: 21pt; font-weight: 600; letter-spacing: 0.2px; }
         .banner-overlay .org { margin: 1.5mm 0 0; font-size: 10pt; opacity: 0.92; }
 
         /* Pending-payment marker: unmistakable, brand crimson.
@@ -47,7 +12,7 @@
            docs/brand-style-guide.md accessibility floor): raw #E6332A vs white is 4.3:1. */
         .pending-banner {
             background: #E4251B; color: #FFFFFF; text-align: center;
-            font-size: 8.5pt; font-weight: 700; letter-spacing: 1.6px;
+            font-size: 8.5pt; font-weight: 600; letter-spacing: 1.6px;
             text-transform: uppercase; padding: 2.2mm 0;
         }
 
@@ -79,30 +44,12 @@
             display: flex; flex-direction: column; align-items: center; text-align: center;
         }
         .stub .eyebrow { color: #E6332A; }
-        .qr-sticker {
-            background: #FFFFFF; border: 1px solid #D6CBE6; border-radius: 14px;
-            padding: 4mm; margin: 3mm 0 4mm;
-        }
+        .qr-sticker { padding: 4mm; margin: 3mm 0 4mm; }
         .qr-sticker img { display: block; width: 36mm; height: 36mm; }
         .seat-big { font-size: 17pt; font-weight: 600; margin: 0; }
         .seat-sub { font-size: 9pt; color: #46405E; margin: 1.2mm 0 0; }
         .stub .instruction { font-size: 7.5pt; color: #46405E; margin-top: 4mm; line-height: 1.5; }
         .stub .tid { font-family: monospace; font-size: 7pt; color: #8C3CDD; margin-top: 6mm; }
-
-        /* Footer */
-        .footer {
-            border-top: 1px solid #EDE7F6;
-            padding: 4mm 9mm; display: flex; align-items: center; justify-content: space-between;
-        }
-        .legal { font-size: 7pt; color: #8A82A6; margin: 0; }
-        /* "Powered by revel." lockup — mirrors the FE RevelWordmark: "revel" SemiBold in the
-           brand gradient (per-letter #8C3CDD → #E6332A: WeasyPrint has no background-clip:text),
-           period in ink, tracking 0.06em on the wordmark. */
-        .powered { display: flex; align-items: center; gap: 1.8mm; white-space: nowrap; }
-        .powered img { width: 4.2mm; height: 4.8mm; }
-        .powered .by { font-size: 8pt; font-weight: 300; color: #46405E; }
-        .powered .wordmark { font-size: 8.5pt; font-weight: 600; letter-spacing: 0.06em; }
-        .powered .dot { color: #0D1E1C; }
     </style>
 </head>
 <body>

--- a/src/templates/_fonts.html
+++ b/src/templates/_fonts.html
@@ -1,3 +1,4 @@
+{# Only the 300 and 600 faces ship in src/fonts/ — templates must not request other weights. #}
 <style>
   @font-face { font-family:'Nata Sans'; font-weight:300; src:url('file://{{ font_dir }}/NataSans-Light.ttf'); }
   @font-face { font-family:'Nata Sans'; font-weight:600; src:url('file://{{ font_dir }}/NataSans-SemiBold.ttf'); }

--- a/src/templates/invoices/_base_styles.html
+++ b/src/templates/invoices/_base_styles.html
@@ -19,7 +19,7 @@
   body {
     font-family: 'Nata Sans', -apple-system, 'Helvetica Neue', Arial, sans-serif;
     font-size: 10pt;
-    color: #1a1a2e;
+    color: #0D1E1C;
     line-height: 1.5;
     padding: 50px 60px;
   }
@@ -57,8 +57,8 @@
 
   .supplier-name {
     font-size: 14pt;
-    font-weight: 700;
-    color: #1a1a2e;
+    font-weight: 600;
+    color: #0D1E1C;
     margin-bottom: 6px;
   }
 
@@ -74,7 +74,7 @@
 
   .invoice-title {
     font-size: 28pt;
-    font-weight: 800;
+    font-weight: 600;
     color: #8C3CDD;
     letter-spacing: 2px;
     margin-bottom: 12px;
@@ -87,7 +87,7 @@
   }
 
   .invoice-meta strong {
-    color: #1a1a2e;
+    color: #0D1E1C;
     display: inline-block;
     width: 100px;
     text-align: right;
@@ -106,7 +106,7 @@
 
   .bill-to-label {
     font-size: 8pt;
-    font-weight: 700;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1.5px;
     color: #8C3CDD;
@@ -115,8 +115,8 @@
 
   .bill-to-name {
     font-size: 12pt;
-    font-weight: 700;
-    color: #1a1a2e;
+    font-weight: 600;
+    color: #0D1E1C;
     margin-bottom: 4px;
   }
 
@@ -134,7 +134,7 @@
 
   .items-table thead th {
     font-size: 8pt;
-    font-weight: 700;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: #8C3CDD;
@@ -188,8 +188,8 @@
   .totals-row.total {
     padding-top: 10px;
     font-size: 14pt;
-    font-weight: 800;
-    color: #1a1a2e;
+    font-weight: 600;
+    color: #0D1E1C;
   }
 
   .footer {
@@ -206,7 +206,7 @@
 
   .footer-label {
     font-size: 8pt;
-    font-weight: 700;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1.5px;
     color: #8C3CDD;

--- a/src/templates/invoices/attendee_invoice.html
+++ b/src/templates/invoices/attendee_invoice.html
@@ -20,7 +20,7 @@
       left: 50%;
       transform: translate(-50%, -50%) rotate(-45deg);
       font-size: 120pt;
-      font-weight: 900;
+      font-weight: 600;
       color: rgba(200, 200, 200, 0.25);
       letter-spacing: 20px;
       z-index: -1;

--- a/src/templates/reports/revenue_vat_report.html
+++ b/src/templates/reports/revenue_vat_report.html
@@ -10,7 +10,7 @@
     .foot { font-size: 9px; color: #666; margin-top: 16px; }
     .items-table td.num, .items-table th.num { text-align: right; white-space: nowrap; }
     .total-row th { border-top: 2px solid #8C3CDD; }
-    h2 { font-size: 12pt; font-weight: 700; color: #8C3CDD; margin: 20px 0 8px; letter-spacing: 0.5px; text-transform: uppercase; }
+    h2 { font-size: 12pt; font-weight: 600; color: #8C3CDD; margin: 20px 0 8px; letter-spacing: 0.5px; text-transform: uppercase; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Brand-compliance audit of all outgoing branded content (emails, invoice/report PDFs, pass PDFs) against `docs/brand-style-guide.md` turned up 4 violations; this PR fixes all of them and extracts the print CSS duplicated between the ticket and membership-card PDFs.

### Brand fixes

- **Email gradient was diagonal** — `emails/base.html` header and CTA button used `linear-gradient(135deg, …)`; the guide mandates the vertical purple → crimson gradient and explicitly calls out the diagonal as the superseded older-deck look. Now `180deg`.
- **Danger button failed the guide's AA floor** — white copy on raw `#E6332A` (≈4.3:1). Now uses the sanctioned deep crimson `#E4251B`, matching how the ticket PDF's pending banner already handles it. Affects 7 templates (account delete, ticket cancelled, membership removed/rejected, …).
- **Invoices used off-brand ink** — `#1a1a2e` (matches no brand token) replaced with Ink `#0D1E1C` in `invoices/_base_styles.html` (5 places), affecting all invoice/credit-note/payout/VAT documents.
- **PDF font weights capped at 600** — templates requested Nata Sans 700/800/900 but only the 300/600 faces ship in `src/fonts/`, so WeasyPrint was silently substituting the 600 face anyway. Requests are now honest (zero visual change); `_fonts.html` documents the constraint.

### Shared pass CSS extraction

`ticket.html` and `membership_card.html` shared ~58 identical CSS lines (page frame, card, banner gradient, QR sticker frame, footer + "Powered by revel." lockup), hand-copied in the #889 restyle. Extracted into `events/_pass_base_styles.html`, mirroring the proven `invoices/_base_styles.html` include pattern. `series_pass.html` is left standalone (only ~25% overlap — genuinely different layout). Net **−44 lines**; the next pass restyle touches one file.

## Test plan

- [x] `test_ticket_templates_branding.py`, `test_email_templates_branding.py`, `test_ticket_templates.py`, `test_membership_card_pdf.py`, `test_invoice_branding.py`, `test_ticket_file_service.py` — **189 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YbEH5FH1ET6EPZCABR2JV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated email headers and buttons with vertical gradients and a deeper danger-button color.
  - Standardized styling across event passes, tickets, and membership cards, including fonts, branding, QR areas, and page layouts.
  - Refined invoice and revenue report PDFs with dark green branding and lighter heading weights.
  - Improved typography consistency across invoice watermarks and payment notices.
- **Accessibility**
  - Added guidance documenting the available font weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->