### PR TITLE
fix(events): tolerate a deleted event in post-delete cascade hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Deleting an event that has tickets or RSVPs no longer answers 500 after the delete has already committed. The ticket and RSVP post-delete hooks defer work to after commit (waitlist spot check, RSVP-cancelled staff notification) or to Celery (attendee visibility rebuild, waitlist offer processing), and each looked the event up again once the cascade had removed it. All four now treat a missing event as "nothing to do"
+- Deleting an event that has tickets or RSVPs no longer returns HTTP 500 after the delete has already committed. The ticket and RSVP post-delete hooks defer work to after commit (waitlist spot check, RSVP-cancelled staff notification) or to Celery (attendee visibility rebuild, waitlist offer processing), and each looked the event up again once the cascade had removed it. Every such lookup, including the attendee rebuild's second fetch after it releases its row lock, now treats a missing event as "nothing to do"
 
 ## [2.9.0] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GET /api/version` now returns `demo_booking_url`, a public "book a demo" link configured on the Common Settings singleton in the admin (new *Public Links* section). It is `null` until set, so clients can show the call-to-action only when a booking page exists
 
+### Fixed
+
+- Deleting an event that has tickets or RSVPs no longer answers 500 after the delete has already committed. The ticket and RSVP post-delete hooks defer work to after commit (waitlist spot check, RSVP-cancelled staff notification) or to Celery (attendee visibility rebuild, waitlist offer processing), and each looked the event up again once the cascade had removed it. All four now treat a missing event as "nothing to do"
+
 ## [2.9.0] - 2026-09-06
 
 ### Added

--- a/src/events/service/waitlist_service.py
+++ b/src/events/service/waitlist_service.py
@@ -23,6 +23,7 @@ class ProcessResult:
     """Outcome of a process_waitlist_for_event call."""
 
     status: t.Literal[
+        "event_deleted",
         "disabled",
         "no_spots",
         "no_eligible_users",
@@ -56,7 +57,10 @@ def process_waitlist_for_event(event_id: uuid.UUID) -> ProcessResult:
     Returns:
         ProcessResult describing what happened.
     """
-    event = Event.objects.select_for_update().get(pk=event_id)
+    event = Event.objects.select_for_update().filter(pk=event_id).first()
+    if event is None:
+        # Enqueued from a post_delete receiver cascaded by event.delete() (#937)
+        return ProcessResult(status="event_deleted")
     if not event.waitlist_open or event.waitlist_time_window is None:
         return ProcessResult(status="disabled")
 

--- a/src/events/tasks/attendees.py
+++ b/src/events/tasks/attendees.py
@@ -41,7 +41,10 @@ def build_attendee_visibility_flags(event_id: str) -> None:
     # Multiple tasks may run concurrently when tickets are confirmed rapidly;
     # this ensures the count is read and written while holding the lock.
     with transaction.atomic():
-        event = Event.objects.with_organization().select_for_update().get(pk=event_id)
+        event = Event.objects.with_organization().select_for_update().filter(pk=event_id).first()
+        if event is None:
+            # Dispatched by a Ticket/RSVP post_delete cascaded from event.delete() (#937)
+            return
         ticket_count = Ticket.objects.filter(
             event=event,
             status__in=[Ticket.TicketStatus.ACTIVE, Ticket.TicketStatus.CHECKED_IN],

--- a/src/events/tasks/attendees.py
+++ b/src/events/tasks/attendees.py
@@ -68,8 +68,12 @@ def build_attendee_visibility_flags(event_id: str) -> None:
         with connection.cursor() as cursor:
             cursor.execute("SELECT pg_advisory_xact_lock(%s)", [visibility_rebuild_lock_key(event_id)])
 
-        # Re-fetch event without a row lock for visibility flag building (read-only)
-        event = Event.objects.with_organization().get(pk=event_id)
+        # Re-fetch event without a row lock for visibility flag building (read-only).
+        # The first block's row lock is released at its commit, so the event can have
+        # been deleted in between (#937).
+        event = Event.objects.with_organization().filter(pk=event_id).first()
+        if event is None:
+            return
 
         organization = event.organization
         owner_id = organization.owner_id

--- a/src/events/tests/test_controllers/test_event_admin/test_core.py
+++ b/src/events/tests/test_controllers/test_event_admin/test_core.py
@@ -1,5 +1,6 @@
 """Tests for event admin core endpoints (update, status, media, delete, duplicate, slug)."""
 
+import typing as t
 from io import BytesIO
 
 import orjson
@@ -9,8 +10,9 @@ from django.test.client import Client
 from django.urls import reverse
 from PIL import Image
 
+from accounts.models import RevelUser
 from common.utils import assert_image_equal
-from events.models import Event, Organization, OrganizationStaff, TicketTier
+from events.models import Event, EventRSVP, Organization, OrganizationStaff, Ticket, TicketTier
 
 pytestmark = pytest.mark.django_db
 
@@ -520,6 +522,39 @@ def test_delete_event_by_owner(organization_owner_client: Client, event: Event) 
 
     assert response.status_code == 204
     assert not Event.objects.filter(pk=event_id).exists()
+
+
+def test_delete_event_with_tickets_survives_post_commit_waitlist_hook(
+    organization_owner_client: Client, ticket: Ticket, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Deleting an event cascades its tickets; the ticket post_delete waitlist hook must not 500 on commit.
+
+    pytest-django rolls the wrapping transaction back so on_commit callbacks never fire on their own;
+    django_capture_on_commit_callbacks(execute=True) runs them, mirroring ATOMIC_REQUESTS in production.
+    Regression test for #937.
+    """
+    event_id = ticket.event_id
+    url = reverse("api:delete_event", kwargs={"event_id": event_id})
+
+    with django_capture_on_commit_callbacks(execute=True):
+        response = organization_owner_client.delete(url)
+
+    assert response.status_code == 204
+    assert not Event.objects.filter(pk=event_id).exists()
+
+
+def test_delete_event_with_rsvps_survives_post_commit_waitlist_hook(
+    organization_owner_client: Client, event: Event, member_user: RevelUser, django_capture_on_commit_callbacks: t.Any
+) -> None:
+    """Same as above for RSVP events: the EventRSVP post_delete hook shares the helper (#937)."""
+    EventRSVP.objects.create(event=event, user=member_user, status=EventRSVP.RsvpStatus.YES)
+    url = reverse("api:delete_event", kwargs={"event_id": event.pk})
+
+    with django_capture_on_commit_callbacks(execute=True):
+        response = organization_owner_client.delete(url)
+
+    assert response.status_code == 204
+    assert not Event.objects.filter(pk=event.pk).exists()
 
 
 def test_delete_event_by_staff_with_permission(

--- a/src/events/tests/test_service/test_waitlist_service.py
+++ b/src/events/tests/test_service/test_waitlist_service.py
@@ -55,6 +55,11 @@ class TestDisabledFeature:
         result = waitlist_service.process_waitlist_for_event(event.id)
         assert result.status == "disabled"
 
+    def test_returns_event_deleted_when_event_is_gone(self) -> None:
+        """The EventWaitList post_delete receiver enqueues this after event.delete() cascades (#937)."""
+        result = waitlist_service.process_waitlist_for_event(uuid.uuid4())
+        assert result.status == "event_deleted"
+
 
 class TestNoSpots:
     def test_returns_no_spots_when_capacity_full(self, event: Event, user: RevelUser) -> None:

--- a/src/events/tests/test_tasks/test_misc.py
+++ b/src/events/tests/test_tasks/test_misc.py
@@ -196,6 +196,28 @@ def test_visibility_rebuild_lock_key_is_stable_and_64_bit() -> None:
     assert visibility_rebuild_lock_key(str(uuid.uuid4())) != key
 
 
+def test_build_attendee_visibility_flags_returns_when_event_is_gone(event: Event) -> None:
+    """Both event lookups tolerate a deleted event (#937).
+
+    The first lookup is reached by the Ticket/RSVP post_delete receivers cascaded from
+    event.delete(). The second runs after the attendee-count block committed and released
+    its row lock, so a concurrent delete can land in between; we simulate it by deleting the
+    event from inside the advisory-lock key call, which sits between the two lookups.
+    """
+    build_attendee_visibility_flags(str(uuid.uuid4()))  # first lookup: unknown id
+
+    event_id = str(event.id)
+
+    def _delete_then_key(key_event_id: str) -> int:
+        Event.objects.filter(pk=key_event_id).delete()
+        return visibility_rebuild_lock_key(key_event_id)
+
+    with patch("events.tasks.attendees.visibility_rebuild_lock_key", side_effect=_delete_then_key):
+        build_attendee_visibility_flags(event_id)  # second lookup: deleted mid-task
+
+    assert not AttendeeVisibilityFlag.objects.filter(event_id=event_id).exists()
+
+
 @pytest.mark.django_db(transaction=True)
 def test_build_attendee_visibility_flags_takes_per_event_advisory_lock(
     event: Event,

--- a/src/notifications/signals/rsvp.py
+++ b/src/notifications/signals/rsvp.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
-from events.models import EventRSVP
+from events.models import Event, EventRSVP
 from events.tasks import build_attendee_visibility_flags
 from notifications.enums import NotificationType
 from notifications.service.eligibility import get_organization_staff_and_owners
@@ -170,7 +170,10 @@ def handle_event_rsvp_delete(sender: type[EventRSVP], instance: EventRSVP, **kwa
     def send_notifications() -> None:
         from common.models import SiteSettings
 
-        event = instance.event
+        event = Event.objects.filter(pk=instance.event_id).first()
+        if event is None:
+            # RSVP cascaded away by event.delete(): nobody to tell about a cancellation (#937)
+            return
         user = instance.user
         frontend_base_url = SiteSettings.get_solo().frontend_base_url
 

--- a/src/notifications/signals/waitlist.py
+++ b/src/notifications/signals/waitlist.py
@@ -104,7 +104,11 @@ def _check_and_notify_waitlist(event_id: t.Any, old_count: int | None = None) ->
         event_id: ID of the event to check
         old_count: Previous attendee count (before the change)
     """
-    event = Event.objects.select_related("organization").get(pk=event_id)
+    event = Event.objects.select_related("organization").filter(pk=event_id).first()
+
+    # The ticket/RSVP may have been cascaded away by event.delete(): nothing left to notify (#937)
+    if event is None:
+        return
 
     # Skip if event has no max attendees (unlimited capacity)
     if event.max_attendees == 0:


### PR DESCRIPTION
Closes #937

## Summary

`DELETE /api/event-admin/{event_id}` answered **500** for any event holding a ticket, after the delete had already committed (the row was gone, the public page 404). Reproduced with a regression test that executes on-commit callbacks the way `ATOMIC_REQUESTS` does in production.

The issue's diagnosis was right but incomplete. `event.delete()` cascades to every `Ticket` / `EventRSVP` row, and each row's `post_delete` receivers defer work that re-fetches the event with an unguarded `.get()` once it no longer exists. Five sites, in two classes:

| Site | Where it runs | Effect before |
|---|---|---|
| `_check_and_notify_waitlist` (`notifications/signals/waitlist.py`), shared by the Ticket and RSVP receivers | `on_commit`, inside the request | the reported 500 (ticket events) |
| `handle_event_rsvp_delete.send_notifications` (`notifications/signals/rsvp.py`), lazy `instance.event` | `on_commit`, inside the request | a second, independent 500 for RSVP events |
| `build_attendee_visibility_flags` (`events/tasks/attendees.py`), dispatched by both receivers | Celery worker | failed task on every such delete |
| `process_waitlist_for_event` (`events/service/waitlist_service.py`), enqueued by the `EventWaitList` receiver when a pending offer is revoked | Celery worker | failed task |
| `build_attendee_visibility_flags` second fetch, after the attendee-count block commits and releases its row lock (found in review) | Celery worker | failed task if an unrelated delete lands in the window |

Guarding only the waitlist helper (fix option 1 in the issue) still 500s for RSVP events and still fails the attendee task, which is what the regression tests showed.

## Fix

Each site re-fetches with `.filter(pk=...).first()` and returns early when the event is gone. A deleted event has nobody to notify and nothing to rebuild, so skipping is the correct behaviour rather than error suppression. `ProcessResult` gains an `"event_deleted"` status so the waitlist task reports honestly instead of pretending the feature was disabled.

Django's cascade deletes children before the parent, so synchronous work inside these receivers (potluck unclaim, offer revoke) still sees the event and needed no change; only deferred work was affected.

## Tests

- `test_event_admin/test_core.py`: delete an event with a ticket, and one with an RSVP, under `django_capture_on_commit_callbacks(execute=True)` → 204. Both failed before the fix with the issue's traceback; the RSVP one additionally failed on the RSVP-cancelled notification and the attendee task until those were guarded too.
- `test_service/test_waitlist_service.py`: `process_waitlist_for_event` on an unknown id returns `"event_deleted"`.
- `test_tasks/test_misc.py`: the attendee task returns cleanly for an unknown id, and when the event is deleted between its two transaction blocks (simulated from inside the advisory-lock key call). Fails with `DoesNotExist` without the second guard.

Related suites (event admin core, waitlist / RSVP signals, attendee task, waitlist service and tasks, RSVP controller) pass; ruff and mypy strict are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed event deletion failures when associated tickets or RSVPs exist.
  - Prevented post-deletion processing from raising errors when an event is no longer available.
  - Ensured waitlist, attendee visibility, and notification processing safely skips deleted events.

- **Tests**
  - Added regression coverage for successful event deletion and missing-event processing.

- **Documentation**
  - Updated the unreleased changelog with the event deletion fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
