### PR TITLE
feat(bootstrap): demo-video scenario seed command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,15 @@ seed:
 bootstrap-tests:
 	uv run python src/manage.py bootstrap_test_events
 
+# Pre-arranged scenarios for recording the product demo videos. Idempotent and
+# additive: it creates only its own orgs and @demovideo.example.com accounts, so
+# it can run before or after the bootstrap chain above (or on its own against an
+# empty-but-migrated DB), and re-running just rolls the event dates forward.
+# `reset_events` wipes it along with everything else — re-run after an e2e reseed.
+.PHONY: demo-video
+demo-video:
+	uv run python src/manage.py bootstrap_demo_video
+
 .PHONY: run
 run:
 	uv run python src/manage.py generate_test_jwts; \

--- a/src/events/management/commands/bootstrap_demo_video.py
+++ b/src/events/management/commands/bootstrap_demo_video.py
@@ -10,7 +10,8 @@ them, or on its own against an empty-but-migrated database.
 import typing as t
 
 import structlog
-from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from .demo_video_helpers import DEMO_PASSWORD, SCENARIOS, ScenarioSummary
@@ -27,7 +28,20 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args: t.Any, **options: t.Any) -> None:
-        """Seed every scenario, then print the org, event, and credential summary."""
+        """Seed every scenario, then print the org, event, and credential summary.
+
+        Raises:
+            CommandError: If DEMO_MODE is not enabled.
+        """
+        # The seed publishes PUBLIC organizations owned by accounts whose password is
+        # printed on screen, so it is gated the same way reset_events is. DEMO_MODE
+        # defaults to DEBUG, and .env.example turns it on, so local runs are unaffected.
+        if not settings.DEMO_MODE:
+            raise CommandError(
+                "This command can only be run when DEMO_MODE=True. "
+                "Set DEMO_MODE=True in your environment to seed the demo-video scenarios."
+            )
+
         logger.info("Seeding demo-video scenarios", count=len(SCENARIOS))
         summaries = [scenario() for scenario in SCENARIOS]
         self._print_summary(summaries)

--- a/src/events/management/commands/bootstrap_demo_video.py
+++ b/src/events/management/commands/bootstrap_demo_video.py
@@ -1,0 +1,62 @@
+# src/events/management/commands/bootstrap_demo_video.py
+"""Seed the five scenarios used to record the product demo videos.
+
+Unlike ``bootstrap_events``, this command is fully idempotent and creates only
+brand-new organizations, events, and ``@demovideo.example.com`` accounts. It never
+reads or mutates the bootstrap / E2E fixtures, so it can run before them, after
+them, or on its own against an empty-but-migrated database.
+"""
+
+import typing as t
+
+import structlog
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from .demo_video_helpers import DEMO_PASSWORD, SCENARIOS, ScenarioSummary
+
+logger = structlog.get_logger(__name__)
+
+RULE = "=" * 78
+
+
+class Command(BaseCommand):
+    """Seed the demo-video scenarios and print the presenter's cheat sheet."""
+
+    help = "Seed the five pre-arranged demo-video scenarios (idempotent, additive)."
+
+    @transaction.atomic
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
+        """Seed every scenario, then print the org, event, and credential summary."""
+        logger.info("Seeding demo-video scenarios", count=len(SCENARIOS))
+        summaries = [scenario() for scenario in SCENARIOS]
+        self._print_summary(summaries)
+
+    def _print_summary(self, summaries: list[ScenarioSummary]) -> None:
+        """Print a readable, copy-pasteable rundown of everything that was seeded."""
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING(RULE))
+        self.stdout.write(self.style.MIGRATE_HEADING(f"DEMO VIDEO SEED — {len(summaries)} scenarios ready"))
+        self.stdout.write(f"Every account below signs in with the password: {DEMO_PASSWORD}")
+        self.stdout.write(self.style.MIGRATE_HEADING(RULE))
+
+        for index, summary in enumerate(summaries, 1):
+            self.stdout.write("")
+            self.stdout.write(self.style.SUCCESS(f"{index}. {summary.title}"))
+            self.stdout.write(f"   org      /org/{summary.org_slug}")
+            for path in summary.event_paths:
+                self.stdout.write(f"   event    {path}")
+            for account in summary.accounts:
+                self.stdout.write(f"   · {account.email:<44} {account.name} — {account.role}")
+            for note in summary.notes:
+                self.stdout.write(self.style.WARNING(f"   ! {note}"))
+
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING(RULE))
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Re-run this command any time — it refreshes the same rows and rolls every "
+                "event date forward relative to today."
+            )
+        )
+        self.stdout.write(self.style.MIGRATE_HEADING(RULE))

--- a/src/events/management/commands/demo_video_helpers/__init__.py
+++ b/src/events/management/commands/demo_video_helpers/__init__.py
@@ -1,0 +1,13 @@
+# src/events/management/commands/demo_video_helpers/__init__.py
+"""Helper modules for the ``bootstrap_demo_video`` command."""
+
+from .base import DEMO_EMAIL_DOMAIN, DEMO_PASSWORD, DemoAccount, ScenarioSummary
+from .scenarios import SCENARIOS
+
+__all__ = [
+    "DEMO_EMAIL_DOMAIN",
+    "DEMO_PASSWORD",
+    "SCENARIOS",
+    "DemoAccount",
+    "ScenarioSummary",
+]

--- a/src/events/management/commands/demo_video_helpers/base.py
+++ b/src/events/management/commands/demo_video_helpers/base.py
@@ -1,0 +1,405 @@
+# src/events/management/commands/demo_video_helpers/base.py
+"""Shared state and idempotent upsert helpers for the demo-video seed.
+
+Every helper here is safe to call repeatedly: rows are keyed on stable slugs,
+emails, or ``(parent, order)`` pairs, so a second run refreshes the existing
+demo world instead of duplicating it.
+"""
+
+import datetime as dt
+import typing as t
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from events import models as events_models
+from geo.models import City
+from questionnaires import models as questionnaires_models
+
+DEMO_PASSWORD = "password123"
+DEMO_EMAIL_DOMAIN = "demovideo.example.com"
+
+#: Every organization gets this tier from the ``Organization`` post-save signal.
+DEFAULT_MEMBERSHIP_TIER_NAME = "General membership"
+
+EvaluationStatus = questionnaires_models.QuestionnaireEvaluation.QuestionnaireEvaluationStatus
+
+
+def demo_email(first_name: str, role: str) -> str:
+    """Build the demo-video address for ``first_name`` in ``role``."""
+    return f"{first_name.lower()}.{role}@{DEMO_EMAIL_DOMAIN}"
+
+
+@dataclass
+class DemoAccount:
+    """A seeded demo login, as printed in the command's credential summary."""
+
+    email: str
+    name: str
+    role: str
+
+
+@dataclass
+class ScenarioSummary:
+    """What one scenario seeded, for the on-camera cheat sheet."""
+
+    title: str
+    org_slug: str
+    event_paths: list[str] = field(default_factory=list)
+    accounts: list[DemoAccount] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def add(self, user: RevelUser, role: str) -> None:
+        """Record ``user`` in the credential table under ``role``."""
+        self.accounts.append(DemoAccount(email=user.email, name=user.get_display_name(), role=role))
+
+
+def at_local_hour(days_ahead: int, hour: int, minute: int = 0) -> dt.datetime:
+    """A timezone-aware datetime ``days_ahead`` days from now, at local ``hour``:``minute``.
+
+    Dates are always computed relative to *now* so a seed recorded against months
+    ago still shows upcoming events the next time the command runs.
+    """
+    return (timezone.localtime() + dt.timedelta(days=days_ahead)).replace(
+        hour=hour, minute=minute, second=0, microsecond=0
+    )
+
+
+def vienna() -> City | None:
+    """The Vienna city row, or ``None`` on a DB without the geo fixtures loaded."""
+    return City.objects.filter(name="Vienna", country="Austria").first()
+
+
+def upsert_user(first_name: str, last_name: str, role: str, *, pronouns: str = "") -> RevelUser:
+    """Create or refresh a demo account, keyed on its ``<first>.<role>@`` address."""
+    email = demo_email(first_name, role)
+    user, _ = RevelUser.objects.update_or_create(
+        username=email,
+        defaults={
+            "email": email,
+            "first_name": first_name,
+            "last_name": last_name,
+            "pronouns": pronouns,
+            "email_verified": True,
+            "is_active": True,
+        },
+    )
+    if not user.check_password(DEMO_PASSWORD):
+        user.set_password(DEMO_PASSWORD)
+        user.save(update_fields=["password"])
+    return user
+
+
+def upsert_organization(
+    *,
+    name: str,
+    slug: str,
+    owner: RevelUser,
+    description: str,
+    address: str,
+    contact_email: str,
+) -> events_models.Organization:
+    """Create or refresh a public demo organization, keyed on its slug."""
+    organization, _ = events_models.Organization.objects.update_or_create(
+        slug=slug,
+        defaults={
+            "name": name,
+            "owner": owner,
+            "description": description,
+            "visibility": events_models.Organization.Visibility.PUBLIC,
+            "city": vienna(),
+            "address": address,
+            "accept_membership_requests": True,
+            "contact_email": contact_email,
+            "contact_email_verified": True,
+        },
+    )
+    return organization
+
+
+def default_membership_tier(organization: events_models.Organization) -> events_models.MembershipTier:
+    """The organization's default membership tier, creating it if it went missing."""
+    tier, _ = events_models.MembershipTier.objects.get_or_create(
+        organization=organization, name=DEFAULT_MEMBERSHIP_TIER_NAME
+    )
+    return tier
+
+
+def upsert_membership(
+    organization: events_models.Organization,
+    user: RevelUser,
+    tier: events_models.MembershipTier | None = None,
+) -> events_models.OrganizationMember:
+    """Give ``user`` an active membership of ``organization``."""
+    member, _ = events_models.OrganizationMember.objects.update_or_create(
+        organization=organization,
+        user=user,
+        defaults={
+            "tier": tier or default_membership_tier(organization),
+            "status": events_models.OrganizationMember.MembershipStatus.ACTIVE,
+        },
+    )
+    return member
+
+
+def upsert_event(
+    *,
+    organization: events_models.Organization,
+    slug: str,
+    name: str,
+    description: str,
+    address: str,
+    start: dt.datetime,
+    duration: dt.timedelta,
+    **extra: t.Any,
+) -> events_models.Event:
+    """Create or refresh a demo event, keyed on ``(organization, slug)``.
+
+    ``extra`` overrides any of the open/public defaults — pass ``requires_ticket``,
+    ``event_type``, ``potluck_open``, and friends there.
+    """
+    defaults: dict[str, t.Any] = {
+        "name": name,
+        "description": description,
+        "address": address,
+        "city": vienna(),
+        "start": start,
+        "end": start + duration,
+        "status": events_models.Event.EventStatus.OPEN,
+        "visibility": events_models.Event.Visibility.PUBLIC,
+        "event_type": events_models.Event.EventType.PUBLIC,
+    }
+    defaults.update(extra)
+    event, _ = events_models.Event.objects.update_or_create(organization=organization, slug=slug, defaults=defaults)
+    return event
+
+
+def drop_default_ticket_tier(event: events_models.Event) -> None:
+    """Remove the tier the event post-save signal auto-creates for ticketed events."""
+    events_models.TicketTier.objects.filter(event=event, name=events_models.DEFAULT_TICKET_TIER_NAME).delete()
+
+
+def upsert_ticket_tier(event: events_models.Event, name: str, **defaults: t.Any) -> events_models.TicketTier:
+    """Create or refresh a ticket tier, keyed on ``(event, name)``."""
+    tier, _ = events_models.TicketTier.objects.update_or_create(event=event, name=name, defaults=defaults)
+    return tier
+
+
+def upsert_rsvp(
+    event: events_models.Event,
+    user: RevelUser,
+    status: str = events_models.EventRSVP.RsvpStatus.YES,
+) -> events_models.EventRSVP:
+    """Create or refresh an RSVP, keyed on ``(event, user)``."""
+    rsvp, _ = events_models.EventRSVP.objects.update_or_create(event=event, user=user, defaults={"status": status})
+    return rsvp
+
+
+def upsert_invitation(
+    event: events_models.Event,
+    user: RevelUser,
+    *,
+    custom_message: str,
+    waives_questionnaire: bool = False,
+    waives_membership_required: bool = False,
+) -> events_models.EventInvitation:
+    """Create or refresh an event invitation, keyed on ``(event, user)``."""
+    invitation, _ = events_models.EventInvitation.objects.update_or_create(
+        event=event,
+        user=user,
+        defaults={
+            "custom_message": custom_message,
+            "waives_questionnaire": waives_questionnaire,
+            "waives_membership_required": waives_membership_required,
+        },
+    )
+    return invitation
+
+
+def upsert_potluck_item(
+    event: events_models.Event,
+    *,
+    name: str,
+    item_type: str,
+    quantity: str,
+    note: str,
+    assignee: RevelUser | None = None,
+) -> events_models.PotluckItem:
+    """Create or refresh a potluck item, keyed on ``(event, name)``.
+
+    An item with no ``assignee`` is a host suggestion waiting for a volunteer.
+    """
+    item, _ = events_models.PotluckItem.objects.update_or_create(
+        event=event,
+        name=name,
+        defaults={
+            "item_type": item_type,
+            "quantity": quantity,
+            "note": note,
+            "is_suggested": assignee is None,
+            "assignee": assignee,
+            "created_by": assignee or event.organization.owner,
+        },
+    )
+    return item
+
+
+def upsert_questionnaire(
+    *,
+    organization: events_models.Organization,
+    name: str,
+    description: str,
+    events: list[events_models.Event],
+) -> questionnaires_models.Questionnaire:
+    """Create or refresh a published, manually-reviewed admission questionnaire.
+
+    Keyed on ``(organization, questionnaire name)`` via the ``OrganizationQuestionnaire``
+    link, so the name only has to be unique within the organization.
+    """
+    org_questionnaire = events_models.OrganizationQuestionnaire.objects.filter(
+        organization=organization, questionnaire__name=name
+    ).first()
+    questionnaire = org_questionnaire.questionnaire if org_questionnaire else questionnaires_models.Questionnaire()
+    questionnaire.name = name
+    questionnaire.description = description
+    questionnaire.status = questionnaires_models.Questionnaire.QuestionnaireStatus.PUBLISHED
+    questionnaire.evaluation_mode = questionnaires_models.Questionnaire.QuestionnaireEvaluationMode.MANUAL
+    questionnaire.llm_backend = questionnaires_models.Questionnaire.QuestionnaireLLMBackend.MOCK
+    questionnaire.min_score = Decimal("60.00")
+    questionnaire.max_attempts = 3
+    questionnaire.save()
+
+    if org_questionnaire is None:
+        org_questionnaire = events_models.OrganizationQuestionnaire.objects.create(
+            organization=organization,
+            questionnaire=questionnaire,
+            questionnaire_type=events_models.OrganizationQuestionnaire.QuestionnaireType.ADMISSION,
+        )
+    org_questionnaire.events.set(events)
+    return questionnaire
+
+
+def upsert_section(
+    questionnaire: questionnaires_models.Questionnaire, name: str, order: int = 1
+) -> questionnaires_models.QuestionnaireSection:
+    """Create or refresh a questionnaire section, keyed on ``(questionnaire, order)``."""
+    section, _ = questionnaires_models.QuestionnaireSection.objects.update_or_create(
+        questionnaire=questionnaire, order=order, defaults={"name": name}
+    )
+    return section
+
+
+def upsert_free_text_question(
+    section: questionnaires_models.QuestionnaireSection,
+    question: str,
+    *,
+    order: int = 1,
+    hint: str | None = None,
+) -> questionnaires_models.FreeTextQuestion:
+    """Create or refresh a mandatory free-text question, keyed on ``(questionnaire, order)``.
+
+    Question text is a ``MarkdownField`` and is rewritten by the sanitizer on save, so
+    the *order* — not the prose — is the stable key.
+    """
+    free_text_question, _ = questionnaires_models.FreeTextQuestion.objects.update_or_create(
+        questionnaire=section.questionnaire,
+        order=order,
+        defaults={
+            "section": section,
+            "question": question,
+            "hint": hint,
+            "is_mandatory": True,
+            "is_fatal": False,
+            "positive_weight": Decimal("3.0"),
+            "negative_weight": Decimal("0.0"),
+        },
+    )
+    return free_text_question
+
+
+def upsert_choice_question(
+    section: questionnaires_models.QuestionnaireSection,
+    question: str,
+    options: list[str],
+    *,
+    order: int = 1,
+) -> tuple[questionnaires_models.MultipleChoiceQuestion, list[questionnaires_models.MultipleChoiceOption]]:
+    """Create or refresh a single-answer multiple-choice question and its options."""
+    choice_question, _ = questionnaires_models.MultipleChoiceQuestion.objects.update_or_create(
+        questionnaire=section.questionnaire,
+        order=order,
+        defaults={
+            "section": section,
+            "question": question,
+            "allow_multiple_answers": False,
+            "shuffle_options": False,
+            "is_mandatory": True,
+            "is_fatal": False,
+            "positive_weight": Decimal("1.0"),
+            "negative_weight": Decimal("0.0"),
+        },
+    )
+    rows = []
+    for index, option in enumerate(options, 1):
+        row, _ = questionnaires_models.MultipleChoiceOption.objects.update_or_create(
+            question=choice_question, order=index, defaults={"option": option, "is_correct": False}
+        )
+        rows.append(row)
+    return choice_question, rows
+
+
+def upsert_submission(
+    *,
+    user: RevelUser,
+    event: events_models.Event,
+    questionnaire: questionnaires_models.Questionnaire,
+    free_text: dict[questionnaires_models.FreeTextQuestion, str],
+    choices: dict[questionnaires_models.MultipleChoiceQuestion, questionnaires_models.MultipleChoiceOption]
+    | None = None,
+    submitted_days_ago: int,
+    status: str = EvaluationStatus.PENDING_REVIEW,
+    score: Decimal | None = None,
+    comments: str = "",
+) -> questionnaires_models.QuestionnaireSubmission:
+    """Create or refresh one submitted questionnaire, its answers, and its evaluation.
+
+    A ``PENDING_REVIEW`` evaluation is what puts an application on the organizer's
+    review board, so pending submissions get a real evaluation row too.
+    """
+    submission = questionnaires_models.QuestionnaireSubmission.objects.filter(
+        user=user, questionnaire=questionnaire
+    ).first()
+    if submission is None:
+        submission = questionnaires_models.QuestionnaireSubmission(user=user, questionnaire=questionnaire)
+    submission.status = questionnaires_models.QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY
+    submission.submitted_at = at_local_hour(-submitted_days_ago, hour=11)
+    submission.save()
+
+    for question, answer in free_text.items():
+        questionnaires_models.FreeTextAnswer.objects.update_or_create(
+            submission=submission, question=question, defaults={"answer": answer}
+        )
+    for choice_question, option in (choices or {}).items():
+        questionnaires_models.MultipleChoiceAnswer.objects.filter(
+            submission=submission, question=choice_question
+        ).exclude(option=option).delete()
+        questionnaires_models.MultipleChoiceAnswer.objects.get_or_create(
+            submission=submission, question=choice_question, option=option
+        )
+
+    questionnaires_models.QuestionnaireEvaluation.objects.update_or_create(
+        submission=submission,
+        defaults={"status": status, "score": score, "comments": comments or None},
+    )
+    events_models.EventQuestionnaireSubmission.objects.update_or_create(
+        submission=submission,
+        defaults={
+            "user": user,
+            "event": event,
+            "questionnaire": questionnaire,
+            "questionnaire_type": events_models.OrganizationQuestionnaire.QuestionnaireType.ADMISSION,
+        },
+    )
+    return submission

--- a/src/events/management/commands/demo_video_helpers/scenarios.py
+++ b/src/events/management/commands/demo_video_helpers/scenarios.py
@@ -1,0 +1,771 @@
+# src/events/management/commands/demo_video_helpers/scenarios.py
+"""The five demo-video scenarios.
+
+Each function seeds one self-contained organization — its own slug, its own
+``@demovideo.example.com`` accounts — and returns the summary the command prints.
+Nothing here touches the ``bootstrap_events`` / ``bootstrap_test_events`` fixtures
+the E2E suite depends on.
+"""
+
+import datetime as dt
+from decimal import Decimal
+
+import structlog
+
+from events import models as events_models
+
+from .base import (
+    EvaluationStatus,
+    ScenarioSummary,
+    at_local_hour,
+    default_membership_tier,
+    drop_default_ticket_tier,
+    upsert_choice_question,
+    upsert_event,
+    upsert_free_text_question,
+    upsert_invitation,
+    upsert_membership,
+    upsert_organization,
+    upsert_potluck_item,
+    upsert_questionnaire,
+    upsert_rsvp,
+    upsert_section,
+    upsert_submission,
+    upsert_ticket_tier,
+    upsert_user,
+)
+
+logger = structlog.get_logger(__name__)
+
+ItemTypes = events_models.PotluckItem.ItemTypes
+TierVisibility = events_models.TicketTier.Visibility
+PaymentMethod = events_models.TicketTier.PaymentMethod
+PurchasableBy = events_models.TicketTier.PurchasableBy
+
+
+def seed_shibari_circle() -> ScenarioSummary:
+    """Scenario 1 — the flagship questionnaire gate: apply, get reviewed, get in."""
+    logger.info("Seeding demo scenario: Shibari Circle Vienna")
+
+    owner = upsert_user("Ren", "Okabe", "owner", pronouns="they/them")
+    organization = upsert_organization(
+        name="Shibari Circle Vienna",
+        slug="shibari-circle-vienna",
+        owner=owner,
+        address="Brunnengasse 71, 1160 Vienna, Austria",
+        contact_email="hello@shibaricircle.example.com",
+        description="""# Shibari Circle Vienna
+
+A small, consent-first rope community that has been meeting in Vienna since 2019. We run
+beginner-friendly workshops, slow practice evenings, and the occasional rope jam — always with
+more room for questions than anyone expects.
+
+## What to expect
+
+- A clear consent culture, and a code of conduct read out at the start of every session
+- Experienced riggers and bottoms on hand all evening, never more than four people per teacher
+- No pressure to tie, to be tied, or to stay past the point where you are enjoying yourself
+
+## Joining us
+
+Every workshop has a short application, so we can balance the room and make sure everyone
+arrives with the same expectations. We read every single one, usually within a day or two.
+""",
+    )
+
+    event = upsert_event(
+        organization=organization,
+        slug="intro-to-shibari-rope-and-trust",
+        name="Intro to Shibari — Rope & Trust",
+        address="Brunnengasse 71, 1160 Vienna, Austria",
+        start=at_local_hour(7, hour=19),
+        duration=dt.timedelta(hours=3),
+        max_attendees=24,
+        description="""# Intro to Shibari — Rope & Trust
+
+An evening for absolute beginners. No experience, no rope and no partner required — we bring
+the rope, and we will pair you up if you come on your own.
+
+## The evening
+
+- **19:00** — Welcome, tea, and the consent briefing
+- **19:30** — Rope handling, tension, and the single-column tie
+- **20:30** — Break, snacks, and questions
+- **21:00** — Two-column tie and a first simple chest harness
+- **21:45** — Cool-down, aftercare, and where to go next
+
+## What to bring
+
+Comfortable clothes you can move in, a water bottle, and a pair of safety shears if you own
+them — we have spares. Trimmed nails, please.
+
+## Access
+
+Ground floor, step-free entrance, accessible bathroom. This is a fragrance-free space, so
+please skip the perfume.
+""",
+    )
+    drop_default_ticket_tier(event)
+    upsert_ticket_tier(
+        event,
+        "Workshop Spot",
+        visibility=TierVisibility.PUBLIC,
+        payment_method=PaymentMethod.FREE,
+        purchasable_by=PurchasableBy.PUBLIC,
+        price=Decimal("0.00"),
+        currency="EUR",
+        total_quantity=24,
+        description="One place at the workshop. Free — we would rather you spent the money on your own rope.",
+    )
+
+    questionnaire = upsert_questionnaire(
+        organization=organization,
+        name="Workshop Application",
+        events=[event],
+        description=(
+            "We keep these evenings small and balanced. Tell us a little about yourself and we "
+            "will come back to you within a couple of days."
+        ),
+    )
+    section = upsert_section(questionnaire, "Your rope journey")
+    experience_question = upsert_free_text_question(
+        section,
+        "Tell us about your experience with rope and what you hope to learn.",
+        hint="There is no wrong answer — complete beginners are exactly who this evening is for.",
+    )
+
+    applicants = [
+        (
+            "Mira",
+            "Lindqvist",
+            "she/her",
+            2,
+            "I have been to two rope jams as a bottom but have never tied anyone myself. I would "
+            "love to finally understand what my rigger is actually doing, and to be able to tie a "
+            "safe single column on my own.",
+        ),
+        (
+            "Tobias",
+            "Ferrand",
+            "he/him",
+            3,
+            "Complete beginner. A friend showed me a chest harness at a party last spring and I "
+            "have not stopped thinking about it since. Mostly I want to learn how to do this safely.",
+        ),
+        (
+            "Yuki",
+            "Sorensen",
+            "they/them",
+            5,
+            "About a year of self-tying at home from books and videos, which I suspect has taught "
+            "me some bad habits. Hoping for eyes on my technique and some proper nerve-safety "
+            "grounding.",
+        ),
+    ]
+
+    summary = ScenarioSummary(
+        title="Questionnaire gate — Shibari Circle Vienna",
+        org_slug=organization.slug,
+        event_paths=[f"/events/{organization.slug}/{event.slug}"],
+    )
+    summary.add(owner, "owner — reviews the applications on camera")
+
+    for first_name, last_name, pronouns, days_ago, answer in applicants:
+        applicant = upsert_user(first_name, last_name, "applicant", pronouns=pronouns)
+        upsert_submission(
+            user=applicant,
+            event=event,
+            questionnaire=questionnaire,
+            free_text={experience_question: answer},
+            submitted_days_ago=days_ago,
+        )
+        summary.add(applicant, "applied — waiting for review")
+
+    newcomer = upsert_user("Noa", "Beckmann", "attendee", pronouns="she/her")
+    summary.add(newcomer, "has NOT applied — use for the gate → apply → approve arc")
+    summary.notes = [
+        '"Workshop Application" is published, manually reviewed, with 3 submissions pending.',
+        'One free tier, "Workshop Spot", 24 places — the gate is the questionnaire, not the price.',
+    ]
+    return summary
+
+
+def seed_velvet_cellar() -> ScenarioSummary:
+    """Scenario 2 — member-only ticket tier next to a public door price."""
+    logger.info("Seeding demo scenario: The Velvet Cellar")
+
+    owner = upsert_user("Dario", "Fenn", "owner", pronouns="he/him")
+    organization = upsert_organization(
+        name="The Velvet Cellar",
+        slug="the-velvet-cellar",
+        owner=owner,
+        address="Lerchenfelder Gürtel 29, 1080 Vienna, Austria",
+        contact_email="door@velvetcellar.example.com",
+        description="""# The Velvet Cellar
+
+A ninety-capacity basement club under the Gürtel, run as a members' club since 2016. Loud
+guitars, cold soda, and a strict no-photos-on-the-floor policy.
+
+## Membership
+
+Membership is free and takes about a minute. Members get in free to most shows, hear about new
+dates first, and can bring one guest on the door price.
+
+## House rules
+
+Look after each other. No photographs of anyone without asking them first. If anything feels
+off, talk to whoever is wearing the red lanyard.
+""",
+    )
+
+    event = upsert_event(
+        organization=organization,
+        slug="basement-sessions-live-and-loud",
+        name="Basement Sessions: Live & Loud",
+        address="Lerchenfelder Gürtel 29, 1080 Vienna, Austria",
+        start=at_local_hour(10, hour=20),
+        duration=dt.timedelta(hours=5),
+        max_attendees=90,
+        description="""# Basement Sessions: Live & Loud
+
+Three bands, one basement, doors at 20:00. This month: a post-punk trio from Graz, a local
+noise-pop four-piece, and a headliner we are not allowed to announce until the day.
+
+## Running order
+
+- **20:00** — Doors and opening DJ set
+- **21:00** — Opener
+- **21:45** — Second band
+- **22:45** — Headliner
+- **00:00** — Records until late
+
+## Getting in
+
+Members come in free — show your membership card at the door. Everyone else pays on the night,
+cash or card. We do not sell tickets online.
+""",
+    )
+    upsert_ticket_tier(
+        event,
+        events_models.DEFAULT_TICKET_TIER_NAME,
+        visibility=TierVisibility.PUBLIC,
+        payment_method=PaymentMethod.AT_THE_DOOR,
+        purchasable_by=PurchasableBy.PUBLIC,
+        price=Decimal("15.00"),
+        currency="EUR",
+        total_quantity=90,
+        description="Pay at the door, cash or card. Reserve your place here so we know to expect you.",
+    )
+    upsert_ticket_tier(
+        event,
+        "Members — Free Entry",
+        visibility=TierVisibility.MEMBERS_ONLY,
+        payment_method=PaymentMethod.FREE,
+        purchasable_by=PurchasableBy.MEMBERS,
+        price=Decimal("0.00"),
+        currency="EUR",
+        total_quantity=60,
+        description="Free entry for club members. Bring your membership card — we do check.",
+    )
+
+    member = upsert_user("Lena", "Krause", "member", pronouns="she/her")
+    upsert_membership(organization, member)
+    guest = upsert_user("Paul", "Vogt", "guest", pronouns="he/him")
+
+    summary = ScenarioSummary(
+        title="Member-only tier — The Velvet Cellar",
+        org_slug=organization.slug,
+        event_paths=[f"/events/{organization.slug}/{event.slug}"],
+    )
+    summary.add(owner, "owner")
+    summary.add(member, "member — sees the free members' tier")
+    summary.add(guest, "not a member — sees only the €15 door tier")
+    summary.notes = [
+        "Log in as each of the two accounts on the same event page for the A/B shot.",
+        "General Admission is at-the-door €15; the members' tier is free and members-only.",
+    ]
+    return summary
+
+
+def seed_picnic_club() -> ScenarioSummary:
+    """Scenario 3 — an RSVP potluck with claimed and unclaimed items."""
+    logger.info("Seeding demo scenario: Sunday Slow Picnic Club")
+
+    owner = upsert_user("Ana", "Ferreira", "owner", pronouns="she/her")
+    organization = upsert_organization(
+        name="Sunday Slow Picnic Club",
+        slug="sunday-slow-picnic-club",
+        owner=owner,
+        address="Obere Augartenstraße 1, 1020 Vienna, Austria",
+        contact_email="hello@slowpicnic.example.com",
+        description="""# Sunday Slow Picnic Club
+
+We meet in a Viennese park roughly twice a month, spread out some blankets, and stay until the
+light goes. No programme, no tickets, and no phones out the whole time. Bring something to
+share if you can, and come anyway if you cannot.
+""",
+    )
+
+    event = upsert_event(
+        organization=organization,
+        slug="picnic-in-the-park",
+        name="Picnic in the Park",
+        address="Augarten, Obere Augartenstraße 1, 1020 Vienna, Austria",
+        start=at_local_hour(5, hour=12),
+        duration=dt.timedelta(hours=5),
+        requires_ticket=False,
+        potluck_open=True,
+        rsvp_before=at_local_hour(4, hour=20),
+        description="""# Picnic in the Park
+
+The Augarten, near the big chestnut trees past the second gate. Look for the yellow bunting.
+
+## How it works
+
+This is a potluck. Have a look at the list below and claim whatever you fancy bringing — or add
+something of your own. Nobody keeps score, and there is always, always too much cake.
+
+## Practical bits
+
+- Step-free from the Obere Augartenstraße entrance
+- Public toilets by the playground
+- We take our rubbish home with us, so bring a bag if you have a spare
+- Dogs welcome on a lead
+""",
+    )
+
+    suggestions = [
+        (
+            "Big pot of something warm",
+            ItemTypes.MAIN_COURSE,
+            "Feeds 8–10",
+            "Chilli, dal, a tray bake — anything that survives a bike ride.",
+        ),
+        (
+            "Seasonal salad",
+            ItemTypes.SIDE_DISH,
+            "One large bowl",
+            "Whatever looks good at the Karmelitermarkt on Saturday morning.",
+        ),
+        (
+            "Bread and spreads",
+            ItemTypes.SIDE_DISH,
+            "For 12",
+            "Please label anything containing nuts.",
+        ),
+        (
+            "Picnic blankets",
+            ItemTypes.SUPPLIES,
+            "3–4 blankets",
+            "The grass is usually still damp until noon.",
+        ),
+        (
+            "Cups, plates and a bin bag",
+            ItemTypes.SUPPLIES,
+            "For 20",
+            "Reusable if you have them, compostable if not.",
+        ),
+        (
+            "Something to play",
+            ItemTypes.ENTERTAINMENT,
+            "One set of anything",
+            "Boules, a pack of cards, a kite. Low stakes only.",
+        ),
+    ]
+    for name, item_type, quantity, note in suggestions:
+        upsert_potluck_item(event, name=name, item_type=item_type, quantity=quantity, note=note)
+
+    claims = [
+        (
+            "Sofia",
+            "Marchetti",
+            "she/her",
+            "Lemon and olive oil cake",
+            ItemTypes.DESSERT,
+            "Two tins",
+            "Vegan, and honestly better on the second day.",
+        ),
+        (
+            "Omar",
+            "Haddad",
+            "he/him",
+            "Mujaddara with crispy onions",
+            ItemTypes.MAIN_COURSE,
+            "Feeds 10",
+            "Vegan and mild — chilli oil on the side for anyone who wants it.",
+        ),
+        (
+            "Greta",
+            "Nowak",
+            "she/they",
+            "Two thermoses of iced hibiscus tea",
+            ItemTypes.NON_ALCOHOLIC,
+            "4 litres",
+            "Unsweetened, with sugar in a jar alongside.",
+        ),
+        (
+            "Felix",
+            "Baumann",
+            "he/him",
+            "Guitar and a very small amp",
+            ItemTypes.ENTERTAINMENT,
+            "One 30-minute set",
+            "Battery powered, park-legal volume, requests welcome.",
+        ),
+    ]
+
+    summary = ScenarioSummary(
+        title="Potluck — Sunday Slow Picnic Club",
+        org_slug=organization.slug,
+        event_paths=[f"/events/{organization.slug}/{event.slug}"],
+    )
+    summary.add(owner, "owner — added the six host suggestions")
+
+    for first_name, last_name, pronouns, item_name, item_type, quantity, note in claims:
+        picnicker = upsert_user(first_name, last_name, "picnicker", pronouns=pronouns)
+        upsert_rsvp(event, picnicker)
+        upsert_potluck_item(
+            event, name=item_name, item_type=item_type, quantity=quantity, note=note, assignee=picnicker
+        )
+        summary.add(picnicker, f"attending — claimed “{item_name}”")
+
+    empty_handed = upsert_user("Jonas", "Reiter", "guest", pronouns="he/him")
+    upsert_rsvp(event, empty_handed)
+    summary.add(empty_handed, "attending with NO claim — use for the claim-an-item shot")
+    summary.notes = [
+        "RSVP event (no tickets) with the potluck board open.",
+        "Six unclaimed host suggestions and four claimed items are already on the board.",
+    ]
+    return summary
+
+
+def seed_photo_walks() -> ScenarioSummary:
+    """Scenario 4 — a questionnaire with enough submissions to show insights."""
+    logger.info("Seeding demo scenario: Analog Photo Walks")
+
+    owner = upsert_user("Kaia", "Lund", "owner", pronouns="she/her")
+    organization = upsert_organization(
+        name="Analog Photo Walks",
+        slug="analog-photo-walks",
+        owner=owner,
+        address="Karlsplatz 1, 1040 Vienna, Austria",
+        contact_email="walks@analogphoto.example.com",
+        description="""# Analog Photo Walks
+
+A film-only photo walk, once a month, around a different corner of Vienna. Any camera that takes
+a roll counts — point-and-shoot, medium format, or the thing you found in your grandmother's
+cupboard. We walk slowly, we stop a lot, and we get a drink at the end.
+
+## Why we ask questions
+
+The walks stay at twelve people, so that nobody spends the evening photographing the back of
+someone's head. The short application below just helps us keep the group mixed and know who is
+bringing what.
+""",
+    )
+
+    event = upsert_event(
+        organization=organization,
+        slug="golden-hour-photo-walk",
+        name="Golden Hour Photo Walk",
+        address="Karlsplatz 1, 1040 Vienna, Austria",
+        start=at_local_hour(12, hour=18, minute=30),
+        duration=dt.timedelta(hours=3),
+        requires_ticket=False,
+        max_attendees=12,
+        description="""# Golden Hour Photo Walk
+
+We meet at the Otto Wagner pavilions on Karlsplatz an hour before sunset, walk through the
+Naschmarkt and along the Wienzeile as the light turns orange, and finish at a bar in the 5th
+about two hours later.
+
+## Bring
+
+- A loaded camera and a spare roll — 400 ISO is the safe bet for this one
+- Shoes you can walk four kilometres in
+- Enough cash for one drink at the end
+
+## Level
+
+All of them. Half the group has never developed a roll, and the other half will happily talk
+your ear off about it.
+""",
+    )
+
+    questionnaire = upsert_questionnaire(
+        organization=organization,
+        name="Walk Application",
+        events=[event],
+        description="Two quick questions so we can keep the group to twelve and nicely mixed.",
+    )
+    section = upsert_section(questionnaire, "About your camera")
+    gear_question = upsert_free_text_question(
+        section,
+        "What do you shoot with?",
+        order=1,
+        hint="Camera, film stock, or “no idea yet, I have just inherited this thing” — all fine.",
+    )
+    referral_question, referral_options = upsert_choice_question(
+        section,
+        "How did you hear about us?",
+        ["A friend brought me along", "Instagram", "I found the group on Revel"],
+        order=2,
+    )
+    friend, instagram, on_revel = referral_options
+
+    approved, rejected, pending = (
+        EvaluationStatus.APPROVED,
+        EvaluationStatus.REJECTED,
+        EvaluationStatus.PENDING_REVIEW,
+    )
+    applicants = [
+        (
+            "Hanna",
+            "Persson",
+            "she/her",
+            "A Pentax K1000 my dad taught me on, usually loaded with HP5. I develop black and "
+            "white at home in the kitchen sink.",
+            friend,
+            2,
+            approved,
+            Decimal("85.00"),
+            "",
+        ),
+        (
+            "Milan",
+            "Kovac",
+            "he/him",
+            "An Olympus mju-II in my coat pocket at all times. Portra 400 when I can afford it, "
+            "Gold 200 when I cannot.",
+            instagram,
+            3,
+            approved,
+            Decimal("85.00"),
+            "",
+        ),
+        (
+            "Aisha",
+            "Rahman",
+            "she/her",
+            "A Mamiya RB67. It is absurdly heavy and I love it. Mostly portraits, so a slow walk suits me perfectly.",
+            on_revel,
+            4,
+            approved,
+            Decimal("85.00"),
+            "",
+        ),
+        (
+            "Lukas",
+            "Berger",
+            "he/him",
+            "Nothing yet — I have just been given my grandmother's Werra and I would like to shoot "
+            "my first roll with people who know what they are doing.",
+            friend,
+            5,
+            approved,
+            Decimal("85.00"),
+            "Total beginner, borrowed a light meter from Hanna. Lovely.",
+        ),
+        (
+            "Zoe",
+            "Martins",
+            "they/them",
+            "A Canon AE-1 and a 50mm, and that is the whole kit. Cinestill 800T for anything after dark.",
+            instagram,
+            6,
+            approved,
+            Decimal("85.00"),
+            "",
+        ),
+        (
+            "Bruno",
+            "Salgado",
+            "he/him",
+            "I shoot digital, is that a problem? I have a very nice Sony.",
+            instagram,
+            7,
+            rejected,
+            Decimal("30.00"),
+            "Film-only walk. Sent a friendly note pointing at the city photo club instead.",
+        ),
+        (
+            "Timo",
+            "Rask",
+            "he/him",
+            "not sure yet, mostly just want to know if there will be models",
+            instagram,
+            8,
+            rejected,
+            Decimal("30.00"),
+            "Asked about models rather than photography. Not a fit for this group.",
+        ),
+        (
+            "Elif",
+            "Demir",
+            "she/her",
+            "A Yashica Mat 124G, twin lens. I have been shooting expired Ektar and getting beautiful mistakes.",
+            on_revel,
+            1,
+            pending,
+            None,
+            "",
+        ),
+        (
+            "Pawel",
+            "Zielinski",
+            "he/him",
+            "A Nikon FM2 with a 28mm. Coming back to film after ten years away, and quite rusty.",
+            friend,
+            1,
+            pending,
+            None,
+            "",
+        ),
+        (
+            "Nora",
+            "Lindgren",
+            "she/her",
+            "A Lomo LC-A and a lot of enthusiasm. I would like to learn to actually meter instead of guessing.",
+            on_revel,
+            2,
+            pending,
+            None,
+            "",
+        ),
+    ]
+
+    summary = ScenarioSummary(
+        title="Questionnaire insights — Analog Photo Walks",
+        org_slug=organization.slug,
+        event_paths=[f"/events/{organization.slug}/{event.slug}"],
+    )
+    summary.add(owner, "owner — open the questionnaire insights here")
+
+    outcomes = {approved: "approved", rejected: "rejected", pending: "pending review"}
+    for first_name, last_name, pronouns, gear, referral, days_ago, status, score, comments in applicants:
+        walker = upsert_user(first_name, last_name, "walker", pronouns=pronouns)
+        upsert_submission(
+            user=walker,
+            event=event,
+            questionnaire=questionnaire,
+            free_text={gear_question: gear},
+            choices={referral_question: referral},
+            submitted_days_ago=days_ago,
+            status=status,
+            score=score,
+            comments=comments,
+        )
+        summary.add(walker, f"applied — {outcomes[status]}")
+
+    summary.notes = [
+        "10 submissions: 5 approved (85), 2 rejected (30), 3 still pending review.",
+        'The multiple-choice "How did you hear about us?" answers drive the insights charts.',
+    ]
+    return summary
+
+
+def seed_book_club() -> ScenarioSummary:
+    """Scenario 5 — three accounts hitting three different eligibility outcomes."""
+    logger.info("Seeding demo scenario: Paper Hearts Book Club")
+
+    owner = upsert_user("Iris", "Halvorsen", "owner", pronouns="she/her")
+    organization = upsert_organization(
+        name="Paper Hearts Book Club",
+        slug="paper-hearts-book-club",
+        owner=owner,
+        address="Gumpendorfer Straße 11, 1060 Vienna, Austria",
+        contact_email="hello@paperhearts.example.com",
+        description="""# Paper Hearts Book Club
+
+Twelve people, one book a month, and a rule that you are welcome whether or not you finished it.
+We read fiction in translation, mostly, and we have been meeting above the same café on
+Gumpendorfer Straße since 2021.
+
+## Membership
+
+The reading circle is for members. Membership is free — send us a short note about what you are
+reading at the moment and we will get you on the list before the next meeting.
+""",
+    )
+
+    event = upsert_event(
+        organization=organization,
+        slug="monthly-reading-circle",
+        name="Monthly Reading Circle",
+        address="Gumpendorfer Straße 11, 1060 Vienna, Austria",
+        start=at_local_hour(9, hour=19, minute=30),
+        duration=dt.timedelta(hours=2, minutes=30),
+        event_type=events_models.Event.EventType.MEMBERS_ONLY,
+        requires_ticket=False,
+        max_attendees=12,
+        description="""# Monthly Reading Circle
+
+**This month:** *The Employees* by Olga Ravn.
+
+Upstairs at the café from 19:30, until they throw us out at around 22:00. Coffee and wine at the
+bar; the first round is on the club.
+
+## How the evening runs
+
+- A quick round of first impressions — one sentence each, no summarising
+- Two passages read aloud, chosen by whoever volunteered last month
+- Open discussion, which is where the actual evening happens
+- Choosing next month's book by a show of hands
+
+## If you have not finished it
+
+Come anyway. Seriously. Half the room never does.
+""",
+    )
+
+    questionnaire = upsert_questionnaire(
+        organization=organization,
+        name="Reading Circle Intro",
+        events=[event],
+        description="A quick hello, so we know who is joining us upstairs.",
+    )
+    section = upsert_section(questionnaire, "Say hello")
+    upsert_free_text_question(
+        section,
+        "What are you reading at the moment, and what made you pick it up?",
+        hint="A sentence is plenty. We are nosy, not strict.",
+    )
+
+    outsider = upsert_user("Bea", "Nilsson", "outsider", pronouns="she/her")
+    member = upsert_user("Hugo", "Almeida", "member", pronouns="he/him")
+    upsert_membership(organization, member, default_membership_tier(organization))
+    invited = upsert_user("Clara", "Mendel", "invited", pronouns="she/her")
+    upsert_invitation(
+        event,
+        invited,
+        waives_questionnaire=True,
+        waives_membership_required=True,
+        custom_message=(
+            "Clara — come straight up on Thursday. No application and no membership needed; "
+            "just ask at the bar for Iris."
+        ),
+    )
+
+    summary = ScenarioSummary(
+        title="Eligibility gates — Paper Hearts Book Club",
+        org_slug=organization.slug,
+        event_paths=[f"/events/{organization.slug}/{event.slug}"],
+    )
+    summary.add(owner, "owner")
+    summary.add(outsider, "no membership, no submission — blocked by both gates")
+    summary.add(member, "member, no submission — blocked by the questionnaire only")
+    summary.add(invited, "invited — invitation waives the questionnaire AND membership")
+    summary.notes = [
+        "Members-only event type, public visibility, RSVP (no tickets).",
+        "Open the same event page as each of the three accounts to show all three outcomes.",
+    ]
+    return summary
+
+
+SCENARIOS = [
+    seed_shibari_circle,
+    seed_velvet_cellar,
+    seed_picnic_club,
+    seed_photo_walks,
+    seed_book_club,
+]

--- a/src/events/management/commands/demo_video_helpers/scenarios.py
+++ b/src/events/management/commands/demo_video_helpers/scenarios.py
@@ -8,11 +8,13 @@ the E2E suite depends on.
 """
 
 import datetime as dt
+from dataclasses import dataclass
 from decimal import Decimal
 
 import structlog
 
 from events import models as events_models
+from questionnaires import models as questionnaires_models
 
 from .base import (
     EvaluationStatus,
@@ -41,6 +43,34 @@ ItemTypes = events_models.PotluckItem.ItemTypes
 TierVisibility = events_models.TicketTier.Visibility
 PaymentMethod = events_models.TicketTier.PaymentMethod
 PurchasableBy = events_models.TicketTier.PurchasableBy
+
+
+@dataclass(frozen=True)
+class WalkOutcome:
+    """How the organizer answered a photo-walk application, and how we describe it."""
+
+    status: str
+    label: str
+    score: Decimal | None
+
+
+APPROVED = WalkOutcome(EvaluationStatus.APPROVED, "approved", Decimal("85.00"))
+REJECTED = WalkOutcome(EvaluationStatus.REJECTED, "rejected", Decimal("30.00"))
+PENDING = WalkOutcome(EvaluationStatus.PENDING_REVIEW, "pending review", None)
+
+
+@dataclass(frozen=True)
+class WalkApplicant:
+    """One seeded application to the photo walk."""
+
+    first_name: str
+    last_name: str
+    pronouns: str
+    gear: str
+    referral: questionnaires_models.MultipleChoiceOption
+    submitted_days_ago: int
+    outcome: WalkOutcome
+    comments: str = ""
 
 
 def seed_shibari_circle() -> ScenarioSummary:
@@ -513,124 +543,103 @@ your ear off about it.
     )
     friend, instagram, on_revel = referral_options
 
-    approved, rejected, pending = (
-        EvaluationStatus.APPROVED,
-        EvaluationStatus.REJECTED,
-        EvaluationStatus.PENDING_REVIEW,
-    )
     applicants = [
-        (
-            "Hanna",
-            "Persson",
-            "she/her",
-            "A Pentax K1000 my dad taught me on, usually loaded with HP5. I develop black and "
+        WalkApplicant(
+            first_name="Hanna",
+            last_name="Persson",
+            pronouns="she/her",
+            gear="A Pentax K1000 my dad taught me on, usually loaded with HP5. I develop black and "
             "white at home in the kitchen sink.",
-            friend,
-            2,
-            approved,
-            Decimal("85.00"),
-            "",
+            referral=friend,
+            submitted_days_ago=2,
+            outcome=APPROVED,
         ),
-        (
-            "Milan",
-            "Kovac",
-            "he/him",
-            "An Olympus mju-II in my coat pocket at all times. Portra 400 when I can afford it, "
-            "Gold 200 when I cannot.",
-            instagram,
-            3,
-            approved,
-            Decimal("85.00"),
-            "",
+        WalkApplicant(
+            first_name="Milan",
+            last_name="Kovac",
+            pronouns="he/him",
+            gear="An Olympus mju-II in my coat pocket at all times. Portra 400 when I can afford "
+            "it, Gold 200 when I cannot.",
+            referral=instagram,
+            submitted_days_ago=3,
+            outcome=APPROVED,
         ),
-        (
-            "Aisha",
-            "Rahman",
-            "she/her",
-            "A Mamiya RB67. It is absurdly heavy and I love it. Mostly portraits, so a slow walk suits me perfectly.",
-            on_revel,
-            4,
-            approved,
-            Decimal("85.00"),
-            "",
+        WalkApplicant(
+            first_name="Aisha",
+            last_name="Rahman",
+            pronouns="she/her",
+            gear="A Mamiya RB67. It is absurdly heavy and I love it. Mostly portraits, so a slow "
+            "walk suits me perfectly.",
+            referral=on_revel,
+            submitted_days_ago=4,
+            outcome=APPROVED,
         ),
-        (
-            "Lukas",
-            "Berger",
-            "he/him",
-            "Nothing yet — I have just been given my grandmother's Werra and I would like to shoot "
-            "my first roll with people who know what they are doing.",
-            friend,
-            5,
-            approved,
-            Decimal("85.00"),
-            "Total beginner, borrowed a light meter from Hanna. Lovely.",
+        WalkApplicant(
+            first_name="Lukas",
+            last_name="Berger",
+            pronouns="he/him",
+            gear="Nothing yet — I have just been given my grandmother's Werra and I would like to "
+            "shoot my first roll with people who know what they are doing.",
+            referral=friend,
+            submitted_days_ago=5,
+            outcome=APPROVED,
+            comments="Total beginner, borrowed a light meter from Hanna. Lovely.",
         ),
-        (
-            "Zoe",
-            "Martins",
-            "they/them",
-            "A Canon AE-1 and a 50mm, and that is the whole kit. Cinestill 800T for anything after dark.",
-            instagram,
-            6,
-            approved,
-            Decimal("85.00"),
-            "",
+        WalkApplicant(
+            first_name="Zoe",
+            last_name="Martins",
+            pronouns="they/them",
+            gear="A Canon AE-1 and a 50mm, and that is the whole kit. Cinestill 800T for anything after dark.",
+            referral=instagram,
+            submitted_days_ago=6,
+            outcome=APPROVED,
         ),
-        (
-            "Bruno",
-            "Salgado",
-            "he/him",
-            "I shoot digital, is that a problem? I have a very nice Sony.",
-            instagram,
-            7,
-            rejected,
-            Decimal("30.00"),
-            "Film-only walk. Sent a friendly note pointing at the city photo club instead.",
+        WalkApplicant(
+            first_name="Bruno",
+            last_name="Salgado",
+            pronouns="he/him",
+            gear="I shoot digital, is that a problem? I have a very nice Sony.",
+            referral=instagram,
+            submitted_days_ago=7,
+            outcome=REJECTED,
+            comments="Film-only walk. Sent a friendly note pointing at the city photo club instead.",
         ),
-        (
-            "Timo",
-            "Rask",
-            "he/him",
-            "not sure yet, mostly just want to know if there will be models",
-            instagram,
-            8,
-            rejected,
-            Decimal("30.00"),
-            "Asked about models rather than photography. Not a fit for this group.",
+        WalkApplicant(
+            first_name="Timo",
+            last_name="Rask",
+            pronouns="he/him",
+            gear="not sure yet, mostly just want to know if there will be models",
+            referral=instagram,
+            submitted_days_ago=8,
+            outcome=REJECTED,
+            comments="Asked about models rather than photography. Not a fit for this group.",
         ),
-        (
-            "Elif",
-            "Demir",
-            "she/her",
-            "A Yashica Mat 124G, twin lens. I have been shooting expired Ektar and getting beautiful mistakes.",
-            on_revel,
-            1,
-            pending,
-            None,
-            "",
+        WalkApplicant(
+            first_name="Elif",
+            last_name="Demir",
+            pronouns="she/her",
+            gear="A Yashica Mat 124G, twin lens. I have been shooting expired Ektar and getting beautiful mistakes.",
+            referral=on_revel,
+            submitted_days_ago=1,
+            outcome=PENDING,
         ),
-        (
-            "Pawel",
-            "Zielinski",
-            "he/him",
-            "A Nikon FM2 with a 28mm. Coming back to film after ten years away, and quite rusty.",
-            friend,
-            1,
-            pending,
-            None,
-            "",
+        WalkApplicant(
+            first_name="Pawel",
+            last_name="Zielinski",
+            pronouns="he/him",
+            gear="A Nikon FM2 with a 28mm. Coming back to film after ten years away, and quite rusty.",
+            referral=friend,
+            submitted_days_ago=1,
+            outcome=PENDING,
         ),
-        (
-            "Nora",
-            "Lindgren",
-            "she/her",
-            "A Lomo LC-A and a lot of enthusiasm. I would like to learn to actually meter instead of guessing.",
-            on_revel,
-            2,
-            pending,
-            None,
-            "",
+        WalkApplicant(
+            first_name="Nora",
+            last_name="Lindgren",
+            pronouns="she/her",
+            gear="A Lomo LC-A and a lot of enthusiasm. I would like to learn to actually meter instead of guessing.",
+            referral=on_revel,
+            submitted_days_ago=2,
+            outcome=PENDING,
         ),
     ]
 
@@ -641,21 +650,20 @@ your ear off about it.
     )
     summary.add(owner, "owner — open the questionnaire insights here")
 
-    outcomes = {approved: "approved", rejected: "rejected", pending: "pending review"}
-    for first_name, last_name, pronouns, gear, referral, days_ago, status, score, comments in applicants:
-        walker = upsert_user(first_name, last_name, "walker", pronouns=pronouns)
+    for applicant in applicants:
+        walker = upsert_user(applicant.first_name, applicant.last_name, "walker", pronouns=applicant.pronouns)
         upsert_submission(
             user=walker,
             event=event,
             questionnaire=questionnaire,
-            free_text={gear_question: gear},
-            choices={referral_question: referral},
-            submitted_days_ago=days_ago,
-            status=status,
-            score=score,
-            comments=comments,
+            free_text={gear_question: applicant.gear},
+            choices={referral_question: applicant.referral},
+            submitted_days_ago=applicant.submitted_days_ago,
+            status=applicant.outcome.status,
+            score=applicant.outcome.score,
+            comments=applicant.comments,
         )
-        summary.add(walker, f"applied — {outcomes[status]}")
+        summary.add(walker, f"applied — {applicant.outcome.label}")
 
     summary.notes = [
         "10 submissions: 5 approved (85), 2 rejected (30), 3 still pending review.",

--- a/src/events/tests/test_management/test_bootstrap_demo_video_command.py
+++ b/src/events/tests/test_management/test_bootstrap_demo_video_command.py
@@ -1,0 +1,119 @@
+"""Tests for the ``bootstrap_demo_video`` management command."""
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from accounts.models import RevelUser
+from events.management.commands.demo_video_helpers import DEMO_EMAIL_DOMAIN
+from events.models import (
+    Event,
+    EventInvitation,
+    Organization,
+    OrganizationMember,
+    PotluckItem,
+    TicketTier,
+)
+from questionnaires.models import QuestionnaireEvaluation, QuestionnaireSubmission
+
+pytestmark = pytest.mark.django_db
+
+DEMO_ORG_SLUGS = {
+    "shibari-circle-vienna",
+    "the-velvet-cellar",
+    "sunday-slow-picnic-club",
+    "analog-photo-walks",
+    "paper-hearts-book-club",
+}
+
+EvalStatus = QuestionnaireEvaluation.QuestionnaireEvaluationStatus
+
+
+def _run() -> str:
+    out = StringIO()
+    call_command("bootstrap_demo_video", stdout=out)
+    return out.getvalue()
+
+
+def _demo_counts() -> dict[str, int]:
+    """Row counts for everything the seed owns, keyed by model name."""
+    demo_orgs = Organization.objects.filter(slug__in=DEMO_ORG_SLUGS)
+    demo_events = Event.objects.filter(organization__in=demo_orgs)
+    return {
+        "users": RevelUser.objects.filter(email__endswith=f"@{DEMO_EMAIL_DOMAIN}").count(),
+        "organizations": demo_orgs.count(),
+        "events": demo_events.count(),
+        "tiers": TicketTier.objects.filter(event__in=demo_events).count(),
+        "potluck_items": PotluckItem.objects.filter(event__in=demo_events).count(),
+        "invitations": EventInvitation.objects.filter(event__in=demo_events).count(),
+        "memberships": OrganizationMember.objects.filter(organization__in=demo_orgs).count(),
+        "submissions": QuestionnaireSubmission.objects.filter(user__email__endswith=f"@{DEMO_EMAIL_DOMAIN}").count(),
+    }
+
+
+class TestBootstrapDemoVideo:
+    """Coverage for the demo-video scenario seed."""
+
+    def test_seeds_the_five_scenarios(self) -> None:
+        output = _run()
+
+        assert set(Organization.objects.values_list("slug", flat=True)) == DEMO_ORG_SLUGS
+        for slug in DEMO_ORG_SLUGS:
+            assert f"/org/{slug}" in output
+
+        # Scenario 1: a free, quantity-capped tier behind a manual questionnaire.
+        workshop = Event.objects.get(slug="intro-to-shibari-rope-and-trust")
+        assert list(workshop.ticket_tiers.values_list("name", flat=True)) == ["Workshop Spot"]
+        assert workshop.ticket_tiers.get().total_quantity == 24
+        assert (
+            QuestionnaireSubmission.objects.filter(
+                questionnaire__name="Workshop Application", evaluation__status=EvalStatus.PENDING_REVIEW
+            ).count()
+            == 3
+        )
+        # ...and one attendee deliberately left without a submission.
+        newcomer = RevelUser.objects.get(email=f"noa.attendee@{DEMO_EMAIL_DOMAIN}")
+        assert not newcomer.questionnaire_submissions.exists()
+
+        # Scenario 2: a public door-price tier alongside a members-only free one.
+        gig = Event.objects.get(slug="basement-sessions-live-and-loud")
+        members_tier = gig.ticket_tiers.get(name="Members — Free Entry")
+        assert members_tier.visibility == TicketTier.Visibility.MEMBERS_ONLY
+        assert members_tier.purchasable_by == TicketTier.PurchasableBy.MEMBERS
+        assert gig.ticket_tiers.get(name="General Admission").payment_method == (TicketTier.PaymentMethod.AT_THE_DOOR)
+
+        # Scenario 3: an RSVP potluck with unclaimed suggestions and claimed items.
+        picnic = Event.objects.get(slug="picnic-in-the-park")
+        assert picnic.requires_ticket is False
+        assert picnic.potluck_open is True
+        assert picnic.potluck_items.filter(is_suggested=True, assignee__isnull=True).count() == 6
+        assert picnic.potluck_items.filter(assignee__isnull=False).count() == 4
+
+        # Scenario 4: enough evaluated submissions for the insights views.
+        walk_evaluations = QuestionnaireEvaluation.objects.filter(submission__questionnaire__name="Walk Application")
+        assert walk_evaluations.filter(status=EvalStatus.APPROVED).count() == 5
+        assert walk_evaluations.filter(status=EvalStatus.REJECTED).count() == 2
+        assert walk_evaluations.filter(status=EvalStatus.PENDING_REVIEW).count() == 3
+
+        # Scenario 5: an invitation that waives both gates.
+        invitation = EventInvitation.objects.get(event__slug="monthly-reading-circle")
+        assert invitation.waives_questionnaire is True
+        assert invitation.waives_membership_required is True
+        assert Event.objects.get(slug="monthly-reading-circle").event_type == Event.EventType.MEMBERS_ONLY
+
+    def test_is_idempotent(self) -> None:
+        """A second run must refresh the same rows, never duplicate them."""
+        _run()
+        first = _demo_counts()
+
+        _run()
+
+        assert _demo_counts() == first
+
+    def test_every_demo_account_signs_in_with_the_shared_password(self) -> None:
+        _run()
+
+        users = RevelUser.objects.filter(email__endswith=f"@{DEMO_EMAIL_DOMAIN}")
+        assert users.count() == 29
+        assert all(user.check_password("password123") and user.email_verified for user in users)

--- a/src/events/tests/test_management/test_bootstrap_demo_video_command.py
+++ b/src/events/tests/test_management/test_bootstrap_demo_video_command.py
@@ -4,9 +4,12 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
 
 from accounts.models import RevelUser
-from events.management.commands.demo_video_helpers import DEMO_EMAIL_DOMAIN
+from events.management.commands import bootstrap_demo_video
+from events.management.commands.demo_video_helpers import DEMO_EMAIL_DOMAIN, SCENARIOS, ScenarioSummary
 from events.models import (
     Event,
     EventInvitation,
@@ -55,6 +58,7 @@ def _demo_counts() -> dict[str, int]:
 class TestBootstrapDemoVideo:
     """Coverage for the demo-video scenario seed."""
 
+    @override_settings(DEMO_MODE=True)
     def test_seeds_the_five_scenarios(self) -> None:
         output = _run()
 
@@ -102,6 +106,7 @@ class TestBootstrapDemoVideo:
         assert invitation.waives_membership_required is True
         assert Event.objects.get(slug="monthly-reading-circle").event_type == Event.EventType.MEMBERS_ONLY
 
+    @override_settings(DEMO_MODE=True)
     def test_is_idempotent(self) -> None:
         """A second run must refresh the same rows, never duplicate them."""
         _run()
@@ -111,9 +116,32 @@ class TestBootstrapDemoVideo:
 
         assert _demo_counts() == first
 
+    @override_settings(DEMO_MODE=True)
     def test_every_demo_account_signs_in_with_the_shared_password(self) -> None:
         _run()
 
         users = RevelUser.objects.filter(email__endswith=f"@{DEMO_EMAIL_DOMAIN}")
         assert users.count() == 29
         assert all(user.check_password("password123") and user.email_verified for user in users)
+
+    @override_settings(DEMO_MODE=True)
+    def test_a_failing_scenario_rolls_the_whole_seed_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One broken scenario must not leave a half-seeded demo world behind."""
+
+        def boom() -> ScenarioSummary:
+            raise RuntimeError("scenario exploded")
+
+        monkeypatch.setattr(bootstrap_demo_video, "SCENARIOS", [SCENARIOS[0], boom])
+
+        with pytest.raises(RuntimeError, match="scenario exploded"):
+            _run()
+
+        assert all(count == 0 for count in _demo_counts().values())
+
+    @override_settings(DEMO_MODE=False)
+    def test_refuses_to_run_outside_demo_mode(self) -> None:
+        """The seed publishes public orgs whose password is printed, so production is off-limits."""
+        with pytest.raises(CommandError, match="DEMO_MODE"):
+            _run()
+
+        assert not Organization.objects.filter(slug__in=DEMO_ORG_SLUGS).exists()


### PR DESCRIPTION
## What

A new management command, `bootstrap_demo_video`, that pre-seeds the five scenarios we record the product demo videos against, plus a `make demo-video` target.

```bash
make demo-video                                   # or:
uv run python src/manage.py bootstrap_demo_video
```

## Why

The frontend team records demo videos against a locally seeded backend, and we're packaging that for a non-developer. Today the on-camera scenarios have to be arranged by hand through the API before every take. This bakes them into a command that can be re-run at will.

The command is **idempotent** (`update_or_create` on stable slugs / emails / `(parent, order)` pairs) and strictly **additive**: it creates only new organizations, events and `@demovideo.example.com` accounts, and never reads or mutates a `bootstrap_events` / `bootstrap_test_events` fixture — the E2E suite is very sensitive to seed mutation. It runs after the bootstrap chain, before it, or on its own against an empty-but-migrated DB. Event dates are computed relative to *now*, so a re-run rolls a stale demo world forward instead of leaving it in the past. It finishes by printing the presenter's cheat sheet (org slugs, event paths, credentials, per-scenario notes).

## Scenarios

All five are public organizations at real Vienna addresses, with warm human copy — this text is on camera.

| # | Organization | Event | The shot |
|---|---|---|---|
| 1 | `shibari-circle-vienna` | `intro-to-shibari-rope-and-trust` | **The flagship questionnaire gate.** Free 24-place "Workshop Spot" tier behind a published, manually-reviewed admission questionnaire. Three pending applications already on the review board; one attendee deliberately has *not* applied, for the gate → apply → approve arc. |
| 2 | `the-velvet-cellar` | `basement-sessions-live-and-loud` | **Member-only tickets, A/B.** At-the-door €15 General Admission next to a free members-only tier. One member sees both tiers; one non-member sees only the door price. |
| 3 | `sunday-slow-picnic-club` | `picnic-in-the-park` | **Potluck.** RSVP event with the potluck board open: six unclaimed host suggestions across main course / side dish / supplies / entertainment, four items already claimed, and one attending guest with nothing claimed. |
| 4 | `analog-photo-walks` | `golden-hour-photo-walk` | **Questionnaire insights.** Ten submissions from ten users — 5 approved (85), 2 rejected (30), 3 pending — over one free-text and one 3-option multiple-choice question. |
| 5 | `paper-hearts-book-club` | `monthly-reading-circle` | **Eligibility gates.** Members-only event type, public visibility, RSVP. Three accounts, three outcomes: outsider → `members_only`, member without a submission → `questionnaire_missing`, invited user → allowed (the invitation sets both `waives_questionnaire` and `waives_membership_required`). |

## Credentials

Every account below signs in with **`password123`**, verified email.

| Email | Name | Role |
|---|---|---|
| `ren.owner@demovideo.example.com` | Ren Okabe | Shibari Circle owner — reviews the applications on camera |
| `mira.applicant@demovideo.example.com` | Mira Lindqvist | applied — pending review |
| `tobias.applicant@demovideo.example.com` | Tobias Ferrand | applied — pending review |
| `yuki.applicant@demovideo.example.com` | Yuki Sorensen | applied — pending review |
| `noa.attendee@demovideo.example.com` | Noa Beckmann | has NOT applied — the gate → apply → approve arc |
| `dario.owner@demovideo.example.com` | Dario Fenn | Velvet Cellar owner |
| `lena.member@demovideo.example.com` | Lena Krause | member — sees the free members' tier |
| `paul.guest@demovideo.example.com` | Paul Vogt | not a member — sees only the €15 door tier |
| `ana.owner@demovideo.example.com` | Ana Ferreira | Picnic Club owner |
| `sofia.picnicker@` / `omar.picnicker@` / `greta.picnicker@` / `felix.picnicker@` | Sofia Marchetti, Omar Haddad, Greta Nowak, Felix Baumann | attending, each claimed one potluck item |
| `jonas.guest@demovideo.example.com` | Jonas Reiter | attending with NO claim — the claim-an-item shot |
| `kaia.owner@demovideo.example.com` | Kaia Lund | Photo Walks owner — open the insights here |
| `hanna.walker@` `milan.walker@` `aisha.walker@` `lukas.walker@` `zoe.walker@` | — | approved (85) |
| `bruno.walker@` `timo.walker@` | — | rejected (30) |
| `elif.walker@` `pawel.walker@` `nora.walker@` | — | pending review |
| `iris.owner@demovideo.example.com` | Iris Halvorsen | Book Club owner |
| `bea.outsider@demovideo.example.com` | Bea Nilsson | no membership, no submission — blocked by both gates |
| `hugo.member@demovideo.example.com` | Hugo Almeida | member, no submission — blocked by the questionnaire only |
| `clara.invited@demovideo.example.com` | Clara Mendel | invited — waives questionnaire AND membership |

## Verification

- `make check` — green (ruff format/lint, mypy strict, migration-check, i18n-check, file-length, task-names). No schema changes, so no migration and no OpenAPI regen.
- `pytest src/events/tests/test_management/ src/events/tests/test_bootstrap_helpers.py` — 52 passed, including three new tests covering the scenario shapes, the shared password, and idempotency.
- Ran for real against a scratch Postgres on this machine:
  - on an **empty-but-migrated** DB → succeeds, prints the summary;
  - **run twice** → every owned row count identical (29 users, 5 orgs, 5 events, 3 tiers, 10 potluck items, 13 submissions, …);
  - **after** `bootstrap_events` + `bootstrap_test_events` → succeeds, adds zero rows on the repeat, bootstrap fixtures untouched;
  - eligibility spot-checked through `EligibilityService` for every scenario: `questionnaire_missing` / `questionnaire_pending_review` / `members_only` / allowed all land on the intended accounts, and `TicketTier.objects.for_user` returns two tiers for the member and one for the non-member.

## Note for packaging

`reset_events` (and therefore `make e2e-seed`) deletes every organization and every non-`@letsrevel.io` user, so it wipes this seed too. Re-run `make demo-video` after any reseed — that's the intended workflow, and the Makefile comment says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a one-step setup command for five ready-to-use demo scenarios covering questionnaires, ticket tiers, RSVPs, potluck planning, insights, and membership eligibility.
  - Demo data includes organizations, events, accounts, invitations, submissions, and evaluation results.
  - The command provides a copy-pasteable reference with demo credentials and scenario details.
  - Re-running the setup refreshes existing demo data without creating duplicates and rolls event dates forward.

- **Tests**
  - Added coverage for scenario creation, repeatability, credentials, verified accounts, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->