### PR TITLE
fix(admin): add Integrations group to the Unfold sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,9 @@ def list_items(self) -> QuerySet[Item]:
 ### Other conventions
 - **Dependency direction**: controllers → services → models/utils. **Models must never import
   from services.** Pure model helpers go in `<app>/utils/` (e.g. `accounts/utils/email_normalization.py`).
+- **Django admin sidebar is curated, not auto-discovered**: `revel/settings/unfold.py` sets
+  `show_all_applications: False`, so a new `admin.py` (or new admin model) is invisible until you
+  add its changelist link to the `SIDEBAR` navigation there.
 - **Don't catch exceptions for the sake of it** — especially in Celery tasks, let them
   propagate rather than failing silently.
 - **Avoid raw dicts** — prefer `TypedDict`, Pydantic, or dataclasses.

--- a/src/integrations/tests/test_admin.py
+++ b/src/integrations/tests/test_admin.py
@@ -1,12 +1,16 @@
 """Admin permission tests: the integrations admin is read-only end to end."""
 
+import typing as t
+
 import pytest
+from django.conf import settings
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory
+from django.urls import reverse
 
 from accounts.models import RevelUser
 from integrations.admin import PlatformConnectionAdmin
-from integrations.models import PlatformConnection
+from integrations.models import EventLink, ImportJob, PlatformConnection, TierLink, WebhookDelivery
 
 pytestmark = pytest.mark.django_db
 
@@ -19,3 +23,15 @@ def test_platform_connection_admin_is_read_only(superuser: RevelUser) -> None:
     assert admin_instance.has_add_permission(request) is False
     assert admin_instance.has_change_permission(request) is False
     assert admin_instance.has_delete_permission(request) is False
+
+
+def test_integrations_models_are_in_unfold_sidebar() -> None:
+    """Every integrations changelist is linked from the curated Unfold sidebar.
+
+    ``show_all_applications`` is off, so an admin page without a sidebar entry is effectively hidden.
+    """
+    sidebar = t.cast(dict[str, t.Any], settings.UNFOLD["SIDEBAR"])
+    navigation: list[dict[str, t.Any]] = sidebar["navigation"]
+    links = {str(item["link"]) for group in navigation for item in group["items"] if "link" in item}
+    for model in (PlatformConnection, EventLink, TierLink, WebhookDelivery, ImportJob):
+        assert reverse(f"admin:integrations_{model._meta.model_name}_changelist") in links

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -5371,6 +5371,24 @@ msgstr "Plattformgebühren-Rechnungen"
 msgid "Platform Fee Credit Notes"
 msgstr "Plattformgebühren-Gutschriften"
 
+msgid "Integrations"
+msgstr "Integrationen"
+
+msgid "Platform Connections"
+msgstr "Plattform-Verbindungen"
+
+msgid "Event Links"
+msgstr "Event-Zuordnungen"
+
+msgid "Tier Links"
+msgstr "Kategorie-Zuordnungen"
+
+msgid "Webhook Deliveries"
+msgstr "Webhook-Zustellungen"
+
+msgid "Import Jobs"
+msgstr "Import-Aufträge"
+
 msgid "Subscriptions"
 msgstr "Abonnements"
 

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -5305,6 +5305,24 @@ msgstr "Facturas de comisiones de plataforma"
 msgid "Platform Fee Credit Notes"
 msgstr "Notas de crédito de comisiones de plataforma"
 
+msgid "Integrations"
+msgstr "Integraciones"
+
+msgid "Platform Connections"
+msgstr "Conexiones de plataforma"
+
+msgid "Event Links"
+msgstr "Vínculos de eventos"
+
+msgid "Tier Links"
+msgstr "Vínculos de tipos de entrada"
+
+msgid "Webhook Deliveries"
+msgstr "Entregas de webhook"
+
+msgid "Import Jobs"
+msgstr "Tareas de importación"
+
 msgid "Subscriptions"
 msgstr "Suscripciones"
 

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -5356,6 +5356,24 @@ msgstr "Factures de frais de plateforme"
 msgid "Platform Fee Credit Notes"
 msgstr "Avoirs de frais de plateforme"
 
+msgid "Integrations"
+msgstr "Intégrations"
+
+msgid "Platform Connections"
+msgstr "Connexions aux plateformes"
+
+msgid "Event Links"
+msgstr "Liaisons d'événements"
+
+msgid "Tier Links"
+msgstr "Liaisons de catégories"
+
+msgid "Webhook Deliveries"
+msgstr "Distributions de webhook"
+
+msgid "Import Jobs"
+msgstr "Tâches d'importation"
+
 msgid "Subscriptions"
 msgstr "Abonnements"
 

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -5329,6 +5329,24 @@ msgstr "Fatture commissioni piattaforma"
 msgid "Platform Fee Credit Notes"
 msgstr "Note di credito commissioni piattaforma"
 
+msgid "Integrations"
+msgstr "Integrazioni"
+
+msgid "Platform Connections"
+msgstr "Connessioni alle piattaforme"
+
+msgid "Event Links"
+msgstr "Collegamenti eventi"
+
+msgid "Tier Links"
+msgstr "Collegamenti livelli"
+
+msgid "Webhook Deliveries"
+msgstr "Consegne webhook"
+
+msgid "Import Jobs"
+msgstr "Processi di importazione"
+
 msgid "Subscriptions"
 msgstr "Abbonamenti"
 

--- a/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/locale/pt/LC_MESSAGES/django.po
@@ -5249,6 +5249,24 @@ msgstr "Faturas de comissões da plataforma"
 msgid "Platform Fee Credit Notes"
 msgstr "Notas de crédito de comissões da plataforma"
 
+msgid "Integrations"
+msgstr "Integrações"
+
+msgid "Platform Connections"
+msgstr "Ligações de plataforma"
+
+msgid "Event Links"
+msgstr "Ligações de eventos"
+
+msgid "Tier Links"
+msgstr "Ligações de tipos de bilhete"
+
+msgid "Webhook Deliveries"
+msgstr "Entregas de webhook"
+
+msgid "Import Jobs"
+msgstr "Tarefas de importação"
+
 msgid "Subscriptions"
 msgstr "Subscrições"
 

--- a/src/revel/settings/unfold.py
+++ b/src/revel/settings/unfold.py
@@ -341,6 +341,38 @@ UNFOLD = {
                 ],
             },
             {
+                "title": _("Integrations"),
+                "separator": True,
+                "collapsible": True,
+                "items": [
+                    {
+                        "title": _("Platform Connections"),
+                        "icon": "link",
+                        "link": reverse_lazy("admin:integrations_platformconnection_changelist"),
+                    },
+                    {
+                        "title": _("Event Links"),
+                        "icon": "sync_alt",
+                        "link": reverse_lazy("admin:integrations_eventlink_changelist"),
+                    },
+                    {
+                        "title": _("Tier Links"),
+                        "icon": "confirmation_number",
+                        "link": reverse_lazy("admin:integrations_tierlink_changelist"),
+                    },
+                    {
+                        "title": _("Webhook Deliveries"),
+                        "icon": "webhook",
+                        "link": reverse_lazy("admin:integrations_webhookdelivery_changelist"),
+                    },
+                    {
+                        "title": _("Import Jobs"),
+                        "icon": "download",
+                        "link": reverse_lazy("admin:integrations_importjob_changelist"),
+                    },
+                ],
+            },
+            {
                 "title": _("Subscriptions"),
                 "separator": True,
                 "collapsible": True,


### PR DESCRIPTION
## Summary
- The five integrations admin pages from #924 were registered but never linked from the curated Unfold sidebar. With `show_all_applications: False` they were effectively hidden (reachable only by URL or the sidebar search).
- Adds an **Integrations** group (Platform Connections, Event Links, Tier Links, Webhook Deliveries, Import Jobs) after Payments.
- Adds a test asserting every integrations changelist is in the sidebar navigation.
- Documents the curated-sidebar rule in `CLAUDE.md` under *Other conventions* so new `admin.py` files get an entry.
- Translates the six new strings in all five catalogs, no fuzzy entries.

## Test plan
- [x] `pytest src/integrations/tests/test_admin.py`
- [x] `make check` (format, lint, mypy, migrations, i18n-check, file-length, task-names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Integrations** section to the admin sidebar.
  - Added navigation links for platform connections, event links, tier links, webhook deliveries, and import jobs.
  - Added localized labels for the new navigation items in German, Spanish, French, Italian, and Portuguese.

- **Documentation**
  - Documented how admin sidebar entries are curated and made visible.

- **Tests**
  - Added coverage ensuring integration-related admin pages appear in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->