### PR TITLE
fix(deps): bump weasyprint to 70.0 for CVE-2026-55073 (SSRF)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "tzfpy>=1.3.1",
     "uvicorn>=0.52.1",
     "uvloop>=0.22.1",
-    "weasyprint>=69.0",
+    "weasyprint>=70.0",
     "whitenoise>=6.12.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3781,7 +3781,7 @@ requires-dist = [
     { name = "tzfpy", specifier = ">=1.3.1" },
     { name = "uvicorn", specifier = ">=0.52.1" },
     { name = "uvloop", specifier = ">=0.22.1" },
-    { name = "weasyprint", specifier = ">=69.0" },
+    { name = "weasyprint", specifier = ">=70.0" },
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
 
@@ -4511,7 +4511,7 @@ wheels = [
 
 [[package]]
 name = "weasyprint"
-version = "69.0"
+version = "70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
@@ -4523,9 +4523,9 @@ dependencies = [
     { name = "tinycss2" },
     { name = "tinyhtml5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/53/dcc3885c2f7a47faa45f6b8b801412f5f9e055173a52801ef01c09943c5a/weasyprint-69.0.tar.gz", hash = "sha256:a7a32f39ca16bd82ef11de99c92ea4b5f14951c9033af035e451ce4f4ee0a88c", size = 1549834, upload-time = "2026-06-02T14:42:17.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/0e/461aeb736762862b511034933d5b98d68f812431b7393b026d9ace5f6b42/weasyprint-70.0.tar.gz", hash = "sha256:c263abf0e86c747b12af678b67f85f4abbfb97d18a20503031e7ba94e4b8cf8c", size = 1565482, upload-time = "2026-09-08T12:25:41.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/cb/208525c6bd5033d7b2589b55e07bec23d9c61bb00703cbaf20ef52c3811f/weasyprint-69.0-py3-none-any.whl", hash = "sha256:475951cfd917014de6d4d005caff48c6aa867e7e42b80cd5b16a0484a1609ee6", size = 322872, upload-time = "2026-06-02T14:42:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8b/0c53c869f29d3273536b896dd17f092549e34e35ffba4c7a60a6de1cb1c2/weasyprint-70.0-py3-none-any.whl", hash = "sha256:5043e55e38d2a2af2b2b871e869697b1f65dad5f8b4a3677961d04ceacf9c5fe", size = 328889, upload-time = "2026-09-08T12:25:39.796Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `pip-audit` (required) started failing today when CVE-2026-55073 (SSRF, medium) was published against weasyprint `< 70.0`, blocking #949.
- Raise the floor to `weasyprint>=70.0` and relock.

## Test plan
- [x] `make audit`: no known vulnerabilities
- [x] PDF rendering tests (invoice branding, ticket files, membership card PDF, blank guest name, invoice delivery, payout statements): 84 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported WeasyPrint version to 70.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->