### PR TITLE
fix(security): remediate 12 findings from the vuln-scan sweep

### DIFF
--- a/.claude/agents/tech-debt-assessor.md
+++ b/.claude/agents/tech-debt-assessor.md
@@ -1,7 +1,7 @@
 ---
 name: tech-debt-assessor
 description: "Use this agent to assess technical debt and code quality in a bounded region of the Revel codebase. It is the region-scoped **hunter** worker dispatched in parallel by the `/tech-debt` command, and can also be used standalone for an ad-hoc tech-debt review of a specific app, service, or module. For a full-repo assessment, prefer the `/tech-debt` slash command (which fans out many hunters + specialists + a verification pass and scores the whole repo) over invoking this agent directly.\\n\\nExamples:\\n\\n<example>\\nContext: The user wants a full repo health assessment.\\nuser: \"Let's do a tech debt review\"\\nassistant: \"I'll run the /tech-debt command, which fans out region + specialist hunters and produces a scored report.\"\\n<commentary>Full-repo sweep — prefer the /tech-debt command over invoking this agent directly.</commentary>\\n</example>\\n\\n<example>\\nContext: The user just finished a feature and wants a quick debt read on one app.\\nuser: \"Can you assess the tech debt in the questionnaires app I just reworked?\"\\nassistant: \"I'll launch the tech-debt-assessor scoped to questionnaires to produce a focused health report.\"\\n<commentary>Single-area review. Use the Task tool to launch tech-debt-assessor (Mode B).</commentary>\\n</example>"
-model: opus
+model: fable
 color: pink
 memory: project
 ---

--- a/.claude/agents/tech-debt-verifier.md
+++ b/.claude/agents/tech-debt-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: tech-debt-verifier
 description: "Adjudicates a single candidate tech-debt finding produced by the tech-debt-assessor hunter. Independently re-reads the cited code, confirms the debt is real and present-day (and for dead-code candidates, proves no references exist anywhere), and returns a verdict with a 0-100 confidence score. Dispatched in parallel (one per candidate) by the `/tech-debt` command's verification phase. Not intended for standalone use — it expects a single candidate finding as input."
-model: sonnet
+model: opus
 color: pink
 ---
 

--- a/.claude/agents/vuln-analyst.md
+++ b/.claude/agents/vuln-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: vuln-analyst
 description: "Use this agent to hunt for security vulnerabilities in a bounded region of the Revel codebase. It is the region-scoped **hunter** worker dispatched in parallel by the `/vuln-scan` command, and can also be used standalone for an ad-hoc security review of a specific endpoint, service, or app. For a full-codebase sweep, prefer the `/vuln-scan` slash command (which fans out many hunters + a verification pass) over invoking this agent directly.\\n\\nExamples:\\n\\n<example>\\nContext: The user just implemented a batch ticket purchase flow.\\nuser: \"I've finished the batch ticket purchase flow in events/controllers/ticket_controller.py and events/service/batch_ticket_service.py\"\\nassistant: \"Let me launch the vuln-analyst on the events ticketing region to hunt for access-control and race-condition issues.\"\\n<commentary>Scoped, high-risk change. Use the Task tool to launch vuln-analyst on those files.</commentary>\\n</example>\\n\\n<example>\\nContext: The user asks for a security review of a specific service.\\nuser: \"Can you do a security review of the questionnaire evaluation changes I just made?\"\\nassistant: \"I'll launch the vuln-analyst scoped to questionnaires/service to review the evaluation logic.\"\\n<commentary>Single-area review. Use the Task tool to launch vuln-analyst.</commentary>\\n</example>"
-model: opus
+model: fable
 color: yellow
 memory: project
 ---

--- a/.claude/agents/vuln-verifier.md
+++ b/.claude/agents/vuln-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: vuln-verifier
 description: "Adjudicates a single candidate security finding produced by the vuln-analyst hunter. Independently re-reads the cited code, attempts to confirm the exploit is real and present-day, and returns a verdict with a 0-100 confidence score. Dispatched in parallel (one per candidate) by the `/vuln-scan` command's verification phase. Not intended for standalone use — it expects a single candidate finding as input."
-model: sonnet
+model: opus
 color: orange
 ---
 

--- a/.claude/commands/tech-debt.md
+++ b/.claude/commands/tech-debt.md
@@ -96,7 +96,7 @@ If there are **zero** candidates after dedup, skip to Phase 5 and report a clean
 
 ## Phase 3 — Fan out VERIFIERS (parallel)
 
-For each surviving candidate, dispatch a `tech-debt-verifier` agent via the **Agent tool** with `subagent_type: "tech-debt-verifier"` (default model sonnet; you may use opus for CRITICAL-severity or repo-wide-impact candidates). One verifier per candidate; you may batch up to 3 closely-related candidates into a single verifier call, but ask it to emit one `### VERDICT` block per `id`. Cap concurrency at ~6 per wave.
+For each surviving candidate, dispatch a `tech-debt-verifier` agent via the **Agent tool** with `subagent_type: "tech-debt-verifier"` (default model opus, set in the agent's frontmatter; you may pass sonnet for trivial/LOW candidates to save cost). One verifier per candidate; you may batch up to 3 closely-related candidates into a single verifier call, but ask it to emit one `### VERDICT` block per `id`. Cap concurrency at ~6 per wave.
 
 Pass each verifier the **complete candidate block verbatim** (all fields). It independently re-reads the code and returns a `### VERDICT` with `verdict`, `confidence`, `severity`, `category`, and `reasoning`. **Dead-code candidates get special rigor** — the verifier must prove no references exist anywhere (including dynamic `getattr`, signal receivers, URL patterns, template/`__init__` re-exports) before confirming.
 

--- a/.claude/commands/vuln-scan.md
+++ b/.claude/commands/vuln-scan.md
@@ -78,7 +78,7 @@ If there are **zero** candidates after dedup, skip to Phase 5 and report a clean
 
 ## Phase 3 — Fan out VERIFIERS (parallel)
 
-For each surviving candidate, dispatch a `vuln-verifier` agent via the **Agent tool** with `subagent_type: "vuln-verifier"` (default model sonnet; you may use opus for CRITICAL-severity candidates). One verifier per candidate; if there are many trivial/low candidates you may batch up to 3 closely-related ones into a single verifier call, but ask it to emit one `### VERDICT` block per `id`. Cap concurrency at ~6 per wave.
+For each surviving candidate, dispatch a `vuln-verifier` agent via the **Agent tool** with `subagent_type: "vuln-verifier"` (default model opus, set in the agent's frontmatter; you may pass sonnet for trivial/LOW candidates to save cost). One verifier per candidate; if there are many trivial/low candidates you may batch up to 3 closely-related ones into a single verifier call, but ask it to emit one `### VERDICT` block per `id`. Cap concurrency at ~6 per wave.
 
 Pass each verifier the **complete candidate block verbatim** (all fields). It will independently re-read the code and return a `### VERDICT` with `verdict`, `confidence`, `severity`, and `reasoning`.
 

--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -319,7 +319,6 @@ def request_account_deletion(user: RevelUser) -> str:
     return token
 
 
-@transaction.atomic
 def reset_password(token: str, new_password: str) -> RevelUser:
     """Reset a user's password.
 
@@ -334,11 +333,19 @@ def reset_password(token: str, new_password: str) -> RevelUser:
     user = get_object_or_404(RevelUser, id=payload.user_id)
     # Re-check the global ban at reset time — a ban added after the token was issued
     # must block the reset (and the guest-to-full-user conversion below), mirroring
-    # verify_email. Blacklist the token so it cannot be retried.
+    # verify_email. Blacklist the token so it cannot be retried. This runs OUTSIDE the
+    # atomic block below on purpose: raising inside it would roll the blacklist row back
+    # along with the savepoint, leaving the token redeemable once the ban is lifted.
     if is_email_globally_banned(user.email):
         blacklist_token(token)
         logger.warning("password_reset_blocked_banned_user", user_id=str(user.id), email=user.email)
         raise HttpError(403, str(BAN_ERROR_MESSAGE))
+    return _apply_password_reset(user, token, new_password)
+
+
+@transaction.atomic
+def _apply_password_reset(user: RevelUser, token: str, new_password: str) -> RevelUser:
+    """Set the new password and consume the token (the atomic half of ``reset_password``)."""
     if GoogleSSOUser.objects.filter(user=user).exists():
         logger.warning("password_reset_blocked_google_sso_user", user_id=str(user.id), email=user.email)
         raise HttpError(400, str(_("Cannot reset password for Google SSO users.")))

--- a/src/accounts/service/account.py
+++ b/src/accounts/service/account.py
@@ -285,6 +285,14 @@ def request_password_reset(email: str) -> str | None:
     except RevelUser.DoesNotExist:
         logger.info("password_reset_user_not_found", email=email)
         return None
+
+    from accounts.service.global_ban_service import is_email_globally_banned
+
+    # Silently no-op for a banned address (mirrors resend_verification_email) so a
+    # banned guest cannot use the reset link to convert into a full account.
+    if is_email_globally_banned(user.email):
+        logger.info("password_reset_blocked_banned_user", user_id=str(user.id), email=email)
+        return None
     if GoogleSSOUser.objects.filter(user=user).exists():
         logger.info("password_reset_blocked_google_sso", user_id=str(user.id), email=email)
         return None
@@ -319,9 +327,18 @@ def reset_password(token: str, new_password: str) -> RevelUser:
         token (str): The password reset token.
         new_password (str): The new password.
     """
+    from accounts.service.global_ban_service import BAN_ERROR_MESSAGE, is_email_globally_banned
+
     payload = token_to_payload(token, schema.PasswordResetJWTPayloadSchema)
     check_blacklist(payload.jti)
     user = get_object_or_404(RevelUser, id=payload.user_id)
+    # Re-check the global ban at reset time — a ban added after the token was issued
+    # must block the reset (and the guest-to-full-user conversion below), mirroring
+    # verify_email. Blacklist the token so it cannot be retried.
+    if is_email_globally_banned(user.email):
+        blacklist_token(token)
+        logger.warning("password_reset_blocked_banned_user", user_id=str(user.id), email=user.email)
+        raise HttpError(403, str(BAN_ERROR_MESSAGE))
     if GoogleSSOUser.objects.filter(user=user).exists():
         logger.warning("password_reset_blocked_google_sso_user", user_id=str(user.id), email=user.email)
         raise HttpError(400, str(_("Cannot reset password for Google SSO users.")))

--- a/src/accounts/tests/test_account_service.py
+++ b/src/accounts/tests/test_account_service.py
@@ -534,3 +534,30 @@ class TestRegisterWithReferralCode:
             account_service.register_user(payload)
 
         assert RevelUser.objects.filter(email="referred@example.com").count() == 0
+
+
+def test_reset_password_for_banned_user_is_blocked_and_token_stays_consumed(user: RevelUser) -> None:
+    """A ban added after the token was issued blocks the reset with a 403, and the token is
+    blacklisted *durably* — the raise must not roll the blacklist row back with the reset's
+    savepoint, or the token would become redeemable again once the ban is lifted."""
+    from ninja_jwt.token_blacklist.models import BlacklistedToken
+
+    from accounts.models import GlobalBan
+
+    payload = schema.PasswordResetJWTPayloadSchema(
+        user_id=user.id, email=user.email, exp=timezone.now() + settings.VERIFY_TOKEN_LIFETIME
+    )
+    token = create_token(payload.model_dump(mode="json"), settings.SECRET_KEY, settings.JWT_ALGORITHM)
+    ban = GlobalBan.objects.create(
+        ban_type=GlobalBan.BanType.EMAIL, value=user.email, normalized_value=user.email, reason="spam"
+    )
+
+    with pytest.raises(HttpError) as exc:
+        account_service.reset_password(token, "a-new-valid-Password-123!")
+    assert exc.value.status_code == 403
+    assert BlacklistedToken.objects.filter(token__jti=payload.jti).exists()
+
+    ban.delete()
+    with pytest.raises(HttpError) as exc:
+        account_service.reset_password(token, "a-new-valid-Password-123!")
+    assert exc.value.status_code == 401  # blacklisted, not redeemable

--- a/src/common/fields.py
+++ b/src/common/fields.py
@@ -16,9 +16,10 @@ from PIL import Image
 from common.sanitizers import render_markdown, sanitize_html, sanitize_markdown
 from common.signing import PROTECTED_PATH_PREFIX
 
-# Backstop against decompression-bomb DoS: Pillow itself refuses to decode any
-# image with more pixels than this (a hard ceiling above the validation budget
-# below, so genuine over-budget images error in Pillow too, not just here).
+# Backstop against decompression-bomb DoS. Pillow only *warns* (DecompressionBombWarning)
+# above this pixel count and refuses to decode (DecompressionBombError) above twice it.
+# The real bound is the MAX_IMAGE_PIXELS budget below, enforced from the header — before
+# any pixel is decoded — on every image path (validate_image_file and strip_exif).
 Image.MAX_IMAGE_PIXELS = 64_000_000
 
 # Sanitizers live in common/sanitizers.py; re-exported here for backward-compatible imports.

--- a/src/common/fields.py
+++ b/src/common/fields.py
@@ -11,9 +11,15 @@ from django.contrib.gis.db import models
 from django.core.exceptions import ValidationError
 from django.core.files.images import get_image_dimensions
 from django.core.files.uploadedfile import UploadedFile
+from PIL import Image
 
 from common.sanitizers import render_markdown, sanitize_html, sanitize_markdown
 from common.signing import PROTECTED_PATH_PREFIX
+
+# Backstop against decompression-bomb DoS: Pillow itself refuses to decode any
+# image with more pixels than this (a hard ceiling above the validation budget
+# below, so genuine over-budget images error in Pillow too, not just here).
+Image.MAX_IMAGE_PIXELS = 64_000_000
 
 # Sanitizers live in common/sanitizers.py; re-exported here for backward-compatible imports.
 __all__ = [
@@ -33,23 +39,34 @@ __all__ = [
 
 ALLOWED_IMAGE_EXTENSIONS: list[str] = ["jpg", "jpeg", "png", "gif", "webp", "heic", "heif"]
 MAX_IMAGE_SIZE_BYTES: int = 10 * 1024 * 1024  # 10MB
+MAX_IMAGE_PIXELS: int = 50_000_000  # 50 megapixels — bound on decoded raster size (memory-DoS guard)
 
 
 def validate_image_file(file: UploadedFile) -> None:
-    """Validate an uploaded image file size and format.
+    """Validate an uploaded image file size, dimensions, and format.
 
     Args:
         file: The uploaded file to validate.
 
     Raises:
-        ValidationError: If the file exceeds the maximum size or is not a valid image.
+        ValidationError: If the file exceeds the maximum size, exceeds the
+            maximum pixel budget, or is not a valid image.
     """
     if file.size > MAX_IMAGE_SIZE_BYTES:  # type: ignore[operator]
         raise ValidationError(f"Image must be under {MAX_IMAGE_SIZE_BYTES // (1024 * 1024)}MB.")
     try:
-        get_image_dimensions(file)
+        dimensions = get_image_dimensions(file)
     except Exception:
         raise ValidationError("File is not a valid image.")
+    # A tiny-on-disk image can still decode to a huge raster (e.g. 8000x8000),
+    # exhausting worker memory downstream (EXIF strip, thumbnails). Bound the
+    # pixel count read from the header, without decoding pixels. When the
+    # dimensions can't be read (get_image_dimensions returns None) we leave the
+    # value as-is — that path is unchanged from the original validator, and a
+    # header we can't parse is not a decompression bomb.
+    width, height = dimensions if dimensions else (None, None)
+    if width is not None and height is not None and width * height > MAX_IMAGE_PIXELS:
+        raise ValidationError(f"Image must be under {MAX_IMAGE_PIXELS // 1_000_000} megapixels.")
 
 
 # ---- Protected File Fields ----

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -253,9 +253,13 @@ def scan_for_malware(*, app: str, model: str, pk: str, field: str) -> None | dic
     file_bytes = file_field.read()
     findings = cd.scan_stream(file_bytes)
     file_hash = hashlib.sha256(file_bytes).hexdigest()
-    audit_qs = FileUploadAudit.objects.filter(app=app, model=model, field=field, file_hash=file_hash)
+    # Scope to this upload's audit rows: never quarantine another instance's file that happens
+    # to share the same bytes, and never re-match an already-quarantined audit on re-upload.
+    audit_qs = FileUploadAudit.objects.filter(app=app, model=model, field=field, file_hash=file_hash, instance_pk=pk)
     if not findings:
-        audit_qs.update(status=FileUploadAudit.FileUploadAuditStatus.CLEAN, updated_at=timezone.now())
+        audit_qs.filter(status=FileUploadAudit.FileUploadAuditStatus.PENDING).update(
+            status=FileUploadAudit.FileUploadAuditStatus.CLEAN, updated_at=timezone.now()
+        )
         return None
     quarantined = []
     filename = getattr(file_field, "name", file_hash)
@@ -263,10 +267,19 @@ def scan_for_malware(*, app: str, model: str, pk: str, field: str) -> None | dic
     for audit in audit_qs:
         quarantined.append(QuarantinedFile(audit=audit, file=ContentFile(file_bytes, name), findings=findings))
     with transaction.atomic():
-        setattr(instance, field, None)
         audit_qs.update(status=FileUploadAudit.FileUploadAuditStatus.MALICIOUS, updated_at=timezone.now())
-        QuarantinedFile.objects.bulk_create(quarantined)
-        instance.save()
+        # ignore_conflicts: a re-upload of identical bytes re-matches an audit whose OneToOne
+        # QuarantinedFile already exists; without this the IntegrityError would roll everything back.
+        QuarantinedFile.objects.bulk_create(quarantined, ignore_conflicts=True)
+        if instance._meta.get_field(field).null:
+            # Nullable field: blank the reference so the live file is dropped.
+            setattr(instance, field, None)
+            instance.save()
+        else:
+            # Non-nullable field: full_clean() would reject a blank value and roll back the
+            # quarantine, so remove the file and the row outright instead.
+            getattr(instance, field).delete(save=False)
+            instance.delete()
     # Notify users about malware detection
     notify_malware_detected.delay(app=app, model=model, pk=pk, field=field, file_hash=file_hash, findings=findings)
     return t.cast(dict[str, t.Any], findings)
@@ -310,11 +323,14 @@ def notify_malware_detected(
     - Organization owner (if applicable)
     - File uploader
     """
-    # Get the file upload audit record
-    audits = FileUploadAudit.objects.filter(file_hash=file_hash, notified=False)
+    # Get the file upload audit record. Scope by app/model/field (not just hash) so a cross-model
+    # hash collision can't pull in an audit that has no QuarantinedFile.
+    audits = FileUploadAudit.objects.filter(app=app, model=model, field=field, file_hash=file_hash, notified=False)
 
     for audit in audits:
-        quarantined_file = QuarantinedFile.objects.get(audit=audit)
+        quarantined_file = QuarantinedFile.objects.filter(audit=audit).first()
+        if quarantined_file is None:
+            continue
         quarantined_file_url = reverse("admin:common_quarantinedfile_change", args=[quarantined_file.id])
 
         uploader = RevelUser.objects.filter(username=audit.uploader).first()

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -264,12 +264,21 @@ def scan_for_malware(*, app: str, model: str, pk: str, field: str) -> None | dic
     quarantined = []
     filename = getattr(file_field, "name", file_hash)
     name = Path(filename).name
-    for audit in audit_qs:
+    # Only audits with no QuarantinedFile yet: a re-upload of identical bytes to the same
+    # instance re-matches earlier audits whose quarantine row already exists, and bulk_create
+    # writes each ContentFile to storage *before* the INSERT — including them would leave an
+    # orphan blob per conflict. The status update is scoped to these same rows so an audit
+    # inserted meanwhile is never marked MALICIOUS without a quarantine row to notify from.
+    pending = list(audit_qs.filter(quarantinedfile__isnull=True))
+    for audit in pending:
         quarantined.append(QuarantinedFile(audit=audit, file=ContentFile(file_bytes, name), findings=findings))
     with transaction.atomic():
-        audit_qs.update(status=FileUploadAudit.FileUploadAuditStatus.MALICIOUS, updated_at=timezone.now())
-        # ignore_conflicts: a re-upload of identical bytes re-matches an audit whose OneToOne
-        # QuarantinedFile already exists; without this the IntegrityError would roll everything back.
+        audit_qs.filter(pk__in=[audit.pk for audit in pending]).update(
+            status=FileUploadAudit.FileUploadAuditStatus.MALICIOUS, updated_at=timezone.now()
+        )
+        # ignore_conflicts: two concurrent scans of the same instance can still race on the
+        # OneToOne; without this the IntegrityError would roll back the detachment below and
+        # leave the malicious file live.
         QuarantinedFile.objects.bulk_create(quarantined, ignore_conflicts=True)
         if instance._meta.get_field(field).null:
             # Nullable field: blank the reference so the live file is dropped.
@@ -323,9 +332,12 @@ def notify_malware_detected(
     - Organization owner (if applicable)
     - File uploader
     """
-    # Get the file upload audit record. Scope by app/model/field (not just hash) so a cross-model
-    # hash collision can't pull in an audit that has no QuarantinedFile.
-    audits = FileUploadAudit.objects.filter(app=app, model=model, field=field, file_hash=file_hash, notified=False)
+    # Get the file upload audit record. Scope by app/model/field/instance (not just hash) so
+    # neither a cross-model hash collision nor another instance's identical upload can pull in
+    # an audit whose uploader/quarantine record don't belong to this ``pk``.
+    audits = FileUploadAudit.objects.filter(
+        app=app, model=model, field=field, file_hash=file_hash, instance_pk=pk, notified=False
+    )
 
     for audit in audits:
         quarantined_file = QuarantinedFile.objects.filter(audit=audit).first()

--- a/src/common/tests/test_tasks.py
+++ b/src/common/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import hashlib
+import typing as t
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -6,7 +7,7 @@ import pytest
 from django.core.files.base import ContentFile
 
 from common.models import FileUploadAudit, QuarantinedFile
-from common.tasks import notify_malware_detected
+from common.tasks import notify_malware_detected, scan_for_malware
 from common.utils import safe_save_uploaded_file
 from conftest import RevelUserFactory
 from events.models import AdditionalResource, Organization
@@ -95,3 +96,83 @@ def test_notify_malware_detected(mock_send_email: MagicMock, revel_user_factory:
 
     # Verify that emails were sent
     assert mock_send_email.call_count == 3  # uploader + org owner + staff/superuser emails
+
+
+@mock.patch("common.tasks.pyclamd.ClamdNetworkSocket")
+def test_scan_for_malware_rescan_skips_already_quarantined_audit(
+    mock_clamd: MagicMock, revel_user_factory: RevelUserFactory, settings: t.Any
+) -> None:
+    """Identical bytes re-uploaded to the same instance: only the audit without a QuarantinedFile
+    is quarantined. The already-linked audit must not be handed to bulk_create at all — its
+    ``ContentFile`` would be written to storage before the conflicting INSERT is ignored."""
+    settings.FEATURE_MALWARE_SCAN = True
+    findings = {"stream": ("FOUND", "Eicar-Test-Signature")}
+    clamd = mock_clamd.return_value
+    clamd.ping.return_value = True
+    clamd.scan_stream.return_value = findings
+
+    uploader = revel_user_factory()
+    org = Organization.objects.create(name="Test Organization", owner=uploader)
+    payload = b"malicious bytes"
+    resource = AdditionalResource.objects.create(
+        organization=org,
+        resource_type=AdditionalResource.ResourceTypes.FILE,
+        file=ContentFile(payload, name="evil.txt"),
+    )
+    file_hash = hashlib.sha256(payload).hexdigest()
+    audit_kwargs: dict[str, t.Any] = {
+        "app": "events",
+        "model": "AdditionalResource",
+        "instance_pk": resource.pk,
+        "field": "file",
+        "uploader": uploader.email,
+    }
+    first = FileUploadAudit.objects.create(
+        file_hash=file_hash, status=FileUploadAudit.FileUploadAuditStatus.MALICIOUS, **audit_kwargs
+    )
+    QuarantinedFile.objects.create(audit=first, file=ContentFile(payload, name="evil.txt"), findings=findings)
+    second = FileUploadAudit.objects.create(file_hash=file_hash, **audit_kwargs)
+
+    with mock.patch.object(
+        QuarantinedFile.objects, "bulk_create", wraps=QuarantinedFile.objects.bulk_create
+    ) as bulk_create:
+        scan_for_malware(app="events", model="AdditionalResource", pk=str(resource.pk), field="file")
+
+    (created,) = bulk_create.call_args.args
+    assert [q.audit_id for q in created] == [second.pk]
+    second.refresh_from_db()
+    assert second.status == FileUploadAudit.FileUploadAuditStatus.MALICIOUS
+    assert QuarantinedFile.objects.filter(audit=second).exists()
+    assert QuarantinedFile.objects.count() == 2
+
+
+@mock.patch("common.tasks.send_email.delay")
+def test_notify_malware_detected_is_scoped_to_the_instance(
+    mock_send_email: MagicMock, revel_user_factory: RevelUserFactory
+) -> None:
+    """Same bytes on two instances: notifying for one must not consume the other's audit."""
+    uploader = revel_user_factory()
+    owner = revel_user_factory()
+    org_a = Organization.objects.create(name="Org A", owner=owner)
+    org_b = Organization.objects.create(name="Org B", owner=owner)
+    findings = {"stream": ("FOUND", "Test-Virus")}
+    file_hash = hashlib.sha256(b"test content").hexdigest()
+    audit_kwargs: dict[str, t.Any] = {
+        "app": "events",
+        "model": "Organization",
+        "field": "logo",
+        "file_hash": file_hash,
+        "uploader": uploader.email,
+        "status": FileUploadAudit.FileUploadAuditStatus.MALICIOUS,
+    }
+    FileUploadAudit.objects.create(instance_pk=org_a.pk, **audit_kwargs)
+    audit_b = FileUploadAudit.objects.create(instance_pk=org_b.pk, **audit_kwargs)
+    QuarantinedFile.objects.create(audit=audit_b, file=ContentFile(b"test content", name="t.jpg"), findings=findings)
+
+    notify_malware_detected(
+        app="events", model="Organization", pk=str(org_a.pk), field="logo", file_hash=file_hash, findings=findings
+    )
+
+    audit_b.refresh_from_db()
+    assert audit_b.notified is False
+    mock_send_email.assert_not_called()  # org_a's own audit has no quarantine row to notify from

--- a/src/common/tests/test_utils.py
+++ b/src/common/tests/test_utils.py
@@ -269,3 +269,54 @@ class TestUpdateOrCreateWithRaceProtection:
         ):
             with pytest.raises(ValidationError):
                 update_or_create_with_race_protection(Tag, {"name": "uoc-tag-e"}, {"description": "x"})
+
+
+@pytest.fixture
+def heif_with_exif() -> InMemoryUploadedFile:
+    """A HEIF image (the iPhone default) carrying EXIF, including a GPS IFD."""
+    exif_bytes = piexif.dump(
+        {
+            "0th": {piexif.ImageIFD.ImageDescription: b"Hello world"},
+            "Exif": {},
+            "GPS": {piexif.GPSIFD.GPSLatitude: ((48, 1), (12, 1), (0, 1))},
+            "1st": {},
+            "thumbnail": None,
+        }
+    )
+    buffer = BytesIO()
+    Image.new("RGB", (10, 10), color="red").save(buffer, format="HEIF", exif=exif_bytes)
+    buffer.seek(0)
+    return InMemoryUploadedFile(
+        file=buffer,
+        field_name="test",
+        name="photo.heic",
+        content_type="image/heic",
+        size=buffer.getbuffer().nbytes,
+        charset=None,
+    )
+
+
+def test_strip_exif_removes_data_from_heif(heif_with_exif: InMemoryUploadedFile) -> None:
+    """pillow-heif's encoder copies ``Image.info`` (EXIF/XMP) into the output — unlike Pillow's
+    built-in encoders — so leaving ``exif=`` out of ``save()`` alone would leak GPS for HEIC."""
+    source = Image.open(heif_with_exif)
+    assert dict(source.getexif().get_ifd(0x8825)), "fixture should carry a GPS IFD"
+    heif_with_exif.seek(0)
+
+    stripped = strip_exif(heif_with_exif)
+    stripped.seek(0)
+
+    image_stripped = Image.open(stripped)
+    assert image_stripped.format == "HEIF"
+    assert not dict(image_stripped.getexif()), "EXIF should be stripped from HEIF output"
+
+
+def test_strip_exif_rejects_image_over_pixel_budget() -> None:
+    """The pixel budget is enforced from the header, before decoding, for every strip_exif caller."""
+    buffer = BytesIO()
+    Image.new("L", (20, 20), color=255).save(buffer, format="PNG")
+    buffer.seek(0)
+
+    with mock.patch("common.utils.MAX_IMAGE_PIXELS", 100):
+        with pytest.raises(ValidationError, match="megapixels"):
+            strip_exif(buffer)  # type: ignore[arg-type]

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -16,19 +16,41 @@ from PIL import Image
 from pydantic import BaseModel
 
 from common import tasks
+from common.fields import MAX_IMAGE_PIXELS
 
 from .models import FileUploadAudit
 
+# ``Image.info`` keys that carry metadata (EXIF incl. GPS, XMP, JPEG comments). Pillow's
+# built-in encoders only write what is passed to ``save()``, but plugins such as
+# pillow-heif copy ``info`` wholesale into the output, so the keys must be dropped from
+# the source image itself rather than merely left out of the ``save()`` call.
+_METADATA_INFO_KEYS = ("exif", "xmp", "XML:com.adobe.xmp", "Raw profile type exif", "comment")
+
 
 def strip_exif(image_file: File) -> InMemoryUploadedFile:  # type: ignore[type-arg]
-    """Strip EXIF data from a Django File or InMemoryUploadedFile."""
-    image = Image.open(image_file)
+    """Strip EXIF data from a Django File or InMemoryUploadedFile.
+
+    Raises:
+        ValidationError: If the image exceeds ``MAX_IMAGE_PIXELS``. Checked from the
+            header before any pixel is decoded, so every image path is bounded here —
+            including ones (questionnaire uploads) that skip ``validate_image_file``.
+    """
+    try:
+        image = Image.open(image_file)
+    except Image.DecompressionBombError:
+        raise ValidationError(f"Image must be under {MAX_IMAGE_PIXELS // 1_000_000} megapixels.")
+    # Image.open is lazy: width/height come from the header, so this bounds the raster
+    # before the save below decodes it (memory-DoS guard).
+    if image.width * image.height > MAX_IMAGE_PIXELS:
+        raise ValidationError(f"Image must be under {MAX_IMAGE_PIXELS // 1_000_000} megapixels.")
     _format = image.format or "JPEG"
 
     output = BytesIO()
-    # Re-saving without an ``exif=`` argument discards metadata without
-    # materializing the decoded raster an extra ~3x (Image.frombytes on
-    # tobytes()) — a memory-DoS guard for large images.
+    # Drop the metadata from ``info`` and re-save the same image object. This strips
+    # EXIF for every registered encoder without materializing the decoded raster an
+    # extra ~3x (Image.frombytes on tobytes()) — a memory-DoS guard for large images.
+    for key in _METADATA_INFO_KEYS:
+        image.info.pop(key, None)
     image.save(output, format=_format)
     output.seek(0)
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -1,7 +1,6 @@
 import functools
 import hashlib
 import mimetypes
-import sys
 import typing as t
 from io import BytesIO
 
@@ -24,12 +23,13 @@ from .models import FileUploadAudit
 def strip_exif(image_file: File) -> InMemoryUploadedFile:  # type: ignore[type-arg]
     """Strip EXIF data from a Django File or InMemoryUploadedFile."""
     image = Image.open(image_file)
-    # Create a new image from raw pixel data to strip EXIF metadata
-    image_no_exif = Image.frombytes(image.mode, image.size, image.tobytes())
+    _format = image.format or "JPEG"
 
     output = BytesIO()
-    _format = image.format or "JPEG"
-    image_no_exif.save(output, format=_format)
+    # Re-saving without an ``exif=`` argument discards metadata without
+    # materializing the decoded raster an extra ~3x (Image.frombytes on
+    # tobytes()) — a memory-DoS guard for large images.
+    image.save(output, format=_format)
     output.seek(0)
 
     # Try to infer some optional fields
@@ -42,7 +42,7 @@ def strip_exif(image_file: File) -> InMemoryUploadedFile:  # type: ignore[type-a
         field_name=field_name,
         name=name,
         content_type=content_type,
-        size=sys.getsizeof(output),
+        size=output.getbuffer().nbytes,
         charset=None,
     )
 

--- a/src/events/controllers/series_pass_admin.py
+++ b/src/events/controllers/series_pass_admin.py
@@ -92,8 +92,9 @@ class SeriesPassAdminController(UserAwareController):
         """Create a series pass and its initial coverage (admin only).
 
         Every event named in ``tier_links`` must pass the enable-time coverage gate
-        (open, ticketed, non-invitation-only event on a non-recurring series, not gated
-        by an admission questionnaire) — 400 otherwise. Requires 'edit_event_series'
+        (open, ticketed, PUBLIC — neither invitation-only nor members-only — event on a
+        non-recurring series, not gated by an admission questionnaire) — 400 otherwise.
+        Requires 'edit_event_series'
         permission.
         """
         series = self.get_one(series_id)

--- a/src/events/models/misc.py
+++ b/src/events/models/misc.py
@@ -13,7 +13,7 @@ from .event import Event
 from .event_series import EventSeries
 from .invitation import EventInvitation
 from .mixins import ResourceVisibility, VisibilityMixin
-from .organization import Organization
+from .organization import Organization, OrganizationMember
 from .rsvp import EventRSVP
 from .ticket import Ticket
 
@@ -66,12 +66,19 @@ class AdditionalResourceQuerySet(models.QuerySet["AdditionalResource"]):
         #    (for non-private resources).
         is_owner = Q(organization__owner=user)
         is_staff_member = Q(organization__staff_members=user)
-        is_org_member = Q(organization__members=user)
+        # Route membership through ``for_visibility()`` so CANCELLED/BANNED
+        # members don't match — mirroring every sibling queryset. The raw
+        # ``members`` M2M has no status filter and would leak MEMBERS_ONLY
+        # resources to lapsed/banned members.
+        valid_member_org_ids = (
+            OrganizationMember.objects.for_visibility().filter(user=user).values_list("organization_id", flat=True)
+        )
+        is_org_member = Q(organization_id__in=valid_member_org_ids)
 
         # Staff and owners see everything up to 'staff-only'.
         role_based_q = is_owner | is_staff_member
         # Regular members see 'members-only' and 'public' resources.
-        role_based_q |= is_org_member & Q(visibility=ResourceVisibility.MEMBERS_ONLY)
+        role_based_q |= is_org_member & Q(visibility=ResourceVisibility.MEMBERS_ONLY) & org_visible
         # Any authenticated user with access to the org can see public and unlisted resources.
         role_based_q |= Q(visibility__in=ResourceVisibility.publicly_accessible()) & org_visible
 

--- a/src/events/schema/event.py
+++ b/src/events/schema/event.py
@@ -43,7 +43,6 @@ class EventEditSchema(CityEditMixin):
     name: OneToOneFiftyString | None = None
     description: StrippedString | None = None
     event_type: Event.EventType | None = None
-    status: Event.EventStatus = Event.EventStatus.DRAFT
     visibility: Event.Visibility | None = None
     invitation_message: StrippedString | None = Field(None, description="Invitation message")
     max_attendees: int = 0
@@ -92,6 +91,11 @@ class EventCreateSchema(EventEditSchema):
     name: OneToOneFiftyString
     start: AwareDatetime
     requires_ticket: bool = False
+    # Status is settable only at create time; the generic edit PUT must not
+    # change status — transitions go through the ``manage_event``-gated
+    # ``update_event_status`` endpoint, which also runs the refund/waitlist
+    # safety logic. Mirrors ``TemplateEditSchema`` excluding status.
+    status: Event.EventStatus = Event.EventStatus.DRAFT
 
 
 # Re-export the pydantic session model as the API schema (single source of truth),

--- a/src/events/service/batch_ticket_service/eligibility.py
+++ b/src/events/service/batch_ticket_service/eligibility.py
@@ -262,13 +262,15 @@ class PurchaseEligibilityMixin(BatchTicketContext):
         Raises:
             HttpError: 400 when the event cap or a tier cap is exceeded.
         """
+        # Lock the Event row BEFORE reading the cap off it: the pre-lock instance can be
+        # stale (an organizer enabling or tightening max_tickets_per_user meanwhile), and a
+        # stale None would skip the check entirely. The tier lock only serializes same-tier
+        # carts; the event cap spans tiers a concurrent cart need not share, so this anchor
+        # (the same one assert_event_capacity takes) is what serializes two carts by the
+        # same buyer against the cap.
+        self.event = Event.objects.select_for_update().get(pk=self.event.pk)
         event_cap = self.event.max_tickets_per_user
         if event_cap is not None:
-            # Lock the Event row before the event-wide count. The tier lock only
-            # serializes same-tier carts; the event cap spans tiers a concurrent cart
-            # need not share, so this anchor (the same one assert_event_capacity takes)
-            # is what serializes two carts by the same buyer against the cap.
-            self.event = Event.objects.select_for_update().get(pk=self.event.pk)
             existing = self.get_user_ticket_count()
             remaining = max(0, event_cap - existing)
             requested = sum(len(g.items) for g in groups)

--- a/src/events/service/batch_ticket_service/eligibility.py
+++ b/src/events/service/batch_ticket_service/eligibility.py
@@ -13,7 +13,7 @@ from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
-from events.models import EventInvitation, OrganizationMember, Ticket, TicketTier
+from events.models import Event, EventInvitation, OrganizationMember, Ticket, TicketTier
 from events.schema import TicketPurchaseItem
 from events.service.batch_ticket_service.context import BatchTicketContext
 from events.service.event_manager import (
@@ -247,6 +247,15 @@ class PurchaseEligibilityMixin(BatchTicketContext):
         width (#846 review fix). ``get_user_ticket_count`` keeps its single-tier form
         for the other callers.
 
+        **Runs under the cart's row locks** (``create_batch`` calls it after the tier
+        ``select_for_update``): the tier-cap counts are serialized by the tier lock two
+        same-tier carts share, and the event-cap count takes the Event row lock below so
+        two carts by the same buyer serialize even when they share no tier. Without those
+        locks the count is a pre-write read under READ COMMITTED — both carts read the
+        old count, both pass, both write past the cap (TOCTOU). Mirrors
+        ``discount_code_service.apply_discount``, which re-checks per-user usage under a
+        row lock.
+
         Args:
             groups: The cart's groups (one per tier).
 
@@ -255,6 +264,11 @@ class PurchaseEligibilityMixin(BatchTicketContext):
         """
         event_cap = self.event.max_tickets_per_user
         if event_cap is not None:
+            # Lock the Event row before the event-wide count. The tier lock only
+            # serializes same-tier carts; the event cap spans tiers a concurrent cart
+            # need not share, so this anchor (the same one assert_event_capacity takes)
+            # is what serializes two carts by the same buyer against the cap.
+            self.event = Event.objects.select_for_update().get(pk=self.event.pk)
             existing = self.get_user_ticket_count()
             remaining = max(0, event_cap - existing)
             requested = sum(len(g.items) for g in groups)

--- a/src/events/service/batch_ticket_service/service.py
+++ b/src/events/service/batch_ticket_service/service.py
@@ -266,8 +266,6 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
             self._assert_purchasable_by(group.tier)
             self._assert_membership_tier_allowed(group.tier)
             self._assert_sale_window(group.tier)
-        # Per-user ticket caps, layered across the whole cart (#846 Decision 4).
-        self.assert_per_user_limits(self.groups)
 
         # Names are enforced here — not in the schema — because only the event knows
         # whether it requires them (#845).
@@ -305,6 +303,13 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
         # uniformity _validate_cart proved on the stale instances is re-proven here:
         # every money decision below is a cart-level read off ONE locked tier.
         self._assert_locked_cart_uniformity(locked_tiers)
+
+        # Per-user ticket caps, layered across the whole cart (#846 Decision 4). Runs
+        # HERE, under the tier locks (and taking the Event row lock for the event-wide
+        # cap), so two concurrent carts by the same buyer are serialized and cannot both
+        # read a stale pre-write count and slip past max_tickets_per_user (TOCTOU).
+        self.assert_per_user_limits(self.groups)
+
         # Dispatch off the LOCKED rows, as the single-tier engine always did — the
         # pre-lock read above only decides whether VIES is worth a round-trip.
         locked_payment_method = locked_tiers[0].payment_method

--- a/src/events/service/batch_ticket_service/service.py
+++ b/src/events/service/batch_ticket_service/service.py
@@ -1,5 +1,6 @@
 """Service for batch ticket purchases with seat selection support."""
 
+import dataclasses
 import typing as t
 from decimal import Decimal
 from uuid import UUID
@@ -307,8 +308,14 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
         # Per-user ticket caps, layered across the whole cart (#846 Decision 4). Runs
         # HERE, under the tier locks (and taking the Event row lock for the event-wide
         # cap), so two concurrent carts by the same buyer are serialized and cannot both
-        # read a stale pre-write count and slip past max_tickets_per_user (TOCTOU).
-        self.assert_per_user_limits(self.groups)
+        # read a stale pre-write count and slip past max_tickets_per_user (TOCTOU). The
+        # groups are rebound to the LOCKED tier rows so the tier caps are read fresh too —
+        # a pre-lock instance could still say None for a cap the organizer just enabled.
+        locked_groups = [
+            dataclasses.replace(group, tier=locked_tier)
+            for group, locked_tier in zip(self.groups, locked_tiers, strict=True)
+        ]
+        self.assert_per_user_limits(locked_groups)
 
         # Dispatch off the LOCKED rows, as the single-tier engine always did — the
         # pre-lock read above only decides whether VIES is worth a round-trip.

--- a/src/events/service/export/attendee_export.py
+++ b/src/events/service/export/attendee_export.py
@@ -11,7 +11,13 @@ from common.models import FileExport
 from common.service.export_service import complete_export, fail_export, start_export
 from events.models import Event, EventRSVP, Ticket
 
-from .formatting import auto_fit_columns, compute_pronoun_distribution, style_header_row, style_summary_sheet
+from .formatting import (
+    auto_fit_columns,
+    compute_pronoun_distribution,
+    sanitize_cell,
+    style_header_row,
+    style_summary_sheet,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -86,10 +92,10 @@ def _write_summary_sheet(
     total_without_pronouns = pronoun_stats.total_without
 
     summary_rows: list[tuple[str, t.Any]] = [
-        ("Event", event.name),
+        ("Event", sanitize_cell(event.name)),
         ("Date", event.start.isoformat() if event.start else "N/A"),
-        ("Venue", event.venue.name if event.venue else "N/A"),
-        ("Organization", event.organization.name),
+        ("Venue", sanitize_cell(event.venue.name) if event.venue else "N/A"),
+        ("Organization", sanitize_cell(event.organization.name)),
         ("Total attendees", len(tickets) + len(rsvps)),
         ("Tickets", len(tickets)),
         ("RSVPs", len(rsvps)),
@@ -146,16 +152,16 @@ def _write_attendees_sheet(wb: Workbook, tickets: list[Ticket], rsvps: list[Even
         is_checked_in = ticket.status == Ticket.TicketStatus.CHECKED_IN
         ws.append(
             [
-                ticket.user.get_full_name() if ticket.user else "",
-                ticket.user.email if ticket.user else "",
-                ticket.user.pronouns if ticket.user else "",
+                sanitize_cell(ticket.user.get_full_name()) if ticket.user else "",
+                sanitize_cell(ticket.user.email) if ticket.user else "",
+                sanitize_cell(ticket.user.pronouns) if ticket.user else "",
                 "Ticket",
                 "",
-                ticket.tier.name if ticket.tier else "",
+                sanitize_cell(ticket.tier.name) if ticket.tier else "",
                 _STATUS_DISPLAY.get(ticket.status, ticket.status),
                 "Yes" if is_checked_in else "No",
                 ticket.checked_in_at.isoformat() if ticket.checked_in_at else "",
-                ticket.guest_name or "",
+                sanitize_cell(ticket.guest_name or ""),
                 seat_label,
                 payment.status if payment else (ticket.tier.payment_method if ticket.tier else ""),
             ]
@@ -164,9 +170,9 @@ def _write_attendees_sheet(wb: Workbook, tickets: list[Ticket], rsvps: list[Even
     for rsvp in rsvps:
         ws.append(
             [
-                rsvp.user.get_full_name() if rsvp.user else "",
-                rsvp.user.email if rsvp.user else "",
-                rsvp.user.pronouns if rsvp.user else "",
+                sanitize_cell(rsvp.user.get_full_name()) if rsvp.user else "",
+                sanitize_cell(rsvp.user.email) if rsvp.user else "",
+                sanitize_cell(rsvp.user.pronouns) if rsvp.user else "",
                 "RSVP",
                 _RSVP_STATUS_DISPLAY.get(rsvp.status, rsvp.status) if rsvp.status else "",
                 "",

--- a/src/events/service/export/attendee_export.py
+++ b/src/events/service/export/attendee_export.py
@@ -148,7 +148,7 @@ def _write_attendees_sheet(wb: Workbook, tickets: list[Ticket], rsvps: list[Even
 
     for ticket in tickets:
         payment = getattr(ticket, "payment", None)
-        seat_label = ticket.seat.label if ticket.seat else ""
+        seat_label = sanitize_cell(ticket.seat.label) if ticket.seat else ""
         is_checked_in = ticket.status == Ticket.TicketStatus.CHECKED_IN
         ws.append(
             [

--- a/src/events/service/export/formatting.py
+++ b/src/events/service/export/formatting.py
@@ -60,7 +60,7 @@ def sanitize_cell(value: t.Any) -> t.Any:
     Prefixes any string a spreadsheet app would interpret as a formula with a
     literal apostrophe so it is rendered as inert text.
     """
-    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r", "\n"):
         return "'" + value
     return value
 

--- a/src/events/service/export/formatting.py
+++ b/src/events/service/export/formatting.py
@@ -54,6 +54,17 @@ MIN_WIDTH = 10
 MAX_WIDTH = 60
 
 
+def sanitize_cell(value: t.Any) -> t.Any:
+    """Neutralise spreadsheet/CSV formula injection (CWE-1236).
+
+    Prefixes any string a spreadsheet app would interpret as a formula with a
+    literal apostrophe so it is rendered as inert text.
+    """
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + value
+    return value
+
+
 def style_header_row(ws: Worksheet) -> None:
     """Apply bold white-on-blue styling to the first row."""
     for cell in ws[1]:

--- a/src/events/service/export/questionnaire_export.py
+++ b/src/events/service/export/questionnaire_export.py
@@ -21,7 +21,13 @@ from questionnaires.models import (
     QuestionnaireSubmission,
 )
 
-from .formatting import auto_fit_columns, compute_pronoun_distribution, style_header_row, style_summary_sheet
+from .formatting import (
+    auto_fit_columns,
+    compute_pronoun_distribution,
+    sanitize_cell,
+    style_header_row,
+    style_summary_sheet,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -251,22 +257,22 @@ def _write_submissions_sheet(
 
         source_event = sub.source_event
         row: list[t.Any] = [
-            sub.user.email if sub.user else "",
-            sub.user.get_full_name() if sub.user else "",
+            sanitize_cell(sub.user.email) if sub.user else "",
+            sanitize_cell(sub.user.get_full_name()) if sub.user else "",
             sub.submitted_at.isoformat() if sub.submitted_at else "",
             eval_status,
             float(eval_obj.score) if eval_obj and eval_obj.score is not None else "",
-            eval_obj.comments if eval_obj and eval_obj.comments else "",
-            source_event["event_name"] if source_event else "",
+            sanitize_cell(eval_obj.comments) if eval_obj and eval_obj.comments else "",
+            sanitize_cell(source_event["event_name"]) if source_event else "",
         ]
 
         for q in all_questions:
             if q.question_type == "mc":
-                row.append("; ".join(mc_answers.get(q.question_id, [])))
+                row.append(sanitize_cell("; ".join(mc_answers.get(q.question_id, []))))
             elif q.question_type == "ft":
-                row.append(ft_answers.get(q.question_id, ""))
+                row.append(sanitize_cell(ft_answers.get(q.question_id, "")))
             else:
-                row.append("; ".join(fu_answers.get(q.question_id, [])))
+                row.append(sanitize_cell("; ".join(fu_answers.get(q.question_id, []))))
 
         ws.append(row)
 

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -46,10 +46,19 @@ def get_or_create_guest_user(email: str, first_name: str = "", last_name: str = 
         Guest user instance
 
     Raises:
-        HttpError: If a non-guest user with this email already exists
+        HttpError: If a non-guest user with this email already exists, or the email
+            is globally banned.
     """
+    from accounts.service.global_ban_service import BAN_ERROR_MESSAGE, is_email_globally_banned
+
     # Normalize email to lowercase for case-insensitive matching
     email = email.lower()
+
+    # Reject globally-banned emails before minting a guest row — otherwise a ban could
+    # be bypassed by creating a guest account (and later converting it via password reset).
+    if is_email_globally_banned(email):
+        logger.warning("guest_user_creation_blocked_banned_email", email=email)
+        raise HttpError(403, str(BAN_ERROR_MESSAGE))
 
     # Check if user exists (case-insensitive)
     existing_user = RevelUser.objects.filter(email__iexact=email).first()
@@ -265,6 +274,7 @@ def validate_and_decode_guest_token(token: str) -> schema.GuestActionPayload:
     return payload
 
 
+@transaction.atomic
 def handle_guest_rsvp(
     event: models.Event,
     answer: models.EventRSVP.RsvpStatus,

--- a/src/events/service/recurrence_service.py
+++ b/src/events/service/recurrence_service.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from pydantic import BaseModel
 
 from events.models import Event, EventSeries, Organization, RecurrenceRule
+from events.models.event_series import MAX_GENERATION_WINDOW_WEEKS
 from events.service.duplication import duplicate_event
 from events.suppression import suppress_event_notifications
 from events.utils.visibility_settings import build_visibility_settings_update
@@ -225,7 +226,15 @@ def _materialize_due_occurrences(
     rule_model = locked_series.recurrence_rule
     assert rule_model is not None  # guaranteed by caller's guard
     rule = rule_model.to_rrule()
-    horizon = until_override or (timezone.now() + timedelta(weeks=locked_series.generation_window_weeks))
+    # Clamp any client-supplied override to the same ceiling that bounds
+    # generation_window_weeks, so an override cannot materialize occurrences
+    # past the 52-week cap in one locked transaction.
+    cap = timezone.now() + timedelta(weeks=MAX_GENERATION_WINDOW_WEEKS)
+    horizon = (
+        min(until_override, cap)
+        if until_override
+        else (timezone.now() + timedelta(weeks=locked_series.generation_window_weeks))
+    )
     # Offset start_from by 1 second so dtstart itself is included in between().
     start_from = locked_series.last_generated_until or (rule_model.dtstart - timedelta(seconds=1))
     # Defense against horizon decreases (e.g. user lowers generation_window_weeks):

--- a/src/events/service/series_pass_service.py
+++ b/src/events/service/series_pass_service.py
@@ -181,9 +181,12 @@ def validate_events_coverable(series: EventSeries, events: t.Sequence[Event]) ->
             raise SeriesPassCoverageError(str(_("Event '%s' is not open.") % event.name))
         if not event.requires_ticket:
             raise SeriesPassCoverageError(str(_("Event '%s' does not require a ticket.") % event.name))
-        if event.visibility == Event.Visibility.PRIVATE:
+        if event.event_type != Event.EventType.PUBLIC:
             raise SeriesPassCoverageError(
-                str(_("Event '%s' is invitation-only and cannot be covered by a series pass.") % event.name)
+                str(
+                    _("Event '%s' is invitation-only or members-only and cannot be covered by a series pass.")
+                    % event.name
+                )
             )
     gated = OrganizationQuestionnaire.objects.filter(
         questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.ADMISSION,

--- a/src/events/service/series_pass_service.py
+++ b/src/events/service/series_pass_service.py
@@ -161,8 +161,8 @@ def validate_events_coverable(series: EventSeries, events: t.Sequence[Event]) ->
 
     Every event covered by a series pass must be "simple": it must belong to
     the given series (which must itself be non-recurring), be OPEN, require a
-    ticket, not be invitation-only, and not be gated by an admission
-    questionnaire targeting either the event or the series.
+    ticket, be PUBLIC (neither invitation-only nor members-only), and not be
+    gated by an admission questionnaire targeting either the event or the series.
 
     Args:
         series: The EventSeries the pass belongs to.

--- a/src/events/tests/test_service/test_attendee_export.py
+++ b/src/events/tests/test_service/test_attendee_export.py
@@ -25,8 +25,11 @@ from events.models import (
     Ticket,
     TicketTier,
     Venue,
+    VenueSeat,
+    VenueSector,
 )
 from events.service.export.attendee_export import generate_attendee_export
+from events.service.export.formatting import sanitize_cell
 
 pytestmark = pytest.mark.django_db
 
@@ -481,3 +484,36 @@ class TestAttendeeExportNoVenue:
         ws_summary = wb["Summary"]
         summary = {row[0]: row[1] for row in ws_summary.iter_rows(values_only=True) if row[0]}
         assert summary["Venue"] == "N/A"
+
+
+# --- Formula-injection hardening ---
+
+
+class TestAttendeeExportCellSanitisation:
+    """Attacker/organizer-controlled strings must land as inert text, never live formulas."""
+
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@", "\t", "\r", "\n"])
+    def test_sanitize_cell_neutralises_formula_prefixes(self, prefix: str) -> None:
+        assert sanitize_cell(prefix + "cmd") == "'" + prefix + "cmd"
+
+    def test_sanitize_cell_leaves_plain_values_alone(self) -> None:
+        assert sanitize_cell("Alice") == "Alice"
+        assert sanitize_cell("") == ""
+        assert sanitize_cell(3) == 3
+        assert sanitize_cell(None) is None
+
+    def test_seat_label_is_sanitised(
+        self, export_user: RevelUser, att_event: Event, venue: Venue, active_ticket: Ticket
+    ) -> None:
+        sector = VenueSector.objects.create(venue=venue, name="Floor")
+        seat = VenueSeat.objects.create(sector=sector, label="=CMD()")
+        Ticket.objects.filter(pk=active_ticket.pk).update(seat=seat, sector=sector)
+        export = _create_attendee_export(export_user, att_event)
+
+        generate_attendee_export(export.id)
+
+        ws_att = _load_workbook_from_export(export)["Attendees"]
+        row = next(ws_att.iter_rows(min_row=2, max_row=2))
+        seat_cell = row[10]  # "Seat" column, right after "Guest Name"
+        assert seat_cell.value == "'=CMD()"
+        assert seat_cell.data_type != "f"

--- a/src/events/tests/test_service/test_batch_ticket_service/test_layered_limits.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_layered_limits.py
@@ -121,3 +121,28 @@ class TestLayeredLimits:
             service.create_batch([TicketPurchaseItem(), TicketPurchaseItem()])
         assert exc.value.status_code == 400
         assert "for this tier" in str(exc.value.message)
+
+    def test_event_cap_is_read_from_the_locked_row(
+        self, event: Event, tier_a: TicketTier, member_user: RevelUser
+    ) -> None:
+        """A cap enabled after the service loaded its Event still binds: the cap is read off the
+        locked row, not the stale pre-lock instance (which would say None and skip the check)."""
+        service = BatchTicketService(event, tier_a, member_user)  # event.max_tickets_per_user is None here
+        make_active_ticket(event, tier_a, member_user)
+        Event.objects.filter(pk=event.pk).update(max_tickets_per_user=1)  # organizer write, behind our back
+        with pytest.raises(HttpError) as exc:
+            service.create_batch([TicketPurchaseItem()])
+        assert exc.value.status_code == 400
+        assert "for this event" in str(exc.value.message)
+
+    def test_tier_cap_is_read_from_the_locked_row(
+        self, event: Event, tier_a: TicketTier, member_user: RevelUser
+    ) -> None:
+        """Same for the tier cap: the groups handed to assert_per_user_limits carry the LOCKED tiers."""
+        service = BatchTicketService(event, tier_a, member_user)  # tier_a.max_tickets_per_user is None here
+        make_active_ticket(event, tier_a, member_user)
+        TicketTier.objects.filter(pk=tier_a.pk).update(max_tickets_per_user=1)
+        with pytest.raises(HttpError) as exc:
+            service.create_batch([TicketPurchaseItem()])
+        assert exc.value.status_code == 400
+        assert "for this tier" in str(exc.value.message)

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -1560,7 +1560,9 @@ msgstr "Dieses Mitglied hat kein Ticket für dieses Event."
 
 #, python-brace-format
 msgid "Invoice totals do not reconcile with its line items: {details}"
-msgstr "Die Rechnungssummen stimmen nicht mit den Rechnungspositionen überein: {details}"
+msgstr ""
+"Die Rechnungssummen stimmen nicht mit den Rechnungspositionen überein: "
+"{details}"
 
 msgid "Only draft invoices can be edited."
 msgstr "Nur Rechnungsentwürfe können bearbeitet werden."
@@ -2340,10 +2342,12 @@ msgid "Event '%s' does not require a ticket."
 msgstr "Event '%s' erfordert kein Ticket."
 
 #, python-format
-msgid "Event '%s' is invitation-only and cannot be covered by a series pass."
+msgid ""
+"Event '%s' is invitation-only or members-only and cannot be covered by a "
+"series pass."
 msgstr ""
-"Event '%s' ist nur auf Einladung zugänglich und kann nicht durch einen "
-"Serienpass abgedeckt werden."
+"Event '%s' ist nur auf Einladung oder nur für Mitglieder zugänglich und kann "
+"nicht durch einen Serienpass abgedeckt werden."
 
 msgid ""
 "Events gated by an admission questionnaire cannot be covered by a series "

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -2309,10 +2309,12 @@ msgid "Event '%s' does not require a ticket."
 msgstr "El evento '%s' no requiere entrada."
 
 #, python-format
-msgid "Event '%s' is invitation-only and cannot be covered by a series pass."
+msgid ""
+"Event '%s' is invitation-only or members-only and cannot be covered by a "
+"series pass."
 msgstr ""
-"El evento '%s' es solo por invitación y no puede estar cubierto por un pase "
-"de serie."
+"El evento '%s' es solo por invitación o solo para miembros y no puede estar "
+"cubierto por un pase de serie."
 
 msgid ""
 "Events gated by an admission questionnaire cannot be covered by a series "

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -2351,10 +2351,12 @@ msgid "Event '%s' does not require a ticket."
 msgstr "L'événement '%s' ne nécessite pas de billet."
 
 #, python-format
-msgid "Event '%s' is invitation-only and cannot be covered by a series pass."
+msgid ""
+"Event '%s' is invitation-only or members-only and cannot be covered by a "
+"series pass."
 msgstr ""
-"L'événement '%s' est sur invitation uniquement et ne peut pas être couvert "
-"par un pass de série."
+"L'événement '%s' est sur invitation uniquement ou réservé aux membres et ne "
+"peut pas être couvert par un pass de série."
 
 msgid ""
 "Events gated by an admission questionnaire cannot be covered by a series "

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -2316,10 +2316,12 @@ msgid "Event '%s' does not require a ticket."
 msgstr "L'evento '%s' non richiede un biglietto."
 
 #, python-format
-msgid "Event '%s' is invitation-only and cannot be covered by a series pass."
+msgid ""
+"Event '%s' is invitation-only or members-only and cannot be covered by a "
+"series pass."
 msgstr ""
-"L'evento '%s' è solo su invito e non può essere coperto da un pass "
-"stagionale."
+"L'evento '%s' è solo su invito o riservato ai membri e non può essere "
+"coperto da un pass stagionale."
 
 msgid ""
 "Events gated by an admission questionnaire cannot be covered by a series "

--- a/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/locale/pt/LC_MESSAGES/django.po
@@ -2285,10 +2285,12 @@ msgid "Event '%s' does not require a ticket."
 msgstr "O evento '%s' não requer bilhete."
 
 #, python-format
-msgid "Event '%s' is invitation-only and cannot be covered by a series pass."
+msgid ""
+"Event '%s' is invitation-only or members-only and cannot be covered by a "
+"series pass."
 msgstr ""
-"O evento '%s' é apenas por convite e não pode ser abrangido por um passe de "
-"série."
+"O evento '%s' é apenas por convite ou apenas para membros e não pode ser "
+"abrangido por um passe de série."
 
 msgid ""
 "Events gated by an admission questionnaire cannot be covered by a series "

--- a/src/questionnaires/admin.py
+++ b/src/questionnaires/admin.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from django.db.models import Count, QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from unfold.admin import ModelAdmin, StackedInline, TabularInline
 from unfold.contrib.filters.admin import AutocompleteSelectFilter
@@ -251,7 +251,7 @@ class QuestionnaireEvaluationInline(StackedInline):  # type: ignore[misc]
         if not obj.raw_evaluation_data:
             return "—"
         pretty_json = json.dumps(obj.raw_evaluation_data, indent=2)
-        return mark_safe(f"<pre>{pretty_json}</pre>")
+        return format_html("<pre>{}</pre>", pretty_json)
 
     raw_evaluation_data_display.short_description = "Raw Evaluation Data"  # type: ignore[attr-defined]
 
@@ -365,7 +365,7 @@ class QuestionnaireSubmissionAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[m
         if not obj.metadata:
             return "—"
         pretty_json = json.dumps(obj.metadata, indent=2)
-        return mark_safe(f"<pre style='background: #f8f9fa; padding: 10px; border-radius: 4px;'>{pretty_json}</pre>")
+        return format_html("<pre style='background: #f8f9fa; padding: 10px; border-radius: 4px;'>{}</pre>", pretty_json)
 
     metadata_display.short_description = "Metadata"  # type: ignore[attr-defined]
 
@@ -504,22 +504,23 @@ class QuestionnaireEvaluationAdmin(ModelAdmin):  # type: ignore[misc]
     submission_link.short_description = "Submission"  # type: ignore[attr-defined]
 
     def evaluation_workflow_display(self, obj: models.QuestionnaireEvaluation) -> str:
-        html = "<h4>Evaluation Workflow:</h4><ul>"
-
-        html += f"<li><strong>Questionnaire:</strong> {obj.submission.questionnaire.name}</li>"
-        html += (
-            f"<li><strong>Evaluation Mode:</strong> {obj.submission.questionnaire.get_evaluation_mode_display()}</li>"
-        )
-        html += f"<li><strong>Min Score Required:</strong> {obj.submission.questionnaire.min_score}</li>"
-
+        questionnaire = obj.submission.questionnaire
+        rows: list[tuple[str, t.Any]] = [
+            ("Questionnaire", questionnaire.name),
+            ("Evaluation Mode", questionnaire.get_evaluation_mode_display()),
+            ("Min Score Required", questionnaire.min_score),
+        ]
         if obj.automatically_evaluated:
-            html += f"<li><strong>LLM Backend:</strong> {obj.submission.questionnaire.get_llm_backend_display()}</li>"
+            rows.append(("LLM Backend", questionnaire.get_llm_backend_display()))
+        rows += [
+            ("Created", obj.created_at),
+            ("Last Updated", obj.updated_at),
+        ]
 
-        html += f"<li><strong>Created:</strong> {obj.created_at}</li>"
-        html += f"<li><strong>Last Updated:</strong> {obj.updated_at}</li>"
-
-        html += "</ul>"
-        return mark_safe(html)
+        # format_html_join escapes every interpolated value, so attacker-controlled data
+        # (e.g. the questionnaire name) can't inject markup.
+        items = format_html_join("", "<li><strong>{}:</strong> {}</li>", rows)
+        return format_html("<h4>Evaluation Workflow:</h4><ul>{}</ul>", items)
 
     evaluation_workflow_display.short_description = "Workflow Info"  # type: ignore[attr-defined]
 
@@ -527,7 +528,7 @@ class QuestionnaireEvaluationAdmin(ModelAdmin):  # type: ignore[misc]
         if not obj.raw_evaluation_data:
             return "—"
         pretty_json = json.dumps(obj.raw_evaluation_data, indent=2)
-        return mark_safe(f"<pre style='background: #f8f9fa; padding: 10px; border-radius: 4px;'>{pretty_json}</pre>")
+        return format_html("<pre style='background: #f8f9fa; padding: 10px; border-radius: 4px;'>{}</pre>", pretty_json)
 
     raw_evaluation_data_display.short_description = "Raw Evaluation Data"  # type: ignore[attr-defined]
 

--- a/src/questionnaires/evaluator.py
+++ b/src/questionnaires/evaluator.py
@@ -219,12 +219,19 @@ class SubmissionEvaluator:
         if self.missing_mandatory:
             return
 
+        # Award each question's positive_weight AT MOST ONCE, even when the question
+        # allows multiple answers and several correct options were selected. Scoring per
+        # answer row would let a multi-correct question contribute N× its weight against a
+        # denominator that counts it once, inflating the score above 100% (see max_mc_points).
+        awarded_positive: set[UUID] = set()
         for answer in self.submission.multiplechoiceanswer_answers.all().select_related("option", "question"):
             # Only score applicable questions
             if answer.question_id not in self._applicable_mcq_ids:
                 continue
             if answer.option.is_correct:
-                self.mc_points_scored += answer.question.positive_weight
+                if answer.question_id not in awarded_positive:
+                    self.mc_points_scored += answer.question.positive_weight
+                    awarded_positive.add(answer.question_id)
             else:
                 self.mc_points_scored -= answer.question.negative_weight
                 self._fatalize(answer.question)
@@ -313,6 +320,8 @@ class SubmissionEvaluator:
                 if total_max_points > 0
                 else Decimal("100.0")
             )
+            # Defense-in-depth: a score can never exceed 100%.
+            score_percent = min(score_percent, Decimal("100.0"))
 
         passed = score_percent >= self.questionnaire.min_score
         proposed_status = (


### PR DESCRIPTION
## Summary

Remediates the 12 confirmed findings (4 HIGH, 8 MEDIUM) from a full-codebase security sweep. Every fix is surgical and mirrors patterns already used elsewhere in the codebase. The exploit tests that reproduced each finding are intentionally **not** included in this PR (kept local, per convention); they now fail against this branch, which is the intended signal that the vulnerabilities are closed.

## HIGH

- **Ban evasion (accounts).** Globally-banned emails were accepted on the guest-user creation and password-reset paths, and a banned domain could be converted into a full active account. Now `is_email_globally_banned` gates guest creation and the reset request/redeem pair, and `handle_guest_rsvp` is atomic so a rejected guest leaves no row.
- **Stored XSS in the Django admin (questionnaires).** Admin display methods interpolated attacker-controlled questionnaire/event names via `mark_safe` f-strings. Rewritten with `format_html` / escaped JSON.
- **Malware re-upload bypass (common).** Re-uploading identical flagged bytes rolled back the quarantine and left the file live. The audit query is now scoped by instance/status and `bulk_create` uses `ignore_conflicts`.
- **Series-pass admission bypass (events).** The coverage gate checked `visibility` instead of `event_type`, letting a public pass grant tickets to invitation-only / members-only events. Now gates on `event_type`.

## MEDIUM

- **Stale-membership resource access (events-models).** `AdditionalResource.for_user` now filters membership through `for_visibility()`, so cancelled/banned members lose MEMBERS_ONLY access.
- **Quarantine no-op on non-nullable file fields (common).** For non-nullable file fields (questionnaire uploads) the row/file is now deleted rather than nulled, so quarantine no longer fails silently.
- **Per-user cap TOCTOU (events-service).** Per-user ticket caps are now enforced under the tier/event row lock, closing a concurrent-checkout bypass of `max_tickets_per_user`.
- **Spreadsheet formula injection (events-service).** Attendee and questionnaire exports route user-derived cells through a `sanitize_cell` helper (CWE-1236).
- **MC scoring inflation (questionnaires).** Each multiple-choice question's weight is awarded at most once and the score is clamped to 100.
- **Event status privilege bypass (events-schema).** `status` moved out of `EventEditSchema` into `EventCreateSchema`, so status transitions go only through the `manage_event`-gated endpoint.
- **Image-upload memory DoS (common).** Added a pixel-dimension bound plus a Pillow backstop and removed the triple-buffer EXIF strip.
- **Recurrence generation cap bypass (events-service).** The client `until` override is clamped to the 52-week generation ceiling.

## Also included

Small updates to the `.claude/agents/*` definitions (vuln-analyst, vuln-verifier, tech-debt-assessor, tech-debt-verifier).

## Verification

- `ruff format`, `ruff check`, and `mypy --strict` pass on all 16 changed source files.
- Full suite (local, parallel): **8525 passed**, with only the 12 (uncommitted) exploit tests failing by design.
- One incidental regression from the image fix (`test_prefers_thumbnail_over_logo`, which saves deliberately-fake bytes) was resolved by only enforcing the pixel budget when dimensions are actually readable, preserving the original validator's leniency.

## Note for review

The MC-scoring fix caps each question's contribution rather than requiring an exact-match (all-or-nothing) answer set, because existing evaluator tests assert that selecting one of several correct options still scores full marks. Switching to all-or-nothing would be a grading-semantics change requiring those tests to be updated — flagging in case that stricter behaviour is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Blocked globally banned addresses from password resets, guest RSVPs, and account creation.
  - Added protections against oversized images, spreadsheet formula injection, and unsafe admin HTML.
  - Improved malware quarantine handling and notification reliability.

- **Bug Fixes**
  - Prevented per-user ticket limits from being bypassed during concurrent purchases.
  - Restricted event status changes to the appropriate workflow.
  - Corrected members-only visibility and questionnaire scoring behavior.
  - Improved safety and accuracy across attendee and questionnaire exports.

- **Improvements**
  - Limited recurrence generation horizons and reduced memory usage when processing images.
  - Prevented restricted events from being included in series passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->