### PR TITLE
feat(auth): pull the IdP profile picture on OIDC account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Accounts created through an OpenID Connect sign-in now get the provider's profile picture (Google's at 400px), fetched in the background and run through the same validation, EXIF stripping, malware scan and thumbnailing as an upload
+
 ## [2.6.0] - 2026-09-04
 
 ### Added

--- a/src/accounts/service/oidc.py
+++ b/src/accounts/service/oidc.py
@@ -7,10 +7,11 @@ and ADR-0016.
 
 import base64
 import hashlib
+import re
 import secrets
 import typing as t
 from dataclasses import dataclass
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlsplit
 from uuid import uuid4
 
 import httpx
@@ -18,6 +19,8 @@ import jwt
 import structlog
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.http import Http404
@@ -33,7 +36,7 @@ from accounts.jwt import blacklist as blacklist_token
 from accounts.jwt import check_blacklist, consume_one_shot_token, create_oidc_login_token, validate_oidc_login_token
 from accounts.models import ExternalIdentity, RevelUser
 from common.models import SiteSettings
-from common.utils import get_or_create_with_race_protection
+from common.utils import get_or_create_with_race_protection, safe_save_uploaded_file
 from revel.oidc_config import OIDCProviderConfig
 
 logger = structlog.get_logger(__name__)
@@ -45,6 +48,9 @@ ALLOWED_ID_TOKEN_ALGS = ["RS256", "ES256"]
 #: Binds the ``state`` to the browser between ``/start`` and ``/callback`` (login-CSRF guard).
 OIDC_STATE_COOKIE = "oidc_state"
 OIDC_STATE_COOKIE_PATH = "/api/auth/oidc"
+PICTURE_MAX_BYTES = 5 * 1024 * 1024
+_PICTURE_EXTENSIONS = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp", "image/gif": "gif"}
+_GOOGLE_PICTURE_SIZE_RE = re.compile(r"=s\d+-c$")
 
 
 def frontend_base_url() -> str:
@@ -370,6 +376,11 @@ def _resolve_user(provider: OIDCProviderConfig, claims: OIDCClaims) -> RevelUser
         if created:
             user.set_unusable_password()
             user.save(update_fields=["password"])
+            if claims.picture:
+                from accounts.tasks.profile_picture import fetch_oidc_profile_picture
+
+                user_id, picture_url = str(user.id), claims.picture
+                transaction.on_commit(lambda: fetch_oidc_profile_picture.delay(user_id=user_id, url=picture_url))
     if not created:
         # Existing account — also reached when a concurrent request won the create race above,
         # so that user still goes through the same checks and upgrades.
@@ -435,6 +446,52 @@ def redeem_login_token(token: str) -> tuple[TokenObtainPairOutputSchema, str]:
     with transaction.atomic():
         consume_one_shot_token(token)  # refuses the loser of two concurrent redemptions
         return get_token_pair_for_user(user), payload.return_url
+
+
+def _picture_fetch_url(url: str) -> str:
+    """Google's ``picture`` claim is a 96px square (``=s96-c``); ask for the 400px preview size instead."""
+    host = urlsplit(url).hostname or ""
+    if host == "googleusercontent.com" or host.endswith(".googleusercontent.com"):
+        return _GOOGLE_PICTURE_SIZE_RE.sub("=s400-c", url)
+    return url
+
+
+def fetch_profile_picture(user: RevelUser, url: str) -> None:
+    """Download the IdP ``picture`` claim into ``user.profile_picture``. Best effort: any problem is logged and dropped.
+
+    Runs from a Celery task after account creation, so it must never fail the login. The bytes go
+    through ``safe_save_uploaded_file`` and get the same validators, EXIF strip, malware scan and
+    thumbnails as a user upload. Never overwrites a picture the user set in the meantime.
+    """
+    if not url.startswith("https://"):
+        logger.warning("oidc_picture_insecure_url", user_id=str(user.id))
+        return
+    if user.profile_picture:
+        return
+    try:
+        with _http_client() as client, client.stream("GET", _picture_fetch_url(url)) as response:
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+            extension = _PICTURE_EXTENSIONS.get(content_type)
+            if extension is None:
+                logger.warning("oidc_picture_not_an_image", user_id=str(user.id), content_type=content_type)
+                return
+            body = b""
+            for chunk in response.iter_bytes():
+                body += chunk
+                if len(body) > PICTURE_MAX_BYTES:
+                    logger.warning("oidc_picture_too_large", user_id=str(user.id))
+                    return
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
+        logger.warning("oidc_picture_fetch_failed", user_id=str(user.id), error=str(e))
+        return
+    file = SimpleUploadedFile(f"oidc.{extension}", body, content_type=content_type)
+    try:
+        safe_save_uploaded_file(instance=user, field="profile_picture", file=file, uploader=user)
+    except DjangoValidationError as e:
+        logger.warning("oidc_picture_invalid", user_id=str(user.id), error=str(e))
+        return
+    logger.info("oidc_picture_saved", user_id=str(user.id))
 
 
 def provider_display_name(key: str) -> str:

--- a/src/accounts/service/oidc.py
+++ b/src/accounts/service/oidc.py
@@ -7,8 +7,10 @@ and ADR-0016.
 
 import base64
 import hashlib
+import ipaddress
 import re
 import secrets
+import socket
 import typing as t
 from dataclasses import dataclass
 from urllib.parse import quote, urlencode, urlsplit
@@ -448,6 +450,31 @@ def redeem_login_token(token: str) -> tuple[TokenObtainPairOutputSchema, str]:
         return get_token_pair_for_user(user), payload.return_url
 
 
+def _resolve_addresses(host: str) -> list[str]:
+    """Resolve ``host`` to its IP addresses (monkeypatched in tests, which never touch DNS)."""
+    return [str(info[4][0]) for info in socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)]
+
+
+def _is_public_host(host: str) -> bool:
+    """Whether ``host`` is (or resolves only to) globally routable addresses.
+
+    A self-hosted IdP may let users edit their ``picture`` attribute, so the worker must not
+    fetch loopback, private, link-local or metadata addresses on their behalf (SSRF).
+    """
+    # ponytail: the address is vetted here and then resolved again by httpx for the connection,
+    # so a DNS-rebinding host could still slip through. Accepted: it is a GET with no body leak
+    # (the response is dropped unless it decodes as an image). Upgrade path: a custom httpx
+    # transport that connects to the vetted address.
+    try:
+        addresses = [ipaddress.ip_address(host)]
+    except ValueError:
+        try:
+            addresses = [ipaddress.ip_address(a) for a in _resolve_addresses(host)]
+        except socket.gaierror, ValueError:
+            return False
+    return bool(addresses) and all(a.is_global for a in addresses)
+
+
 def _picture_fetch_url(url: str) -> str:
     """Google's ``picture`` claim is a 96px square (``=s96-c``); ask for the 400px preview size instead."""
     host = urlsplit(url).hostname or ""
@@ -463,8 +490,12 @@ def fetch_profile_picture(user: RevelUser, url: str) -> None:
     through ``safe_save_uploaded_file`` and get the same validators, EXIF strip, malware scan and
     thumbnails as a user upload. Never overwrites a picture the user set in the meantime.
     """
-    if not url.startswith("https://"):
-        logger.warning("oidc_picture_insecure_url", user_id=str(user.id))
+    try:
+        host = urlsplit(url).hostname or ""
+    except ValueError:
+        host = ""
+    if not url.startswith("https://") or not host or not _is_public_host(host):
+        logger.warning("oidc_picture_url_refused", user_id=str(user.id))
         return
     if user.profile_picture:
         return
@@ -486,11 +517,16 @@ def fetch_profile_picture(user: RevelUser, url: str) -> None:
         logger.warning("oidc_picture_fetch_failed", user_id=str(user.id), error=str(e))
         return
     file = SimpleUploadedFile(f"oidc.{extension}", body, content_type=content_type)
-    try:
-        safe_save_uploaded_file(instance=user, field="profile_picture", file=file, uploader=user)
-    except DjangoValidationError as e:
-        logger.warning("oidc_picture_invalid", user_id=str(user.id), error=str(e))
-        return
+    with transaction.atomic():
+        # Re-read under lock: an upload that landed during the download must win over this one.
+        locked = RevelUser.objects.select_for_update().filter(pk=user.pk).first()
+        if locked is None or locked.profile_picture:
+            return
+        try:
+            safe_save_uploaded_file(instance=locked, field="profile_picture", file=file, uploader=locked)
+        except DjangoValidationError as e:
+            logger.warning("oidc_picture_invalid", user_id=str(user.id), error=str(e))
+            return
     logger.info("oidc_picture_saved", user_id=str(user.id))
 
 

--- a/src/accounts/tasks/__init__.py
+++ b/src/accounts/tasks/__init__.py
@@ -23,6 +23,7 @@ from accounts.tasks.gdpr import (
 )
 from accounts.tasks.notifications import notify_admin_new_user_joined, notify_admin_new_user_joined_discord
 from accounts.tasks.payouts import generate_and_send_payout_statement, process_referral_payouts
+from accounts.tasks.profile_picture import fetch_oidc_profile_picture
 from accounts.tasks.tokens import flush_expired_tokens
 from accounts.tasks.verification_reminders import (
     deactivate_unverified_accounts,
@@ -39,6 +40,7 @@ __all__ = [
     "deactivate_unverified_accounts",
     "delete_old_inactive_accounts",
     "delete_user_account",
+    "fetch_oidc_profile_picture",
     "flush_expired_tokens",
     "generate_and_send_payout_statement",
     "generate_user_data_export",

--- a/src/accounts/tasks/profile_picture.py
+++ b/src/accounts/tasks/profile_picture.py
@@ -1,0 +1,19 @@
+"""Pull the IdP ``picture`` claim into ``RevelUser.profile_picture`` after an OIDC account creation."""
+
+import structlog
+from celery import shared_task
+
+from accounts.models import RevelUser
+from accounts.service.oidc import fetch_profile_picture
+
+logger = structlog.get_logger(__name__)
+
+
+@shared_task(name="accounts.fetch_oidc_profile_picture")
+def fetch_oidc_profile_picture(*, user_id: str, url: str) -> None:
+    """Best-effort download of the IdP ``picture`` claim for a freshly created account."""
+    user = RevelUser.objects.filter(id=user_id).first()
+    if user is None:
+        logger.warning("oidc_picture_user_missing", user_id=user_id)
+        return
+    fetch_profile_picture(user, url)

--- a/src/accounts/tests/test_oidc_profile_picture.py
+++ b/src/accounts/tests/test_oidc_profile_picture.py
@@ -1,0 +1,191 @@
+"""Tests for pulling the IdP ``picture`` claim into ``RevelUser.profile_picture`` on account creation."""
+
+import typing as t
+import uuid
+from unittest.mock import patch
+
+import httpx
+import pytest
+from django.core.files.base import ContentFile
+
+from accounts.models import ExternalIdentity, RevelUser
+from accounts.service import oidc
+from accounts.service.oidc import OIDCClaims
+from accounts.tasks import fetch_oidc_profile_picture
+from revel.oidc_config import OIDCProviderConfig
+
+pytestmark = pytest.mark.django_db
+
+GOOGLE = OIDCProviderConfig(
+    key="google", name="Google", issuer="https://accounts.google.com", client_id="c", client_secret="s"
+)
+PICTURE_URL = "https://lh3.googleusercontent.com/a/ACg8ocK=s96-c"
+
+
+def claims(**overrides: t.Any) -> OIDCClaims:
+    base: dict[str, t.Any] = {
+        "sub": "sub-1",
+        "email": "alice@example.com",
+        "email_verified": True,
+        "picture": PICTURE_URL,
+    }
+    return OIDCClaims(**{**base, **overrides})
+
+
+@pytest.fixture
+def image_server(monkeypatch: pytest.MonkeyPatch, png_bytes: bytes) -> list[httpx.Request]:
+    """Serve ``png_bytes`` for any https URL; records the requests made."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=png_bytes, headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    return seen
+
+
+def _serve(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -> list[httpx.Request]:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return response
+
+    monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    return seen
+
+
+# --- dispatch from _resolve_user ---
+
+
+def test_new_account_schedules_picture_fetch(django_capture_on_commit_callbacks: t.Any) -> None:
+    with (
+        patch("accounts.tasks.profile_picture.fetch_oidc_profile_picture.delay") as delay,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        user = oidc._resolve_user(GOOGLE, claims())
+    delay.assert_called_once_with(user_id=str(user.id), url=PICTURE_URL)
+
+
+def test_new_account_without_picture_claim_does_not_fetch(django_capture_on_commit_callbacks: t.Any) -> None:
+    with (
+        patch("accounts.tasks.profile_picture.fetch_oidc_profile_picture.delay") as delay,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        oidc._resolve_user(GOOGLE, claims(picture=None))
+    delay.assert_not_called()
+
+
+def test_linking_existing_account_does_not_fetch(user: RevelUser, django_capture_on_commit_callbacks: t.Any) -> None:
+    """Only a freshly created account gets the IdP picture; an existing one keeps whatever it has (or hasn't)."""
+    with (
+        patch("accounts.tasks.profile_picture.fetch_oidc_profile_picture.delay") as delay,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        oidc._resolve_user(GOOGLE, claims(email=user.email))
+    delay.assert_not_called()
+
+
+def test_returning_identity_does_not_fetch(user: RevelUser, django_capture_on_commit_callbacks: t.Any) -> None:
+    ExternalIdentity.objects.create(user=user, provider="google", subject="sub-1")
+    with (
+        patch("accounts.tasks.profile_picture.fetch_oidc_profile_picture.delay") as delay,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        oidc._resolve_user(GOOGLE, claims())
+    delay.assert_not_called()
+
+
+# --- fetch_profile_picture (service) ---
+
+
+def test_fetch_saves_image_as_profile_picture(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert user.profile_picture
+    assert user.profile_picture.name.endswith(".png")
+
+
+def test_fetch_requests_google_picture_at_preview_size(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    """Google's claim URL is a 96px square; ask for 400px so the preview thumbnail isn't upscaled."""
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    assert [str(r.url) for r in image_server] == ["https://lh3.googleusercontent.com/a/ACg8ocK=s400-c"]
+
+
+def test_fetch_leaves_non_google_url_untouched(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    oidc.fetch_profile_picture(user, "https://idp.example.test/avatars/alice.png?size=96")
+    assert [str(r.url) for r in image_server] == ["https://idp.example.test/avatars/alice.png?size=96"]
+
+
+def test_fetch_refuses_non_https_url(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    oidc.fetch_profile_picture(user, "http://idp.example.test/avatars/alice.png")
+    assert image_server == []
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+def test_fetch_skips_when_user_already_has_picture(
+    user: RevelUser, png_bytes: bytes, image_server: list[httpx.Request]
+) -> None:
+    """The user uploaded a picture between account creation and the task running: never overwrite it."""
+    user.profile_picture.save("mine.png", ContentFile(png_bytes), save=True)
+    before = user.profile_picture.name
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    assert image_server == []
+    user.refresh_from_db()
+    assert user.profile_picture.name == before
+
+
+def test_fetch_skips_non_2xx(user: RevelUser, monkeypatch: pytest.MonkeyPatch) -> None:
+    _serve(monkeypatch, httpx.Response(404))
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+def test_fetch_skips_non_image_content_type(user: RevelUser, monkeypatch: pytest.MonkeyPatch, png_bytes: bytes) -> None:
+    _serve(monkeypatch, httpx.Response(200, content=png_bytes, headers={"Content-Type": "text/html"}))
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+def test_fetch_skips_oversized_body(user: RevelUser, monkeypatch: pytest.MonkeyPatch, png_bytes: bytes) -> None:
+    monkeypatch.setattr(oidc, "PICTURE_MAX_BYTES", len(png_bytes) - 1)
+    _serve(monkeypatch, httpx.Response(200, content=png_bytes, headers={"Content-Type": "image/png"}))
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+def test_fetch_skips_bytes_that_are_not_an_image(user: RevelUser, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A lying Content-Type must not get garbage into an ImageField."""
+    _serve(monkeypatch, httpx.Response(200, content=b"not a png", headers={"Content-Type": "image/png"}))
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+def test_fetch_transport_error_is_swallowed(user: RevelUser, monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+# --- task ---
+
+
+def test_task_fetches_for_user(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    fetch_oidc_profile_picture.delay(user_id=str(user.id), url=PICTURE_URL)
+    user.refresh_from_db()
+    assert user.profile_picture
+
+
+def test_task_unknown_user_is_noop(image_server: list[httpx.Request]) -> None:
+    fetch_oidc_profile_picture.delay(user_id=str(uuid.uuid4()), url=PICTURE_URL)
+    assert image_server == []

--- a/src/accounts/tests/test_oidc_profile_picture.py
+++ b/src/accounts/tests/test_oidc_profile_picture.py
@@ -1,5 +1,6 @@
 """Tests for pulling the IdP ``picture`` claim into ``RevelUser.profile_picture`` on account creation."""
 
+import socket
 import typing as t
 import uuid
 from unittest.mock import patch
@@ -20,6 +21,7 @@ GOOGLE = OIDCProviderConfig(
     key="google", name="Google", issuer="https://accounts.google.com", client_id="c", client_secret="s"
 )
 PICTURE_URL = "https://lh3.googleusercontent.com/a/ACg8ocK=s96-c"
+PUBLIC_IP = "142.250.74.46"
 
 
 def claims(**overrides: t.Any) -> OIDCClaims:
@@ -42,6 +44,7 @@ def image_server(monkeypatch: pytest.MonkeyPatch, png_bytes: bytes) -> list[http
         return httpx.Response(200, content=png_bytes, headers={"Content-Type": "image/png"})
 
     monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    monkeypatch.setattr(oidc, "_resolve_addresses", lambda host: [PUBLIC_IP])
     return seen
 
 
@@ -53,6 +56,7 @@ def _serve(monkeypatch: pytest.MonkeyPatch, response: httpx.Response) -> list[ht
         return response
 
     monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    monkeypatch.setattr(oidc, "_resolve_addresses", lambda host: [PUBLIC_IP])
     return seen
 
 
@@ -175,6 +179,66 @@ def test_fetch_transport_error_is_swallowed(user: RevelUser, monkeypatch: pytest
     oidc.fetch_profile_picture(user, PICTURE_URL)
     user.refresh_from_db()
     assert not user.profile_picture
+
+
+def test_fetch_malformed_url_is_dropped(user: RevelUser, image_server: list[httpx.Request]) -> None:
+    """``urlsplit`` raises ValueError on ``https://[``; best effort means log and drop, not crash the task."""
+    oidc.fetch_profile_picture(user, "https://[")
+    assert image_server == []
+    user.refresh_from_db()
+    assert not user.profile_picture
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://10.0.0.5/a.png",
+        "https://127.0.0.1/a.png",
+        "https://[::1]/a.png",
+        "https://169.254.169.254/latest/meta-data",
+        "https://[::ffff:10.0.0.5]/a.png",
+    ],
+)
+def test_fetch_refuses_literal_non_public_address(user: RevelUser, image_server: list[httpx.Request], url: str) -> None:
+    """A self-hosted IdP may let users edit ``picture``; the worker must not be a proxy into the network."""
+    oidc.fetch_profile_picture(user, url)
+    assert image_server == []
+
+
+def test_fetch_refuses_host_resolving_to_private_address(
+    user: RevelUser, image_server: list[httpx.Request], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(oidc, "_resolve_addresses", lambda host: [PUBLIC_IP, "10.0.0.5"])
+    oidc.fetch_profile_picture(user, "https://internal.example.test/a.png")
+    assert image_server == []
+
+
+def test_fetch_unresolvable_host_is_dropped(
+    user: RevelUser, image_server: list[httpx.Request], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(host: str) -> list[str]:
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(oidc, "_resolve_addresses", fail)
+    oidc.fetch_profile_picture(user, "https://nope.example.test/a.png")
+    assert image_server == []
+
+
+def test_fetch_does_not_overwrite_upload_that_landed_during_download(
+    user: RevelUser, png_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-download check saw no picture; the save must recheck the row, not trust the stale instance."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fresh = RevelUser.objects.get(pk=user.pk)
+        fresh.profile_picture.save("mine.png", ContentFile(png_bytes), save=True)
+        return httpx.Response(200, content=png_bytes, headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(oidc, "_http_client", lambda: httpx.Client(transport=httpx.MockTransport(handler)))
+    monkeypatch.setattr(oidc, "_resolve_addresses", lambda host: [PUBLIC_IP])
+    oidc.fetch_profile_picture(user, PICTURE_URL)
+    user.refresh_from_db()
+    assert user.profile_picture.name.endswith("mine.png")
 
 
 # --- task ---

--- a/src/accounts/tests/test_oidc_resolve_user.py
+++ b/src/accounts/tests/test_oidc_resolve_user.py
@@ -14,6 +14,7 @@ from accounts.models import ExternalIdentity, GlobalBan, RevelUser
 from accounts.service import account as account_service
 from accounts.service import oidc
 from accounts.service.oidc import OIDCClaims
+from common.models import SiteSettings
 from common.utils import get_or_create_with_race_protection
 from revel.oidc_config import OIDCProviderConfig
 
@@ -218,3 +219,30 @@ def test_email_change_allowed_with_linked_identity(mock_send: t.Any, user: Revel
         user=user, new_email="new@example.com", password="strong-password-123!"
     )
     assert isinstance(token, str) and token
+
+
+def test_new_account_dispatches_admin_new_user_notification(django_capture_on_commit_callbacks: t.Any) -> None:
+    """An OIDC signup must reach the same post_save notification path as a password signup."""
+    site_settings = SiteSettings.get_solo()
+    site_settings.notify_user_joined = True
+    site_settings.save()
+    with (
+        patch("accounts.signals.notify_admin_new_user_joined.delay") as pushover,
+        patch("accounts.signals.notify_admin_new_user_joined_discord.delay") as discord,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        user = oidc._resolve_user(GOOGLE, claims())
+    pushover.assert_called_once_with(user_id=str(user.id), user_email=user.email, is_guest=False)
+    discord.assert_called_once_with(is_guest=False)
+
+
+def test_linking_existing_account_does_not_notify(user: RevelUser, django_capture_on_commit_callbacks: t.Any) -> None:
+    site_settings = SiteSettings.get_solo()
+    site_settings.notify_user_joined = True
+    site_settings.save()
+    with (
+        patch("accounts.signals.notify_admin_new_user_joined.delay") as pushover,
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        oidc._resolve_user(GOOGLE, claims(email=user.email))
+    pushover.assert_not_called()

--- a/src/accounts/tests/test_oidc_resolve_user.py
+++ b/src/accounts/tests/test_oidc_resolve_user.py
@@ -242,7 +242,9 @@ def test_linking_existing_account_does_not_notify(user: RevelUser, django_captur
     site_settings.save()
     with (
         patch("accounts.signals.notify_admin_new_user_joined.delay") as pushover,
+        patch("accounts.signals.notify_admin_new_user_joined_discord.delay") as discord,
         django_capture_on_commit_callbacks(execute=True),
     ):
         oidc._resolve_user(GOOGLE, claims(email=user.email))
     pushover.assert_not_called()
+    discord.assert_not_called()


### PR DESCRIPTION
## Summary

Accounts created through an OpenID Connect sign-in now get the provider's profile picture. The `picture` claim was parsed by `OIDCClaims` but never used (the pre-#919 Google flow stored `picture_url` and never used it either), so this is new behaviour rather than a regression fix.

- `_resolve_user` schedules `accounts.fetch_oidc_profile_picture` via `transaction.on_commit` **only when the account was just created** and the ID token carries a `picture` claim. Linking an existing account or a returning identity never touches the picture.
- `fetch_profile_picture` (service) does the download: https-only, `image/*` content types only, 5MB cap enforced while streaming, Google URLs rewritten from `=s96-c` to `=s400-c` so the 400px preview isn't upscaled, and a no-op if the user uploaded a picture in the meantime.
- The bytes go through the existing `safe_save_uploaded_file`, so the picture gets the same validators, EXIF strip, malware-scan audit and thumbnail generation as a user upload. No second image pipeline.
- Every failure (transport error, non-2xx, wrong content type, oversized, bytes that aren't an image) is logged and dropped; the login is never affected.

## Test plan

- [x] `accounts/tests/test_oidc_profile_picture.py` (16 tests, written first): dispatch on create vs. link vs. returning identity, Google resize, non-Google URL untouched, non-https refused, already-has-picture guard, non-2xx, non-image content type, oversized body, lying content type, transport error, task happy path and unknown-user no-op
- [x] Existing OIDC suites + `test_tasks.py` still green (133 total)
- [x] ruff format/check, mypy strict on touched files, `make task-names`, `make i18n-check`

Note: accounts already provisioned on demo/prod won't get a picture retroactively by design (creation-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New accounts created through OpenID Connect can automatically receive their identity provider’s profile picture.
  - Profile pictures are retrieved asynchronously, keeping sign-in responsive.
  - Images are validated, malware-scanned, stripped of EXIF data, and resized before being saved.
  - Google profile-picture URLs are optimized for an appropriate preview size.
  - Invalid, inaccessible, oversized, or unsupported images are safely skipped without interrupting account creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->