### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-09-06
+
 ### Added
 
 - `bootstrap_demo_video` (`make demo-video`) now gives every demo organization a logo and every demo event 16:9 cover art, so the scenarios the product videos are recorded against no longer render bare cards and placeholder heroes. The images are bundled CC0 / public-domain photographs, credited in `src/events/management/commands/demo_video_helpers/assets/IMAGE_CREDITS.md`; a re-run relinks the cached files instead of re-uploading them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.8.1"
+version = "2.9.0"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.8.1"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.9.0] - 2026-09-06

### Added

- `bootstrap_demo_video` (`make demo-video`) now gives every demo organization a logo and every demo event 16:9 cover art, so the scenarios the product videos are recorded against no longer render bare cards and placeholder heroes. The images are bundled CC0 / public-domain photographs, credited in `src/events/management/commands/demo_video_helpers/assets/IMAGE_CREDITS.md`; a re-run relinks the cached files instead of re-uploading them

---

Minor bump: the only change since v2.8.1 is #934, whose `[Unreleased]` entry sits under `Added` (no `Breaking`/`Removed`), which the release rules map to a minor bump.
