### PR TITLE
refactor(stripe): centralize stripe-python init in configure_stripe()

### DIFF
--- a/docs/engineering-notes.md
+++ b/docs/engineering-notes.md
@@ -258,8 +258,9 @@ preview (`build_event_refund_preview`, which calls `stripe.Balance.retrieve`) ta
 locks at all — it is read-only and racy by design.
 
 **Mitigation:** `STRIPE_HTTP_TIMEOUT_SECONDS` (`revel/settings/stripe.py`, default 15,
-configured on `stripe.default_http_client` in `stripe_service`/`stripe_webhooks` and every
-other module that pins `stripe.api_key` at import) bounds stripe-python's own HTTP timeout,
+configured on `stripe.default_http_client` by
+`common/service/stripe_config.py::configure_stripe`, which every module making an outbound
+stripe-python call invokes at import) bounds stripe-python's own HTTP timeout,
 which otherwise defaults to ~80s. `ATOMIC_REQUESTS` (see above) keeps the request's DB
 transaction — and with it the row lock and the PgBouncer connection it's pinned to for the
 transaction's lifetime (see the transaction-pooling note above) — open for as long as the

--- a/src/accounts/tasks/payouts.py
+++ b/src/accounts/tasks/payouts.py
@@ -14,16 +14,13 @@ from django.utils.translation import gettext as _
 
 from accounts.models import Referral, ReferralPayout, ReferralPayoutStatement, RevelUser
 from common.models import SiteSettings
+from common.service.stripe_config import configure_stripe
 from common.tasks import send_email
 from events.utils.currency import to_stripe_amount
 
 logger = structlog.get_logger(__name__)
 
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 def _reclaim_stale_payouts() -> None:

--- a/src/common/service/stripe_config.py
+++ b/src/common/service/stripe_config.py
@@ -1,0 +1,23 @@
+"""Process-wide stripe-python configuration.
+
+See docs/engineering-notes.md "Row locks across Stripe calls" for why the HTTP
+timeout in particular matters.
+"""
+
+import stripe
+from django.conf import settings
+
+
+def configure_stripe() -> None:
+    """Pin credentials, API version and the HTTP timeout on the ``stripe`` module.
+
+    Called at import time by every module that makes an outbound stripe-python call, so no
+    module depends on another module's import side effects. The pinned API version guards
+    outbound response shapes against silent changes when the stripe SDK (whose default version
+    tracks its release) gets bumped by a ``uv sync``. The three attributes are process-wide, so
+    repeated calls are idempotent.
+    """
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    stripe.api_version = settings.STRIPE_API_VERSION
+    # Bound every outbound call's HTTP timeout (stripe-python's own default is ~80s).
+    stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)

--- a/src/common/service/stripe_connect_service.py
+++ b/src/common/service/stripe_connect_service.py
@@ -9,20 +9,16 @@ import typing as t
 
 import stripe
 import structlog
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 from pydantic import EmailStr
 
 from common.models import StripeConnectMixin
+from common.service.stripe_config import configure_stripe
 
 logger = structlog.get_logger(__name__)
 
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 def get_account_details(account_id: str) -> stripe.Account:

--- a/src/events/management/commands/provision_stripe_webhooks.py
+++ b/src/events/management/commands/provision_stripe_webhooks.py
@@ -24,6 +24,8 @@ import stripe
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
+from common.service.stripe_config import configure_stripe
+
 # Must stay in sync with the dispatch map in
 # events/service/stripe_webhooks.py::StripeEventHandler.handle — Stripe only
 # delivers events you subscribe to.
@@ -101,11 +103,7 @@ class Command(BaseCommand):
             self.stdout.write(f"Would create Connect endpoint at {url}: {', '.join(CONNECT_EVENTS)}")
             return
 
-        stripe.api_key = settings.STRIPE_SECRET_KEY
-        stripe.api_version = settings.STRIPE_API_VERSION
-        # Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-        # another module's import to configure stripe.default_http_client.
-        stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+        configure_stripe()
 
         existing = [ep for ep in stripe.WebhookEndpoint.list(limit=100).auto_paging_iter() if ep.url == url]
         if existing and not options["force"]:

--- a/src/events/management/commands/scrub_stripe_products.py
+++ b/src/events/management/commands/scrub_stripe_products.py
@@ -23,14 +23,11 @@ import stripe
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
 
+from common.service.stripe_config import configure_stripe
 from events.models import MembershipSubscriptionPlan, Organization
 from events.service.subscription_stripe_payloads import StripeAccountKwargs, _stripe_account_kwargs
 
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 # Prefixes of the legacy organizer-authored product names → generic replacement.
 _PREFIX_TO_GENERIC: dict[str, str] = {

--- a/src/events/service/pending_checkout.py
+++ b/src/events/service/pending_checkout.py
@@ -22,20 +22,13 @@ from ninja.errors import HttpError
 from stripe.checkout import Session
 
 from accounts.models import RevelUser
+from common.service.stripe_config import configure_stripe
 from events.models import Payment, Ticket, TicketTier
 from events.service.waitlist_service import enqueue_waitlist_processing
 
 logger = structlog.get_logger(__name__)
 
-# Pin both credentials and API version at import time (mirrors stripe_service).
-# This module makes its own outbound call (Session.retrieve in
-# resume_pending_checkout), so it must not rely on another module's import
-# side effects to set the pin.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 def _release_batch_tier_capacity(ticket_ids: list[UUID]) -> None:

--- a/src/events/service/stripe_service.py
+++ b/src/events/service/stripe_service.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from uuid import UUID
 
-import stripe
 import structlog
 from django.conf import settings
 from django.db import transaction
@@ -17,6 +16,7 @@ from stripe.checkout import Session
 from accounts.models import RevelUser
 from common.models import SiteSettings
 from common.service.exchange_rate_service import convert as convert_currency
+from common.service.stripe_config import configure_stripe
 from common.service.stripe_connect_service import (
     create_account_link as _create_account_link,
 )
@@ -76,15 +76,7 @@ if t.TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-# Pin both credentials and API version at import time. The pinned version
-# guards outbound response shapes against silent changes when the stripe SDK
-# (whose default version tracks its release) gets bumped by a `uv sync`.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Bound every outbound call's HTTP timeout (stripe-python's own default is
-# ~80s) — see docs/engineering-notes.md "Row locks across Stripe calls" for
-# why this matters on the refund paths that hold a row lock across the call.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 def create_connect_account(organization: Organization, stripe_account_email: EmailStr) -> str:

--- a/src/events/service/stripe_webhooks.py
+++ b/src/events/service/stripe_webhooks.py
@@ -14,6 +14,7 @@ from django.db.models import F
 
 from accounts.models import RevelUser
 from common.models import StripeConnectMixin
+from common.service.stripe_config import configure_stripe
 from events.exceptions import InvalidStripeWebhookSignatureError, SessionTotalMismatchError
 from events.models import (
     HeldSeriesPass,
@@ -37,14 +38,7 @@ from notifications.signals.series_pass import send_series_pass_purchased
 logger = structlog.get_logger(__name__)
 
 
-# Pin both credentials and API version at import time (mirrors stripe_service).
-# This module makes its own outbound call (Refund.list in _resolve_refunds), so
-# it must not rely on another module's import side effects to set the pin.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 # Placeholder values that must never be treated as real signing secrets.
 _PLACEHOLDER_SECRETS = frozenset({"whsec_...", "whsec_placeholder", ""})

--- a/src/events/service/subscription_stripe_base.py
+++ b/src/events/service/subscription_stripe_base.py
@@ -8,24 +8,17 @@ extracted so the two can depend on this module instead of on each other.
 
 import stripe
 import structlog
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
+from common.service.stripe_config import configure_stripe
 from events.models import MembershipSubscriptionPlan, Organization
 from events.service.subscription_stripe_payloads import _stripe_account_kwargs, stripe_interval
 from events.utils.currency import to_stripe_amount
 
 logger = structlog.get_logger(__name__)
 
-# Pin both credentials and API version at import time (mirrors stripe_service):
-# this module makes its own outbound calls and must not rely on another
-# module's import side effects to set the pin.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 def _require_stripe_connected(organization: Organization) -> None:

--- a/src/events/service/subscription_stripe_payloads.py
+++ b/src/events/service/subscription_stripe_payloads.py
@@ -17,18 +17,12 @@ import stripe
 import structlog
 from django.conf import settings
 
+from common.service.stripe_config import configure_stripe
 from events.models import Organization
 
 logger = structlog.get_logger(__name__)
 
-# Pin both credentials and API version at import time (mirrors stripe_service):
-# this module makes its own outbound call (Invoice.retrieve) and must not rely
-# on another module's import side effects to set the pin.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 class StripeAccountKwargs(t.TypedDict, total=False):

--- a/src/events/service/subscription_stripe_service.py
+++ b/src/events/service/subscription_stripe_service.py
@@ -22,6 +22,7 @@ from ninja.errors import HttpError
 
 from accounts.models import RevelUser
 from common.models import SiteSettings
+from common.service.stripe_config import configure_stripe
 from common.service.vat_utils import b2b_vat_context
 from common.utils import get_or_create_with_race_protection
 from events.exceptions import SubscriptionActivationPendingError
@@ -49,14 +50,7 @@ from events.service.subscription_stripe_plan_change import (
 
 logger = structlog.get_logger(__name__)
 
-# Pin both credentials and API version at import time (mirrors stripe_service):
-# this module makes its own outbound calls and must not rely on another
-# module's import side effects to set the pin.
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 # ---- Customer profile --------------------------------------------------------

--- a/src/events/service/subscription_stripe_sync.py
+++ b/src/events/service/subscription_stripe_sync.py
@@ -11,14 +11,13 @@ import typing as t
 from datetime import datetime
 from decimal import Decimal
 
-import stripe
 import structlog
-from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
 from common.models import SiteSettings
+from common.service.stripe_config import configure_stripe
 from common.service.vat_utils import b2b_fee_vat_from_gross
 from common.utils import get_or_create_with_race_protection
 from events.models import (
@@ -45,12 +44,7 @@ from events.utils.currency import from_stripe_amount
 
 logger = structlog.get_logger(__name__)
 
-# Pin credentials + API version at import time (mirrors subscription_stripe_service).
-stripe.api_key = settings.STRIPE_SECRET_KEY
-stripe.api_version = settings.STRIPE_API_VERSION
-# Same reasoning for the HTTP timeout (see stripe_service): don't rely on
-# another module's import to configure stripe.default_http_client.
-stripe.default_http_client = stripe.RequestsClient(timeout=settings.STRIPE_HTTP_TIMEOUT_SECONDS)
+configure_stripe()
 
 
 # ---- Webhook helpers --------------------------------------------------------

--- a/src/events/tests/test_service/test_stripe_http_client_config.py
+++ b/src/events/tests/test_service/test_stripe_http_client_config.py
@@ -1,23 +1,60 @@
-"""Pin the global Stripe HTTP timeout config (issue #865 follow-up).
+"""Pin the process-wide stripe-python configuration.
 
-Every module that pins ``stripe.api_key``/``stripe.api_version`` at import
-time also configures ``stripe.default_http_client`` with
-``settings.STRIPE_HTTP_TIMEOUT_SECONDS``, so no outbound stripe-python call
-(refund paths in particular — see docs/engineering-notes.md "Row locks
-across Stripe calls") can hang anywhere near stripe-python's own ~80s
-default. Importing either of the two primary sites is enough to prove the
-client is configured, since ``stripe.default_http_client`` is a single
-process-wide attribute on the ``stripe`` module.
+Every module that makes an outbound stripe-python call routes its setup through
+``common.service.stripe_config.configure_stripe``, which pins ``stripe.api_key``,
+``stripe.api_version`` and a ``stripe.default_http_client`` bounded by
+``settings.STRIPE_HTTP_TIMEOUT_SECONDS`` — so no call (refund paths in particular, see
+docs/engineering-notes.md "Row locks across Stripe calls") can hang anywhere near
+stripe-python's own ~80s default, and no module depends on another module's import side
+effects.
 """
 
+import importlib
+
+import pytest
 import stripe
 from django.conf import settings
 
-# Import side effect under test.
-from events.service import stripe_service, stripe_webhooks  # noqa: F401
+from common.service.stripe_config import configure_stripe
+
+# Import side effect under test (a module that configures at import time).
+from events.service import stripe_service  # noqa: F401
+
+# Every module that configures stripe-python. All but provision_stripe_webhooks do it at
+# import time; that command calls configure_stripe() inside handle(), after the --dry-run
+# early return, so a dry run stays free of any Stripe setup.
+STRIPE_CONFIGURING_MODULES = [
+    "accounts.tasks.payouts",
+    "common.service.stripe_connect_service",
+    "events.management.commands.provision_stripe_webhooks",
+    "events.management.commands.scrub_stripe_products",
+    "events.service.pending_checkout",
+    "events.service.stripe_service",
+    "events.service.stripe_webhooks",
+    "events.service.subscription_stripe_base",
+    "events.service.subscription_stripe_payloads",
+    "events.service.subscription_stripe_service",
+    "events.service.subscription_stripe_sync",
+]
+
+
+@pytest.mark.parametrize("module_path", STRIPE_CONFIGURING_MODULES)
+def test_module_routes_stripe_setup_through_configure_stripe(module_path: str) -> None:
+    """Each stripe-calling module imports the shared helper (lint proves it also uses it)."""
+    module = importlib.import_module(module_path)
+    assert getattr(module, "configure_stripe", None) is configure_stripe
 
 
 def test_default_http_client_is_configured_with_the_settings_timeout() -> None:
-    """``stripe.default_http_client`` is a ``RequestsClient`` pinned to the setting."""
+    """Importing a configuring module is enough: the client is pinned to the setting."""
+    assert isinstance(stripe.default_http_client, stripe.RequestsClient)
+    assert stripe.default_http_client._timeout == settings.STRIPE_HTTP_TIMEOUT_SECONDS
+
+
+def test_configure_stripe_pins_credentials_and_api_version() -> None:
+    """``configure_stripe`` sets all three process-wide attributes and is idempotent."""
+    configure_stripe()
+    assert stripe.api_key == settings.STRIPE_SECRET_KEY
+    assert stripe.api_version == settings.STRIPE_API_VERSION
     assert isinstance(stripe.default_http_client, stripe.RequestsClient)
     assert stripe.default_http_client._timeout == settings.STRIPE_HTTP_TIMEOUT_SECONDS

--- a/src/revel/settings/stripe.py
+++ b/src/revel/settings/stripe.py
@@ -28,8 +28,8 @@ STRIPE_API_VERSION = config("STRIPE_API_VERSION", default="2026-03-25.dahlia")
 STRIPE_WEBHOOK_EVENT_RETENTION_DAYS = config("STRIPE_WEBHOOK_EVENT_RETENTION_DAYS", cast=int, default=90)
 STRIPE_ACCOUNT = config("STRIPE_ACCOUNT", default="test_...")
 # Bounds every outbound stripe-python call (stripe-python's own default is
-# ~80s). Applied globally via stripe.default_http_client — see stripe_service
-# / stripe_webhooks for where it's configured.
+# ~80s). Applied globally via stripe.default_http_client in
+# common/service/stripe_config.py::configure_stripe.
 STRIPE_HTTP_TIMEOUT_SECONDS = config("STRIPE_HTTP_TIMEOUT_SECONDS", cast=int, default=15)
 # Note: minimum 30 minutes
 PAYMENT_DEFAULT_EXPIRY_MINUTES = config("PAYMENT_DEFAULT_EXPIRY_MINUTES", cast=int, default=45)


### PR DESCRIPTION
Tech-debt sweep finding 14.

The identical stripe.api_key / stripe.api_version / stripe.default_http_client
triple was copy-pasted across 11 modules, each with its own near-identical
comment block. History shows the cost: #870 had to edit 5 files to add
default_http_client, and #493 propagated api_version the same way.

Add common/service/stripe_config.py::configure_stripe(), a leaf helper that
pins credentials, the API version and the timeout-bounded RequestsClient, and
call it from all 11 sites. The attributes are process-wide, so the call is
idempotent and every module stays independent of another module's import side
effects. provision_stripe_webhooks keeps its call inside handle(), after the
--dry-run early return, so a dry run still makes no Stripe setup.

Ruff's autofix dropped the `import stripe` / `from django.conf import settings`
lines that this change orphaned in four modules.

Extend the pinning test to parametrize over all 11 modules so a dropped call is
caught, and redirect the two stale "where is this configured" pointers in
revel/settings/stripe.py and docs/engineering-notes.md at the new module.

Prerequisite for the subscription-package PR (#972), which moves four of these modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
