### PR TITLE
chore(release): v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-09-05
+
 ### Added
 
 - Accounts created through an OpenID Connect sign-in now get the provider's profile picture (Google's at 400px), fetched in the background and run through the same validation, EXIF stripping, malware scan and thumbnailing as an upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.6.0"
+version = "2.6.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.6.0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.6.1] - 2026-09-05

### Added

- Accounts created through an OpenID Connect sign-in now get the provider's profile picture (Google's at 400px), fetched in the background and run through the same validation, EXIF stripping, malware scan and thumbnailing as an upload


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a changelog entry for version 2.6.1.

- **Release**
  - Updated the project version to 2.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->