### PR TITLE
chore(release): v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-09-04
+
 ### Added
 
 - Sign in with any OpenID Connect provider (Google, Keycloak, Authentik, …) configured via `OIDC_PROVIDERS`; linked identities can be listed and unlinked from account settings
+- Guest checkout and RSVP can claim an event invitation link directly (via `X-Event-Token` or `?et=`), so link holders no longer need an account to buy from the tiers the link unlocks
+- `GET /events/{id}/tickets/tiers` for an anonymous viewer holding a granting invitation link now lists the private tiers it unlocks and reports `can_purchase` accordingly
 
 ### Changed
 
 - **Breaking (`.env`):** `FEATURE_GOOGLE_SSO` is removed; configure `OIDC_PROVIDERS=google` with `OIDC_GOOGLE_*` instead. The `/version` payload replaces `features.google_sso` with `sso_providers`
 - Accounts created through an identity provider can now also set a password, reset it, and change their email
+
+### Fixed
+
+- Guest checkout on a tier restricted by `purchasable_by` (or a membership tier) is now rejected up front with a 403 instead of sending a confirmation email whose link then failed with 403
+- A guest invitation link to a private tier no longer 404s at checkout; the four guest endpoints now declare their 403 response
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.5.1"
+version = "2.6.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.5.1"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.6.0] - 2026-09-04

### Added

- Sign in with any OpenID Connect provider (Google, Keycloak, Authentik, …) configured via `OIDC_PROVIDERS`; linked identities can be listed and unlinked from account settings
- Guest checkout and RSVP can claim an event invitation link directly (via `X-Event-Token` or `?et=`), so link holders no longer need an account to buy from the tiers the link unlocks
- `GET /events/{id}/tickets/tiers` for an anonymous viewer holding a granting invitation link now lists the private tiers it unlocks and reports `can_purchase` accordingly

### Changed

- **Breaking (`.env`):** `FEATURE_GOOGLE_SSO` is removed; configure `OIDC_PROVIDERS=google` with `OIDC_GOOGLE_*` instead. The `/version` payload replaces `features.google_sso` with `sso_providers`
- Accounts created through an identity provider can now also set a password, reset it, and change their email

### Fixed

- Guest checkout on a tier restricted by `purchasable_by` (or a membership tier) is now rejected up front with a 403 instead of sending a confirmation email whose link then failed with 403
- A guest invitation link to a private tier no longer 404s at checkout; the four guest endpoints now declare their 403 response

### Removed

- `POST /api/auth/google/login` (superseded by the generic OIDC flow)


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OIDC sign-in support, replacing Google SSO.
  - Guests can check out or RSVP through invitation links without creating an account.
  - Anonymous link holders can view unlocked private tiers.

- **Bug Fixes**
  - Fixed guest checkout for restricted tiers.
  - Fixed guest invitation links for private tiers.

- **Release**
  - Updated the application to version 2.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->