### PR TITLE
fix(geo): degrade gracefully when the IP2Location DB is unavailable

### DIFF
--- a/src/geo/ip2.py
+++ b/src/geo/ip2.py
@@ -17,29 +17,44 @@ logger = structlog.get_logger(__name__)
 _local = threading.local()
 
 
-def get_ip2location() -> IP2Location:
-    """Return a thread-local IP2Location database handle.
+def get_ip2location() -> IP2Location | None:
+    """Return a thread-local IP2Location database handle, or None if unavailable.
 
     Each thread gets its own file descriptor because FILE_IO mode is not
     thread-safe. Uses the database file's modification time to detect when a new
     database has been downloaded, reloading the calling thread's handle.
+
+    Returns:
+        The calling thread's handle, or ``None`` when the database file is absent
+        or unusable — the downloader may not have run yet, and a bind mount for a
+        missing file leaves a directory behind. Callers degrade to "no geo data"
+        rather than failing the request (see issue #931).
     """
-    # Get current file modification time
-    current_mtime = conf.IP2LOCATION_DB_PATH.stat().st_mtime
+    try:
+        # Get current file modification time
+        current_mtime = conf.IP2LOCATION_DB_PATH.stat().st_mtime
 
-    # Reload if this thread hasn't loaded the database or the file has changed
-    db: IP2Location | None = getattr(_local, "db", None)
-    if db is None or _local.mtime != current_mtime:
-        db = IP2Location(conf.IP2LOCATION_DB_PATH)
-        _local.db = db
-        _local.mtime = current_mtime
+        # Reload if this thread hasn't loaded the database or the file has changed
+        db: IP2Location | None = getattr(_local, "db", None)
+        if db is None or _local.mtime != current_mtime:
+            # OSError if the path is gone; ValueError if it isn't a regular file.
+            db = IP2Location(conf.IP2LOCATION_DB_PATH)
+            _local.db = db
+            _local.mtime = current_mtime
 
-    return db
+        return db
+    except OSError, ValueError:
+        # warning, not debug: an unavailable database silently disables
+        # nearest-first sorting everywhere, exactly like a corrupt one.
+        logger.warning("ip2location_db_unavailable", path=str(conf.IP2LOCATION_DB_PATH), exc_info=True)
+        return None
 
 
 def resolve_ip_to_point(ip: str) -> Point | None:
     """Resolves an IP address to a geographical point."""
     ipdb = get_ip2location()
+    if ipdb is None:
+        return None
     try:
         record = ipdb.get_all(ip)
         if record is None or record.city == "-":

--- a/src/geo/tests/test_ip2.py
+++ b/src/geo/tests/test_ip2.py
@@ -8,12 +8,13 @@ replaced by the downloader.
 
 import threading
 import typing as t
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from pytest import MonkeyPatch
 
-from geo.ip2 import get_ip2location
+from geo.ip2 import get_ip2location, resolve_ip_to_point
 
 
 @pytest.fixture(autouse=True)
@@ -102,3 +103,26 @@ def test_get_ip2location_reloads_on_mtime_change(monkeypatch: MonkeyPatch) -> No
     th.join()
 
     assert not errors, errors
+
+
+def test_get_ip2location_returns_none_when_db_missing(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """An absent .BIN degrades to None instead of raising FileNotFoundError (issue #931)."""
+    monkeypatch.setattr("geo.ip2.conf.IP2LOCATION_DB_PATH", tmp_path / "IP2LOCATION-LITE-DB5.BIN")
+
+    assert get_ip2location() is None
+
+
+def test_get_ip2location_returns_none_when_db_path_is_a_directory(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """A bind mount for a missing file leaves a directory; that must degrade too (issue #931)."""
+    db_dir = tmp_path / "IP2LOCATION-LITE-DB5.BIN"
+    db_dir.mkdir()
+    monkeypatch.setattr("geo.ip2.conf.IP2LOCATION_DB_PATH", db_dir)
+
+    assert get_ip2location() is None
+
+
+def test_resolve_ip_to_point_returns_none_when_db_missing(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """The regression: a missing .BIN 500'd public discovery instead of dropping geo data (issue #931)."""
+    monkeypatch.setattr("geo.ip2.conf.IP2LOCATION_DB_PATH", tmp_path / "IP2LOCATION-LITE-DB5.BIN")
+
+    assert resolve_ip_to_point("8.8.8.8") is None


### PR DESCRIPTION
Closes #931

## The bug

`src/geo/ip2.py` — `get_ip2location()` read the database's mtime and constructed the handle **outside any guard**:

```python
current_mtime = conf.IP2LOCATION_DB_PATH.stat().st_mtime   # FileNotFoundError
...
db = IP2Location(conf.IP2LOCATION_DB_PATH)                 # ValueError
```

`resolve_ip_to_point()` called it on the line *before* its own `try`, so neither failure was caught.

## Why it 500s public discovery

`GET /api/events/` defaults to `order_by="distance"` (`events/controllers/event_public/discovery.py`), so **every** public listing request walks `user_location()` → `LazyGeoPoint.get()` → `resolve_ip_to_point()` → `get_ip2location()`. With no `.BIN` on disk the `FileNotFoundError` propagates to the global `Exception → 500` handler and the discovery page renders "try again later" with no events. `GET /api/organizations/` (`organization.py:134`) shares the same path.

Reproduced both failure shapes against a nonexistent path:

```
stat -> FileNotFoundError [Errno 2] No such file or directory: ...
ctor -> ValueError The database file does not seem to exist.
```

## The fix

`get_ip2location()` now returns `IP2Location | None` and guards its body, logging a warning — the module's existing style for a database that would otherwise fail invisibly, per the comment already in `resolve_ip_to_point` — and returning `None`. `resolve_ip_to_point()` short-circuits to `None`, which callers already treat as "no geo data" (`get_cities_by_ip` falls back to `City.objects.all()`; `order_by_distance` takes `Point | None`).

Both `OSError` and `ValueError` are caught: a bind mount for a missing file leaves a **directory** at the path, which stats fine but makes the constructor raise `ValueError` — the exact shape a docker-compose deployment produces.

Behavior is unchanged when the file exists: same thread-local handle, same mtime-based hot reload when the downloader replaces the `.BIN`. Recovery is automatic — once the file appears, the next call loads it.

## Tests

Three regression tests in `src/geo/tests/test_ip2.py`. All three fail on `main` with the exact reported exceptions and pass with the fix:

- missing `.BIN` → `get_ip2location()` returns `None`
- path is a directory → `get_ip2location()` returns `None`
- missing `.BIN` → `resolve_ip_to_point()` returns `None` (the 500 itself)

`make check` green (ruff, mypy --strict, migrations, i18n, file-length, task-names); `src/geo/`, `common/tests/test_controllers/test_base.py` and `events/tests/test_controllers/test_event_public` — 144 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IP geolocation now handles missing or unusable location databases gracefully.
  * Address resolution returns no result instead of raising an error when geolocation data is unavailable.

* **Tests**
  * Added coverage for missing database files, invalid database paths, and graceful resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->