### PR TITLE
chore(release): v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-08-12
+
+### Fixed
+
+- Email headers and CTA buttons now use the brand's vertical purple → crimson gradient (was the superseded diagonal look)
+- Destructive-action email buttons (account deletion, ticket cancelled, membership removed/rejected, …) now use the deep crimson `#E4251B`, restoring WCAG AA contrast behind white copy
+- Invoice, credit-note, payout, and VAT-report PDFs now use the brand Ink color instead of an off-brand near-black
+
 ## [2.3.1] - 2026-08-12
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.3.1"
+version = "2.3.2"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.3.1"
+version = "2.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.3.2] - 2026-08-12

### Fixed

- Email headers and CTA buttons now use the brand's vertical purple → crimson gradient (was the superseded diagonal look)
- Destructive-action email buttons (account deletion, ticket cancelled, membership removed/rejected, …) now use the deep crimson `#E4251B`, restoring WCAG AA contrast behind white copy
- Invoice, credit-note, payout, and VAT-report PDFs now use the brand Ink color instead of an off-brand near-black


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email gradient styling.
  - Updated destructive-action button colors and contrast for better visibility.
  - Corrected Ink color usage in PDF documents.

- **Chores**
  - Updated the application version to 2.3.2.
  - Added release notes for version 2.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->