### PR TITLE
feat(seating): serve seatRotations through the public chart metadata whitelist

### DIFF
--- a/src/events/schema/seating.py
+++ b/src/events/schema/seating.py
@@ -33,11 +33,14 @@ class ChartSeatSchema(Schema):
 #   sector `metadata.aisles` / `metadata.transform`;
 # - the multi-floor convention (letsrevel/revel-frontend#680): venue
 #   `metadata.floors = [{id, name, order}]`, sector `metadata.floor = <floor id>`.
+# - per-seat rotation (letsrevel/revel-frontend#852): the designer's row-layout recipe
+#   (sector `metadata.rowLayout`) stays admin-only; only its compact buyer-facing mirror,
+#   sector `metadata.seatRotations = {"<seat label>": <degrees clockwise>}`, is whitelisted.
 # Admin/designer endpoints keep serving the full blob. Applied via
 # ``project_chart_metadata`` in ``events.service.seating.chart.build_chart`` (both levels)
 # and ``events.service.venue_service.get_tier_seat_availability`` (sector level).
 CHART_VENUE_METADATA_KEYS: t.Final = frozenset({"stage", "floors"})
-CHART_SECTOR_METADATA_KEYS: t.Final = frozenset({"transform", "aisles", "floor"})
+CHART_SECTOR_METADATA_KEYS: t.Final = frozenset({"transform", "aisles", "floor", "seatRotations"})
 
 
 def project_chart_metadata(metadata: dict[str, t.Any] | None, allowed: frozenset[str]) -> dict[str, t.Any] | None:

--- a/src/events/tests/test_controllers/test_seating_public.py
+++ b/src/events/tests/test_controllers/test_seating_public.py
@@ -73,9 +73,11 @@ def test_chart_projects_metadata_to_whitelisted_keys(
     """The anonymous chart serves a whitelisted projection, not the verbatim blob (#761).
 
     Venue level keeps only ``stage``/``floors``; sector level only
-    ``transform``/``aisles``/``floor`` — the keys the buyer renderer reads, including
-    the floors convention (letsrevel/revel-frontend#680). Whitelisted values pass
-    through verbatim; everything else the designer wrote is stripped.
+    ``transform``/``aisles``/``floor``/``seatRotations`` — the keys the buyer renderer
+    reads, including the floors convention (letsrevel/revel-frontend#680) and per-seat
+    rotation (letsrevel/revel-frontend#852). Whitelisted values pass through verbatim;
+    everything else the designer wrote — including the admin-only ``rowLayout`` recipe
+    that ``seatRotations`` is mirrored from — is stripped.
     """
     event, seats = seated_event
     venue = event.venue
@@ -91,7 +93,16 @@ def test_chart_projects_metadata_to_whitelisted_keys(
     sector = seats[0].sector
     transform = {"x": 0.0, "y": 120.0, "rotation": 90.0}
     aisles = {"verticalAisles": [4], "horizontalAisles": [2], "invertRowOrder": False}
-    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground", "scratch": "not for buyers"}
+    seat_rotations = {"A1": 45}
+    row_layout = {"curve": 0.3, "seed": 7}  # admin-only recipe; must never reach buyers
+    sector.metadata = {
+        "transform": transform,
+        "aisles": aisles,
+        "floor": "ground",
+        "seatRotations": seat_rotations,
+        "rowLayout": row_layout,
+        "scratch": "not for buyers",
+    }
     sector.save(update_fields=["metadata"])
 
     resp = client.get(f"/api/events/{event.id}/seating/chart")
@@ -99,7 +110,14 @@ def test_chart_projects_metadata_to_whitelisted_keys(
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["metadata"] == {"stage": stage, "floors": floors}
-    assert body["sectors"][0]["metadata"] == {"transform": transform, "aisles": aisles, "floor": "ground"}
+    sector_metadata = body["sectors"][0]["metadata"]
+    assert sector_metadata == {
+        "transform": transform,
+        "aisles": aisles,
+        "floor": "ground",
+        "seatRotations": seat_rotations,
+    }
+    assert "rowLayout" not in sector_metadata
 
 
 def test_chart_projects_non_whitelisted_metadata_to_empty_object(
@@ -158,20 +176,37 @@ def test_tier_seats_projects_sector_metadata_to_whitelisted_keys(
     """The anonymous seats endpoint serves the chart's sector projection, not the verbatim blob (#769).
 
     ``GET /events/{event_id}/tickets/{tier_id}/seats`` is the second anonymous surface
-    carrying sector metadata — same whitelist as the chart: ``transform``/``aisles``/``floor``.
+    carrying sector metadata — same whitelist as the chart: ``transform``/``aisles``/
+    ``floor``/``seatRotations`` (letsrevel/revel-frontend#852). The admin-only ``rowLayout``
+    recipe that ``seatRotations`` is mirrored from must never reach this surface.
     """
     event, seats = seated_event
     tier = _seated_tier(event, seats)
     sector = seats[0].sector
     transform = {"x": 0.0, "y": 120.0, "rotation": 90.0}
     aisles = {"verticalAisles": [4], "horizontalAisles": [2], "invertRowOrder": False}
-    sector.metadata = {"transform": transform, "aisles": aisles, "floor": "ground", "designer_note": "dock code 4711"}
+    seat_rotations = {"A1": 45}
+    sector.metadata = {
+        "transform": transform,
+        "aisles": aisles,
+        "floor": "ground",
+        "seatRotations": seat_rotations,
+        "rowLayout": {"curve": 0.3, "seed": 7},
+        "designer_note": "dock code 4711",
+    }
     sector.save(update_fields=["metadata"])
 
     resp = client.get(f"/api/events/{event.id}/tickets/{tier.id}/seats")
 
     assert resp.status_code == 200, resp.content
-    assert resp.json()["metadata"] == {"transform": transform, "aisles": aisles, "floor": "ground"}
+    body_metadata = resp.json()["metadata"]
+    assert body_metadata == {
+        "transform": transform,
+        "aisles": aisles,
+        "floor": "ground",
+        "seatRotations": seat_rotations,
+    }
+    assert "rowLayout" not in body_metadata
 
 
 def test_tier_seats_metadata_is_null_when_unset(client: Client, seated_event: tuple[Event, list[VenueSeat]]) -> None:


### PR DESCRIPTION
## Summary
- The frontend seat-geometry feature (letsrevel/revel-frontend#852) adds buyer-visible per-seat rotation, mirrored into `sector.metadata.seatRotations = {"<seat label>": <degrees clockwise>}` (sparse — only rotated seats), separate from the admin-only `rowLayout` recipe.
- Adds `"seatRotations"` to `CHART_SECTOR_METADATA_KEYS` in `src/events/schema/seating.py` so the public chart projection (`project_chart_metadata`) serves it verbatim.
- One constant, two consumers: `events.service.seating.chart.build_chart` (chart endpoint) and `events.service.venue_service.get_tier_seat_availability` (anonymous per-tier seats endpoint) both key off this same frozenset, so both anonymous surfaces pick it up with a single edit.
- `rowLayout` is **not** added to the whitelist and stays private — verified by test.
- Pure runtime projection change — no schema shape change, so no OpenAPI regen needed (metadata is already `dict[str, Any] | None`).
- Deploy-order-free: the frontend already renders nothing when the key is absent, so this can ship independently of the frontend PR in either order.

## Test plan
- [x] Extended `test_chart_projects_metadata_to_whitelisted_keys` and `test_tier_seats_projects_sector_metadata_to_whitelisted_keys` in `src/events/tests/test_controllers/test_seating_public.py`: sector metadata now includes both `seatRotations` (asserted present, verbatim) and `rowLayout` (asserted absent from the response) alongside the existing `transform`/`aisles`/`floor` keys.
- [x] `uv run pytest src/events/tests/test_controllers/test_seating_public.py src/events/tests/test_schema/test_venue_metadata_limits.py -q` → 48 passed
- [x] `uv run ruff format --check` / `uv run ruff check` / `uv run mypy` on changed files → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDXmzqVQzDQTBwT98KL9Wf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Seating chart metadata now includes per-seat rotation information for supported chart and tier-seat views.

- **Access and Privacy**
  - Internal row-layout details remain excluded from publicly displayed seating metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->