### PR TITLE
fix(notifications): replace legacy #2196F3 with the brand token in email HTML

### DIFF
--- a/src/accounts/tests/test_account_email_branding.py
+++ b/src/accounts/tests/test_account_email_branding.py
@@ -5,6 +5,8 @@ import typing as t
 import pytest
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
+
 pytestmark = pytest.mark.django_db
 
 TEMPLATES = [
@@ -23,7 +25,6 @@ TEMPLATES = [
     "data_export_failed",
     "data_export_failed_admin",
 ]
-LEGACY = ("#667eea", "#764ba2", "#28a745", "#2196F3", "#3498db")
 
 
 @pytest.mark.parametrize("base", TEMPLATES)
@@ -41,7 +42,7 @@ def test_account_email_branded(base: str) -> None:
     }
     html = render_to_string(f"accounts/emails/{base}_body.html", ctx)
     assert "revel-email-logo.png" in html, f"{base} not on branded base"
-    for legacy in LEGACY:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"{base} still has {legacy}"
     # The two content-bearing templates must actually render their key value
     # (guards against context-key drift like download_link vs download_url).

--- a/src/common/tests/branding.py
+++ b/src/common/tests/branding.py
@@ -1,0 +1,14 @@
+"""Shared banned-hex list for the email/PDF branding guard tests (see docs/brand-style-guide.md)."""
+
+# Pre-rebrand accents that must never reappear in rendered output. Union of the
+# per-file tuples the branding guards used to each declare on their own.
+LEGACY_BRAND_HEXES = (
+    "#2196F3",
+    "#28a745",
+    "#3498db",
+    "#4CAF50",
+    "#667eea",
+    "#764ba2",
+    "#dc3545",
+    "#ff9800",
+)

--- a/src/common/tests/test_email_base_template.py
+++ b/src/common/tests/test_email_base_template.py
@@ -3,6 +3,8 @@ import typing as t
 import pytest
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
+
 pytestmark = pytest.mark.django_db
 
 CTX: dict[str, t.Any] = {"frontend_base_url": "https://letsrevel.io", "context": {}}
@@ -17,5 +19,5 @@ def test_base_has_brand_gradient_and_logo() -> None:
 
 def test_base_has_no_legacy_colors() -> None:
     html = render_to_string("emails/_test_probe.html", CTX)
-    for legacy in ("#667eea", "#764ba2", "#28a745", "#2196F3"):
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"legacy color {legacy} leaked into base"

--- a/src/common/tests/test_invoice_branding.py
+++ b/src/common/tests/test_invoice_branding.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 
 from common.service.invoice_utils import render_pdf
+from common.tests.branding import LEGACY_BRAND_HEXES
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -185,8 +186,6 @@ _TEMPLATES_AND_CONTEXTS: list[tuple[str, dict[str, t.Any]]] = [
     ("invoices/referral_payout_statement.html", _REFERRAL_CTX),
 ]
 
-_LEGACY_ACCENTS = ("#667eea", "#764ba2")
-
 
 @pytest.mark.parametrize("tpl,ctx", _TEMPLATES_AND_CONTEXTS, ids=[t_[0] for t_ in _TEMPLATES_AND_CONTEXTS])
 def test_invoice_template_branding(tpl: str, ctx: dict[str, t.Any]) -> None:
@@ -202,7 +201,7 @@ def test_invoice_template_branding(tpl: str, ctx: dict[str, t.Any]) -> None:
     body_html = html.split("<body", 1)[1]
     assert "revel-logo.png" in body_html, f"{tpl}: brand logo is not in <body> — WeasyPrint would render it invisible"
 
-    for legacy in _LEGACY_ACCENTS:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"{tpl}: still contains legacy accent {legacy}"
 
 

--- a/src/common/tests/test_standalone_email_branding.py
+++ b/src/common/tests/test_standalone_email_branding.py
@@ -3,6 +3,8 @@ import typing as t
 import pytest
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
+
 pytestmark = pytest.mark.django_db
 
 TEMPLATES = [
@@ -11,7 +13,6 @@ TEMPLATES = [
     "events/emails/organization_contact_message_body.html",
     "events/emails/organization_contact_email_verification_body.html",
 ]
-LEGACY = ("#667eea", "#764ba2", "#28a745", "#2196F3", "#3498db")
 
 
 @pytest.mark.parametrize("tpl", TEMPLATES)
@@ -28,5 +29,5 @@ def test_standalone_email_branded(tpl: str) -> None:
     }
     html = render_to_string(tpl, ctx)
     assert "revel-email-logo.png" in html, f"{tpl} not on branded base"
-    for legacy in LEGACY:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"{tpl} still has {legacy}"

--- a/src/events/tests/test_branded_body_emails.py
+++ b/src/events/tests/test_branded_body_emails.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
+
 pytestmark = pytest.mark.django_db
 
 HTML_TEMPLATES = [
@@ -17,8 +19,6 @@ HTML_TEMPLATES = [
     "events/emails/platform_fee_invoice_email.html",
     "accounts/emails/referral_payout_email.html",
 ]
-
-LEGACY_HEX = ("#667eea", "#764ba2", "#28a745", "#2196F3")
 
 
 @pytest.mark.parametrize("tpl", HTML_TEMPLATES)
@@ -35,7 +35,7 @@ def test_branded_body_email(tpl: str) -> None:
     }
     html = render_to_string(tpl, ctx)
     assert "revel-email-logo.png" in html, f"{tpl}: logo missing"
-    for legacy in LEGACY_HEX:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"{tpl}: legacy hex {legacy} found"
 
 

--- a/src/events/tests/test_revenue_report_branding.py
+++ b/src/events/tests/test_revenue_report_branding.py
@@ -14,6 +14,8 @@ import pytest
 from django.conf import settings
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
+
 # ---------------------------------------------------------------------------
 # Helpers — minimal context stubs
 # ---------------------------------------------------------------------------
@@ -63,8 +65,6 @@ _CTX: dict[str, t.Any] = {
     "org": _SCOPE.org,
 }
 
-_LEGACY_ACCENTS = ("#667eea", "#2196F3")
-
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -105,5 +105,5 @@ def test_revenue_report_logo_in_body() -> None:
 def test_revenue_report_no_legacy_accents() -> None:
     """Rendered HTML must not contain any legacy accent hex values."""
     html = render_to_string("reports/revenue_vat_report.html", _CTX)
-    for legacy in _LEGACY_ACCENTS:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"Still contains legacy accent {legacy}"

--- a/src/notifications/tests/test_email_templates_branding.py
+++ b/src/notifications/tests/test_email_templates_branding.py
@@ -4,11 +4,25 @@ import pytest
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 
+from common.tests.branding import LEGACY_BRAND_HEXES
 from notifications.enums import NotificationType
+from notifications.utils import get_formatted_context_for_template
 
 pytestmark = pytest.mark.django_db
 
-LEGACY = ("#667eea", "#764ba2", "#28a745", "#4CAF50", "#dc3545", "#2196F3", "#ff9800")
+HEARTY_PURPLE = "#8C3CDD"
+
+# Raw context that exercises every Python-generated HTML fragment in notifications.utils:
+# the org signature (with logo) and the event link/button.
+RAW_CONTEXT: dict[str, t.Any] = {
+    "events_count": 1,
+    "new_event_count": 1,
+    "organization_name": "Org",
+    "organization_slug": "org",
+    "organization_logo_url": "https://letsrevel.io/logo.png",
+    "event_name": "E",
+    "event_id": "00000000-0000-0000-0000-000000000000",
+}
 
 
 @pytest.mark.parametrize("ntype", list(NotificationType))
@@ -17,15 +31,26 @@ def test_email_template_extends_base_and_has_no_legacy_hex(ntype: NotificationTy
     # Provide events_count/new_event_count as numbers so blocktranslate count works in
     # series_events_generated / series_pass_extended. All other context keys default to
     # falsy values which templates handle via {% if %} guards.
+    # The context is enriched exactly like the real render path (service/templates/base.py)
+    # so the Python-generated fragments injected via |safe are scanned too.
     ctx: dict[str, t.Any] = {
         "frontend_base_url": "https://letsrevel.io",
         "user": None,
-        "context": {"events_count": 1, "new_event_count": 1},
+        "context": get_formatted_context_for_template(RAW_CONTEXT),
     }
     try:
         html = render_to_string(tpl, ctx)
     except TemplateDoesNotExist:
         pytest.skip(f"no html template for {ntype}")
     assert "revel-email-logo.png" in html, f"{tpl} not using branded base"
-    for legacy in LEGACY:
+    for legacy in LEGACY_BRAND_HEXES:
         assert legacy not in html, f"{tpl} still contains legacy {legacy}"
+
+
+def test_python_generated_email_fragments_have_no_legacy_hex() -> None:
+    """Guard the HTML built in notifications.utils, which no template literal covers."""
+    enriched = get_formatted_context_for_template(RAW_CONTEXT)
+    for key in ("org_signature_html", "event_button_html", "event_link_html"):
+        for legacy in LEGACY_BRAND_HEXES:
+            assert legacy not in enriched[key], f"{key} still contains legacy {legacy}"
+        assert HEARTY_PURPLE in enriched[key], f"{key} does not use the brand token"

--- a/src/notifications/utils.py
+++ b/src/notifications/utils.py
@@ -9,6 +9,10 @@ from django.utils import timezone, translation
 
 ChannelType = t.Literal["email", "markdown", "telegram"]
 
+# Brand primary (docs/brand-style-guide.md); mirrors the `a { color: … }` rule in
+# common/templates/emails/base.html so inline styles don't override the brand token.
+_HEARTY_PURPLE = "#8C3CDD"
+
 _MARKDOWN_SPECIAL_CHARS = re.compile(r"([\[\]()\\`*_{}##+\-!|~>])")
 
 
@@ -90,7 +94,7 @@ def format_org_signature(
             logo_style = "height: 32px; margin-right: 8px; vertical-align: middle;"
             logo_html = f'<img src="{html.escape(logo_url)}" alt="{safe_name}" style="{logo_style}">'
 
-        link_style = "color: #2196F3; text-decoration: none;"
+        link_style = f"color: {_HEARTY_PURPLE}; text-decoration: none;"
         escaped_url = html.escape(org_url)
         return f'<p style="margin: 0;">{logo_html}<a href="{escaped_url}" style="{link_style}">{safe_name}</a></p>'
 
@@ -127,12 +131,14 @@ def format_event_link(
 
     if channel == "email":
         if button:
+            # Solid-purple fallback for clients that strip <style>; the .button class in
+            # emails/base.html upgrades this to the vertical brand gradient where supported.
             button_style = (
-                "display: inline-block; padding: 12px 24px; background: #2196F3; "
+                f"display: inline-block; padding: 12px 24px; background: {_HEARTY_PURPLE}; "
                 "color: white; text-decoration: none; border-radius: 4px; margin: 10px 0;"
             )
             return f'<a href="{event_url}" class="button" style="{button_style}">View Event Details</a>'
-        link_style = "color: #2196F3; text-decoration: none;"
+        link_style = f"color: {_HEARTY_PURPLE}; text-decoration: none;"
         safe_name = html.escape(event_name)
         return f'<a href="{event_url}" style="{link_style}">{safe_name}</a>'
 


### PR DESCRIPTION
Tech-debt sweep finding 10.

format_org_signature and format_event_link built inline styles with the
legacy Material blue #2196F3. The org signature ships in production: it is
injected into emails/base.html and _footer.html via
{{ context.org_signature_html|safe }}, where the inline blue overrode the
base template's brand rule `a { color:#8C3CDD; }`.

All three occurrences now use a single _HEARTY_PURPLE constant (#8C3CDD,
docs/brand-style-guide.md). The event button keeps its `class="button"`
gradient and uses solid purple only as the inline fallback for clients that
strip <style>; Light Crimson is avoided because white on it fails AA for
normal text.

The branding guard missed this because it rendered templates with a stub
context lacking organization_name/slug, so the Python-generated fragment
never reached the scanned HTML. The parametrized test now builds its context
through get_formatted_context_for_template(), and a new unit guard covers
org_signature_html, event_button_html and event_link_html directly; the
latter two have no template consumer at all.

Seven branding guards each carried their own near-duplicate banned-hex tuple
(2 to 7 entries, no two alike), so a colour banned in one app was silently
allowed in another. They now share LEGACY_BRAND_HEXES from the new
common/tests/branding.py, the deduplicated union of all variants, following
the existing convention for shared test helpers (vies_test_utils,
oidc_helpers, fake_provider). Every guard asserts a strict superset of what
it did before and all still pass.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
