### PR TITLE
fix(tiers): un-pausing an ONLINE tier must require Stripe Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resuming a paused online ticket tier now requires Stripe Connect (and billing info when platform fees apply), the same gate as creating one. Previously a `sales_paused: false` update skipped the check, so an organizer could put a paid tier live that every buyer would then fail to check out — the exact dead end the Eventbrite import's pause-on-import guard exists to prevent
+
 ## [2.11.0] - 2026-09-08
 
 ### Added

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -577,8 +577,8 @@ def update_ticket_tier(tier: TicketTier, payload: "TicketTierUpdateSchema") -> T
     Raises:
         StripeNotConnectedError: When transitioning to online payment, or resuming a paused online tier,
             but the org has no Stripe Connect.
-        BillingInfoRequiredError: When transitioning to online payment with platform fees and the
-            org has incomplete billing info.
+        BillingInfoRequiredError: When transitioning to online payment, or resuming a paused online tier,
+            with platform fees but the org has incomplete billing info.
         HttpError 404: If any provided membership tier ID is invalid or belongs to another org.
 
     Note:

--- a/src/events/service/ticket_service.py
+++ b/src/events/service/ticket_service.py
@@ -575,7 +575,8 @@ def update_ticket_tier(tier: TicketTier, payload: "TicketTierUpdateSchema") -> T
         The updated tier, re-fetched via ``with_venue_and_sector()`` for serialization.
 
     Raises:
-        StripeNotConnectedError: When transitioning to online payment but org has no Stripe Connect.
+        StripeNotConnectedError: When transitioning to online payment, or resuming a paused online tier,
+            but the org has no Stripe Connect.
         BillingInfoRequiredError: When transitioning to online payment with platform fees and the
             org has incomplete billing info.
         HttpError 404: If any provided membership tier ID is invalid or belongs to another org.
@@ -597,8 +598,14 @@ def update_ticket_tier(tier: TicketTier, payload: "TicketTierUpdateSchema") -> T
     restricted_to_membership_tiers_ids = payload_dict.pop("restricted_to_membership_tiers_ids", None)
     _drop_null_category_prices(payload_dict)
 
-    if payload.payment_method is not None:
-        check_online_tier_prerequisites(tier.event.organization, payload.payment_method)
+    # Resuming a paused tier is the other way to put an ONLINE tier on sale (the Eventbrite import
+    # creates paid tiers paused when the org has no Stripe Connect), so gate it like a create (#945).
+    # ``payload.payment_method`` defaults to OFFLINE on the schema, so only ``payload_dict`` (built
+    # with ``exclude_unset``) can tell a sent value from the default; fall back to the stored one.
+    resuming = payload.sales_paused is False and tier.sales_paused
+    if "payment_method" in payload_dict or resuming:
+        effective_method = TicketTier.PaymentMethod(payload_dict.get("payment_method", tier.payment_method))
+        check_online_tier_prerequisites(tier.event.organization, effective_method)
 
     # Update regular fields
     for field, value in payload_dict.items():

--- a/src/events/tests/test_tier_sales_paused.py
+++ b/src/events/tests/test_tier_sales_paused.py
@@ -1,5 +1,7 @@
 """Revel-side pause: a paused tier is not purchasable and is reported as paused, not ended."""
 
+import typing as t
+
 import orjson
 import pytest
 from django.test.client import Client
@@ -7,7 +9,7 @@ from django.urls import reverse
 from ninja_jwt.tokens import RefreshToken
 
 from accounts.models import RevelUser
-from events.models import Event, TicketTier
+from events.models import Event, Organization, TicketTier
 from events.service import ticket_service
 from events.service.event_manager.enums import ReasonCode
 from events.service.event_manager.gates import TicketSalesGate
@@ -86,3 +88,97 @@ def test_anonymous_listing_does_not_advertise_a_paused_tier(event: Event, ticket
     assert ticket_service.anonymous_can_purchase(ticket_tier, event, None) is True
     ticket_tier.sales_paused = True
     assert ticket_service.anonymous_can_purchase(ticket_tier, event, None) is False
+
+
+# --- Resuming an ONLINE tier is gated on Stripe Connect (#945) -------------------------------
+#
+# The Eventbrite import creates paid classes as *paused* ONLINE tiers when the org has no Stripe
+# Connect. That guard is only as good as the resume path, so un-pausing must run the same
+# prerequisite check as creating an ONLINE tier — even when the payload omits ``payment_method``.
+
+
+def _make_stripe_connected(org: Organization) -> None:
+    """Satisfy both online prerequisites: Stripe Connect and (fees apply by default) billing info."""
+    org.stripe_account_id = "acct_test_123"
+    org.stripe_charges_enabled = True
+    org.stripe_details_submitted = True
+    org.billing_name = "Test Legal Entity S.r.l."
+    org.vat_country_code = "IT"
+    org.billing_address = "Via Roma 1, 00100 Roma"
+    org.save()
+
+
+def _paused_tier(event: Event, payment_method: TicketTier.PaymentMethod) -> TicketTier:
+    return TicketTier.objects.create(
+        event=event, name="Paused", price=10, total_quantity=100, payment_method=payment_method, sales_paused=True
+    )
+
+
+def _resume(client: Client, tier: TicketTier) -> t.Any:
+    url = reverse("api:update_ticket_tier", kwargs={"event_id": tier.event_id, "tier_id": tier.id})
+    return client.put(url, data=orjson.dumps({"sales_paused": False}), content_type="application/json")
+
+
+def test_resume_online_tier_without_stripe_is_rejected(organization_owner_client: Client, event: Event) -> None:
+    tier = _paused_tier(event, TicketTier.PaymentMethod.ONLINE)
+    assert not event.organization.is_stripe_connected
+
+    response = _resume(organization_owner_client, tier)
+
+    assert response.status_code == 400, response.content
+    assert response.json() == {"detail": "You must connect to Stripe first."}
+    tier.refresh_from_db()
+    assert tier.sales_paused is True
+
+
+def test_resume_online_tier_with_stripe_connected(organization_owner_client: Client, event: Event) -> None:
+    tier = _paused_tier(event, TicketTier.PaymentMethod.ONLINE)
+    _make_stripe_connected(event.organization)
+
+    response = _resume(organization_owner_client, tier)
+
+    assert response.status_code == 200, response.content
+    tier.refresh_from_db()
+    assert tier.sales_paused is False
+
+
+@pytest.mark.parametrize("payment_method", [TicketTier.PaymentMethod.FREE, TicketTier.PaymentMethod.OFFLINE])
+def test_resume_non_online_tier_without_stripe_is_allowed(
+    organization_owner_client: Client, event: Event, payment_method: TicketTier.PaymentMethod
+) -> None:
+    tier = _paused_tier(event, payment_method)
+
+    response = _resume(organization_owner_client, tier)
+
+    assert response.status_code == 200, response.content
+    tier.refresh_from_db()
+    assert tier.sales_paused is False
+
+
+def test_pausing_online_tier_never_checks_stripe(organization_owner_client: Client, event: Event) -> None:
+    """Pausing is always safe, so it must work even for an ONLINE tier on an org without Stripe."""
+    tier = TicketTier.objects.create(
+        event=event, name="Live", price=10, total_quantity=100, payment_method=TicketTier.PaymentMethod.ONLINE
+    )
+    url = reverse("api:update_ticket_tier", kwargs={"event_id": tier.event_id, "tier_id": tier.id})
+
+    response = organization_owner_client.put(
+        url, data=orjson.dumps({"sales_paused": True}), content_type="application/json"
+    )
+
+    assert response.status_code == 200, response.content
+    tier.refresh_from_db()
+    assert tier.sales_paused is True
+
+
+def test_sales_paused_false_on_already_live_online_tier_is_not_a_resume(
+    organization_owner_client: Client, event: Event
+) -> None:
+    """Only a paused→live transition is gated; re-sending ``sales_paused: false`` on a live tier is a no-op."""
+    tier = TicketTier.objects.create(
+        event=event, name="Live", price=10, total_quantity=100, payment_method=TicketTier.PaymentMethod.ONLINE
+    )
+
+    response = _resume(organization_owner_client, tier)
+
+    assert response.status_code == 200, response.content


### PR DESCRIPTION
Closes #945

## Problem

`ticket_service.update_ticket_tier` ran `check_online_tier_prerequisites` only when the payload changed `payment_method`. A `PUT .../ticket-tier/{id}` with just `{"sales_paused": false}` skipped it, so an organizer without Stripe Connect could resume the paused ONLINE tiers the Eventbrite import creates (#924) and put a paid tier live that no buyer can check out (400 at reserve).

## Fix

Resuming a paused tier (`sales_paused: false` on a tier that is currently paused) now runs the same prerequisite gate as creating an ONLINE tier, using the stored `payment_method` when the payload omits one. Same `StripeNotConnectedError` → 400 `"You must connect to Stripe first."` (and `BillingInfoRequiredError` when platform fees apply) as on create. No schema or migration changes.

**Deviation from the issue's sketch:** `TicketTierUpdateSchema.payment_method` is inherited from `TicketTierPriceValidationMixin` with an `OFFLINE` default, so `payload.payment_method or tier.payment_method` always evaluates to OFFLINE and the check stays a no-op (confirmed by instrumenting the service call). The gate therefore reads `payload_dict` (built with `exclude_unset=True`) to tell a sent value from the default, and falls back to the stored one.

## Tests (`src/events/tests/test_tier_sales_paused.py`)

- Resume paused ONLINE tier, no Stripe → 400 with the Stripe message, tier stays paused
- Resume paused ONLINE tier, Stripe + billing info → 200, tier live
- Resume paused FREE / OFFLINE tier, no Stripe → 200 (parametrized)
- `sales_paused: true` on an ONLINE tier without Stripe → 200 (pausing never checks)
- `sales_paused: false` on an already-live ONLINE tier → 200 (not a resume)

Ran `test_tier_sales_paused.py`, `test_event_admin/test_tickets/`, `test_error_response_contracts.py`, and `integrations/tests/`: 560 passed. ruff + mypy clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
