### PR TITLE
chore(release): v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-09-09
+
+### Fixed
+
+- The Eventbrite integration admin pages (platform connections, event and tier links, webhook deliveries, import jobs) now appear in the admin sidebar under a new **Integrations** group. They were registered but missing from the curated navigation, so operators could only reach them by typing the URL or using the sidebar search
+
+### Security
+
+- Upgraded `weasyprint` to 70.0 for CVE-2026-55073 (server-side request forgery in PDF rendering)
+
 ## [2.12.0] - 2026-09-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "revel"
-version = "2.12.0"
+version = "2.12.1"
 description = "The Revel Event Manager"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3610,7 +3610,7 @@ wheels = [
 
 [[package]]
 name = "revel"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## [2.12.1] - 2026-09-09

### Fixed

- The Eventbrite integration admin pages (platform connections, event and tier links, webhook deliveries, import jobs) now appear in the admin sidebar under a new **Integrations** group. They were registered but missing from the curated navigation, so operators could only reach them by typing the URL or using the sidebar search


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Integrations** group to the admin sidebar, making Eventbrite integration pages easier to find.

* **Documentation**
  * Added release notes for version 2.12.1, documenting the admin navigation update.

* **Chores**
  * Updated the project version to 2.12.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->