### PR TITLE
fix(guest): enforce tier purchasable_by at guest checkout, not only at confirm

### DIFF
--- a/src/events/controllers/event_public/base.py
+++ b/src/events/controllers/event_public/base.py
@@ -27,6 +27,7 @@ class EventPublicBaseController(UserAwareController):
     """
 
     _token_rejection: TokenRejection | None = None
+    _event_token: models.EventToken | None
 
     def get_queryset(self, include_past: bool = False, full: bool = True) -> models.event.EventQuerySet:
         """Get the queryset based on the user."""
@@ -99,16 +100,20 @@ class EventPublicBaseController(UserAwareController):
         Side effect: if the token exists but is expired/used up, stores
         the rejection reason in ``self._token_rejection`` so that downstream
         helpers can raise 410 instead of 404.
+
+        Resolved once per request: ``get_queryset`` already calls this to widen
+        event visibility, and the guest endpoints ask again to claim the token.
         """
+        if "_event_token" in self.__dict__:
+            return self._event_token
         token = (
             self.context.request.META.get("HTTP_X_EVENT_TOKEN")  # type: ignore[union-attr]
             or self.context.request.GET.get("et")  # type: ignore[union-attr]
         )
-        if not token:
-            return None
-        event_token = event_service.get_event_token(token)
-        if event_token is None:
+        event_token = event_service.get_event_token(token) if token else None
+        if token and event_token is None:
             self._token_rejection = event_service.get_token_rejection_reason(token)
+        self._event_token = event_token
         return event_token
 
     def get_questionnaire_service(self, questionnaire_id: UUID) -> SubmissionService:

--- a/src/events/controllers/event_public/discovery.py
+++ b/src/events/controllers/event_public/discovery.py
@@ -244,6 +244,7 @@ class EventPublicDiscoveryController(EventPublicBaseController):
         response={
             200: schema.EventRSVPSchema | schema.BatchCheckoutResponse,
             400: EventUserEligibility | ErrorDetail,
+            403: ErrorDetail,
         },
         throttle=WriteThrottle(),
     )
@@ -255,6 +256,7 @@ class EventPublicDiscoveryController(EventPublicBaseController):
         Validates the token, executes the action (creates RSVP or ticket), and blacklists the token
         to prevent reuse. Returns the created RSVP or BatchCheckoutResponse with tickets on success.
         Returns 400 if token is invalid, expired, already used, or if eligibility checks fail (e.g., event became full).
+        Returns 403 if the tier's purchase rule or sale window rejects the buyer at confirmation time.
         """
         from events.service.guest_hold_session import GUEST_HOLD_COOKIE, resolve_guest_session
 

--- a/src/events/controllers/event_public/guest.py
+++ b/src/events/controllers/event_public/guest.py
@@ -45,11 +45,21 @@ class EventPublicGuestController(EventPublicBaseController):
         the provided email. Accepts an optional plain-text ``note`` (max 500 chars) when the event
         has ``accept_rsvp_notes`` enabled; the note is applied when the RSVP is confirmed via the
         email link.
+
+        Send an invitation link's token as ``X-Event-Token`` (or ``?et=``) and it is claimed for
+        the guest first, exactly as the join page does for a logged-in user — this is how a guest
+        passes a private event's invitation gate.
         """
         self.ensure_not_authenticated()
         event = self.get_one(event_id)
         return guest_service.handle_guest_rsvp(
-            event, answer, payload.email, payload.first_name, payload.last_name, note=payload.note
+            event,
+            answer,
+            payload.email,
+            payload.first_name,
+            payload.last_name,
+            note=payload.note,
+            event_token=self.get_event_token(),
         )
 
     @route.post(
@@ -118,6 +128,7 @@ class EventPublicGuestController(EventPublicBaseController):
             discount_code=payload.discount_code,
             billing_info=payload.billing_info,
             guest_session=self._resolve_guest_session(),
+            event_token=self.get_event_token(),
         )
 
     @route.post(
@@ -185,6 +196,7 @@ class EventPublicGuestController(EventPublicBaseController):
             payload.last_name,
             billing_info=payload.billing_info,
             guest_session=self._resolve_guest_session(),
+            event_token=self.get_event_token(),
         )
 
     @route.post(
@@ -215,6 +227,11 @@ class EventPublicGuestController(EventPublicBaseController):
         `POST /events/reservations/{reservation_id}/checkout-session/public` next to
         obtain the Stripe `checkout_url`. Free / offline / at-the-door tiers complete
         here (`requires_payment=false`, email confirmation sent).
+
+        **Invitation links:** send the link's token as ``X-Event-Token`` (or ``?et=``) and
+        it is claimed for the guest first, exactly as the join page does for a logged-in
+        user — this is how a guest buys from an invited-only tier. Returns 403 if a tier's
+        `purchasable_by` rule or sale window rejects the buyer.
         """
         self.ensure_not_authenticated()
         event = self.get_one(event_id)
@@ -250,6 +267,7 @@ class EventPublicGuestController(EventPublicBaseController):
             discount_code=payload.discount_code,
             billing_info=payload.billing_info,
             guest_session=self._resolve_guest_session(),
+            event_token=self.get_event_token(),
         )
 
     @route.post(

--- a/src/events/controllers/event_public/guest.py
+++ b/src/events/controllers/event_public/guest.py
@@ -31,7 +31,7 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/rsvp/{answer}/public",
         url_name="guest_rsvp",
-        response={200: schema.GuestActionResponseSchema, 400: EventUserEligibility | ErrorDetail},
+        response={200: schema.GuestActionResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
         throttle=WriteThrottle(),
     )
     def guest_rsvp(
@@ -65,7 +65,7 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/tickets/{tier_id}/checkout/public",
         url_name="guest_ticket_checkout",
-        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail},
+        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
         throttle=WriteThrottle(),
         deprecated=True,
     )
@@ -104,9 +104,8 @@ class EventPublicGuestController(EventPublicBaseController):
         self.ensure_not_authenticated()
         event = self.get_one(event_id)
         tier = get_object_or_404(
-            models.TicketTier.objects.for_user(self.maybe_user()),
+            models.TicketTier.objects.for_visible_event(event, self.maybe_user(), event_token=self.get_event_token()),
             pk=tier_id,
-            event=event,
         )
         if tier.price_type == models.TicketTier.PriceType.PWYC:
             raise HttpError(400, str(_("Use /pwyc endpoint for pay-what-you-can tickets")))
@@ -134,7 +133,7 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/tickets/{tier_id}/checkout/pwyc/public",
         url_name="guest_ticket_pwyc_checkout",
-        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail},
+        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
         throttle=WriteThrottle(),
         deprecated=True,
     )
@@ -175,9 +174,8 @@ class EventPublicGuestController(EventPublicBaseController):
         self.ensure_not_authenticated()
         event = self.get_one(event_id)
         tier = get_object_or_404(
-            models.TicketTier.objects.for_user(self.maybe_user()),
+            models.TicketTier.objects.for_visible_event(event, self.maybe_user(), event_token=self.get_event_token()),
             pk=tier_id,
-            event=event,
         )
         if tier.price_type != models.TicketTier.PriceType.PWYC:
             raise HttpError(400, str(_("This endpoint is only for pay-what-you-can tickets")))
@@ -202,7 +200,12 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/checkout/public",
         url_name="guest_multi_tier_checkout",
-        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail, 404: ErrorDetail},
+        response={
+            200: schema.GuestCheckoutResponseSchema,
+            400: EventUserEligibility | ErrorDetail,
+            403: ErrorDetail,
+            404: ErrorDetail,
+        },
         throttle=WriteThrottle(),
     )
     def guest_multi_tier_checkout(
@@ -238,7 +241,9 @@ class EventPublicGuestController(EventPublicBaseController):
         tiers = {
             tier.id: tier
             # sector joined up front: assert_sector_capacities walks tier.sector per group
-            for tier in models.TicketTier.objects.for_visible_event(event, self.maybe_user())
+            for tier in models.TicketTier.objects.for_visible_event(
+                event, self.maybe_user(), event_token=self.get_event_token()
+            )
             .select_related("sector")
             .filter(pk__in=[g.tier_id for g in payload.items])
         }

--- a/src/events/controllers/event_public/tickets.py
+++ b/src/events/controllers/event_public/tickets.py
@@ -60,8 +60,9 @@ class EventPublicTicketsController(EventPublicBaseController):
         """
         event = self.get_one(event_id)
         user = self.maybe_user()
+        event_token = self.get_event_token()
         visible_tiers = list(
-            models.TicketTier.objects.for_visible_event(event, user)
+            models.TicketTier.objects.for_visible_event(event, user, event_token=event_token)
             .select_related("event__organization")
             .with_venue_and_sector()
             .distinct()
@@ -70,9 +71,11 @@ class EventPublicTicketsController(EventPublicBaseController):
         if user and not user.is_anonymous:
             eligible_ids = {tier.id for tier in ticket_service.get_eligible_tiers(event, user)}
         else:
-            # Anonymous users can only purchase PUBLIC tiers
+            # Anonymous users can only purchase PUBLIC tiers — plus what a granting
+            # invitation link for this event unlocks: guest checkout claims it
+            # (EventPublicGuestController), so the listing must say so up front.
             eligible_ids = {
-                tier.id for tier in visible_tiers if tier.purchasable_by == models.TicketTier.PurchasableBy.PUBLIC
+                tier.id for tier in visible_tiers if ticket_service.anonymous_can_purchase(tier, event, event_token)
             }
         for tier in visible_tiers:
             tier._can_purchase = tier.id in eligible_ids  # type: ignore[attr-defined]

--- a/src/events/models/ticket.py
+++ b/src/events/models/ticket.py
@@ -24,6 +24,7 @@ from .venue import Venue, VenueSeat, VenueSector
 if t.TYPE_CHECKING:
     from accounts.models import RevelUser
     from events.models.event import Event
+    from events.models.invitation import EventToken
 
 DEFAULT_TICKET_TIER_NAME = "General Admission"
 
@@ -134,7 +135,9 @@ class TicketTierQuerySet(models.QuerySet["TicketTier"]):
 
         return qs.filter(final_q).distinct()
 
-    def for_visible_event(self, event: "Event", user: "RevelUser | AnonymousUser") -> t.Self:
+    def for_visible_event(
+        self, event: "Event", user: "RevelUser | AnonymousUser", event_token: "EventToken | None" = None
+    ) -> t.Self:
         """Return ticket tiers for an already visibility-checked event.
 
         Use this when you already have an event that passed visibility checks via Event.for_user().
@@ -143,6 +146,9 @@ class TicketTierQuerySet(models.QuerySet["TicketTier"]):
         Args:
             event: An event that already passed visibility checks for this user.
             user: The user to check tier visibility for.
+            event_token: An invitation link the request carries. For an anonymous user it
+                grants the private-tier visibility the invitation it would create grants,
+                so a guest can reach an invitation-gated tier before the claim exists.
 
         Returns:
             QuerySet of tiers the user can see for this specific event.
@@ -155,9 +161,28 @@ class TicketTierQuerySet(models.QuerySet["TicketTier"]):
         if not user.is_anonymous and (user.is_superuser or user.is_staff):
             return qs
 
-        # Anonymous users: only publicly accessible tiers (PUBLIC + UNLISTED)
+        # Anonymous users: only publicly accessible tiers (PUBLIC + UNLISTED), plus the
+        # private tiers a granting invitation link for this event would unlock — the same
+        # rule as the invitation branch below, keyed on the token's tier links instead.
         if user.is_anonymous:
-            return qs.filter(visibility__in=TicketTier.Visibility.publicly_accessible())
+            is_public_tier = Q(visibility__in=TicketTier.Visibility.publicly_accessible())
+            if event_token is None or not event_token.grants_invitation or event_token.event_id != event.id:
+                return qs.filter(is_public_tier)
+            token_tier_ids = {tier.id for tier in event_token.ticket_tiers.all()}
+            unrestricted_private = Q(
+                visibility=TicketTier.Visibility.PRIVATE,
+                restrict_visibility_to_linked_invitations=False,
+            )
+            restricted_private = (
+                Q(
+                    visibility=TicketTier.Visibility.PRIVATE,
+                    restrict_visibility_to_linked_invitations=True,
+                    pk__in=token_tier_ids,
+                )
+                if token_tier_ids
+                else Q(pk__isnull=True)
+            )
+            return qs.filter(is_public_tier | unrestricted_private | restricted_private)
 
         # Check if user is org owner or staff - they see all tiers
         if event.organization.is_owner_or_staff(user):
@@ -211,9 +236,11 @@ class TicketTierManager(models.Manager["TicketTier"]):
         """Return ticket tiers visible to a given user, combining event and tier-level access."""
         return self.get_queryset().for_user(user)
 
-    def for_visible_event(self, event: "Event", user: "RevelUser | AnonymousUser") -> TicketTierQuerySet:
+    def for_visible_event(
+        self, event: "Event", user: "RevelUser | AnonymousUser", event_token: "EventToken | None" = None
+    ) -> TicketTierQuerySet:
         """Return ticket tiers for an already visibility-checked event."""
-        return self.get_queryset().for_visible_event(event, user)
+        return self.get_queryset().for_visible_event(event, user, event_token=event_token)
 
 
 class TicketTier(TimeStampedModel, VisibilityMixin):

--- a/src/events/service/batch_ticket_service/eligibility.py
+++ b/src/events/service/batch_ticket_service/eligibility.py
@@ -24,6 +24,7 @@ from events.service.event_manager import (
 )
 
 if t.TYPE_CHECKING:
+    from accounts.models import RevelUser
     from events.service.batch_ticket_service.context import CartGroup
 
 
@@ -45,6 +46,63 @@ def assert_sale_window(tier: TicketTier) -> None:
     """
     if not tier.can_purchase():
         raise HttpError(403, str(_("You're outside of the sale window.")))
+
+
+def assert_purchasable_by(
+    tier: TicketTier, *, is_owner_or_staff: bool, is_member: bool, invitation: EventInvitation | None
+) -> None:
+    """Assert a buyer with these standings may purchase from this tier.
+
+    The pure ``purchasable_by`` rule, module-level for the same reason as
+    :func:`assert_sale_window`: guest checkout's non-online branch defers
+    ``create_batch`` to the emailed confirmation click and must answer this up
+    front, or an uninvited guest gets a 200, an email, and a link that 403s.
+
+    Args:
+        tier: The tier being purchased from.
+        is_owner_or_staff: Whether the buyer owns or staffs the organization —
+            exempt from every restriction (consistent with CanPurchaseTicket).
+        is_member: Whether the buyer holds an active organization membership.
+        invitation: The buyer's invitation to the event, if any. When the tier
+            restricts purchase to linked invitations, it must link this tier.
+
+    Raises:
+        HttpError: 403 when the buyer does not satisfy the tier's rule.
+    """
+    PB = TicketTier.PurchasableBy
+    if tier.purchasable_by == PB.PUBLIC or is_owner_or_staff:
+        return
+
+    def _invited_passes() -> bool:
+        if invitation is None:
+            return False
+        if tier.restrict_purchase_to_linked_invitations:
+            return invitation.tiers.filter(pk=tier.pk).exists()
+        return True
+
+    if tier.purchasable_by == PB.MEMBERS and is_member:
+        return
+    if tier.purchasable_by == PB.INVITED and _invited_passes():
+        return
+    if tier.purchasable_by == PB.INVITED_AND_MEMBERS and (is_member or _invited_passes()):
+        return
+
+    raise HttpError(403, str(_("You are not allowed to purchase from this tier.")))
+
+
+def assert_cart_purchasable_by(event: Event, user: "RevelUser", tiers: t.Iterable[TicketTier]) -> None:
+    """Run :func:`assert_purchasable_by` over a cart, resolving the buyer's standings once.
+
+    Args:
+        event: The event the cart belongs to.
+        user: The buyer.
+        tiers: Every tier in the cart.
+    """
+    is_owner_or_staff = event.organization.is_owner_or_staff(user)
+    is_member = OrganizationMember.objects.active_only().filter(organization=event.organization, user=user).exists()
+    invitation = EventInvitation.objects.filter(event=event, user=user).first()
+    for tier in tiers:
+        assert_purchasable_by(tier, is_owner_or_staff=is_owner_or_staff, is_member=is_member, invitation=invitation)
 
 
 class PurchaseEligibilityMixin(BatchTicketContext):
@@ -83,31 +141,12 @@ class PurchaseEligibilityMixin(BatchTicketContext):
         Args:
             tier: The tier being purchased from.
         """
-        PB = TicketTier.PurchasableBy
-        if tier.purchasable_by == PB.PUBLIC:
-            return
-
-        if self._buyer_is_owner_or_staff:
-            return
-
-        is_member = self._buyer_membership is not None
-        invitation = self._buyer_invitation
-
-        def _invited_passes() -> bool:
-            if invitation is None:
-                return False
-            if tier.restrict_purchase_to_linked_invitations:
-                return invitation.tiers.filter(pk=tier.pk).exists()
-            return True
-
-        if tier.purchasable_by == PB.MEMBERS and is_member:
-            return
-        if tier.purchasable_by == PB.INVITED and _invited_passes():
-            return
-        if tier.purchasable_by == PB.INVITED_AND_MEMBERS and (is_member or _invited_passes()):
-            return
-
-        raise HttpError(403, str(_("You are not allowed to purchase from this tier.")))
+        assert_purchasable_by(
+            tier,
+            is_owner_or_staff=self._buyer_is_owner_or_staff,
+            is_member=self._buyer_membership is not None,
+            invitation=self._buyer_invitation,
+        )
 
     def _assert_membership_tier_allowed(self, tier: TicketTier) -> None:
         """Assert the buyer holds one of the membership tiers this tier is restricted to.

--- a/src/events/service/batch_ticket_service/eligibility.py
+++ b/src/events/service/batch_ticket_service/eligibility.py
@@ -90,8 +90,60 @@ def assert_purchasable_by(
     raise HttpError(403, str(_("You are not allowed to purchase from this tier.")))
 
 
+def assert_membership_tier_allowed(
+    tier: TicketTier, event: Event, *, is_owner_or_staff: bool, membership: OrganizationMember | None
+) -> None:
+    """Assert the buyer holds one of the membership tiers this tier is restricted to.
+
+    Same guard as the membership-tier check in ``ticket_service.get_eligible_tiers``,
+    applied to the purchase path (#807): the tier listing hid the tier, but nothing
+    stopped a direct checkout call. Semantics are copied verbatim — an empty
+    restriction is unrestricted, only an ACTIVE membership counts, and the member's
+    tier must be one of the required ones (a member with no tier does not qualify).
+    Module-level for the same reason as :func:`assert_purchasable_by`.
+
+    Args:
+        tier: The tier being purchased from.
+        event: The event the tier belongs to (for the eligibility payload).
+        is_owner_or_staff: Whether the buyer owns or staffs the organization — exempt.
+        membership: The buyer's active membership, if any.
+
+    Raises:
+        UserIsIneligibleError: If the buyer does not hold a required membership tier.
+            Rendered as 400 + the eligibility payload, so the frontend gets the
+            ``membership_tier_required`` reason code instead of an opaque 403.
+    """
+    required_tier_ids = set(tier.restricted_to_membership_tiers.values_list("id", flat=True))
+    if not required_tier_ids:
+        return
+
+    if is_owner_or_staff:
+        return
+
+    if membership is not None and membership.tier_id in required_tier_ids:
+        return
+
+    # UPGRADE_MEMBERSHIP for members and non-members alike: the only way through is
+    # to hold one of the named tiers. BECOME_MEMBER would be a dead end — a plain
+    # membership request grants no tier, so it would not unblock the purchase.
+    raise UserIsIneligibleError(
+        message="Membership tier required.",
+        eligibility=EventUserEligibility(
+            allowed=False,
+            event_id=event.id,
+            reason=str(_(Reasons.MEMBERSHIP_TIER_REQUIRED)),
+            reason_code=Reasons.MEMBERSHIP_TIER_REQUIRED.code,
+            next_step=NextStep.UPGRADE_MEMBERSHIP,
+        ),
+    )
+
+
 def assert_cart_purchasable_by(event: Event, user: "RevelUser", tiers: t.Iterable[TicketTier]) -> None:
-    """Run :func:`assert_purchasable_by` over a cart, resolving the buyer's standings once.
+    """Run the per-tier access rules over a cart, resolving the buyer's standings once.
+
+    The same two rules, in the same order, as ``BatchTicketService.create_batch``:
+    :func:`assert_purchasable_by` first (so its coarser 403 answers first), then
+    :func:`assert_membership_tier_allowed`.
 
     Args:
         event: The event the cart belongs to.
@@ -99,10 +151,13 @@ def assert_cart_purchasable_by(event: Event, user: "RevelUser", tiers: t.Iterabl
         tiers: Every tier in the cart.
     """
     is_owner_or_staff = event.organization.is_owner_or_staff(user)
-    is_member = OrganizationMember.objects.active_only().filter(organization=event.organization, user=user).exists()
+    membership = OrganizationMember.objects.active_only().filter(organization=event.organization, user=user).first()
     invitation = EventInvitation.objects.filter(event=event, user=user).first()
     for tier in tiers:
-        assert_purchasable_by(tier, is_owner_or_staff=is_owner_or_staff, is_member=is_member, invitation=invitation)
+        assert_purchasable_by(
+            tier, is_owner_or_staff=is_owner_or_staff, is_member=membership is not None, invitation=invitation
+        )
+        assert_membership_tier_allowed(tier, event, is_owner_or_staff=is_owner_or_staff, membership=membership)
 
 
 class PurchaseEligibilityMixin(BatchTicketContext):
@@ -167,29 +222,8 @@ class PurchaseEligibilityMixin(BatchTicketContext):
                 Rendered as 400 + the eligibility payload, so the frontend gets the
                 ``membership_tier_required`` reason code instead of an opaque 403.
         """
-        required_tier_ids = set(tier.restricted_to_membership_tiers.values_list("id", flat=True))
-        if not required_tier_ids:
-            return
-
-        if self._buyer_is_owner_or_staff:
-            return
-
-        membership = self._buyer_membership
-        if membership is not None and membership.tier_id in required_tier_ids:
-            return
-
-        # UPGRADE_MEMBERSHIP for members and non-members alike: the only way through is
-        # to hold one of the named tiers. BECOME_MEMBER would be a dead end — a plain
-        # membership request grants no tier, so it would not unblock the purchase.
-        raise UserIsIneligibleError(
-            message="Membership tier required.",
-            eligibility=EventUserEligibility(
-                allowed=False,
-                event_id=self.event.id,
-                reason=str(_(Reasons.MEMBERSHIP_TIER_REQUIRED)),
-                reason_code=Reasons.MEMBERSHIP_TIER_REQUIRED.code,
-                next_step=NextStep.UPGRADE_MEMBERSHIP,
-            ),
+        assert_membership_tier_allowed(
+            tier, self.event, is_owner_or_staff=self._buyer_is_owner_or_staff, membership=self._buyer_membership
         )
 
     def _assert_sale_window(self, tier: TicketTier) -> None:

--- a/src/events/service/batch_ticket_service/service.py
+++ b/src/events/service/batch_ticket_service/service.py
@@ -27,6 +27,7 @@ from events.service.seating.pricing import (
 
 if t.TYPE_CHECKING:
     from events.schema.ticket import BuyerBillingInfoSchema
+    from events.service.attendee_vat_service import BuyerVATContext
 
 logger = structlog.get_logger(__name__)
 
@@ -223,6 +224,7 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
         items: list[TicketPurchaseItem] | None = None,
         pwyc_amount: Decimal | None = None,
         billing_info: "BuyerBillingInfoSchema | None" = None,
+        buyer_vat_context: "BuyerVATContext | None" = None,
     ) -> list[Ticket] | tuple[list[Ticket], UUID]:
         """Create a batch of tickets, spanning as many tiers as the cart holds.
 
@@ -240,6 +242,10 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
                 pass the validated code as ``discount_code`` to the constructor and
                 the pricing service applies it per ticket. Single-tier form only.
             billing_info: Optional buyer billing info for attendee invoicing.
+            buyer_vat_context: The buyer's VAT context, when the caller already ran the
+                VIES round-trip. Guest checkout pre-resolves it before claiming an
+                invitation link, so the token row lock is never held across VIES
+                (the same discipline as the tier lock, #632). Resolved here otherwise.
 
         Returns:
             Either a `(tickets, reservation_id)` tuple for the ONLINE payment
@@ -282,8 +288,12 @@ class BatchTicketService(PurchaseEligibilityMixin, CapacityMixin, SeatResolution
         # (#632). Price-independent: the arithmetic runs post-lock against each
         # locked tier's fresh price. Only the paid-online path creates Stripe
         # Payment rows; other methods skip it.
-        buyer_vat = None
-        if payment_method == TicketTier.PaymentMethod.ONLINE and not self._cart_is_certainly_free():
+        buyer_vat = buyer_vat_context
+        if (
+            buyer_vat is None
+            and payment_method == TicketTier.PaymentMethod.ONLINE
+            and not self._cart_is_certainly_free()
+        ):
             from events.service import stripe_service
 
             buyer_vat = stripe_service.resolve_attendee_vat_for_reserve(billing_info=billing_info)

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -459,6 +459,18 @@ def handle_guest_ticket_checkout(
     for group in groups:
         assert_sale_window(group.tier)
 
+    # Run the VIES round-trip HERE, before any row lock is taken: claim_invitation_link
+    # below locks the EventToken row for the rest of the request (ATOMIC_REQUESTS — the
+    # inner atomic() only releases a savepoint), and create_batch takes the tier locks.
+    # Neither may be held across a network call (#632). Answerable with no user at all,
+    # so it sits with the other user-independent gates. Only the paid-online path needs
+    # it; create_batch resolves it itself when handed None.
+    from events.service import stripe_service
+
+    buyer_vat_context = None
+    if groups[0].tier.payment_method == models.TicketTier.PaymentMethod.ONLINE and billing_info:
+        buyer_vat_context = stripe_service.resolve_attendee_vat_for_reserve(billing_info=billing_info)
+
     # Create or update guest user. Must come AFTER the gates above (#846 review
     # fix): all are answerable with no user at all, and creating a row / touching
     # the "does an account exist" check before them turns a login-required event
@@ -515,7 +527,7 @@ def handle_guest_ticket_checkout(
             discount_valid_tier_ids=valid_tier_ids,
             guest_session=guest_session,
         )
-        result = service.create_batch(billing_info=billing_info)
+        result = service.create_batch(billing_info=billing_info, buyer_vat_context=buyer_vat_context)
 
         # Branch on the returned SHAPE, never on the tier's payment method (#740):
         # a PWYC/discount input that zeroes every unit reroutes an ONLINE cart to

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -401,7 +401,7 @@ def handle_guest_ticket_checkout(
     from events.service import discount_code_service
     from events.service.batch_ticket_service import BatchTicketService
     from events.service.batch_ticket_service.context import validate_cart_shape
-    from events.service.batch_ticket_service.eligibility import assert_sale_window
+    from events.service.batch_ticket_service.eligibility import assert_cart_purchasable_by, assert_sale_window
     from events.service.seating.pick import resolve_requested_zone
     from events.tasks import send_guest_ticket_confirmation
 
@@ -436,6 +436,14 @@ def handle_guest_ticket_checkout(
     # Check eligibility (before validating PWYC/discount to prevent information leakage)
     manager = EventManager(user, event)
     manager.check_eligibility(raise_on_false=True)
+
+    # Enforce each tier's purchasable_by rule HERE, before the payment-method branch,
+    # for the same reason as the sale window above: the non-online branch defers
+    # create_batch — the only other place the rule runs — to the confirmation click,
+    # so an uninvited guest on an invited-only tier would otherwise get a 200, an
+    # email, and a link that 403s. Must run AFTER get_or_create_guest_user: a pending
+    # email invitation becomes this user's EventInvitation on row creation.
+    assert_cart_purchasable_by(event, user, (group.tier for group in groups))
 
     # Cart-shape validation (duplicate tier, uniform currency/payment method, PWYC
     # required-iff-PWYC and in bounds, no seat twice) — the single authority shared

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -87,6 +87,31 @@ def get_or_create_guest_user(email: str, first_name: str = "", last_name: str = 
     return existing_user
 
 
+def claim_invitation_link(user: RevelUser, event: models.Event, event_token: models.EventToken | None) -> None:
+    """Claim an invitation link carried by a guest request, if it is for this event.
+
+    The guest counterpart of the join page's ``POST /events/claim-invitation/{token}``,
+    which requires a login: a guest sends the same token as ``X-Event-Token`` and gets
+    the same ``EventInvitation``. All token rules are ``tokens.claim_invitation``'s —
+    read-only tokens, expiry and ``max_uses`` are enforced there, and it is idempotent
+    for a returning guest. A token for another event is ignored. Must run AFTER the
+    guest user row exists and BEFORE any eligibility or tier-access check, which is
+    where the resulting invitation is consulted.
+
+    Args:
+        user: The guest user.
+        event: The event being RSVP'd to or purchased for.
+        event_token: The token resolved from the request, if any.
+    """
+    from events.service.tokens import claim_invitation
+
+    if event_token is None or event_token.event_id != event.id:
+        return
+    # claim_invitation locks the token row (select_for_update) — needs a transaction.
+    with transaction.atomic():
+        claim_invitation(user, event_token.pk)
+
+
 def create_guest_rsvp_token(
     user: RevelUser, event_id: UUID, answer: t.Literal["yes", "no", "maybe"], note: str = ""
 ) -> str:
@@ -282,6 +307,7 @@ def handle_guest_rsvp(
     first_name: str,
     last_name: str,
     note: str = "",
+    event_token: models.EventToken | None = None,
 ) -> schema.GuestActionResponseSchema:
     """Handle guest RSVP request (business logic extracted from controller).
 
@@ -292,6 +318,8 @@ def handle_guest_rsvp(
         first_name: Guest first name
         last_name: Guest last name
         note: Optional RSVP note (rejected if the event doesn't accept notes)
+        event_token: Invitation link carried by the request, claimed for the guest
+            before eligibility is checked (see :func:`claim_invitation_link`)
 
     Returns:
         Response with confirmation message
@@ -311,6 +339,7 @@ def handle_guest_rsvp(
 
     # Create or update guest user
     user = get_or_create_guest_user(email, first_name, last_name)
+    claim_invitation_link(user, event, event_token)
 
     # Check eligibility (without creating RSVP yet)
     manager = EventManager(user, event)
@@ -359,6 +388,7 @@ def handle_guest_ticket_checkout(
     discount_code: str | None = None,
     billing_info: "schema.BuyerBillingInfoSchema | None" = None,
     guest_session: str | None = None,
+    event_token: models.EventToken | None = None,
 ) -> schema.GuestCheckoutResponseSchema:
     """Handle guest ticket checkout request, spanning as many tiers as the cart holds (#846).
 
@@ -385,6 +415,8 @@ def handle_guest_ticket_checkout(
             the authenticated multi-tier endpoint uses), after eligibility.
         billing_info: Optional buyer billing info for attendee invoicing.
         guest_session: Resolved guest-hold session id (seat holds are owned by it).
+        event_token: Invitation link carried by the request, claimed for the guest
+            before eligibility and tier access are checked (see :func:`claim_invitation_link`).
 
     Returns:
         GuestCheckoutResponseSchema. Non-online carts: `message` (email confirmation
@@ -432,6 +464,7 @@ def handle_guest_ticket_checkout(
     # the "does an account exist" check before them turns a login-required event
     # into an account-creation side channel / existence oracle.
     user = get_or_create_guest_user(email, first_name, last_name)
+    claim_invitation_link(user, event, event_token)
 
     # Check eligibility (before validating PWYC/discount to prevent information leakage)
     manager = EventManager(user, event)

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -468,7 +468,7 @@ def handle_guest_ticket_checkout(
     from events.service import stripe_service
 
     buyer_vat_context = None
-    if groups[0].tier.payment_method == models.TicketTier.PaymentMethod.ONLINE and billing_info:
+    if billing_info and any(group.tier.payment_method == models.TicketTier.PaymentMethod.ONLINE for group in groups):
         buyer_vat_context = stripe_service.resolve_attendee_vat_for_reserve(billing_info=billing_info)
 
     # Create or update guest user. Must come AFTER the gates above (#846 review

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -225,6 +225,10 @@ def anonymous_can_purchase(tier: TicketTier, event: Event, event_token: EventTok
     Returns:
         True if an anonymous viewer carrying ``event_token`` can purchase from the tier.
     """
+    # A membership-tier restriction can never be met without an account (mirrors
+    # get_eligible_tiers step 4). ``.all()`` reads the manager's prefetch.
+    if tier.restricted_to_membership_tiers.all():
+        return False
     if tier.purchasable_by == TicketTier.PurchasableBy.PUBLIC:
         return True
     if event_token is None or not event_token.grants_invitation or event_token.event_id != event.id:

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -23,6 +23,7 @@ from events.models import (
     Event,
     EventInvitation,
     EventRSVP,
+    EventToken,
     MembershipTier,
     Organization,
     OrganizationMember,
@@ -205,6 +206,31 @@ def _check_tier_visibility(
 
     # STAFF_ONLY - only staff/owner (already checked above)
     return False
+
+
+def anonymous_can_purchase(tier: TicketTier, event: Event, event_token: EventToken | None) -> bool:
+    """Whether an anonymous viewer may buy from this tier.
+
+    Public tiers always. Otherwise only what a granting invitation link for this
+    event would unlock once guest checkout claims it — the same rule as
+    :func:`_check_purchasable_by` for an invited non-member, keyed on the token's
+    tier links instead of an invitation's. Keeps the listing's ``can_purchase``
+    honest for link holders, so the frontend need not second-guess it.
+
+    Args:
+        tier: The tier being listed.
+        event: The event the tier belongs to.
+        event_token: The invitation link the request carries, if any.
+
+    Returns:
+        True if an anonymous viewer carrying ``event_token`` can purchase from the tier.
+    """
+    if tier.purchasable_by == TicketTier.PurchasableBy.PUBLIC:
+        return True
+    if event_token is None or not event_token.grants_invitation or event_token.event_id != event.id:
+        return False
+    token_tier_ids = {linked.id for linked in event_token.ticket_tiers.all()}
+    return _check_purchasable_by(tier, is_member=False, is_invited=True, invitation_tier_ids=token_tier_ids)
 
 
 def _check_purchasable_by(

--- a/src/events/tests/test_controllers/test_event_public/test_ticket_tiers.py
+++ b/src/events/tests/test_controllers/test_event_public/test_ticket_tiers.py
@@ -6,7 +6,7 @@ import pytest
 from django.test.client import Client
 from django.urls import reverse
 
-from events.models import Event, EventToken, TicketTier
+from events.models import Event, EventToken, MembershipTier, TicketTier
 
 pytestmark = pytest.mark.django_db
 
@@ -71,6 +71,13 @@ def test_list_tiers_defaults_when_cancellation_disabled(
     assert no_cancel["refund_policy"] is None
 
 
+class _TierRow(t.TypedDict):
+    """The slice of ``TicketTierSchema`` the listing tests read."""
+
+    name: str
+    can_purchase: bool
+
+
 class TestAnonymousListingWithInvitationLink:
     """An anonymous viewer carrying a granting invitation link sees what the claimed
     invitation would unlock, and ``can_purchase`` says so — guest checkout claims the
@@ -97,11 +104,12 @@ class TestAnonymousListingWithInvitationLink:
         )
 
     @staticmethod
-    def _list(client: Client, event: Event, link: EventToken | None = None) -> dict[str, dict[str, t.Any]]:
+    def _list(client: Client, event: Event, link: EventToken | None = None) -> dict[str, _TierRow]:
         headers = {"X-Event-Token": link.pk} if link else None
         response = client.get(reverse("api:tier_list", kwargs={"event_id": event.pk}), headers=headers)
         assert response.status_code == 200, response.content
-        return {tier["name"]: tier for tier in response.json()}
+        rows = t.cast(list[_TierRow], response.json())
+        return {row["name"]: row for row in rows}
 
     def test_without_link_invited_tier_is_not_purchasable_and_private_tier_hidden(
         self, client: Client, public_event: Event, invited_tier: TicketTier, private_tier: TicketTier
@@ -140,3 +148,23 @@ class TestAnonymousListingWithInvitationLink:
 
         link.ticket_tiers.set([invited_tier])
         assert self._list(client, public_event, link)["Invited Only"]["can_purchase"] is True
+
+    def test_membership_tier_restriction_is_never_met_anonymously(
+        self,
+        client: Client,
+        public_event: Event,
+        invited_tier: TicketTier,
+        link: EventToken,
+        tier_factory: t.Callable[..., TicketTier],
+    ) -> None:
+        general = MembershipTier.objects.get(organization=public_event.organization, name="General membership")
+        invited_tier.restricted_to_membership_tiers.set([general])
+        public_tier = tier_factory(
+            event=public_event, name="Public Gated", purchasable_by=TicketTier.PurchasableBy.PUBLIC
+        )
+        public_tier.restricted_to_membership_tiers.set([general])
+
+        tiers = self._list(client, public_event, link)
+
+        assert tiers["Invited Only"]["can_purchase"] is False
+        assert tiers["Public Gated"]["can_purchase"] is False

--- a/src/events/tests/test_controllers/test_event_public/test_ticket_tiers.py
+++ b/src/events/tests/test_controllers/test_event_public/test_ticket_tiers.py
@@ -6,7 +6,7 @@ import pytest
 from django.test.client import Client
 from django.urls import reverse
 
-from events.models import Event, TicketTier
+from events.models import Event, EventToken, TicketTier
 
 pytestmark = pytest.mark.django_db
 
@@ -69,3 +69,74 @@ def test_list_tiers_defaults_when_cancellation_disabled(
     assert no_cancel["allow_user_cancellation"] is False
     assert no_cancel["cancellation_deadline_hours"] is None
     assert no_cancel["refund_policy"] is None
+
+
+class TestAnonymousListingWithInvitationLink:
+    """An anonymous viewer carrying a granting invitation link sees what the claimed
+    invitation would unlock, and ``can_purchase`` says so — guest checkout claims the
+    link, so the listing must not steer a link holder away from an invited-only tier.
+    """
+
+    @pytest.fixture
+    def invited_tier(self, public_event: Event, tier_factory: t.Callable[..., TicketTier]) -> TicketTier:
+        return tier_factory(event=public_event, name="Invited Only", purchasable_by=TicketTier.PurchasableBy.INVITED)
+
+    @pytest.fixture
+    def private_tier(self, public_event: Event, tier_factory: t.Callable[..., TicketTier]) -> TicketTier:
+        return tier_factory(
+            event=public_event,
+            name="Private",
+            visibility=TicketTier.Visibility.PRIVATE,
+            purchasable_by=TicketTier.PurchasableBy.INVITED,
+        )
+
+    @pytest.fixture
+    def link(self, public_event: Event) -> EventToken:
+        return EventToken.objects.create(
+            event=public_event, issuer=public_event.organization.owner, grants_invitation=True
+        )
+
+    @staticmethod
+    def _list(client: Client, event: Event, link: EventToken | None = None) -> dict[str, dict[str, t.Any]]:
+        headers = {"X-Event-Token": link.pk} if link else None
+        response = client.get(reverse("api:tier_list", kwargs={"event_id": event.pk}), headers=headers)
+        assert response.status_code == 200, response.content
+        return {tier["name"]: tier for tier in response.json()}
+
+    def test_without_link_invited_tier_is_not_purchasable_and_private_tier_hidden(
+        self, client: Client, public_event: Event, invited_tier: TicketTier, private_tier: TicketTier
+    ) -> None:
+        tiers = self._list(client, public_event)
+
+        assert tiers["Invited Only"]["can_purchase"] is False
+        assert "Private" not in tiers
+
+    def test_granting_link_unlocks_invited_and_private_tiers(
+        self, client: Client, public_event: Event, invited_tier: TicketTier, private_tier: TicketTier, link: EventToken
+    ) -> None:
+        tiers = self._list(client, public_event, link)
+
+        assert tiers["Invited Only"]["can_purchase"] is True
+        assert tiers["Private"]["can_purchase"] is True
+
+    def test_read_only_link_unlocks_nothing(
+        self, client: Client, public_event: Event, invited_tier: TicketTier, private_tier: TicketTier, link: EventToken
+    ) -> None:
+        link.grants_invitation = False
+        link.save(update_fields=["grants_invitation"])
+
+        tiers = self._list(client, public_event, link)
+
+        assert tiers["Invited Only"]["can_purchase"] is False
+        assert "Private" not in tiers
+
+    def test_purchase_linked_restriction_follows_the_link_tiers(
+        self, client: Client, public_event: Event, invited_tier: TicketTier, link: EventToken
+    ) -> None:
+        invited_tier.restrict_purchase_to_linked_invitations = True
+        invited_tier.save(update_fields=["restrict_purchase_to_linked_invitations"])
+
+        assert self._list(client, public_event, link)["Invited Only"]["can_purchase"] is False
+
+        link.ticket_tiers.set([invited_tier])
+        assert self._list(client, public_event, link)["Invited Only"]["can_purchase"] is True

--- a/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
@@ -16,7 +16,7 @@ from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 
-from events.models import Event, EventInvitation, Organization, PendingEventInvitation, TicketTier
+from events.models import Event, EventInvitation, EventToken, Organization, PendingEventInvitation, TicketTier
 
 pytestmark = pytest.mark.django_db
 
@@ -49,7 +49,8 @@ def invited_tier(guest_event: Event) -> TicketTier:
     )
 
 
-def _checkout(event: Event, tier: TicketTier, email: str) -> t.Any:
+def _checkout(event: Event, tier: TicketTier, email: str, *, event_token: str | None = None) -> t.Any:
+    headers = {"X-Event-Token": event_token} if event_token else None
     return Client().post(
         reverse("api:guest_multi_tier_checkout", kwargs={"event_id": event.pk}),
         data={
@@ -59,6 +60,7 @@ def _checkout(event: Event, tier: TicketTier, email: str) -> t.Any:
             "items": [{"tier_id": str(tier.id), "tickets": [{"guest_name": "Guest Buyer"}]}],
         },
         content_type="application/json",
+        headers=headers,
     )
 
 
@@ -117,3 +119,144 @@ class TestGuestTierAccessEnforcement:
         assert response.status_code == 403, response.content
         assert "not allowed to purchase from this tier" in response.json()["detail"]
         mock_send_email.assert_not_called()
+
+
+@pytest.fixture
+def invitation_link(guest_event: Event) -> EventToken:
+    """A shareable invitation link for the event, as an organizer would hand out."""
+    return EventToken.objects.create(event=guest_event, issuer=guest_event.organization.owner, grants_invitation=True)
+
+
+class TestGuestInvitationLinkClaim:
+    """A guest carrying an invitation link (``X-Event-Token``) claims it at checkout,
+    exactly like a logged-in user does on the join page, so the tier rule and the
+    later confirmation click both see a real ``EventInvitation``.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_link_holder_is_invited_and_gets_confirmation(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        response = _checkout(guest_event, invited_tier, "linkholder@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 200, response.content
+        assert EventInvitation.objects.filter(event=guest_event, user__email="linkholder@example.com").exists()
+        invitation_link.refresh_from_db()
+        assert invitation_link.uses == 1
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_returning_guest_does_not_consume_a_second_use(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        _checkout(guest_event, invited_tier, "returning@example.com", event_token=invitation_link.pk)
+        response = _checkout(guest_event, invited_tier, "returning@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 200, response.content
+        invitation_link.refresh_from_db()
+        assert invitation_link.uses == 1
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_read_only_link_does_not_invite(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        invitation_link.grants_invitation = False
+        invitation_link.save(update_fields=["grants_invitation"])
+
+        response = _checkout(guest_event, invited_tier, "readonly@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 403, response.content
+        assert not EventInvitation.objects.filter(event=guest_event, user__email="readonly@example.com").exists()
+        mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_link_for_another_event_is_ignored(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier, organization: Organization
+    ) -> None:
+        other_event = Event.objects.create(
+            organization=organization,
+            name="Other Event",
+            slug="other-event",
+            event_type=Event.EventType.PUBLIC,
+            start=timezone.now() + timedelta(days=7),
+            status=Event.EventStatus.OPEN,
+            visibility=Event.Visibility.PUBLIC,
+        )
+        foreign_link = EventToken.objects.create(event=other_event, issuer=organization.owner, grants_invitation=True)
+
+        response = _checkout(guest_event, invited_tier, "foreign@example.com", event_token=foreign_link.pk)
+
+        assert response.status_code == 403, response.content
+        assert not EventInvitation.objects.filter(user__email="foreign@example.com").exists()
+        mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_tier_linked_link_satisfies_linked_restriction(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        invited_tier.restrict_purchase_to_linked_invitations = True
+        invited_tier.save(update_fields=["restrict_purchase_to_linked_invitations"])
+        invitation_link.ticket_tiers.set([invited_tier])
+
+        response = _checkout(guest_event, invited_tier, "tierlink@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 200, response.content
+        mock_send_email.assert_called_once()
+
+
+class TestGuestInvitationLinkRsvp:
+    """Same claim on the guest RSVP path: a private RSVP event's invitation gate
+    otherwise blocks every guest, link or no link.
+    """
+
+    @pytest.fixture
+    def private_rsvp_event(self, organization: Organization) -> Event:
+        return Event.objects.create(
+            organization=organization,
+            name="Private RSVP Event",
+            slug="private-rsvp-event",
+            event_type=Event.EventType.PRIVATE,
+            start=timezone.now() + timedelta(days=7),
+            status=Event.EventStatus.OPEN,
+            visibility=Event.Visibility.PUBLIC,
+            requires_ticket=False,
+            can_attend_without_login=True,
+            max_attendees=100,
+        )
+
+    @staticmethod
+    def _rsvp(event: Event, email: str, *, event_token: str | None = None) -> t.Any:
+        headers = {"X-Event-Token": event_token} if event_token else None
+        return Client().post(
+            reverse("api:guest_rsvp", kwargs={"event_id": event.pk, "answer": "yes"}),
+            data={"email": email, "first_name": "Guest", "last_name": "Rsvp"},
+            content_type="application/json",
+            headers=headers,
+        )
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_rsvp_confirmation.delay")
+    def test_without_link_private_event_blocks_guest(self, mock_send_email: Mock, private_rsvp_event: Event) -> None:
+        response = self._rsvp(private_rsvp_event, "nolink@example.com")
+
+        assert response.status_code == 400, response.content
+        assert response.json()["allowed"] is False
+        mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_rsvp_confirmation.delay")
+    def test_link_holder_can_rsvp(self, mock_send_email: Mock, private_rsvp_event: Event) -> None:
+        link = EventToken.objects.create(
+            event=private_rsvp_event, issuer=private_rsvp_event.organization.owner, grants_invitation=True
+        )
+
+        response = self._rsvp(private_rsvp_event, "rsvplink@example.com", event_token=link.pk)
+
+        assert response.status_code == 200, response.content
+        assert EventInvitation.objects.filter(event=private_rsvp_event, user__email="rsvplink@example.com").exists()
+        mock_send_email.assert_called_once()

--- a/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
@@ -1,0 +1,119 @@
+"""Tests for guest-checkout enforcement of the tier's ``purchasable_by`` rule.
+
+Production incident (2026-09-04): an organizer set a tier to INVITED on an event
+open to guest checkout. The guest cart's non-online branch defers ``create_batch``
+— where ``_assert_purchasable_by`` runs — to the emailed confirmation click, so
+every guest got a 200 and a confirmation email, and every click on the link then
+403'd. The initial checkout request has to answer the rule up front.
+"""
+
+import typing as t
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from events.models import Event, EventInvitation, Organization, PendingEventInvitation, TicketTier
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def guest_event(organization: Organization) -> Event:
+    """Future-dated public event open to unauthenticated (guest) checkout."""
+    return Event.objects.create(
+        organization=organization,
+        name="Guest Tier Access Event",
+        slug="guest-tier-access-event",
+        event_type=Event.EventType.PUBLIC,
+        start=timezone.now() + timedelta(days=7),
+        status=Event.EventStatus.OPEN,
+        visibility=Event.Visibility.PUBLIC,
+        require_ticket_names=False,
+        can_attend_without_login=True,
+        max_attendees=100,
+    )
+
+
+@pytest.fixture
+def invited_tier(guest_event: Event) -> TicketTier:
+    """Offline (non-online) tier restricted to invited buyers — the incident's shape."""
+    return TicketTier.objects.create(
+        event=guest_event,
+        name="Invited Only",
+        payment_method=TicketTier.PaymentMethod.OFFLINE,
+        purchasable_by=TicketTier.PurchasableBy.INVITED,
+    )
+
+
+def _checkout(event: Event, tier: TicketTier, email: str) -> t.Any:
+    return Client().post(
+        reverse("api:guest_multi_tier_checkout", kwargs={"event_id": event.pk}),
+        data={
+            "email": email,
+            "first_name": "Guest",
+            "last_name": "Buyer",
+            "items": [{"tier_id": str(tier.id), "tickets": [{"guest_name": "Guest Buyer"}]}],
+        },
+        content_type="application/json",
+    )
+
+
+class TestGuestTierAccessEnforcement:
+    """``transaction=True`` because the assertion is about the confirmation email,
+    whose dispatch is registered with ``transaction.on_commit`` and so never fires
+    under pytest-django's wrapping transaction.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_uninvited_guest_rejected_at_checkout_and_no_email(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier
+    ) -> None:
+        response = _checkout(guest_event, invited_tier, "uninvited@example.com")
+
+        assert response.status_code == 403, response.content
+        assert "not allowed to purchase from this tier" in response.json()["detail"]
+        mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_email_invited_guest_still_gets_confirmation(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier
+    ) -> None:
+        # The organizer invited this address before it had an account: the pending
+        # invitation is converted to a real one when the guest user row is created,
+        # so the rule must be evaluated only after that conversion.
+        PendingEventInvitation.objects.create(event=guest_event, email="invited@example.com")
+
+        response = _checkout(guest_event, invited_tier, "invited@example.com")
+
+        assert response.status_code == 200, response.content
+        assert response.json()["message"]
+        assert EventInvitation.objects.filter(event=guest_event, user__email="invited@example.com").exists()
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_tier_linked_invitation_is_honoured(
+        self, mock_send_email: Mock, guest_event: Event, invited_tier: TicketTier
+    ) -> None:
+        invited_tier.restrict_purchase_to_linked_invitations = True
+        invited_tier.save(update_fields=["restrict_purchase_to_linked_invitations"])
+        other_tier = TicketTier.objects.create(
+            event=guest_event,
+            name="Other Invited",
+            payment_method=TicketTier.PaymentMethod.OFFLINE,
+            purchasable_by=TicketTier.PurchasableBy.INVITED,
+        )
+        pending = PendingEventInvitation.objects.create(event=guest_event, email="linked@example.com")
+        pending.tiers.set([other_tier])
+
+        response = _checkout(guest_event, invited_tier, "linked@example.com")
+
+        assert response.status_code == 403, response.content
+        assert "not allowed to purchase from this tier" in response.json()["detail"]
+        mock_send_email.assert_not_called()

--- a/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
@@ -24,6 +24,7 @@ from events.models import (
     EventToken,
     MembershipTier,
     Organization,
+    OrganizationMember,
     PendingEventInvitation,
     TicketTier,
 )
@@ -394,6 +395,28 @@ class TestGuestMembershipTierEnforcement:
         assert response.status_code == 400, response.content
         assert response.json()["reason_code"] == "membership_tier_required"
         mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_member_of_the_required_tier_gets_confirmation(
+        self, mock_send_email: Mock, guest_event: Event, organization: Organization
+    ) -> None:
+        # A guest row can hold a membership (the organizer added the address as a member
+        # before it ever checked out as a guest); the required tier must let it through.
+        general = MembershipTier.objects.get(organization=organization, name="General membership")
+        gated_tier = TicketTier.objects.create(
+            event=guest_event, name="Members Only", payment_method=TicketTier.PaymentMethod.OFFLINE
+        )
+        gated_tier.restricted_to_membership_tiers.set([general])
+        member = guest_service.get_or_create_guest_user("member@example.com", "Guest", "Member")
+        OrganizationMember.objects.create(
+            organization=organization, user=member, status=OrganizationMember.MembershipStatus.ACTIVE, tier=general
+        )
+
+        response = _checkout(guest_event, gated_tier, "member@example.com")
+
+        assert response.status_code == 200, response.content
+        mock_send_email.assert_called_once()
 
 
 class TestGuestClaimNeverHoldsTokenLockAcrossVies:

--- a/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
+++ b/src/events/tests/test_service/test_batch_ticket_service/test_guest_tier_access_enforcement.py
@@ -9,16 +9,36 @@ every guest got a 200 and a confirmation email, and every click on the link then
 
 import typing as t
 from datetime import timedelta
+from decimal import Decimal
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import pytest
 from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 
-from events.models import Event, EventInvitation, EventToken, Organization, PendingEventInvitation, TicketTier
+from events.models import (
+    Event,
+    EventInvitation,
+    EventToken,
+    MembershipTier,
+    Organization,
+    PendingEventInvitation,
+    TicketTier,
+)
+from events.schema import TicketPurchaseItem
+from events.schema.checkout import BuyerBillingInfoSchema
+from events.service import event_service
+from events.service import guest as guest_service
+from events.service.batch_ticket_service import CartGroup
 
 pytestmark = pytest.mark.django_db
+
+
+def _token_headers(event_token: str | None) -> dict[str, str] | None:
+    """Request headers carrying an invitation link, if any."""
+    return {"X-Event-Token": event_token} if event_token else None
 
 
 @pytest.fixture
@@ -50,7 +70,7 @@ def invited_tier(guest_event: Event) -> TicketTier:
 
 
 def _checkout(event: Event, tier: TicketTier, email: str, *, event_token: str | None = None) -> t.Any:
-    headers = {"X-Event-Token": event_token} if event_token else None
+    headers = _token_headers(event_token)
     return Client().post(
         reverse("api:guest_multi_tier_checkout", kwargs={"event_id": event.pk}),
         data={
@@ -231,7 +251,7 @@ class TestGuestInvitationLinkRsvp:
 
     @staticmethod
     def _rsvp(event: Event, email: str, *, event_token: str | None = None) -> t.Any:
-        headers = {"X-Event-Token": event_token} if event_token else None
+        headers = _token_headers(event_token)
         return Client().post(
             reverse("api:guest_rsvp", kwargs={"event_id": event.pk, "answer": "yes"}),
             data={"email": email, "first_name": "Guest", "last_name": "Rsvp"},
@@ -260,3 +280,172 @@ class TestGuestInvitationLinkRsvp:
         assert response.status_code == 200, response.content
         assert EventInvitation.objects.filter(event=private_rsvp_event, user__email="rsvplink@example.com").exists()
         mock_send_email.assert_called_once()
+
+
+@pytest.fixture
+def private_invited_tier(guest_event: Event) -> TicketTier:
+    """Invitation-gated tier that is also hidden (PRIVATE visibility): only a link can reach it."""
+    return TicketTier.objects.create(
+        event=guest_event,
+        name="Private Invited",
+        payment_method=TicketTier.PaymentMethod.OFFLINE,
+        visibility=TicketTier.Visibility.PRIVATE,
+        purchasable_by=TicketTier.PurchasableBy.INVITED,
+    )
+
+
+class TestGuestInvitationLinkPrivateTier:
+    """PRIVATE tiers are invisible to anonymous users, and the guest routes resolve
+    the tier BEFORE the claim can run — so a link to a private tier used to 404. The
+    tier lookup now grants the visibility the claimed invitation would grant.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_without_link_private_tier_is_not_found(
+        self, mock_send_email: Mock, guest_event: Event, private_invited_tier: TicketTier
+    ) -> None:
+        response = _checkout(guest_event, private_invited_tier, "nolink@example.com")
+
+        assert response.status_code == 404, response.content
+        mock_send_email.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_link_unlocks_private_tier(
+        self, mock_send_email: Mock, guest_event: Event, private_invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        response = _checkout(guest_event, private_invited_tier, "private@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 200, response.content
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_link_unlocks_private_tier_on_deprecated_single_tier_route(
+        self, mock_send_email: Mock, guest_event: Event, private_invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        response = Client().post(
+            reverse(
+                "api:guest_ticket_checkout", kwargs={"event_id": guest_event.pk, "tier_id": private_invited_tier.pk}
+            ),
+            data={
+                "email": "legacy@example.com",
+                "first_name": "Guest",
+                "last_name": "Legacy",
+                "tickets": [{"guest_name": "Guest Legacy"}],
+            },
+            content_type="application/json",
+            headers=_token_headers(invitation_link.pk),
+        )
+
+        assert response.status_code == 200, response.content
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_visibility_linked_restriction_needs_a_linked_link(
+        self, mock_send_email: Mock, guest_event: Event, private_invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        private_invited_tier.restrict_visibility_to_linked_invitations = True
+        private_invited_tier.save(update_fields=["restrict_visibility_to_linked_invitations"])
+
+        unlinked = _checkout(guest_event, private_invited_tier, "unlinked@example.com", event_token=invitation_link.pk)
+        assert unlinked.status_code == 404, unlinked.content
+
+        invitation_link.ticket_tiers.set([private_invited_tier])
+        linked = _checkout(guest_event, private_invited_tier, "linked@example.com", event_token=invitation_link.pk)
+        assert linked.status_code == 200, linked.content
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_read_only_link_does_not_unlock_private_tier(
+        self, mock_send_email: Mock, guest_event: Event, private_invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        invitation_link.grants_invitation = False
+        invitation_link.save(update_fields=["grants_invitation"])
+
+        response = _checkout(guest_event, private_invited_tier, "readonly@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 404, response.content
+        mock_send_email.assert_not_called()
+
+
+class TestGuestMembershipTierEnforcement:
+    """The membership-tier restriction is the sibling of ``purchasable_by`` and was
+    equally deferred to the confirmation click on the non-online guest path.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("events.tasks.send_guest_ticket_confirmation.delay")
+    def test_membership_gated_tier_rejected_at_checkout_and_no_email(
+        self, mock_send_email: Mock, guest_event: Event, organization: Organization
+    ) -> None:
+        gated_tier = TicketTier.objects.create(
+            event=guest_event, name="Members Only", payment_method=TicketTier.PaymentMethod.OFFLINE
+        )
+        gated_tier.restricted_to_membership_tiers.set(
+            [MembershipTier.objects.get(organization=organization, name="General membership")]
+        )
+
+        response = _checkout(guest_event, gated_tier, "nonmember@example.com")
+
+        assert response.status_code == 400, response.content
+        assert response.json()["reason_code"] == "membership_tier_required"
+        mock_send_email.assert_not_called()
+
+
+class TestGuestClaimNeverHoldsTokenLockAcrossVies:
+    """Claiming the link locks the EventToken row for the rest of the request, so the
+    VIES round-trip must already be done by then (#632 discipline) and handed to
+    create_batch rather than resolved again under the lock.
+    """
+
+    def test_vies_resolves_before_the_claim_and_is_reused(
+        self, guest_event: Event, invitation_link: EventToken
+    ) -> None:
+        online_tier = TicketTier.objects.create(
+            event=guest_event, name="Online", payment_method=TicketTier.PaymentMethod.ONLINE, price=Decimal("10.00")
+        )
+        billing_info = BuyerBillingInfoSchema(billing_name="ACME", vat_id="ATU12345678", vat_country_code="AT")
+        order = Mock()
+        with (
+            patch("events.service.stripe_service.resolve_attendee_vat_for_reserve", return_value="vat-ctx") as vies,
+            patch("events.service.tokens.claim_invitation") as claim,
+            patch(
+                "events.service.batch_ticket_service.service.BatchTicketService.create_batch",
+                return_value=([], uuid4()),
+            ) as create_batch,
+        ):
+            order.attach_mock(vies, "vies")
+            order.attach_mock(claim, "claim")
+            guest_service.handle_guest_ticket_checkout(
+                guest_event,
+                [CartGroup(tier=online_tier, items=[TicketPurchaseItem(guest_name="Guest Vies")])],
+                "vies@example.com",
+                "Guest",
+                "Vies",
+                billing_info=billing_info,
+                event_token=invitation_link,
+            )
+
+        call_names = [name for name, _args, _kwargs in order.mock_calls]
+        assert call_names.index("vies") < call_names.index("claim")
+        create_batch.assert_called_once()
+        assert create_batch.call_args.kwargs["buyer_vat_context"] == "vat-ctx"
+
+
+class TestEventTokenResolvedOnce:
+    """``get_one`` already resolves the token for event visibility; the claim must reuse it."""
+
+    def test_guest_checkout_looks_the_token_up_once(
+        self, guest_event: Event, invited_tier: TicketTier, invitation_link: EventToken
+    ) -> None:
+        with patch(
+            "events.controllers.event_public.base.event_service.get_event_token", wraps=event_service.get_event_token
+        ) as lookup:
+            response = _checkout(guest_event, invited_tier, "once@example.com", event_token=invitation_link.pk)
+
+        assert response.status_code == 200, response.content
+        lookup.assert_called_once_with(invitation_link.pk)


### PR DESCRIPTION
## Summary

Prod incident 2026-09-04: an organizer set a tier to `purchasable_by=invited` on an event open to guest checkout and shared an invitation link. Every anonymous guest got a 200 and a confirmation email; every click on the emailed link then answered 403 ("You are not allowed to purchase from this tier.") because the `purchasable_by` rule only ran inside `create_batch`, which the guest cart's non-online branch defers to the confirmation click. The frontend then masked the 403 as "No data returned from confirmation" (separate FE fix in progress).

### 1. `fix(guest)`: enforce tier `purchasable_by` at guest checkout, not only at confirm
- Extract the `purchasable_by` rule to a module-level `assert_purchasable_by` in `batch_ticket_service/eligibility.py` (same shape as `assert_sale_window` from #846); `PurchaseEligibilityMixin._assert_purchasable_by` delegates to it.
- `assert_cart_purchasable_by(event, user, tiers)` runs from guest checkout right after the guest user is created and event eligibility passes. Ordering is load-bearing: a `PendingEventInvitation` becomes the guest's `EventInvitation` on user-row creation, so email-invited guests must still pass.
- Declare `403: ErrorDetail` on `POST /events/guest-actions/confirm`.

### 2. `feat(guest)`: claim invitation links at guest checkout and RSVP
Invitation links could only be claimed via the join page, which requires a login. All four guest endpoints now read the link's token from `X-Event-Token` (or legacy `?et=`) and claim it for the guest user via the existing `tokens.claim_invitation`, before eligibility and tier access are checked. Read-only, expired, exhausted and other-event tokens are ignored; the claim is idempotent for a returning guest.

### 3. `fix(guest)`: review follow-ups (Copilot, CodeRabbit, self-review)
- `for_visible_event` takes the event token and unlocks PRIVATE tiers for an anonymous holder of a granting link, mirroring the invitation branch; all three guest checkout routes use it (a link to a private tier used to 404 before the claim could run).
- `403: ErrorDetail` declared on all four guest endpoints.
- The membership-tier restriction is extracted like `purchasable_by` and enforced in the guest pre-flight too.
- The VIES round-trip runs before the invitation claim and is handed to `create_batch` via a new `buyer_vat_context` argument, so the `EventToken` row lock never spans the network call under `ATOMIC_REQUESTS` (#632 discipline).
- The event token is resolved once per request (memoized on the base controller).

### 4. `feat(guest)`: anonymous tier listing honours a granting invitation link
`GET /events/{id}/tickets/tiers` for an anonymous viewer with a granting link now lists the private tiers the link unlocks and reports `can_purchase` per the same `purchasable_by` rule an invited non-member gets, keyed on the token's tier links. Without this the listing steered link holders away from the very tier the link unlocks.

No schema or migration changes. New generated-client surface: 403 on the guest endpoints.

## Test plan

- [x] `test_guest_tier_access_enforcement.py` (18 tests): tier rule at checkout (uninvited 403 + no email; email-invited 200; tier-linked invitation), invitation-link claim (link holder, returning guest, read-only, other-event, tier-linked), private-tier visibility via link (multi-tier and deprecated route, linked restriction, read-only), membership-tier rule at checkout, VIES-before-claim ordering with the context reused by `create_batch`, token resolved once. Positive-path tests fail without the corresponding change.
- [x] `test_ticket_tiers.py::TestAnonymousListingWithInvitationLink` (4 tests).
- [x] 645 + 287 tests green across batch service, guest, public-event, tier-visibility, tier-linked invitations, token, permission and error-contract suites.
- [x] ruff format / ruff check / mypy --strict clean on touched files.
- [x] After merge: `make dump-openapi` + FE `pnpm generate:api`; FE follow-up sends `X-Event-Token` on the tier list, guest checkout and RSVP calls, and adds "continue as guest" on the join page.

Organizer-side workaround until deployed: set the tier to Public, or invite guests by email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Invitation links now work across guest RSVP and ticket checkout.
  - Valid links can reveal private ticket tiers and unlock invitation-only purchases.
  - Invitation links can be supplied through the `X-Event-Token` header or `?et=` parameter.
  - Eligible tiers now display as purchasable for anonymous visitors using valid invitation links.

- **Bug Fixes**
  - Guest purchases now validate invitation and membership requirements before checkout.
  - Clearer 403 responses are provided when purchase rules or sale windows reject a request.
  - Invitation links are handled consistently without being reused unnecessarily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->