### PR TITLE
ci: drop the runner's Chrome apt source before apt-get update

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -35,6 +35,11 @@ runs:
     - name: Install system deps
       shell: bash
       run: |
+        # The runner image ships Google's Chrome apt source, which we never use
+        # and which intermittently serves a "Hash Sum mismatch" that fails
+        # `apt-get update` outright. Drop it so a third-party mirror can't
+        # block every job.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome*
         sudo apt-get update
         sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=30 \
           gdal-bin libgdal-dev gettext


### PR DESCRIPTION
## Summary
- The ubuntu-24.04 runner image ships Google's `chrome-stable` apt source. We never install from it, but a `Hash Sum mismatch` it is currently serving makes `sudo apt-get update` exit 100 and fails every backend job in *Setup backend environment* (four consecutive attempts on #949).
- Remove that source before `apt-get update` so a third-party mirror can't block CI.

## Test plan
- [ ] This PR's own CI passes the setup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment setup reliability by preventing an unused Chrome package source from blocking system package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->