### PR TITLE
fix(vat): bound the VIES timeout on the checkout path

### DIFF
--- a/src/common/service/vies_service.py
+++ b/src/common/service/vies_service.py
@@ -25,9 +25,13 @@ logger = structlog.get_logger(__name__)
 
 VIES_REST_URL = "https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number"
 VIES_TIMEOUT_SECONDS = 10
-# Checkout runs a live VIES call (on a cold cache) inside a payment request; a
-# third-party hang must not stall it. The user-initiated "validate my VAT" flows in
-# settings keep the shared default, where waiting is acceptable (#633).
+# Bound for the payment-reservation call only (resolve_attendee_vat_for_reserve):
+# on a cold cache it runs a live VIES call inside a payment request, and a
+# third-party hang must not stall that. Every other surface keeps the shared
+# default on purpose (#633): the VAT preview is not a payment request and, by
+# warming the shared cache, is what normally spares checkout the live call at all;
+# the user/org "validate my VAT" settings flows are user-initiated, where a slow but
+# authoritative answer beats a fast "unavailable".
 VIES_CHECKOUT_TIMEOUT_SECONDS = 2
 
 VAT_RESET_FIELDS = [

--- a/src/common/service/vies_service.py
+++ b/src/common/service/vies_service.py
@@ -25,6 +25,10 @@ logger = structlog.get_logger(__name__)
 
 VIES_REST_URL = "https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number"
 VIES_TIMEOUT_SECONDS = 10
+# Checkout runs a live VIES call (on a cold cache) inside a payment request; a
+# third-party hang must not stall it. The user-initiated "validate my VAT" flows in
+# settings keep the shared default, where waiting is acceptable (#633).
+VIES_CHECKOUT_TIMEOUT_SECONDS = 2
 
 VAT_RESET_FIELDS = [
     "vat_id",
@@ -92,11 +96,12 @@ def parse_vat_id(vat_id: str) -> tuple[str, str]:
     return vat_id[:2], vat_id[2:]
 
 
-def validate_vat_id(vat_id: str) -> VIESValidationResult:
+def validate_vat_id(vat_id: str, *, timeout: float = VIES_TIMEOUT_SECONDS) -> VIESValidationResult:
     """Validate a VAT ID against the VIES REST API.
 
     Args:
         vat_id: Full VAT ID with country prefix (e.g., "IT12345678901").
+        timeout: Seconds to wait for VIES before treating it as unavailable.
 
     Returns:
         VIESValidationResult with validation details.
@@ -118,7 +123,7 @@ def validate_vat_id(vat_id: str) -> VIESValidationResult:
                 "countryCode": country_code,
                 "vatNumber": vat_number,
             },
-            timeout=VIES_TIMEOUT_SECONDS,
+            timeout=timeout,
         )
     except httpx.HTTPError as e:
         raise VIESUnavailableError(f"VIES service unreachable: {e}") from e
@@ -142,7 +147,7 @@ def validate_vat_id(vat_id: str) -> VIESValidationResult:
 VIES_CACHE_TTL = 1800  # 30 minutes
 
 
-def validate_vat_id_cached(vat_id: str) -> VIESValidationResult:
+def validate_vat_id_cached(vat_id: str, *, timeout: float = VIES_TIMEOUT_SECONDS) -> VIESValidationResult:
     """Validate a VAT ID with Redis caching.
 
     Returns cached result if available. On cache miss, validates via VIES
@@ -151,6 +156,7 @@ def validate_vat_id_cached(vat_id: str) -> VIESValidationResult:
 
     Args:
         vat_id: Full VAT ID with country prefix.
+        timeout: Seconds to wait for VIES on a cache miss.
 
     Returns:
         VIESValidationResult.
@@ -166,7 +172,7 @@ def validate_vat_id_cached(vat_id: str) -> VIESValidationResult:
     if cached is not None:
         return VIESValidationResult(**cached)
 
-    result = validate_vat_id(normalized)  # may raise VIESUnavailableError
+    result = validate_vat_id(normalized, timeout=timeout)  # may raise VIESUnavailableError
     cache.set(cache_key, asdict(result), timeout=VIES_CACHE_TTL)
     return result
 

--- a/src/common/tests/test_vies_cached_validation.py
+++ b/src/common/tests/test_vies_cached_validation.py
@@ -12,6 +12,7 @@ import pytest
 
 from common.service.vies_service import (
     VIES_CACHE_TTL,
+    VIES_TIMEOUT_SECONDS,
     VIESUnavailableError,
     VIESValidationResult,
     validate_vat_id_cached,
@@ -68,13 +69,29 @@ class TestValidateVatIdCached:
         result = validate_vat_id_cached("IT12345678901")
 
         assert result == vies_result
-        mock_validate.assert_called_once_with("IT12345678901")
+        mock_validate.assert_called_once_with("IT12345678901", timeout=VIES_TIMEOUT_SECONDS)
         mock_cache_set.assert_called_once()
 
         # Verify cache key and TTL
         call_args = mock_cache_set.call_args
         assert call_args[0][0] == "vies:validation:IT12345678901"
         assert call_args[1]["timeout"] == VIES_CACHE_TTL
+
+    @patch(MOCK_CACHE_SET)
+    @patch(MOCK_VALIDATE)
+    @patch(MOCK_CACHE_GET, return_value=None)
+    def test_cache_miss_forwards_caller_timeout(
+        self,
+        mock_cache_get: MagicMock,
+        mock_validate: MagicMock,
+        mock_cache_set: MagicMock,
+    ) -> None:
+        """On a miss the caller's timeout bounds the live VIES call (#633)."""
+        mock_validate.return_value = VIESValidationResult(valid=True, name="", address="", request_identifier="")
+
+        validate_vat_id_cached("IT12345678901", timeout=2)
+
+        mock_validate.assert_called_once_with("IT12345678901", timeout=2)
 
     @patch(MOCK_CACHE_SET)
     @patch(MOCK_VALIDATE)

--- a/src/common/tests/test_vies_service.py
+++ b/src/common/tests/test_vies_service.py
@@ -71,6 +71,15 @@ class TestValidateVatId:
             timeout=VIES_TIMEOUT_SECONDS,
         )
 
+    @patch("common.service.vies_service.httpx.post")
+    def test_timeout_override_reaches_httpx(self, mock_post: MagicMock) -> None:
+        """A caller-supplied timeout replaces the shared default on the wire (#633)."""
+        mock_post.return_value = mock_vies_response()
+
+        validate_vat_id("DE123456789", timeout=2)
+
+        assert mock_post.call_args.kwargs["timeout"] == 2
+
     def test_short_vat_id_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Invalid VAT ID format"):
             validate_vat_id("IT")

--- a/src/events/service/attendee_vat_service.py
+++ b/src/events/service/attendee_vat_service.py
@@ -28,6 +28,7 @@ from django.utils.translation import gettext as _
 
 from common.constants import EU_MEMBER_STATES
 from common.service.vat_utils import TWO_PLACES, calculate_vat_inclusive
+from common.service.vies_service import VIES_TIMEOUT_SECONDS
 
 if t.TYPE_CHECKING:
     from events.models.event import Event
@@ -198,6 +199,8 @@ class VATPreviewResult:
 def validate_and_resolve_buyer_country(
     vat_id: str | None,
     vat_country_code: str | None,
+    *,
+    timeout: float = VIES_TIMEOUT_SECONDS,
 ) -> tuple[bool | None, str | None, str | None]:
     """Validate a buyer's VAT ID via VIES and resolve their country.
 
@@ -208,6 +211,7 @@ def validate_and_resolve_buyer_country(
     Args:
         vat_id: The buyer's VAT ID (if provided).
         vat_country_code: Explicit buyer country code (if provided).
+        timeout: Seconds to wait for a live VIES call on a cache miss.
 
     Returns:
         Tuple of (vat_id_valid, vat_id_validation_error, buyer_country).
@@ -220,7 +224,7 @@ def validate_and_resolve_buyer_country(
         from common.service.vies_service import VIESUnavailableError, validate_vat_id_cached
 
         try:
-            result = validate_vat_id_cached(vat_id)
+            result = validate_vat_id_cached(vat_id, timeout=timeout)
             vat_id_valid = result.valid
         except VIESUnavailableError:
             vat_id_valid = None

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -520,13 +520,17 @@ def resolve_attendee_vat_for_reserve(
     Returns:
         The buyer's VAT context, or None when no billing info was provided.
     """
+    from common.service.vies_service import VIES_CHECKOUT_TIMEOUT_SECONDS
     from events.service.attendee_vat_service import BuyerVATContext, validate_and_resolve_buyer_country
 
     if not billing_info:
         return None
+    # Bounded timeout: this is a payment request, so a VIES hang degrades to
+    # "not validated" fast instead of stalling the checkout for 10s (#633).
     vat_id_valid, _, buyer_country = validate_and_resolve_buyer_country(
         vat_id=billing_info.vat_id,
         vat_country_code=billing_info.vat_country_code,
+        timeout=VIES_CHECKOUT_TIMEOUT_SECONDS,
     )
     return BuyerVATContext(buyer_country=buyer_country, buyer_vat_validated=bool(vat_id_valid))
 

--- a/src/events/tests/test_attendee_vat_service.py
+++ b/src/events/tests/test_attendee_vat_service.py
@@ -13,13 +13,15 @@ Tests cover:
 
 import typing as t
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from common.service.vies_service import VIESValidationResult
 from events.service.attendee_vat_service import (
     determine_attendee_vat,
     get_effective_vat_rate,
+    validate_and_resolve_buyer_country,
 )
 
 # ---------------------------------------------------------------------------
@@ -349,3 +351,15 @@ class TestGetEffectiveVatRate:
         org.vat_rate = Decimal("22.00")
 
         assert get_effective_vat_rate(tier, org) == Decimal("0.00")
+
+
+class TestValidateAndResolveBuyerCountryTimeout:
+    """The shared resolver forwards a caller-supplied VIES timeout (#633)."""
+
+    @patch("common.service.vies_service.validate_vat_id_cached")
+    def test_timeout_is_forwarded_to_vies(self, mock_validate: MagicMock) -> None:
+        mock_validate.return_value = VIESValidationResult(valid=True, name="", address="", request_identifier="")
+
+        validate_and_resolve_buyer_country("DE123456789", None, timeout=2)
+
+        mock_validate.assert_called_once_with("DE123456789", timeout=2)

--- a/src/events/tests/test_attendee_vat_service.py
+++ b/src/events/tests/test_attendee_vat_service.py
@@ -358,6 +358,7 @@ class TestValidateAndResolveBuyerCountryTimeout:
 
     @patch("common.service.vies_service.validate_vat_id_cached")
     def test_timeout_is_forwarded_to_vies(self, mock_validate: MagicMock) -> None:
+        """A caller-supplied timeout reaches the cached VIES validator unchanged."""
         mock_validate.return_value = VIESValidationResult(valid=True, name="", address="", request_identifier="")
 
         validate_and_resolve_buyer_country("DE123456789", None, timeout=2)

--- a/src/events/tests/test_service/test_batch_ticket_service_reserve.py
+++ b/src/events/tests/test_service/test_batch_ticket_service_reserve.py
@@ -66,7 +66,7 @@ def test_online_create_batch_charges_lock_time_price_when_price_changes_during_v
     """
 
     def vies_bumps_price(
-        vat_id: str | None, vat_country_code: str | None
+        vat_id: str | None, vat_country_code: str | None, *, timeout: float
     ) -> tuple[bool | None, str | None, str | None]:
         # Simulates an organizer repricing the tier while VIES is in flight.
         TicketTier.objects.filter(pk=paid_ticket_tier.pk).update(price=Decimal("60.00"))

--- a/src/events/tests/test_service/test_stripe_service/test_batch_reserve_and_session.py
+++ b/src/events/tests/test_service/test_stripe_service/test_batch_reserve_and_session.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from ninja.errors import HttpError
 
 from accounts.models import RevelUser
+from common.service.vies_service import VIES_CHECKOUT_TIMEOUT_SECONDS
 from events.models import Event, Organization, Payment, Ticket, TicketTier
 from events.schema.ticket import BuyerBillingInfoSchema
 from events.service import pending_checkout, stripe_service
@@ -173,6 +174,19 @@ class TestResolveAttendeeVatForReserve:
         billing_info = BuyerBillingInfoSchema(billing_name="Acme Corp", vat_country_code="DE")  # type: ignore[call-arg]
         context = stripe_service.resolve_attendee_vat_for_reserve(billing_info=billing_info)
         assert context == BuyerVATContext(buyer_country="DE", buyer_vat_validated=False)
+
+    def test_checkout_bounds_the_vies_timeout(self) -> None:
+        """Checkout passes the short VIES timeout: a third-party hang must not stall a payment request (#633)."""
+        billing_info = BuyerBillingInfoSchema(billing_name="Acme Corp", vat_id="DE123456789")  # type: ignore[call-arg]
+        with mock.patch(
+            "events.service.attendee_vat_service.validate_and_resolve_buyer_country",
+            return_value=(True, None, "DE"),
+        ) as resolve:
+            stripe_service.resolve_attendee_vat_for_reserve(billing_info=billing_info)
+
+        resolve.assert_called_once_with(
+            vat_id="DE123456789", vat_country_code="", timeout=VIES_CHECKOUT_TIMEOUT_SECONDS
+        )
 
 
 class TestCreateBatchSession:


### PR DESCRIPTION
Closes #633.

## What

No 10s third-party timeout belongs inside a payment request. The checkout path's live VIES call (buyer supplied a `vat_id`, cache cold) now runs with a **2s** bound; every other VIES surface keeps the shared 10s default.

## Premise update

The issue's "while the tier lock is held inside the request transaction" half is already resolved: since #632, `resolve_attendee_vat_for_reserve` runs *before* `BatchTicketService` takes the `TicketTier` `select_for_update` (pinned by `test_online_create_batch_resolves_vat_before_locking_tier`). What remained was the bare 10s hang inside the request, which this bounds.

## How

- `common/service/vies_service.py`: new `VIES_CHECKOUT_TIMEOUT_SECONDS = 2`; keyword-only `timeout` on `validate_vat_id` and `validate_vat_id_cached`, defaulting to `VIES_TIMEOUT_SECONDS` (10).
- `events/service/attendee_vat_service.py`: `validate_and_resolve_buyer_country` gains the same keyword-only `timeout` and forwards it on a cache miss.
- `events/service/stripe_service.py`: `resolve_attendee_vat_for_reserve` (the checkout entry, shared by authenticated and guest carts) passes the 2s bound.

Unchanged on purpose, per the issue: the VAT preview (surface B) and the user/org "validate my VAT" settings flows (C, D), where waiting ~10s for an authoritative answer is acceptable. The graceful `VIESUnavailableError` fallback (no crash, just no zero-rating) is untouched — a timeout now simply reaches it ~8s sooner.

## Tests

- `validate_vat_id(..., timeout=2)` reaches `httpx.post` as `timeout=2`.
- `validate_vat_id_cached` forwards the caller's timeout on a miss (and the existing miss test now pins the default).
- `validate_and_resolve_buyer_country` forwards `timeout` to the cached validator.
- `resolve_attendee_vat_for_reserve` calls the resolver with `timeout=VIES_CHECKOUT_TIMEOUT_SECONDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout VAT validation now uses a short timeout, preventing slow tax-service responses from delaying payment requests.
  * VAT validation supports configurable timeouts across checkout and related validation flows.

* **Tests**
  * Added coverage confirming timeout values are correctly applied and forwarded during VAT validation and checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->