### PR TITLE
fix(openapi): declare 401/403/422 API-wide and add the request-validation schema

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -49,6 +49,7 @@ from telegram.controllers import TelegramController
 from wallet.controllers import MembershipWalletController, MembershipWalletSignedController, TicketWalletController
 
 from .exception_handlers import handle_django_validation_error, handle_general_exception
+from .openapi import RevelOpenAPISchema
 
 
 class CachedSchemaNinjaExtraAPI(NinjaExtraAPI):
@@ -58,6 +59,9 @@ class CachedSchemaNinjaExtraAPI(NinjaExtraAPI):
     ``/openapi.json`` request — seconds of CPU per hit, on a public, unthrottled
     view (#880). The schema depends only on the registered routes and the mount
     ``path_prefix``, both fixed after startup, so it is safe to memoize.
+
+    Builds the spec with :class:`~api.openapi.RevelOpenAPISchema`, which layers the
+    API-wide 401/403/422 declarations onto every operation (#826).
     """
 
     _schema_cache: dict[str, OpenAPISchema]
@@ -76,7 +80,7 @@ class CachedSchemaNinjaExtraAPI(NinjaExtraAPI):
             cache = self._schema_cache = {}
         if path_prefix not in cache:
             # Racing threads both build; the result is identical and idempotent.
-            cache[path_prefix] = super().get_openapi_schema(path_prefix=path_prefix)
+            cache[path_prefix] = RevelOpenAPISchema(self, path_prefix)
         return cache[path_prefix]
 
 

--- a/src/api/openapi.py
+++ b/src/api/openapi.py
@@ -1,0 +1,82 @@
+"""OpenAPI schema builder with the API-wide default error responses (#826).
+
+django-ninja builds each operation's ``responses`` solely from its own
+``response=`` mapping, so statuses produced by shared machinery — the auth
+class (401), permission classes and ``PermissionDenied`` (403), and ninja's
+own request validation (422) — were declared on ~1% of routes although they
+are reachable on nearly all of them. Declaring them per endpoint would drift
+the moment a route is added; this builder adds them once, at spec time.
+
+Schema-only by design: ``operation.response_models`` also drives runtime
+serialisation of ``return status, obj`` tuples, so it is deliberately left
+untouched.
+"""
+
+import typing as t
+from http.client import responses as http_reasons
+
+from ninja import Schema
+from ninja.openapi.schema import OpenAPISchema
+from ninja.operation import Operation
+from ninja.types import DictStrAny
+
+from common.schema import ErrorDetail, RequestValidationError
+
+
+# ``OpenAPISchema._create_schema_from_model`` expects the single-field wrapper ninja
+# builds around every ``response=`` model (it unwraps the ``response`` property), so
+# the shared defaults are wrapped the same way, once.
+class _ErrorDetailResponse(Schema):
+    response: ErrorDetail
+
+
+class _RequestValidationErrorResponse(Schema):
+    response: RequestValidationError
+
+
+class RevelOpenAPISchema(OpenAPISchema):
+    """``OpenAPISchema`` that layers the universal error statuses onto every operation."""
+
+    def responses(self, operation: Operation) -> dict[int, DictStrAny]:
+        """Add 401/403 to secured operations and 422 to parameterised ones.
+
+        An explicit per-endpoint 401/403 wins untouched. At 422 both shapes are
+        real — a domain ``HttpError(422)`` renders ``{detail: str}`` while ninja's
+        validation renders ``{detail: [...]}`` — so the validation schema is
+        merged into an ``anyOf`` rather than replacing the declaration.
+        """
+        result = super().responses(operation)
+        if operation.auth_callbacks:
+            for status in (401, 403):
+                result.setdefault(status, self._json_response(status, _ErrorDetailResponse))
+        if operation.models:
+            validation = self._json_response(422, _RequestValidationErrorResponse)
+            declared = result.get(422)
+            if declared is None:
+                result[422] = validation
+            else:
+                self._merge_into_any_of(declared, validation)
+        return result
+
+    def _json_response(self, status: int, model: type[Schema]) -> DictStrAny:
+        """Build a ``responses`` entry the way ninja does for an explicit ``response=`` model."""
+        # ninja types the helper's param as a ``ParamModel`` but feeds it these
+        # response wrappers itself (``Operation._create_response_model``).
+        schema = self._create_schema_from_model(t.cast(t.Any, model), by_alias=True, mode="serialization")[0]
+        return {
+            "description": http_reasons[status],
+            "content": {self.api.renderer.media_type: {"schema": schema}},
+        }
+
+    def _merge_into_any_of(self, declared: DictStrAny, extra: DictStrAny) -> None:
+        """Union ``extra``'s schema into ``declared``'s, preserving an existing ``anyOf``."""
+        media_type = self.api.renderer.media_type
+        content = declared.setdefault("content", {}).setdefault(media_type, {})
+        current = content.get("schema")
+        extra_schema = extra["content"][media_type]["schema"]
+        if current is None:  # declared as ``422: None``
+            content["schema"] = extra_schema
+            return
+        options = current["anyOf"] if "anyOf" in current else [current]
+        if extra_schema not in options:
+            content["schema"] = {"anyOf": [*options, extra_schema]}

--- a/src/api/tests/test_openapi_schema.py
+++ b/src/api/tests/test_openapi_schema.py
@@ -107,6 +107,13 @@ RESPONSE_MESSAGE_400_ALLOWLIST = {
     "/api/organizations/claim-invitation/{token}",
 }
 
+#: Every ``(path, status)`` at which a view genuinely returns ``ResponseMessage`` as
+#: an *error* body. Anything else declaring it at >= 400 is a mis-declaration (#826).
+RESPONSE_MESSAGE_ERROR_ALLOWLIST = {(path, "400") for path in RESPONSE_MESSAGE_400_ALLOWLIST} | {
+    ("/api/events/tokens/{token_id}", "404"),
+    ("/api/organizations/tokens/{token_id}", "404"),
+}
+
 #: Every component a 400 is allowed to resolve to.
 KNOWN_400_COMPONENTS = {
     "ErrorDetail",
@@ -116,18 +123,6 @@ KNOWN_400_COMPONENTS = {
     "ResponseMessage",
     "ValidationErrorResponse",
 }
-
-
-#: Path prefixes of the two subscription controllers, whose every error status was
-#: audited in #712. ``ResponseMessage`` must never reappear on them.
-SUBSCRIPTION_PATH_MARKERS = (
-    "/api/me/organizations/{org_id}/sub",
-    "/api/me/organizations/{org_id}/billing-portal",
-    "/api/organization-admin/{slug}/plans",
-    "/api/organization-admin/{slug}/subscriptions",
-    "/api/organization-admin/{slug}/tiers/{tier_id}/plans",
-    "/api/organization-admin/{slug}/payments",
-)
 
 
 def _declared_error_schemas(status_filter: t.Callable[[str], bool]) -> dict[tuple[str, str, str], set[str]]:
@@ -161,25 +156,22 @@ def _declared_400_schemas() -> dict[tuple[str, str], set[str]]:
     }
 
 
-def test_subscription_controllers_never_declare_response_message() -> None:
-    """Every error status on the two subscription controllers emits ``{detail}``.
+def test_response_message_never_declared_on_error_responses_outside_allowlist() -> None:
+    """Every error status repo-wide emits ``{detail}`` unless a view really returns ``{message}``.
 
-    #712 fixed the 400s; the same mis-declaration covered 403/404/422/502 on
-    these two controllers (21 sites), where no view returns a ``message`` key
-    at any status.
+    #712 fixed the 400s and the two subscription controllers; #826 widens the rule
+    to every operation, since 403/404/422/502 were declared as ``ResponseMessage``
+    on routes whose only producers are ``HttpError``/``get_object_or_404``.
     """
     declared = _declared_error_schemas(lambda s: s.isdigit() and int(s) >= 400)
-    covered = [key for key in declared if any(key[0].startswith(marker) for marker in SUBSCRIPTION_PATH_MARKERS)]
-    # Guard against the markers silently drifting off the real paths, which would
-    # make this test pass vacuously.
-    assert len(covered) > 40, f"expected the subscription controllers' error responses, matched {len(covered)}"
+    assert len(declared) > 400, f"expected the whole API's error responses, matched {len(declared)}"
 
     offenders = sorted(
         f"{method.upper()} {path} -> {status}"
-        for (path, method, status) in covered
-        if "ResponseMessage" in declared[(path, method, status)]
+        for (path, method, status), names in declared.items()
+        if "ResponseMessage" in names and (path, status) not in RESPONSE_MESSAGE_ERROR_ALLOWLIST
     )
-    assert not offenders, f"ResponseMessage declared on subscription error responses: {offenders}"
+    assert not offenders, f"ResponseMessage declared on error responses that never return it: {offenders}"
 
 
 def test_response_message_declared_at_400_only_where_it_is_returned() -> None:
@@ -236,3 +228,68 @@ def test_guest_endpoints_declare_the_coded_error_shape() -> None:
         "/api/events/{event_id}/checkout/public",
     ):
         assert declared[(path, "post")] == {"EventUserEligibility", "ErrorDetail", "GuestActionErrorSchema"}, path
+
+
+def _operations() -> dict[tuple[str, str], dict[str, t.Any]]:
+    """Map each ``(path, method)`` to its raw OpenAPI operation object."""
+    api._schema_cache = {}
+    with schema_name_collision_guard():
+        spec = api.get_openapi_schema()
+    return {
+        (path, method): operation
+        for path, operations in spec["paths"].items()
+        for method, operation in operations.items()
+        if isinstance(operation, dict)
+    }
+
+
+def test_secured_operations_declare_401_and_403_as_error_detail() -> None:
+    """Every operation behind an auth class can fail auth (401) or a permission check (403).
+
+    ``RootPermission.has_permission`` is unconditionally ``True`` and the real check is
+    object-level inside ``get_one()``, so 403 is reachable on effectively every
+    permissioned route while only a handful declared it (#826). Declared globally.
+    """
+    declared = _declared_error_schemas(lambda s: s in {"401", "403"})
+    secured = [key for key, op in _operations().items() if "security" in op]
+    assert len(secured) > 400, f"expected most operations to be secured, matched {len(secured)}"
+
+    missing = sorted(
+        f"{method.upper()} {path} -> {status}"
+        for (path, method) in secured
+        for status in ("401", "403")
+        if declared.get((path, method, status)) != {"ErrorDetail"}
+    )
+    assert not missing, f"secured operations without an ErrorDetail 401/403: {missing}"
+
+
+def test_parameterised_operations_declare_the_request_validation_422() -> None:
+    """Every operation that parses a path/query/body param can answer ninja's 422.
+
+    Its body is ``{"detail": [ {type, loc, msg, ctx?}, ... ]}`` — a *list*, so it must
+    resolve to ``RequestValidationError`` rather than ``ErrorDetail`` (#826).
+    """
+    declared = _declared_error_schemas(lambda s: s == "422")
+    parameterised = [key for key, op in _operations().items() if op.get("parameters") or op.get("requestBody")]
+    assert len(parameterised) > 400, f"expected most operations to take params, matched {len(parameterised)}"
+
+    missing = sorted(
+        f"{method.upper()} {path}"
+        for (path, method) in parameterised
+        if "RequestValidationError" not in declared.get((path, method, "422"), set())
+    )
+    assert not missing, f"parameterised operations without the RequestValidationError 422: {missing}"
+
+
+def test_domain_422s_keep_their_detail_shape_alongside_the_validation_one() -> None:
+    """A route with its own ``HttpError(422)``/static-handler 422 declares both shapes."""
+    declared = _declared_error_schemas(lambda s: s == "422")
+    for path, method in (
+        ("/api/organization-admin/{slug}/tiers/{tier_id}/plans", "post"),
+        ("/api/organization-admin/{slug}/plans/{plan_id}", "patch"),
+        # ``BillingInfoRequiredError`` renders ``{detail}`` via a static handler; these
+        # two declared the ``{errors}`` shape that nothing at 422 produces.
+        ("/api/event-admin/{event_id}/ticket-tier", "post"),
+        ("/api/event-admin/{event_id}/ticket-tier/{tier_id}", "put"),
+    ):
+        assert declared[(path, method, "422")] == {"ErrorDetail", "RequestValidationError"}, path

--- a/src/common/schema.py
+++ b/src/common/schema.py
@@ -185,6 +185,27 @@ class ValidationErrorResponse(Schema):
     errors: dict[str, str | list[str]]
 
 
+class RequestValidationErrorItem(Schema):
+    """One entry of django-ninja's request-validation 422 body (a pydantic error, minus ``input``)."""
+
+    type: str
+    loc: list[str | int]
+    msg: str
+    ctx: dict[str, t.Any] | None = None
+
+
+class RequestValidationError(Schema):
+    """The body django-ninja renders when a path/query/body param fails validation.
+
+    ``detail`` is a *list* of error items — structurally incompatible with
+    :class:`ErrorDetail`, which is why the two are distinct schemas even though
+    they share the key. Declared API-wide on every parameterised operation
+    (see ``api.openapi``, #826).
+    """
+
+    detail: list[RequestValidationErrorItem]
+
+
 class TagSchema(ModelSchema):
     class Meta:
         model = Tag

--- a/src/events/controllers/event_admin/tickets.py
+++ b/src/events/controllers/event_admin/tickets.py
@@ -127,12 +127,13 @@ class EventAdminTicketsController(EventAdminBaseController):
         "/ticket-tier",
         url_name="create_ticket_tier",
         # ONLINE tiers are gated on the online-payment prerequisites: 400 when the
-        # organization has no Stripe Connect, 422 when platform fees apply but its
+        # organization has no Stripe Connect, 422 (``{detail}``, via the static
+        # ``BillingInfoRequiredError`` handler) when platform fees apply but its
         # billing info is incomplete.
         response={
             200: schema.TicketTierDetailSchema,
             400: ValidationErrorResponse | ErrorDetail,
-            422: ValidationErrorResponse,
+            422: ErrorDetail,
         },
     )
     def create_ticket_tier(self, event_id: UUID, payload: schema.TicketTierCreateSchema) -> models.TicketTier:
@@ -147,7 +148,7 @@ class EventAdminTicketsController(EventAdminBaseController):
         response={
             200: schema.TicketTierDetailSchema,
             400: ValidationErrorResponse | ErrorDetail,
-            422: ValidationErrorResponse,
+            422: ErrorDetail,
         },
     )
     def update_ticket_tier(

--- a/src/events/controllers/event_public/discovery.py
+++ b/src/events/controllers/event_public/discovery.py
@@ -122,7 +122,9 @@ class EventPublicDiscoveryController(EventPublicBaseController):
         response={
             200: schema.EventTokenSchema,
             410: schema.EventTokenRejectionSchema,
-            404: ResponseMessage,
+            # ``{message}`` for an unknown token; ``{detail}`` when the rejected
+            # token's event has since been deleted (``get_object_or_404``).
+            404: ResponseMessage | ErrorDetail,
         },
     )
     def get_event_token_details(
@@ -271,7 +273,7 @@ class EventPublicDiscoveryController(EventPublicBaseController):
     @route.get(
         "/checkout/{payment_id}/resume",
         url_name="resume_checkout",
-        response={200: schema.StripeCheckoutSessionSchema, 404: ResponseMessage},
+        response={200: schema.StripeCheckoutSessionSchema, 404: ErrorDetail},
         auth=I18nJWTAuth(),
     )
     def resume_checkout(

--- a/src/events/controllers/event_public/discovery.py
+++ b/src/events/controllers/event_public/discovery.py
@@ -246,7 +246,6 @@ class EventPublicDiscoveryController(EventPublicBaseController):
         response={
             200: schema.EventRSVPSchema | schema.BatchCheckoutResponse,
             400: EventUserEligibility | ErrorDetail,
-            403: ErrorDetail,
         },
         throttle=WriteThrottle(),
     )

--- a/src/events/controllers/event_public/guest.py
+++ b/src/events/controllers/event_public/guest.py
@@ -34,7 +34,6 @@ class EventPublicGuestController(EventPublicBaseController):
         response={
             200: schema.GuestActionResponseSchema,
             400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
-            403: ErrorDetail,
         },
         throttle=WriteThrottle(),
     )
@@ -72,7 +71,6 @@ class EventPublicGuestController(EventPublicBaseController):
         response={
             200: schema.GuestCheckoutResponseSchema,
             400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
-            403: ErrorDetail,
         },
         throttle=WriteThrottle(),
         deprecated=True,
@@ -145,7 +143,6 @@ class EventPublicGuestController(EventPublicBaseController):
         response={
             200: schema.GuestCheckoutResponseSchema,
             400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
-            403: ErrorDetail,
         },
         throttle=WriteThrottle(),
         deprecated=True,
@@ -217,7 +214,6 @@ class EventPublicGuestController(EventPublicBaseController):
         response={
             200: schema.GuestCheckoutResponseSchema,
             400: EventUserEligibility | ErrorDetail | schema.GuestActionErrorSchema,
-            403: ErrorDetail,
             404: ErrorDetail,
         },
         throttle=WriteThrottle(),

--- a/src/events/controllers/event_public/tickets.py
+++ b/src/events/controllers/event_public/tickets.py
@@ -512,7 +512,7 @@ class EventPublicTicketsController(EventPublicBaseController):
     @route.get(
         "/tickets/{ticket_id}/cancellation-preview",
         url_name="ticket_cancellation_preview",
-        response={200: schema.CancellationPreviewSchema, 403: ErrorDetail},
+        response={200: schema.CancellationPreviewSchema},
         auth=I18nJWTAuth(),
     )
     def cancellation_preview(self, ticket_id: UUID) -> schema.CancellationPreviewSchema:
@@ -560,7 +560,6 @@ class EventPublicTicketsController(EventPublicBaseController):
         url_name="cancel_my_ticket",
         response={
             200: schema.TicketCancellationResponseSchema,
-            403: ErrorDetail,
             409: schema.CancellationBlockedErrorSchema,
             502: ErrorDetail,
         },

--- a/src/events/controllers/event_public/tickets.py
+++ b/src/events/controllers/event_public/tickets.py
@@ -12,7 +12,7 @@ from ninja_extra import (
 )
 
 from common.authentication import I18nJWTAuth, OptionalAuth
-from common.schema import ErrorDetail, ResponseMessage
+from common.schema import ErrorDetail
 from common.throttling import WriteThrottle
 from events import models, schema
 from events.controllers.permissions import CanPurchaseTicket
@@ -84,7 +84,7 @@ class EventPublicTicketsController(EventPublicBaseController):
     @route.get(
         "/{uuid:event_id}/tickets/{tier_id}/seats",
         url_name="tier_seat_availability",
-        response={200: schema.SectorAvailabilitySchema, 404: ResponseMessage},
+        response={200: schema.SectorAvailabilitySchema, 404: ErrorDetail},
     )
     def get_tier_seat_availability(self, event_id: UUID, tier_id: UUID) -> schema.SectorAvailabilitySchema:
         """Get available seats for a ticket tier with seat assignment.
@@ -512,7 +512,7 @@ class EventPublicTicketsController(EventPublicBaseController):
     @route.get(
         "/tickets/{ticket_id}/cancellation-preview",
         url_name="ticket_cancellation_preview",
-        response={200: schema.CancellationPreviewSchema, 403: ResponseMessage},
+        response={200: schema.CancellationPreviewSchema, 403: ErrorDetail},
         auth=I18nJWTAuth(),
     )
     def cancellation_preview(self, ticket_id: UUID) -> schema.CancellationPreviewSchema:
@@ -560,9 +560,9 @@ class EventPublicTicketsController(EventPublicBaseController):
         url_name="cancel_my_ticket",
         response={
             200: schema.TicketCancellationResponseSchema,
-            403: ResponseMessage,
+            403: ErrorDetail,
             409: schema.CancellationBlockedErrorSchema,
-            502: ResponseMessage,
+            502: ErrorDetail,
         },
         auth=I18nJWTAuth(),
         throttle=WriteThrottle(),

--- a/src/events/controllers/me_applications.py
+++ b/src/events/controllers/me_applications.py
@@ -82,7 +82,6 @@ class MeMembershipApplicationsController(UserAwareController):
         response={
             201: schema.ApplyResponseSchema,
             400: schema.MembershipEligibilitySchema | ErrorDetail,
-            403: ErrorDetail,
             404: ErrorDetail,
             409: ErrorDetail,
         },

--- a/src/events/controllers/me_subscriptions.py
+++ b/src/events/controllers/me_subscriptions.py
@@ -216,8 +216,7 @@ class MeSubscriptionsController(UserAwareController):
         response={
             200: schema.MySubscriptionSchema,
             400: ErrorDetail,
-            # Refused while the membership is PAUSED / BANNED by the organizers.
-            403: ErrorDetail,
+            # 403 (declared API-wide) is also refused while the membership is PAUSED / BANNED.
             404: ErrorDetail,
             502: ErrorDetail,
         },
@@ -298,8 +297,7 @@ class MeSubscriptionsController(UserAwareController):
         response={
             200: schema.RevivalResponseSchema,
             400: ErrorDetail,
-            # ``_validate_revivable`` refuses BANNED / blacklisted members here.
-            403: ErrorDetail,
+            # 403 (declared API-wide): ``_validate_revivable`` refuses BANNED / blacklisted members.
             404: ErrorDetail,
             502: ErrorDetail,
         },

--- a/src/events/controllers/organization_admin/subscriptions.py
+++ b/src/events/controllers/organization_admin/subscriptions.py
@@ -289,7 +289,6 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         response={
             201: schema.SubscriptionSchema,
             400: ValidationErrorResponse | ErrorDetail,
-            403: ErrorDetail,
             404: ErrorDetail,
         },
     )
@@ -455,7 +454,6 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         response={
             200: schema.SubscriptionSchema,
             400: ErrorDetail,
-            403: ErrorDetail,
             404: ErrorDetail,
             502: ErrorDetail,
         },
@@ -506,7 +504,6 @@ class OrganizationAdminSubscriptionsController(OrganizationAdminBaseController):
         response={
             200: schema.StaffRevivalResponseSchema,
             400: ValidationErrorResponse | ErrorDetail,
-            403: ErrorDetail,
             404: ErrorDetail,
             502: ErrorDetail,
         },

--- a/src/events/controllers/series_pass.py
+++ b/src/events/controllers/series_pass.py
@@ -14,7 +14,7 @@ from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseS
 
 from common.authentication import I18nJWTAuth, OptionalAuth
 from common.controllers import UserAwareController
-from common.schema import ResponseMessage
+from common.schema import ErrorDetail
 from common.signing import get_file_url
 from common.throttling import WriteThrottle
 from events import models, schema
@@ -159,7 +159,7 @@ class SeriesPassController(UserAwareController):
     @route.post(
         "/reservations/{uuid:reservation_id}/checkout-session",
         url_name="series_pass_checkout_session",
-        response={200: schema.CheckoutSessionResponse, 404: ResponseMessage},
+        response={200: schema.CheckoutSessionResponse, 404: ErrorDetail},
         auth=I18nJWTAuth(),
         throttle=WriteThrottle(),
     )

--- a/src/events/tests/test_controllers/test_error_response_contracts.py
+++ b/src/events/tests/test_controllers/test_error_response_contracts.py
@@ -37,6 +37,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from accounts.models import RevelUser
+from common.schema import RequestValidationError
 from events.exception_handlers import HANDLERS
 from events.exceptions import (
     EventRefundsStartedError,
@@ -584,9 +585,13 @@ class TestRevivalAmountBound:
         body = response.json()
         assert "message" not in body, body
         # ninja's request-validation 422 carries a *list* under ``detail`` — a
-        # different shape from ``ErrorDetail``'s ``{detail: str}``. Pinned here
-        # because that distinction is systemically under-declared repo-wide.
+        # different shape from ``ErrorDetail``'s ``{detail: str}``. The spec
+        # declares it as ``RequestValidationError`` API-wide (#826); pin that the
+        # schema really matches the wire body so the generated client can trust it.
         assert isinstance(body.get("detail"), list), body
+        parsed = RequestValidationError.model_validate(body)
+        assert parsed.detail, body
+        assert parsed.detail[0].loc[0] == "body", body
 
 
 class TestOrganizerRefundExceptionContracts:

--- a/src/wallet/controllers.py
+++ b/src/wallet/controllers.py
@@ -12,6 +12,7 @@ from ninja_extra import api_controller, route
 
 from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
+from common.schema import ErrorDetail
 from common.signing import get_file_url, verify_signature
 from events.models import OrganizationMember, Ticket
 from events.service import ticket_file_service
@@ -95,7 +96,7 @@ class TicketWalletController(UserAwareController):
         summary="Download Apple Wallet pass via signed link",
         description="Auth-free pkpass download guarded by an HMAC signature and expiry; "
         "used by the Add to Apple Wallet badge in ticket emails.",
-        response={200: None, 403: None, 404: None, 410: None, 503: None},
+        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: None},
         auth=None,
     )
     def download_apple_pass_signed(
@@ -252,7 +253,7 @@ class MembershipWalletSignedController(UserAwareController):
         summary="Download Apple Wallet membership card via signed link",
         description="Auth-free pkpass download guarded by an HMAC signature and expiry; "
         "used by the Add to Apple Wallet badge in membership emails.",
-        response={200: None, 403: None, 404: None, 410: None, 503: None},
+        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: None},
         auth=None,
     )
     def download_apple_pass_signed(


### PR DESCRIPTION
Closes #826. Follow-up to #712 / #824.

## Summary

Two error statuses were reachable on nearly every route but declared on ~1% of them, and the 422 one could not be declared as `ErrorDetail` at all because ninja's request-validation body is `{detail: [...]}`, not `{detail: str}`.

| Status | Declared before | Declared after |
|---|---|---|
| 401 | 1 | 467 |
| 403 | 15 | 468 |
| 422 | 4 | 463 |

**Neither ninja 1.6.2 nor ninja-extra 0.31.6 has a default-responses option** (the issue assumed one exists). Each operation's responses come solely from its own `response=` mapping via `OpenAPISchema.responses()`. So the global mechanism is a schema-builder subclass, `api/openapi.py`, that the cached API class in `api/api.py` now instantiates:

- `ErrorDetail` at **401 and 403** on every operation with an auth class. Explicit per-endpoint declarations win.
- `RequestValidationError` at **422** on every operation that parses path/query/body params. Where an endpoint already declares a domain 422 (`HttpError(422)` / static handler → `{detail: str}`), both shapes are merged into an `anyOf`.

Schema-only by design: `operation.response_models` also drives runtime serialisation of `return status, obj` tuples, so it is deliberately untouched. **No behaviour change.**

## New schema

`RequestValidationError` with `detail: list[RequestValidationErrorItem]` (`type`, `loc`, `msg`, optional `ctx`), typed so the generated client narrows `loc`/`msg`. Pinned against ninja's live body in `TestRevivalAmountBound`. The frontend's `isErrorDetail` helper already rejects the list shape (its test cites this issue).

## Audit fold-in

The issue's table was partly stale. What actually changed:

| Endpoint | Was | Now | Why |
|---|---|---|---|
| `GET …/tickets/{ticket_id}/cancellation-preview` 403 | ResponseMessage | ErrorDetail | `HttpError(403)` |
| `POST …/tickets/{ticket_id}/cancel` 403, 502 | ResponseMessage | ErrorDetail | `HttpError` |
| `GET …/checkout/{payment_id}/resume` 404 | ResponseMessage | ErrorDetail | `HttpError(404)` |
| `GET …/{event_id}/tickets/{tier_id}/seats` 404 | ResponseMessage | ErrorDetail | `HttpError(404)` |
| `POST /api/series-passes/reservations/{id}/checkout-session` 404 | ResponseMessage | ErrorDetail | `HttpError(404)` |
| `GET /api/events/tokens/{token_id}` 404 | ResponseMessage | ResponseMessage \| ErrorDetail | genuinely returns `{message}`, but the 410 branch's `get_object_or_404` can also 404 with `{detail}` |
| `GET /api/organizations/tokens/{token_id}` 404 | ResponseMessage | unchanged | genuinely returns `{message}`; allowlisted |
| `POST/PUT /api/event-admin/{event_id}/ticket-tier[/{tier_id}]` 422 | ValidationErrorResponse | ErrorDetail | only producer is the static `BillingInfoRequiredError` handler (`{detail}`); nothing emits `{errors}` at 422 |
| `GET …/wallet/apple/signed` 403 (×2) | `None` | ErrorDetail | `HttpError(403, "Invalid link")` |

The two event reservation checkout-session endpoints already declared `ErrorDetail`. The media-validate 401 is a bare empty `HttpResponse`, so `None` stays honest there.

## Invariants (`api/tests/test_openapi_schema.py`)

- `test_subscription_controllers_never_declare_response_message` → widened repo-wide as `test_response_message_never_declared_on_error_responses_outside_allowlist`, allowlist = the two `claim-invitation` 400s + the two token 404s.
- New: every secured operation declares 401 and 403 as `ErrorDetail`.
- New: every parameterised operation's 422 contains `RequestValidationError`.
- New: the four domain-422 routes keep `{ErrorDetail, RequestValidationError}`.

## Not done / follow-ups

- The wallet controllers still declare 404/410/503 as `None` while their producers emit `{detail}` JSON. Pre-existing, outside the 403/422 scope; worth its own small issue.
- Frontend: regenerate the client after merge.

## Verification

- `make check` green (format, lint, mypy --strict, migrations, i18n, file-length, task-names)
- `api/tests/test_openapi_schema.py` + `TestRevivalAmountBound`: 13 passed
- Touched controllers' tests (event_public, tokens, wallet, series-pass checkout, ticket tiers, billing-info, cancellation, stripe checkout): 505 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API documentation now consistently describes authentication, authorization, and request-validation errors across operations.
  - Added a structured schema for 422 request-validation responses.

- **Bug Fixes**
  - Corrected documented error response formats across event, ticket, series-pass, and wallet endpoints.
  - Preserved endpoint-specific error details where multiple 422 response formats are supported.

- **Tests**
  - Expanded coverage to verify standardized 401, 403, 404, and 422 response schemas throughout the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->