### PR TITLE
chore(release): v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-09-06
+
+### Fixed
+
+- Public event and organization listings no longer return a 500 when the IP2Location database file is missing from the deployment. Both endpoints sort by distance from the visitor's IP by default, and the geo lookup raised instead of degrading, so a deployment that had never run the database downloader — or whose bind mount left a directory in place of the `.BIN` — served an error page with no events at all. A missing or unusable database now simply disables nearest-first sorting (logged as a warning) and the listing falls back to its normal ordering; the database is picked up automatically once it appears
+
 ## [2.8.0] - 2026-09-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.8.0"
+version = "2.8.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.8.0"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
### Fixed

- Public event and organization listings no longer return a 500 when the IP2Location database file is missing from the deployment. Both endpoints sort by distance from the visitor's IP by default, and the geo lookup raised instead of degrading, so a deployment that had never run the database downloader — or whose bind mount left a directory in place of the `.BIN` — served an error page with no events at all. A missing or unusable database now simply disables nearest-first sorting (logged as a warning) and the listing falls back to its normal ordering; the database is picked up automatically once it appears


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Public event and organization listings no longer fail with a server error when the location database is missing or unusable.
  - Listings now fall back to normal ordering when location-based sorting is unavailable and automatically resume nearest-first sorting when the database becomes available.

- **Chores**
  - Updated the application version to 2.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->