### PR TITLE
fix(questionnaires): three live defects from the 2026-09-10 tech-debt sweep

### DIFF
--- a/src/events/controllers/questionnaire/questions.py
+++ b/src/events/controllers/questionnaire/questions.py
@@ -83,7 +83,7 @@ class QuestionnaireQuestionsMixin(QuestionnaireControllerBase):
     @route.post(
         "/{org_questionnaire_id}/multiple-choice-questions/{question_id}/options",
         url_name="create_mc_option",
-        response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
+        response=questionnaire_schema.MultipleChoiceOptionResponseSchema,
         permissions=[QuestionnairePermission("edit_questionnaire")],
     )
     def create_mc_option(
@@ -107,7 +107,7 @@ class QuestionnaireQuestionsMixin(QuestionnaireControllerBase):
     @route.put(
         "/{org_questionnaire_id}/multiple-choice-options/{option_id}",
         url_name="update_mc_option",
-        response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
+        response=questionnaire_schema.MultipleChoiceOptionResponseSchema,
         permissions=[QuestionnairePermission("edit_questionnaire")],
     )
     def update_mc_option(

--- a/src/events/service/event_questionnaire_service.py
+++ b/src/events/service/event_questionnaire_service.py
@@ -30,6 +30,7 @@ from events.schema.questionnaire import (
     ScoreStatsSchema,
     StatusBreakdownSchema,
 )
+from events.service.membership_questionnaire_service import approval_is_stale
 from questionnaires.models import (
     MultipleChoiceOption,
     Questionnaire,
@@ -113,6 +114,9 @@ def _validate_admission_resubmission(
 
     # Case 2: Already approved
     if evaluation.status == QuestionnaireEvaluation.QuestionnaireEvaluationStatus.APPROVED:
+        if approval_is_stale(org_questionnaire, evaluation):
+            # max_submission_age elapsed: the gate asks for a fresh submission again.
+            return
         raise HttpError(400, str(_("Your questionnaire has already been approved.")))
 
     # Case 3: Rejected - check retake eligibility

--- a/src/events/service/membership_questionnaire_service.py
+++ b/src/events/service/membership_questionnaire_service.py
@@ -112,7 +112,7 @@ def _validate_resubmission(*, user: RevelUser, org_questionnaire: OrganizationQu
         raise HttpError(400, str(_("You have a submission pending evaluation.")))
 
     if evaluation.status == statuses.APPROVED:
-        if _approval_is_stale(org_questionnaire, evaluation):
+        if approval_is_stale(org_questionnaire, evaluation):
             # max_submission_age elapsed: the gate asks for a fresh submission again.
             return
         raise HttpError(400, str(_("Your questionnaire has already been approved.")))
@@ -135,7 +135,7 @@ def _validate_resubmission(*, user: RevelUser, org_questionnaire: OrganizationQu
         raise HttpError(400, str(_("You can retry after %(retry_on)s.") % {"retry_on": retry_on}))
 
 
-def _approval_is_stale(
+def approval_is_stale(
     org_questionnaire: OrganizationQuestionnaire,
     evaluation: QuestionnaireEvaluation,
 ) -> bool:

--- a/src/events/tests/test_controllers/test_questionnaire/test_questions.py
+++ b/src/events/tests/test_controllers/test_questionnaire/test_questions.py
@@ -214,6 +214,8 @@ def test_create_mc_option_success(organization: Organization, organization_owner
     # Verify option was created
     option = MultipleChoiceOption.objects.get(question=question, option="New Option")
     assert option.is_correct is True
+    # The frontend reads ``id`` off this response to wire conditional questions (#956).
+    assert data["id"] == str(option.id)
 
 
 def test_create_mc_option_cross_questionnaire_404(

--- a/src/events/tests/test_service/test_event_questionnaire_resubmission.py
+++ b/src/events/tests/test_service/test_event_questionnaire_resubmission.py
@@ -584,3 +584,76 @@ class TestAdmissionResubmissionValidation:
             ).count()
             == 2
         )
+
+
+class TestAdmissionStaleApproval:
+    """An APPROVED evaluation older than ``max_submission_age`` must be resubmittable (#956).
+
+    The eligibility gate already reports such a submission as missing and asks the
+    user to complete the questionnaire again; refusing the resubmission here would
+    trap the user in an unrecoverable loop.
+    """
+
+    def test_allows_resubmission_when_approval_is_stale(
+        self,
+        eq_user: RevelUser,
+        eq_event: Event,
+        admission_org_questionnaire: OrganizationQuestionnaire,
+    ) -> None:
+        admission_org_questionnaire.max_submission_age = timedelta(days=30)
+        admission_org_questionnaire.save()
+        first_submission = QuestionnaireSubmission.objects.create(
+            questionnaire=admission_org_questionnaire.questionnaire,
+            user=eq_user,
+            status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+            submitted_at=timezone.now() - timedelta(days=60),
+        )
+        EventQuestionnaireSubmission.objects.create(
+            user=eq_user,
+            event=eq_event,
+            questionnaire=admission_org_questionnaire.questionnaire,
+            submission=first_submission,
+            questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.ADMISSION,
+        )
+        evaluation = QuestionnaireEvaluation.objects.create(
+            submission=first_submission,
+            status=QuestionnaireEvaluation.QuestionnaireEvaluationStatus.APPROVED,
+        )
+        # updated_at is auto_now; push it past the age window the way the gate measures it.
+        QuestionnaireEvaluation.objects.filter(pk=evaluation.pk).update(updated_at=timezone.now() - timedelta(days=60))
+
+        event_questionnaire_service._validate_admission_resubmission(
+            user=eq_user, event=eq_event, org_questionnaire=admission_org_questionnaire
+        )
+
+    def test_blocks_resubmission_when_approval_is_fresh(
+        self,
+        eq_user: RevelUser,
+        eq_event: Event,
+        admission_org_questionnaire: OrganizationQuestionnaire,
+    ) -> None:
+        admission_org_questionnaire.max_submission_age = timedelta(days=30)
+        admission_org_questionnaire.save()
+        first_submission = QuestionnaireSubmission.objects.create(
+            questionnaire=admission_org_questionnaire.questionnaire,
+            user=eq_user,
+            status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+            submitted_at=timezone.now(),
+        )
+        EventQuestionnaireSubmission.objects.create(
+            user=eq_user,
+            event=eq_event,
+            questionnaire=admission_org_questionnaire.questionnaire,
+            submission=first_submission,
+            questionnaire_type=OrganizationQuestionnaire.QuestionnaireType.ADMISSION,
+        )
+        QuestionnaireEvaluation.objects.create(
+            submission=first_submission,
+            status=QuestionnaireEvaluation.QuestionnaireEvaluationStatus.APPROVED,
+        )
+
+        with pytest.raises(HttpError) as exc_info:
+            event_questionnaire_service._validate_admission_resubmission(
+                user=eq_user, event=eq_event, org_questionnaire=admission_org_questionnaire
+            )
+        assert "already been approved" in str(exc_info.value.message)

--- a/src/polls/controllers/question_controller.py
+++ b/src/polls/controllers/question_controller.py
@@ -173,7 +173,7 @@ class PollQuestionController(UserAwareController):
     @route.post(
         "/{poll_id}/multiple-choice-questions/{question_id}/options",
         url_name="poll_create_mc_option",
-        response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
+        response=questionnaire_schema.MultipleChoiceOptionResponseSchema,
     )
     def create_mc_option(
         self,
@@ -194,7 +194,7 @@ class PollQuestionController(UserAwareController):
     @route.put(
         "/{poll_id}/multiple-choice-options/{option_id}",
         url_name="poll_update_mc_option",
-        response=questionnaire_schema.MultipleChoiceOptionUpdateSchema,
+        response=questionnaire_schema.MultipleChoiceOptionResponseSchema,
     )
     def update_mc_option(
         self,

--- a/src/polls/tests/test_controller_drift.py
+++ b/src/polls/tests/test_controller_drift.py
@@ -55,7 +55,12 @@ def _strip_parent_param(path: str, parent_param: str) -> str | None:
 
 
 def _collect_question_crud_routes(prefix: str, parent_param: str) -> set[tuple[str, str]]:
-    """Walk the registered API and return ``{(normalised_path, method), ...}``.
+    """Walk the registered API and return ``{(normalised_path, method), ...}``."""
+    return {(tail, method) for tail, method, _ in _collect_question_crud_operations(prefix, parent_param)}
+
+
+def _collect_question_crud_operations(prefix: str, parent_param: str) -> set[tuple[str, str, str]]:
+    """Walk the registered API and return ``{(normalised_path, method, response_schema), ...}``.
 
     ``parent_param`` is the path parameter name immediately under ``prefix``
     (e.g. ``poll_id`` or ``org_questionnaire_id``). It's stripped so the
@@ -63,7 +68,7 @@ def _collect_question_crud_routes(prefix: str, parent_param: str) -> set[tuple[s
     """
     from api.api import api
 
-    found: set[tuple[str, str]] = set()
+    found: set[tuple[str, str, str]] = set()
     for router_prefix, router in api._routers:
         if router_prefix != prefix:
             continue
@@ -74,8 +79,10 @@ def _collect_question_crud_routes(prefix: str, parent_param: str) -> set[tuple[s
             if not any(pattern.match(tail) for pattern in _SHARED_PATH_SHAPES):
                 continue
             for operation in path_view.operations:
+                response = operation.response_models.get(200)
+                response_name = response.__name__ if response is not None else "None"
                 for method in operation.methods:
-                    found.add((tail, method.upper()))
+                    found.add((tail, method.upper(), response_name))
     return found
 
 
@@ -108,6 +115,22 @@ def test_polls_and_org_questionnaire_question_crud_in_sync() -> None:
             + "\n  ".join(f"{method:6} {path}" for path, method in sorted(only_in_questionnaires))
         )
     assert not sections, "Question-CRUD endpoints drifted between controllers:\n\n" + "\n\n".join(sections)
+
+
+def test_polls_and_org_questionnaire_response_schemas_in_sync() -> None:
+    """Each shared route must declare the same ``response=`` schema on both controllers.
+
+    Path/method parity alone let both sides ship the option endpoints with a
+    response schema that dropped ``id`` (#956); comparing the declared 200
+    response catches a fix landing on one side only.
+    """
+    poll_ops = _collect_question_crud_operations(prefix="/polls", parent_param="poll_id")
+    org_ops = _collect_question_crud_operations(prefix="/questionnaires", parent_param="org_questionnaire_id")
+    assert poll_ops == org_ops, (
+        "Response schemas drifted between controllers:\n"
+        f"  only in polls: {sorted(poll_ops - org_ops)}\n"
+        f"  only in questionnaires: {sorted(org_ops - poll_ops)}"
+    )
 
 
 def test_drift_test_actually_finds_routes() -> None:

--- a/src/polls/tests/test_controllers_questions.py
+++ b/src/polls/tests/test_controllers_questions.py
@@ -117,7 +117,9 @@ def test_create_mc_option(owner_client: Client, draft_poll: Poll) -> None:
         content_type="application/json",
     )
     assert response.status_code == 200, response.content
-    assert MultipleChoiceOption.objects.filter(question_id=question_id, option="c").exists()
+    option = MultipleChoiceOption.objects.get(question_id=question_id, option="c")
+    # The frontend reads ``id`` off this response to wire conditional questions (#956).
+    assert response.json()["id"] == str(option.id)
 
 
 def test_create_ft_question(owner_client: Client, draft_poll: Poll) -> None:

--- a/src/questionnaires/llms/llm_backends.py
+++ b/src/questionnaires/llms/llm_backends.py
@@ -155,7 +155,7 @@ class BaseLLMEvaluator(FreeTextEvaluator):
                 question_id=item.question_id,
                 question_text=self._escape_jinja2(item.question_text),
                 answer_text=self._escape_jinja2(item.answer_text),
-                guidelines=self._escape_jinja2(item.guidelines),
+                guidelines=self._escape_jinja2(item.guidelines) if item.guidelines else None,
             )
             for item in questions_to_evaluate
         ]

--- a/src/questionnaires/llms/llm_interfaces.py
+++ b/src/questionnaires/llms/llm_interfaces.py
@@ -12,7 +12,7 @@ class AnswerToEvaluate(BaseModel):
     question_id: UUID = Field(..., description="The unique ID of the question being answered.")
     question_text: str
     answer_text: str
-    guidelines: str
+    guidelines: str | None = None
 
 
 class EvaluationResult(BaseModel):

--- a/src/questionnaires/tests/test_evaluator.py
+++ b/src/questionnaires/tests/test_evaluator.py
@@ -516,3 +516,22 @@ def test_free_text_evaluation_tolerates_question_without_llm_guidelines(
     evaluation = SubmissionEvaluator(submission=submitted_submission, llm_evaluator=mock_evaluator).evaluate()
 
     assert evaluation.evaluation_data.ft_points_scored == Decimal("1.0")
+
+
+@pytest.mark.django_db
+def test_free_text_rejection_without_llm_guidelines_scores_zero(
+    submitted_submission: QuestionnaireSubmission,
+    mock_evaluator: MockEvaluator,
+) -> None:
+    """A rejected answer on a guideline-less question records zero free-text points (#956)."""
+    submitted_submission.questionnaire.evaluation_mode = Questionnaire.QuestionnaireEvaluationMode.AUTOMATIC
+    submitted_submission.questionnaire.save()
+    question = FreeTextQuestion.objects.create(
+        questionnaire=submitted_submission.questionnaire, question="Why?", order=1, llm_guidelines=None
+    )
+    FreeTextAnswer.objects.create(submission=submitted_submission, question=question, answer="Because.")
+
+    evaluation = SubmissionEvaluator(submission=submitted_submission, llm_evaluator=mock_evaluator).evaluate()
+
+    assert evaluation.evaluation_data.ft_points_scored == Decimal("0.0")
+    assert evaluation.status == QuestionnaireEvaluation.QuestionnaireEvaluationStatus.REJECTED

--- a/src/questionnaires/tests/test_evaluator.py
+++ b/src/questionnaires/tests/test_evaluator.py
@@ -494,3 +494,25 @@ def test_non_applicable_questions_not_counted_in_max_points(
     assert evaluation.evaluation_data.max_mc_points == Decimal("4.0")
     assert evaluation.evaluation_data.mc_points_scored == Decimal("4.0")  # Q1 + Q2 answered correctly
     assert evaluation.score == Decimal("100.00")
+
+
+@pytest.mark.django_db
+def test_free_text_evaluation_tolerates_question_without_llm_guidelines(
+    submitted_submission: QuestionnaireSubmission,
+    mock_evaluator: MockEvaluator,
+) -> None:
+    """A free-text question with ``llm_guidelines=None`` must still evaluate (#956).
+
+    The model allows NULL and the create schema defaults to it, so a guideline-less
+    question is the common case, not an edge case.
+    """
+    submitted_submission.questionnaire.evaluation_mode = Questionnaire.QuestionnaireEvaluationMode.AUTOMATIC
+    submitted_submission.questionnaire.save()
+    question = FreeTextQuestion.objects.create(
+        questionnaire=submitted_submission.questionnaire, question="Why?", order=1, llm_guidelines=None
+    )
+    FreeTextAnswer.objects.create(submission=submitted_submission, question=question, answer="Because it is good.")
+
+    evaluation = SubmissionEvaluator(submission=submitted_submission, llm_evaluator=mock_evaluator).evaluate()
+
+    assert evaluation.evaluation_data.ft_points_scored == Decimal("1.0")


### PR DESCRIPTION
Closes #956

Independently re-verified findings 1–3 of the 2026-09-10 tech-debt report against `main`, then fixed each test-first.

## Changes

**1. Null per-question LLM guidelines crashed automatic evaluation**
- `AnswerToEvaluate.guidelines` → `str | None = None`; the OpenAI backend only escapes it when present (the per-question template already guards with `{% if response.guidelines %}`).
- Regression: `test_free_text_evaluation_tolerates_question_without_llm_guidelines` (reproduced the pydantic `string_type` error before the fix).

**2. Admission-questionnaire staleness deadlock**
- `_validate_admission_resubmission` gains the same stale-approval branch the membership path has. `_approval_is_stale` is renamed `approval_is_stale` and imported, not copied.
- Regression: `TestAdmissionStaleApproval` (stale → allowed, fresh → still 400 "already approved").
- The wider retake/staleness policy extraction (report finding 12) is intentionally out of scope.

**3. MC-option create/update responses dropped `id`**
- All four routes (`polls` + `questionnaires`, POST + PUT) now declare `MultipleChoiceOptionResponseSchema`.
- `test_controller_drift.py` gains `test_polls_and_org_questionnaire_response_schemas_in_sync` so a one-sided fix can't land again.
- Existing create-option tests now assert `id` in the body. `.artifacts/openapi.json` regenerated (gitignored).

## Verification
- `make check` green.
- 196 passed across the questionnaire/poll/event-questionnaire test files plus `test_error_response_contracts.py`.

## Follow-up (frontend)
`pnpm generate:api`, then drop the `(response.data as { id?: string })` casts in `poll-api-sync-questions.ts` and `questionnaire-api-sync-questions.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approved questionnaire submissions can be resubmitted after their configured approval period expires.
  * Multiple-choice option responses now consistently include the created option’s ID.
  * Automatic evaluation supports free-text questions without item-specific guidelines.

* **Bug Fixes**
  * Freshly approved submissions remain protected from duplicate resubmission.
  * Improved handling of optional evaluation guidelines.
  * Synchronized response formats across questionnaire and poll question endpoints.

* **Tests**
  * Added coverage for stale approvals, response IDs, endpoint consistency, and guideline-free evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->