### PR TITLE
feat(guest): machine-readable `code` on guest account-exists / cart-too-large 400s

### DIFF
--- a/src/api/tests/test_openapi_schema.py
+++ b/src/api/tests/test_openapi_schema.py
@@ -111,6 +111,7 @@ RESPONSE_MESSAGE_400_ALLOWLIST = {
 KNOWN_400_COMPONENTS = {
     "ErrorDetail",
     "EventUserEligibility",
+    "GuestActionErrorSchema",
     "MembershipEligibilitySchema",
     "ResponseMessage",
     "ValidationErrorResponse",
@@ -218,3 +219,20 @@ def test_eligibility_endpoints_also_declare_the_detail_shape() -> None:
         "/api/events/{event_id}/tickets/{tier_id}/checkout/pwyc",
     ):
         assert declared[(path, "post")] == {"EventUserEligibility", "ErrorDetail"}, path
+
+
+def test_guest_endpoints_declare_the_coded_error_shape() -> None:
+    """Guest RSVP/checkout can also refuse with a ``code``-bearing body (#905).
+
+    ``guest_account_exists`` is reachable from every endpoint that mints a guest
+    user; ``guest_cart_too_large`` from the non-online checkout branches. One
+    schema covers both so the generated client narrows ``code`` to the enum.
+    """
+    declared = _declared_400_schemas()
+    for path in (
+        "/api/events/{event_id}/rsvp/{answer}/public",
+        "/api/events/{event_id}/tickets/{tier_id}/checkout/public",
+        "/api/events/{event_id}/tickets/{tier_id}/checkout/pwyc/public",
+        "/api/events/{event_id}/checkout/public",
+    ):
+        assert declared[(path, "post")] == {"EventUserEligibility", "ErrorDetail", "GuestActionErrorSchema"}, path

--- a/src/events/controllers/event_public/guest.py
+++ b/src/events/controllers/event_public/guest.py
@@ -31,7 +31,11 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/rsvp/{answer}/public",
         url_name="guest_rsvp",
-        response={200: schema.GuestActionResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
+        response={
+            200: schema.GuestActionResponseSchema,
+            400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
+            403: ErrorDetail,
+        },
         throttle=WriteThrottle(),
     )
     def guest_rsvp(
@@ -65,7 +69,11 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/tickets/{tier_id}/checkout/public",
         url_name="guest_ticket_checkout",
-        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
+        response={
+            200: schema.GuestCheckoutResponseSchema,
+            400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
+            403: ErrorDetail,
+        },
         throttle=WriteThrottle(),
         deprecated=True,
     )
@@ -134,7 +142,11 @@ class EventPublicGuestController(EventPublicBaseController):
     @route.post(
         "/{uuid:event_id}/tickets/{tier_id}/checkout/pwyc/public",
         url_name="guest_ticket_pwyc_checkout",
-        response={200: schema.GuestCheckoutResponseSchema, 400: EventUserEligibility | ErrorDetail, 403: ErrorDetail},
+        response={
+            200: schema.GuestCheckoutResponseSchema,
+            400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
+            403: ErrorDetail,
+        },
         throttle=WriteThrottle(),
         deprecated=True,
     )
@@ -204,7 +216,7 @@ class EventPublicGuestController(EventPublicBaseController):
         url_name="guest_multi_tier_checkout",
         response={
             200: schema.GuestCheckoutResponseSchema,
-            400: EventUserEligibility | ErrorDetail,
+            400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
             403: ErrorDetail,
             404: ErrorDetail,
         },

--- a/src/events/exception_handlers.py
+++ b/src/events/exception_handlers.py
@@ -27,6 +27,7 @@ from events.exceptions import (
     BillingInfoRequiredError,
     DuplicateDiscountCodeError,
     EventRefundsStartedError,
+    GuestActionError,
     InvalidPeriodError,
     InvalidResourceStateError,
     InvalidStripeWebhookSignatureError,
@@ -50,7 +51,7 @@ from events.exceptions import (
     TicketAlreadyCancelledError,
     TooManyItemsError,
 )
-from events.schema import SubscriptionActivationPendingSchema
+from events.schema import GuestActionErrorSchema, SubscriptionActivationPendingSchema
 from events.service.event_manager import UserIsIneligibleError
 from events.service.membership_manager import MembershipApplicationIneligibleError
 from events.service.organization_service import (
@@ -126,8 +127,31 @@ def handle_subscription_activation_pending_error(request: HttpRequest, exc: Exce
     )
 
 
+def handle_guest_action_error(request: HttpRequest, exc: Exception | t.Type[Exception]) -> Response:
+    """Render a guest RSVP/checkout refusal with a machine-readable ``code`` (#905).
+
+    The frontend cannot key on the translated ``detail`` (localization rule), so
+    the body carries the exception's stable ``code`` for it to branch on.
+
+    Args:
+        request: The current HTTP request (unused; required by the handler signature).
+        exc: The raised ``GuestActionError`` subclass (bare-raised; carries its own message).
+
+    Returns:
+        Response: A 400 response shaped like ``GuestActionErrorSchema``.
+    """
+    error = t.cast(GuestActionError, exc)
+    return Response(
+        status=400,
+        data=GuestActionErrorSchema(detail=str(error.message), code=error.code).model_dump(mode="json"),
+    )
+
+
 # Single source of truth for the exception → status mapping.
 HANDLERS: dict[type[Exception], ExceptionHandler] = {
+    # Guest refusals the FE renders as CTAs → 400 with a stable ``code`` (#905).
+    # MRO covers GuestAccountExistsError and GuestCartTooLargeError.
+    GuestActionError: handle_guest_action_error,
     UserIsIneligibleError: handle_user_is_ineligible_error,
     MembershipApplicationIneligibleError: handle_membership_application_ineligible_error,
     # Checkout already paid, activation webhooks in flight → 409 with a stable

--- a/src/events/exceptions.py
+++ b/src/events/exceptions.py
@@ -1,4 +1,11 @@
+import enum
+import typing as t
+
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils.translation import gettext_lazy as _
+
+if t.TYPE_CHECKING:
+    from django_stubs_ext import StrPromise
 
 
 class InvalidResourceStateError(DjangoValidationError):
@@ -131,3 +138,40 @@ class NothingToRefundError(Exception):
 
 class EventRefundsStartedError(Exception):
     """Raised on an un-cancel attempt after the bulk refund sweep already started."""
+
+
+class GuestActionErrorCode(str, enum.Enum):
+    """Stable discriminators for guest RSVP/checkout refusals (#905).
+
+    The frontend branches on these to render a CTA ("Log in", "split your
+    purchase") instead of echoing the translated ``detail``. Renaming a value is a
+    breaking change; rewording the message is always safe.
+    """
+
+    ACCOUNT_EXISTS = "guest_account_exists"
+    CART_TOO_LARGE = "guest_cart_too_large"
+
+
+class GuestActionError(Exception):
+    """Base for guest RSVP/checkout refusals rendered with a machine-readable ``code`` (#905).
+
+    Subclasses are bare-raised; the handler renders ``message`` (lazy, so it is
+    translated in the request's language) alongside ``code``.
+    """
+
+    code: t.ClassVar[GuestActionErrorCode]
+    message: t.ClassVar["StrPromise"]
+
+
+class GuestAccountExistsError(GuestActionError):
+    """Raised when a guest action names an email that belongs to a non-guest account."""
+
+    code = GuestActionErrorCode.ACCOUNT_EXISTS
+    message = _("An account with this email already exists. Please log in.")
+
+
+class GuestCartTooLargeError(GuestActionError):
+    """Raised when a cart's guest-confirmation JWT would blow past the emailed-link URL budget."""
+
+    code = GuestActionErrorCode.CART_TOO_LARGE
+    message = _("Your cart is too large for guest checkout. Please log in or split your purchase.")

--- a/src/events/schema/__init__.py
+++ b/src/events/schema/__init__.py
@@ -28,6 +28,11 @@ from .application import (
     MembershipEligibilitySchema,
 )
 
+# Checkout schemas (multi-tier cart, #846) — the single-tier checkout schemas
+# still resolve through .ticket, which re-exports .checkout for backward compat.
+# Attribution (#922)
+from .attribution import AttributionPayloadMixin
+
 # Blacklist schemas
 from .blacklist import (
     BlacklistCreateSchema,
@@ -38,11 +43,6 @@ from .blacklist import (
     WhitelistRequestSchema,
 )
 from .bookmark import EventBookmarkSchema
-
-# Checkout schemas (multi-tier cart, #846) — the single-tier checkout schemas
-# still resolve through .ticket, which re-exports .checkout for backward compat.
-# Attribution (#922)
-from .attribution import AttributionPayloadMixin
 from .checkout import (
     CheckoutGroupSchema,
     MultiTierCheckoutPayload,
@@ -292,11 +292,11 @@ from .seating import (
 
 # Series pass schemas
 from .series_pass import (
-    SeriesPassCheckoutPayload,
     HeldSeriesPassAdminSchema,
     HeldSeriesPassCancelSchema,
     HeldSeriesPassSchema,
     SeriesPassAdminSchema,
+    SeriesPassCheckoutPayload,
     SeriesPassCheckoutResponseSchema,
     SeriesPassCreateSchema,
     SeriesPassQuoteSchema,
@@ -347,7 +347,6 @@ from .ticket import (
     AdminIssueRefundSchema,
     AdminRefundTicketSchema,
     AdminTicketSchema,
-    TicketAttributionBucketSchema,
     BatchCheckoutPayload,
     BatchCheckoutPWYCPayload,
     BatchCheckoutResponse,
@@ -362,6 +361,7 @@ from .ticket import (
     EventRefundPreviewSchema,
     ExternalSalesSchema,
     GuestActionConfirmSchema,
+    GuestActionErrorSchema,
     GuestActionPayload,
     GuestActionResponseSchema,
     GuestBatchCheckoutPayload,
@@ -386,6 +386,7 @@ from .ticket import (
     StripeAccountStatusSchema,
     StripeCheckoutSessionSchema,
     StripeOnboardingLinkSchema,
+    TicketAttributionBucketSchema,
     TicketCancellationRequestSchema,
     TicketCancellationResponseSchema,
     TicketDiscountCodeSchema,
@@ -460,7 +461,6 @@ __all__ = [
     "AdminIssueRefundSchema",
     "AdminRefundTicketSchema",
     "AdminTicketSchema",
-    "TicketAttributionBucketSchema",
     "AffectedTierSchema",
     "AggregatedDietaryPreferenceSchema",
     "AggregatedDietaryRestrictionSchema",
@@ -473,11 +473,11 @@ __all__ = [
     "ApplyRequestSchema",
     "ApplyResponseSchema",
     "ApproveMembershipRequestSchema",
-    "AttributionPayloadMixin",
     "AttendeeInvoiceCreditNoteSchema",
     "AttendeeInvoiceDetailSchema",
     "AttendeeInvoiceSchema",
     "AttendeeSchema",
+    "AttributionPayloadMixin",
     "BatchCheckoutPWYCPayload",
     "BatchCheckoutPayload",
     "BatchCheckoutResponse",
@@ -559,6 +559,7 @@ __all__ = [
     "GeneralUserPreferencesUpdateSchema",
     "GenerateSeriesEventsSchema",
     "GuestActionConfirmSchema",
+    "GuestActionErrorSchema",
     "GuestActionPayload",
     "GuestActionResponseSchema",
     "GuestBatchCheckoutPWYCPayload",
@@ -723,6 +724,7 @@ __all__ = [
     "SubscriptionStatusBreakdownSchema",
     "TagUpdateSchema",
     "TemplateEditSchema",
+    "TicketAttributionBucketSchema",
     "TicketCancellationRequestSchema",
     "TicketCancellationResponseSchema",
     "TicketDiscountCodeSchema",

--- a/src/events/schema/guest_checkout.py
+++ b/src/events/schema/guest_checkout.py
@@ -9,6 +9,7 @@ from pydantic import UUID4, EmailStr, Field
 
 from accounts.schema import BaseEmailJWTPayloadSchema
 from common.schema import StrippedString
+from events.exceptions import GuestActionErrorCode
 from events.models import TicketAttribution
 
 from .attribution import AttributionPayloadMixin
@@ -70,6 +71,19 @@ class GuestActionResponseSchema(Schema):
     """Response after guest action initiated (RSVP or non-online-payment ticket)."""
 
     message: str = Field(default="Please check your email to confirm your action")
+
+
+class GuestActionErrorSchema(Schema):
+    """Refusal body for a guest RSVP/checkout carrying a stable ``code`` (#905).
+
+    ``detail`` is translated and must never be matched on; ``code`` is the
+    machine-readable discriminator the frontend keys on to render a proper CTA
+    (``guest_account_exists`` → "Log in", ``guest_cart_too_large`` → "log in or
+    split your purchase").
+    """
+
+    detail: str
+    code: GuestActionErrorCode
 
 
 class GuestCheckoutResponseSchema(Schema):

--- a/src/events/schema/ticket.py
+++ b/src/events/schema/ticket.py
@@ -19,6 +19,7 @@ from .checkout import (
 )
 from .guest_checkout import (
     GuestActionConfirmSchema,
+    GuestActionErrorSchema,
     GuestActionPayload,
     GuestActionResponseSchema,
     GuestBatchCheckoutPayload,
@@ -103,6 +104,7 @@ __all__ = [
     "EventRefundPreviewSchema",
     "ExternalSalesSchema",
     "GuestActionConfirmSchema",
+    "GuestActionErrorSchema",
     "GuestActionPayload",
     "GuestActionResponseSchema",
     "GuestBatchCheckoutPWYCPayload",

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -20,6 +20,7 @@ from accounts.jwt import blacklist as blacklist_token
 from accounts.jwt import check_blacklist, create_token
 from accounts.models import RevelUser
 from events import models, schema
+from events.exceptions import GuestAccountExistsError, GuestCartTooLargeError
 from events.service.event_manager import EventManager
 
 if t.TYPE_CHECKING:
@@ -47,8 +48,8 @@ def get_or_create_guest_user(email: str, first_name: str = "", last_name: str = 
         Guest user instance
 
     Raises:
-        HttpError: If a non-guest user with this email already exists, or the email
-            is globally banned.
+        GuestAccountExistsError: 400 with ``code`` if a non-guest user with this email exists.
+        HttpError: If the email is globally banned.
     """
     from accounts.service.global_ban_service import BAN_ERROR_MESSAGE, is_email_globally_banned
 
@@ -81,7 +82,7 @@ def get_or_create_guest_user(email: str, first_name: str = "", last_name: str = 
     if not existing_user.guest:
         # Non-guest user exists, reject
         logger.warning("guest_user_creation_blocked_existing_account", email=email)
-        raise HttpError(400, str(_("An account with this email already exists. Please log in.")))
+        raise GuestAccountExistsError()
 
     # Guest user already exists — keep existing names to prevent overwrite by third parties.
     # Per-ticket guest_name is captured separately in the JWT payload.
@@ -437,7 +438,8 @@ def handle_guest_ticket_checkout(
 
     Raises:
         HttpError: If event doesn't allow guest access, the cart is malformed, tier
-            issues, eligibility checks fail, or (non-online carts) the confirmation
+            issues, or eligibility checks fail.
+        GuestCartTooLargeError: 400 with ``code`` if (non-online carts) the confirmation
             token would exceed ``_GUEST_TOKEN_MAX_CHARS``.
         InvalidZoneSelectionError: 400 if a requested zone is unusable on its tier.
     """
@@ -585,9 +587,7 @@ def handle_guest_ticket_checkout(
         # ponytail: the real fix is to persist the cart and put an opaque handle in the
         # link (as the ONLINE branch's reservation_id already does) — see #632.
         if len(token) > _GUEST_TOKEN_MAX_CHARS:
-            raise HttpError(
-                400, str(_("Your cart is too large for guest checkout. Please log in or split your purchase."))
-            )
+            raise GuestCartTooLargeError()
 
         tier_name = _cart_tier_name_summary(groups)
         transaction.on_commit(lambda: send_guest_ticket_confirmation.delay(user.email, token, event.name, tier_name))

--- a/src/events/service/guest.py
+++ b/src/events/service/guest.py
@@ -336,6 +336,7 @@ def handle_guest_rsvp(
     Raises:
         HttpError: If event doesn't allow guest access, doesn't accept notes but one was
             provided, or eligibility checks fail
+        GuestAccountExistsError: 400 with ``code`` if the email belongs to a non-guest account.
     """
     from events.tasks import send_guest_rsvp_confirmation
 
@@ -439,6 +440,7 @@ def handle_guest_ticket_checkout(
     Raises:
         HttpError: If event doesn't allow guest access, the cart is malformed, tier
             issues, or eligibility checks fail.
+        GuestAccountExistsError: 400 with ``code`` if the email belongs to a non-guest account.
         GuestCartTooLargeError: 400 with ``code`` if (non-online carts) the confirmation
             token would exceed ``_GUEST_TOKEN_MAX_CHARS``.
         InvalidZoneSelectionError: 400 if a requested zone is unusable on its tier.

--- a/src/events/tests/test_controllers/test_error_response_contracts.py
+++ b/src/events/tests/test_controllers/test_error_response_contracts.py
@@ -1,11 +1,14 @@
 """Wire-contract tests for 400 response bodies (#712).
 
-Endpoints declare a 400 schema in OpenAPI, but 400 bodies are produced by three
+Endpoints declare a 400 schema in OpenAPI, but 400 bodies are produced by four
 independent mechanisms that never pass through Ninja's response serialization:
 
 - ``{"detail": ...}`` — a raised ``ninja.errors.HttpError``, or an exception
   mapped by an app's ``exception_handlers.py`` via ``make_simple_handler`` /
   ``make_static_handler``.
+- ``{"detail": ..., "code": ...}`` — a refusal with a stable, machine-readable
+  discriminator, rendered by a dedicated handler (``GuestActionError`` in
+  ``events/exception_handlers.py``, #905).
 - ``{"errors": {field: [msgs]}}`` — the global Django ``ValidationError``
   handler in ``api/exception_handlers.py``.
 - the eligibility payload — ``UserIsIneligibleError`` in
@@ -272,7 +275,11 @@ class TestMultiTierCheckoutErrorContracts:
 
 
 class TestGuestErrorContracts:
-    """The three guest endpoints declared ``ResponseMessage``; they emit ``{detail}``/eligibility."""
+    """The guest endpoints declared ``ResponseMessage``; they emit ``{detail}``/eligibility.
+
+    Since #905 the account-exists refusal additionally carries a ``code``
+    (``{detail, code}``), pinned end-to-end here on guest RSVP.
+    """
 
     def test_guest_rsvp_requires_login_returns_detail(self, client: Client, public_event: Event) -> None:
         public_event.requires_ticket = False
@@ -356,6 +363,13 @@ class TestGuestErrorContracts:
         assert set(body) == {"detail", "code"}, body
 
 
+class GuestActionErrorBody(t.TypedDict):
+    """Decoded ``GuestActionErrorSchema`` body as it reaches the wire."""
+
+    detail: str
+    code: str
+
+
 class TestGuestActionErrorHandlerContracts:
     """The two guest refusals with a machine-readable ``code`` (#905), pinned at the handler.
 
@@ -365,11 +379,11 @@ class TestGuestActionErrorHandlerContracts:
     """
 
     @staticmethod
-    def _invoke(exc: Exception) -> tuple[int, dict[str, t.Any]]:
+    def _invoke(exc: Exception) -> tuple[int, GuestActionErrorBody]:
         # Registered on the base class; resolve by MRO the way ninja-extra dispatches.
         handler = next(HANDLERS[cls] for cls in type(exc).__mro__ if cls in HANDLERS)
         response = handler(HttpRequest(), exc)
-        return response.status_code, json.loads(response.content)
+        return response.status_code, t.cast(GuestActionErrorBody, json.loads(response.content))
 
     @pytest.mark.parametrize(
         ("exc", "code"),

--- a/src/events/tests/test_controllers/test_error_response_contracts.py
+++ b/src/events/tests/test_controllers/test_error_response_contracts.py
@@ -37,6 +37,8 @@ from accounts.models import RevelUser
 from events.exception_handlers import HANDLERS
 from events.exceptions import (
     EventRefundsStartedError,
+    GuestAccountExistsError,
+    GuestCartTooLargeError,
     NothingToRefundError,
     RefundInsufficientBalanceError,
     StripeRefundFailed,
@@ -328,6 +330,60 @@ class TestGuestErrorContracts:
         url = reverse("api:confirm_guest_action")
         response = client.post(url, data={"token": "not-a-jwt"}, content_type="application/json")
         assert_detail_body(response)
+
+    def test_guest_rsvp_existing_account_returns_stable_code(self, client: Client, public_event: Event) -> None:
+        """A non-guest account on the email is a 400 carrying a ``code`` the FE can key on (#905).
+
+        The translated ``detail`` is unmatchable; ``code`` lets the frontend render a
+        "Log in" CTA instead of echoing the message.
+        """
+        public_event.requires_ticket = False
+        public_event.can_attend_without_login = True
+        public_event.save(update_fields=["requires_ticket", "can_attend_without_login"])
+        RevelUser.objects.create_user(username="taken@example.com", email="taken@example.com", password="p")
+
+        url = reverse("api:guest_rsvp", kwargs={"event_id": public_event.id, "answer": "yes"})
+        response = client.post(
+            url,
+            data={"email": "Taken@example.com", "first_name": "G", "last_name": "U"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400, response.content
+        body = response.json()
+        assert isinstance(body.get("detail"), str) and body["detail"]
+        assert body["code"] == "guest_account_exists"
+        assert set(body) == {"detail", "code"}, body
+
+
+class TestGuestActionErrorHandlerContracts:
+    """The two guest refusals with a machine-readable ``code`` (#905), pinned at the handler.
+
+    The cart-too-large refusal needs a ~50-ticket offline cart to trip the JWT
+    size guard, which the endpoint fixtures here don't support; its exception
+    type is proven at the service level, so pin the wire shape on the handler.
+    """
+
+    @staticmethod
+    def _invoke(exc: Exception) -> tuple[int, dict[str, t.Any]]:
+        # Registered on the base class; resolve by MRO the way ninja-extra dispatches.
+        handler = next(HANDLERS[cls] for cls in type(exc).__mro__ if cls in HANDLERS)
+        response = handler(HttpRequest(), exc)
+        return response.status_code, json.loads(response.content)
+
+    @pytest.mark.parametrize(
+        ("exc", "code"),
+        [
+            (GuestAccountExistsError(), "guest_account_exists"),
+            (GuestCartTooLargeError(), "guest_cart_too_large"),
+        ],
+    )
+    def test_returns_400_detail_and_code(self, exc: Exception, code: str) -> None:
+        status, body = self._invoke(exc)
+        assert status == 400
+        assert isinstance(body.get("detail"), str) and body["detail"]
+        assert body["code"] == code
+        assert set(body) == {"detail", "code"}, body
 
 
 class TestCheckoutManagementErrorContracts:

--- a/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
+++ b/src/events/tests/test_controllers/test_guest_user/test_guest_service.py
@@ -14,6 +14,7 @@ from ninja_jwt.token_blacklist.models import BlacklistedToken
 
 from accounts.models import RevelUser
 from events import schema
+from events.exceptions import GuestAccountExistsError, GuestCartTooLargeError
 from events.models import Event, EventRSVP, TicketTier
 from events.models.discount_code import DiscountCode
 from events.service import guest as guest_service
@@ -61,10 +62,8 @@ class TestGuestServiceLayer:
     def test_get_or_create_guest_user_rejects_non_guest(self, existing_regular_user: RevelUser) -> None:
         """Test that attempting to create guest with existing non-guest email fails."""
         # Act & Assert
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(GuestAccountExistsError):
             guest_service.get_or_create_guest_user(existing_regular_user.email, "New", "Name")
-
-        assert "already exists" in str(exc_info.value).lower()
 
     def test_create_guest_rsvp_token(self, existing_guest_user: RevelUser, guest_event: Event) -> None:
         """Test creating a guest RSVP JWT token."""
@@ -388,13 +387,11 @@ class TestGuestServiceLayer:
         items = [schema.TicketPurchaseItem(guest_name="N" * 255) for _ in range(50)]
         group = CartGroup(tier=offline_tier, items=items)
 
-        with pytest.raises(HttpError) as exc_info:
+        with pytest.raises(GuestCartTooLargeError):
             guest_service.handle_guest_ticket_checkout(
                 guest_event_with_tickets, [group], "biggie@test.com", "Big", "Cart"
             )
 
-        assert exc_info.value.status_code == 400
-        assert "too large" in str(exc_info.value.message)
         mock_send_email.assert_not_called()
 
     def test_handle_guest_ticket_checkout_large_cart_with_discount(


### PR DESCRIPTION
Closes #905.

## What

The guest cart checkout's two special 400s — "an account with this email already exists" and "your cart is too large for guest checkout" — were plain `HttpError(400, detail)` with no structural discriminator. The frontend correctly refuses to match on message text, so it could only echo the verbatim detail.

They now render as:

```json
{"detail": "<translated message>", "code": "guest_account_exists" | "guest_cart_too_large"}
```

## How

- `events/exceptions.py`: `GuestActionErrorCode` enum, a `GuestActionError` base, and two bare-raised subclasses that carry their `code` and a lazy `message` (so `detail` is translated per request, as `make_static_handler` does).
- `events/exception_handlers.py`: one handler registered on the base class (MRO covers both subclasses), rendering `GuestActionErrorSchema`.
- `events/schema/guest_checkout.py`: `GuestActionErrorSchema` (`detail: str`, `code: GuestActionErrorCode`), re-exported through `schema.ticket` and the package `__init__`.
- `events/service/guest.py`: the two raise sites switch to the typed exceptions. Message text is unchanged, so no catalog regeneration.
- `controllers/event_public/guest.py`: the four guest endpoints (RSVP, single-tier, PWYC, multi-tier) declare the schema in their 400 union so the generated client narrows `code` to the enum. `guest_account_exists` is reachable from all four (they all mint a guest user); `guest_cart_too_large` from the non-online checkout branches.

Chose the `code`-field option over folding into the eligibility shape: it mirrors the existing `subscription_activation_pending` precedent and doesn't overload `EventUserEligibility` with a refusal that isn't an eligibility verdict.

## Tests

- Endpoint-level: guest RSVP with an existing non-guest email → 400 `{detail, code: guest_account_exists}` (case-insensitive email match).
- Handler-level: both codes pinned via `HANDLERS` (cart-too-large needs a ~50-ticket offline cart to trip the JWT size guard; its exception type is proven at the service level).
- Service tests tightened from `pytest.raises(Exception)`/`HttpError` to the specific types.
- OpenAPI invariants: new schema added to `KNOWN_400_COMPONENTS`; new test pins all four guest endpoints' 400 union.

Purely additive; FE degrades gracefully today (verbatim message includes "please log in"), so no deploy coupling. FE follow-up issue to branch on `code` and render the CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest RSVP and checkout errors now provide clear translated messages and stable error codes.
  * Added specific responses for existing accounts and oversized guest carts.
  * Updated API documentation to describe these 400-level error responses.

* **Bug Fixes**
  * Improved consistency and reliability of guest checkout error handling.

* **Tests**
  * Added coverage for guest action error responses and API response contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->