### PR TITLE
fix(deps): bump pip to 26.2.1 to resolve PYSEC-2026-3721 (#903)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2771,11 +2771,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Targeted lock bump: `pip` 26.1.2 → 26.2.1.

## Why

Nightly `pip-audit` on `main` has failed every night since 2026-08-22 (#903, 10 consecutive runs) on:

| Package | Version | Advisory | Fixed in |
|---|---|---|---|
| `pip` | 26.1.2 | `PYSEC-2026-3721` / `CVE-2026-13346` | 26.2 |

> pip would incorrectly handle doubly-encoded package URLs from indexes, allowing for files to be installed to arbitrary locations on disk even when installing wheels.

Exploitation requires downloading from a **malicious package index** — malicious packages alone are insufficient — and materially impacts `pip download --only-binary`. We resolve from PyPI via `uv`, so practical exposure is negligible. Bumping regardless, per the runbook's "**Bump** — preferred when a fixed version exists".

## How it reaches us

We never declare `pip`. The chain is `dev group → pip-audit → pip-api → pip` — pip-audit flagging its own transitive dependency. `pip-api` declares a bare, unconstrained `pip` requirement, so nothing pinned us to 26.1.2 except lockfile inertia.

Because `deps.yaml` is path-filtered on `pyproject.toml` / `uv.lock`, the graph is only re-resolved when a PR touches it. Nothing in the repo changed on 2026-08-22 — the *advisory database* did. That is exactly the case the nightly job exists to catch.

## Approach

```bash
uv lock --upgrade-package pip
```

Retargets that single node and leaves the other 320 packages pinned — a 3-line diff. `uv add` / `uv lock --upgrade` would have re-resolved the whole graph for no benefit.

`pyproject.toml` is untouched: no `[tool.uv]` security floor was added, since `pip` is not a direct dependency and the resolver now picks 26.2.1 on its own.

## Verification

```
$ make audit
No known vulnerabilities found
```

## Note

`pip` is not merely a CI artifact — `Dockerfile:132` copies the builder venv (which includes the `dev` group) into the runtime stage, so vulnerable `pip` was present in the deployed image. Narrowing what ships to production is out of scope here and tracked separately.

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDK2iN5sf8JDdGgKmo6cPC