### PR TITLE
feat(wallet): 503 handlers for signer/generator failures, shared field resolution

### DIFF
--- a/src/api/tests/test_openapi_schema.py
+++ b/src/api/tests/test_openapi_schema.py
@@ -230,6 +230,31 @@ def test_guest_endpoints_declare_the_coded_error_shape() -> None:
         assert declared[(path, "post")] == {"EventUserEligibility", "ErrorDetail", "GuestActionErrorSchema"}, path
 
 
+def test_wallet_endpoints_declare_both_503_shapes() -> None:
+    """Wallet 503s come in two flavours and the client must narrow on ``code``.
+
+    "Wallet is not configured" is a bare ``HttpError`` (``ErrorDetail``); a
+    signer/generator failure is rendered by ``wallet/exception_handlers.py`` with
+    a ``code`` (``WalletPassErrorSchema``). Both are declared so the generated
+    client sees the union instead of an untyped 503.
+    """
+    declared = {
+        (path, method): names
+        for (path, method, _status), names in _declared_error_schemas(lambda s: s == "503").items()
+    }
+    for path in (
+        "/api/tickets/{ticket_id}/wallet/apple",
+        "/api/tickets/{ticket_id}/wallet/google",
+        "/api/tickets/{ticket_id}/wallet/apple/signed",
+        "/api/me/organizations/{slug}/membership/wallet/apple",
+        "/api/me/organizations/{slug}/membership/wallet/google",
+        "/api/memberships/{member_id}/wallet/apple/signed",
+        "/api/series-passes/me/{held_pass_id}/pkpass",
+        "/api/series-passes/me/{held_pass_id}/wallet/google",
+    ):
+        assert declared[(path, "get")] == {"WalletPassErrorSchema", "ErrorDetail"}, path
+
+
 def _operations() -> dict[tuple[str, str], dict[str, t.Any]]:
     """Map each ``(path, method)`` to its raw OpenAPI operation object."""
     api._schema_cache = {}

--- a/src/events/controllers/series_pass.py
+++ b/src/events/controllers/series_pass.py
@@ -22,7 +22,7 @@ from events.service import series_pass_file_service, series_pass_service
 from events.service.series_pass_purchase import SeriesPassPurchaseService
 from events.utils import apple_wallet_configured, google_wallet_configured
 from wallet.google import service as google_wallet_service
-from wallet.schema import GoogleWalletSaveUrlSchema
+from wallet.schema import GoogleWalletSaveUrlSchema, WalletPassErrorSchema
 
 
 class _CheckoutResult(t.TypedDict):
@@ -227,7 +227,7 @@ class SeriesPassController(UserAwareController):
         url_name="series_pass_apple_wallet_pass",
         summary="Download Apple Wallet pass",
         description="Generate and download an Apple Wallet pass (.pkpass) for a held series pass.",
-        response={200: None, 404: None, 503: None},
+        response={200: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
         auth=I18nJWTAuth(),
     )
     def download_series_pass_pkpass(self, held_pass_id: UUID) -> HttpResponse:
@@ -254,7 +254,7 @@ class SeriesPassController(UserAwareController):
         description="Redirects to a signed 'save to Google Wallet' link for a held series pass. "
         "Pass ?format=json to receive the link as JSON instead — browser clients cannot "
         "follow the cross-origin redirect.",
-        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: None},
+        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
         auth=I18nJWTAuth(),
     )
     def google_wallet_save_link(

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -19,6 +19,27 @@ msgstr ""
 msgid "Impersonate"
 msgstr "Als Anwender:in anmelden"
 
+msgid "Impersonation Details"
+msgstr "Details zur Identitätsübernahme"
+
+msgid "Request Information"
+msgstr "Anfrage-Informationen"
+
+msgid "Admin"
+msgstr "Admin"
+
+msgid "Target User"
+msgstr "Ziel-Anwender:in"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Redeemed"
+msgstr "Eingelöst"
+
+msgid "Pending"
+msgstr "Ausstehend"
+
 msgid "Requeue failed payouts"
 msgstr "Fehlgeschlagene Auszahlungen erneut einreihen"
 
@@ -80,27 +101,6 @@ msgstr[1] ""
 
 msgid "Impersonate User"
 msgstr "Als Anwender:in anmelden"
-
-msgid "Impersonation Details"
-msgstr "Details zur Identitätsübernahme"
-
-msgid "Request Information"
-msgstr "Anfrage-Informationen"
-
-msgid "Admin"
-msgstr "Admin"
-
-msgid "Target User"
-msgstr "Ziel-Anwender:in"
-
-msgid "Status"
-msgstr "Status"
-
-msgid "Redeemed"
-msgstr "Eingelöst"
-
-msgid "Pending"
-msgstr "Ausstehend"
 
 msgid "organization owner"
 msgstr "Organisationsinhaber:in"
@@ -1120,6 +1120,16 @@ msgstr ""
 "Die Ticket-Rückerstattungen für diese Veranstaltung haben bereits begonnen; "
 "sie kann nicht mehr rückgängig gemacht werden."
 
+msgid "An account with this email already exists. Please log in."
+msgstr "Ein Konto mit dieser E-Mail existiert bereits. Bitte melde dich an."
+
+msgid ""
+"Your cart is too large for guest checkout. Please log in or split your "
+"purchase."
+msgstr ""
+"Dein Warenkorb ist zu groß für den Gast-Checkout. Bitte melde dich an oder "
+"teile deinen Kauf auf."
+
 msgid "Draft"
 msgstr "Entwurf"
 
@@ -1934,9 +1944,6 @@ msgstr "Du hast bereits Feedback für dieses Event abgegeben."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Feedback-Fragebögen können nicht bewertet werden."
 
-msgid "An account with this email already exists. Please log in."
-msgstr "Ein Konto mit dieser E-Mail existiert bereits. Bitte melde dich an."
-
 msgid "Invalid token."
 msgstr "Ungültiger Token."
 
@@ -1951,13 +1958,6 @@ msgstr "Bitte überprüfe deine E-Mails, um deine RSVP zu bestätigen"
 
 msgid "This event requires login to purchase tickets."
 msgstr "Dieses Event erfordert eine Anmeldung, um Tickets zu kaufen."
-
-msgid ""
-"Your cart is too large for guest checkout. Please log in or split your "
-"purchase."
-msgstr ""
-"Dein Warenkorb ist zu groß für den Gast-Checkout. Bitte melde dich an oder "
-"teile deinen Kauf auf."
 
 msgid "Please check your email to confirm your ticket purchase"
 msgstr "Bitte überprüfe deine E-Mails, um deinen Ticketkauf zu bestätigen"
@@ -5511,3 +5511,9 @@ msgstr "Gesperrtes Telegram-Konto verbunden"
 
 msgid "Django site admin"
 msgstr "Django-Website-Admin"
+
+msgid ""
+"Wallet pass generation is temporarily unavailable. Please try again later."
+msgstr ""
+"Die Erstellung des Wallet-Passes ist vorübergehend nicht verfügbar. Bitte "
+"versuche es später erneut."

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -19,6 +19,27 @@ msgstr ""
 msgid "Impersonate"
 msgstr "Suplantar identidad"
 
+msgid "Impersonation Details"
+msgstr "Detalles de la suplantación"
+
+msgid "Request Information"
+msgstr "Información de la solicitud"
+
+msgid "Admin"
+msgstr "Administrador"
+
+msgid "Target User"
+msgstr "Usuario objetivo"
+
+msgid "Status"
+msgstr "Estado"
+
+msgid "Redeemed"
+msgstr "Canjeado"
+
+msgid "Pending"
+msgstr "Pendiente"
+
 msgid "Requeue failed payouts"
 msgstr "Reencolar pagos fallidos"
 
@@ -79,27 +100,6 @@ msgstr[1] "%d usuarios omitidos (staff/superusuario o ya bloqueados)."
 
 msgid "Impersonate User"
 msgstr "Suplantar usuario"
-
-msgid "Impersonation Details"
-msgstr "Detalles de la suplantación"
-
-msgid "Request Information"
-msgstr "Información de la solicitud"
-
-msgid "Admin"
-msgstr "Administrador"
-
-msgid "Target User"
-msgstr "Usuario objetivo"
-
-msgid "Status"
-msgstr "Estado"
-
-msgid "Redeemed"
-msgstr "Canjeado"
-
-msgid "Pending"
-msgstr "Pendiente"
 
 msgid "organization owner"
 msgstr "propietario de la organización"
@@ -1108,6 +1108,16 @@ msgstr ""
 "Los reembolsos de entradas para este evento ya han comenzado; ya no se puede "
 "revertir la cancelación."
 
+msgid "An account with this email already exists. Please log in."
+msgstr "Ya existe una cuenta con este correo electrónico. Inicia sesión."
+
+msgid ""
+"Your cart is too large for guest checkout. Please log in or split your "
+"purchase."
+msgstr ""
+"Tu carrito es demasiado grande para la compra como invitado. Inicia sesión o "
+"divide tu compra."
+
 msgid "Draft"
 msgstr "Borrador"
 
@@ -1904,9 +1914,6 @@ msgstr "Ya has enviado feedback para este evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Los cuestionarios de feedback no se pueden evaluar."
 
-msgid "An account with this email already exists. Please log in."
-msgstr "Ya existe una cuenta con este correo electrónico. Inicia sesión."
-
 msgid "Invalid token."
 msgstr "Token no válido."
 
@@ -1921,13 +1928,6 @@ msgstr "Consulta tu correo para confirmar tu asistencia"
 
 msgid "This event requires login to purchase tickets."
 msgstr "Este evento requiere iniciar sesión para comprar entradas."
-
-msgid ""
-"Your cart is too large for guest checkout. Please log in or split your "
-"purchase."
-msgstr ""
-"Tu carrito es demasiado grande para la compra como invitado. Inicia sesión o "
-"divide tu compra."
 
 msgid "Please check your email to confirm your ticket purchase"
 msgstr "Consulta tu correo para confirmar la compra de la entrada"
@@ -5445,3 +5445,9 @@ msgstr "Cuenta de Telegram bloqueada conectada"
 
 msgid "Django site admin"
 msgstr "Administración del sitio Django"
+
+msgid ""
+"Wallet pass generation is temporarily unavailable. Please try again later."
+msgstr ""
+"La generación del pase para Wallet no está disponible temporalmente. "
+"Inténtalo de nuevo más tarde."

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -19,6 +19,27 @@ msgstr ""
 msgid "Impersonate"
 msgstr "Emprunter l'identité"
 
+msgid "Impersonation Details"
+msgstr "Détails de l'emprunt d'identité"
+
+msgid "Request Information"
+msgstr "Informations sur la demande"
+
+msgid "Admin"
+msgstr "Admin"
+
+msgid "Target User"
+msgstr "Utilisateur·rice cible"
+
+msgid "Status"
+msgstr "Statut"
+
+msgid "Redeemed"
+msgstr "Utilisé"
+
+msgid "Pending"
+msgstr "En attente"
+
 msgid "Requeue failed payouts"
 msgstr "Remettre en file les versements échoués"
 
@@ -85,27 +106,6 @@ msgstr[1] ""
 
 msgid "Impersonate User"
 msgstr "Emprunter l'identité de l'utilisateur·rice"
-
-msgid "Impersonation Details"
-msgstr "Détails de l'emprunt d'identité"
-
-msgid "Request Information"
-msgstr "Informations sur la demande"
-
-msgid "Admin"
-msgstr "Admin"
-
-msgid "Target User"
-msgstr "Utilisateur·rice cible"
-
-msgid "Status"
-msgstr "Statut"
-
-msgid "Redeemed"
-msgstr "Utilisé"
-
-msgid "Pending"
-msgstr "En attente"
 
 msgid "organization owner"
 msgstr "propriétaire de l'organisation"
@@ -1128,6 +1128,16 @@ msgstr ""
 "Les remboursements des billets pour cet événement ont déjà commencé ; il ne "
 "peut plus être décommandé."
 
+msgid "An account with this email already exists. Please log in."
+msgstr "Un compte avec cette adresse e-mail existe déjà. Connecte-toi."
+
+msgid ""
+"Your cart is too large for guest checkout. Please log in or split your "
+"purchase."
+msgstr ""
+"Ton panier est trop volumineux pour l'achat en tant qu'invité. Connecte-toi "
+"ou divise ton achat."
+
 msgid "Draft"
 msgstr "Brouillon"
 
@@ -1941,9 +1951,6 @@ msgstr "Tu as déjà soumis un retour d'expérience pour cet événement."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Les questionnaires de retour d'expérience ne peuvent pas être évalués."
 
-msgid "An account with this email already exists. Please log in."
-msgstr "Un compte avec cette adresse e-mail existe déjà. Connecte-toi."
-
 msgid "Invalid token."
 msgstr "Jeton invalide."
 
@@ -1958,13 +1965,6 @@ msgstr "Consulte tes e-mails pour confirmer ta réponse à l'invitation"
 
 msgid "This event requires login to purchase tickets."
 msgstr "Cet événement nécessite de se connecter pour acheter des tickets."
-
-msgid ""
-"Your cart is too large for guest checkout. Please log in or split your "
-"purchase."
-msgstr ""
-"Ton panier est trop volumineux pour l'achat en tant qu'invité. Connecte-toi "
-"ou divise ton achat."
 
 msgid "Please check your email to confirm your ticket purchase"
 msgstr "Consulte tes e-mails pour confirmer ton achat de ticket"
@@ -5496,3 +5496,9 @@ msgstr "Compte Telegram banni connecté"
 
 msgid "Django site admin"
 msgstr "Administration du site Django"
+
+msgid ""
+"Wallet pass generation is temporarily unavailable. Please try again later."
+msgstr ""
+"La génération du pass Wallet est temporairement indisponible. Réessaie plus "
+"tard."

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -19,6 +19,27 @@ msgstr ""
 msgid "Impersonate"
 msgstr "Impersona"
 
+msgid "Impersonation Details"
+msgstr "Dettagli impersonificazione"
+
+msgid "Request Information"
+msgstr "Informazioni sulla richiesta"
+
+msgid "Admin"
+msgstr "Amministratore"
+
+msgid "Target User"
+msgstr "Utente target"
+
+msgid "Status"
+msgstr "Stato"
+
+msgid "Redeemed"
+msgstr "Riscattato"
+
+msgid "Pending"
+msgstr "In sospeso"
+
 msgid "Requeue failed payouts"
 msgstr "Rimetti in coda i pagamenti falliti"
 
@@ -78,27 +99,6 @@ msgstr[1] "%d utenti saltati (staff/superuser o già bloccati)."
 
 msgid "Impersonate User"
 msgstr "Impersona utente"
-
-msgid "Impersonation Details"
-msgstr "Dettagli impersonificazione"
-
-msgid "Request Information"
-msgstr "Informazioni sulla richiesta"
-
-msgid "Admin"
-msgstr "Amministratore"
-
-msgid "Target User"
-msgstr "Utente target"
-
-msgid "Status"
-msgstr "Stato"
-
-msgid "Redeemed"
-msgstr "Riscattato"
-
-msgid "Pending"
-msgstr "In sospeso"
 
 msgid "organization owner"
 msgstr "proprietario dell'organizzazione"
@@ -1108,6 +1108,16 @@ msgstr ""
 "I rimborsi dei biglietti per questo evento sono già iniziati; non è più "
 "possibile annullare la cancellazione."
 
+msgid "An account with this email already exists. Please log in."
+msgstr "Esiste già un account con questa email. Effettua l'accesso."
+
+msgid ""
+"Your cart is too large for guest checkout. Please log in or split your "
+"purchase."
+msgstr ""
+"Il tuo carrello è troppo grande per il checkout come ospite. Accedi oppure "
+"dividi il tuo acquisto."
+
 msgid "Draft"
 msgstr "Bozza"
 
@@ -1909,9 +1919,6 @@ msgstr "Hai già inviato un feedback per questo evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "I questionari di feedback non possono essere valutati."
 
-msgid "An account with this email already exists. Please log in."
-msgstr "Esiste già un account con questa email. Effettua l'accesso."
-
 msgid "Invalid token."
 msgstr "Token non valido."
 
@@ -1926,13 +1933,6 @@ msgstr "Controlla la tua email per confermare la tua partecipazione"
 
 msgid "This event requires login to purchase tickets."
 msgstr "Questo evento richiede l'accesso per acquistare i biglietti."
-
-msgid ""
-"Your cart is too large for guest checkout. Please log in or split your "
-"purchase."
-msgstr ""
-"Il tuo carrello è troppo grande per il checkout come ospite. Accedi oppure "
-"dividi il tuo acquisto."
 
 msgid "Please check your email to confirm your ticket purchase"
 msgstr "Controlla la tua email per confermare l'acquisto del biglietto"
@@ -5469,3 +5469,9 @@ msgstr "Account Telegram bloccato collegato"
 
 msgid "Django site admin"
 msgstr "Amministrazione del sito Django"
+
+msgid ""
+"Wallet pass generation is temporarily unavailable. Please try again later."
+msgstr ""
+"La generazione del pass per il Wallet non è temporaneamente disponibile. Per "
+"favore riprova più tardi."

--- a/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/locale/pt/LC_MESSAGES/django.po
@@ -19,6 +19,27 @@ msgstr ""
 msgid "Impersonate"
 msgstr "Personificar"
 
+msgid "Impersonation Details"
+msgstr "Detalhes da personificação"
+
+msgid "Request Information"
+msgstr "Informações do pedido"
+
+msgid "Admin"
+msgstr "Admin"
+
+msgid "Target User"
+msgstr "Utilizador alvo"
+
+msgid "Status"
+msgstr "Estado"
+
+msgid "Redeemed"
+msgstr "Resgatado"
+
+msgid "Pending"
+msgstr "Pendente"
+
 msgid "Requeue failed payouts"
 msgstr "Recolocar na fila os pagamentos falhados"
 
@@ -78,27 +99,6 @@ msgstr[1] "%d utilizadores ignorados (staff/superuser ou já bloqueados)."
 
 msgid "Impersonate User"
 msgstr "Personificar utilizador"
-
-msgid "Impersonation Details"
-msgstr "Detalhes da personificação"
-
-msgid "Request Information"
-msgstr "Informações do pedido"
-
-msgid "Admin"
-msgstr "Admin"
-
-msgid "Target User"
-msgstr "Utilizador alvo"
-
-msgid "Status"
-msgstr "Estado"
-
-msgid "Redeemed"
-msgstr "Resgatado"
-
-msgid "Pending"
-msgstr "Pendente"
 
 msgid "organization owner"
 msgstr "proprietário da organização"
@@ -1104,6 +1104,16 @@ msgstr ""
 "Os reembolsos de bilhetes para este evento já começaram; já não é possível "
 "desfazer o cancelamento."
 
+msgid "An account with this email already exists. Please log in."
+msgstr "Já existe uma conta com este e-mail. Inicia sessão."
+
+msgid ""
+"Your cart is too large for guest checkout. Please log in or split your "
+"purchase."
+msgstr ""
+"O teu carrinho é demasiado grande para a compra como convidado. Inicia "
+"sessão ou divide a tua compra."
+
 msgid "Draft"
 msgstr "Rascunho"
 
@@ -1883,9 +1893,6 @@ msgstr "Já enviaste feedback para este evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Os questionários de feedback não podem ser avaliados."
 
-msgid "An account with this email already exists. Please log in."
-msgstr "Já existe uma conta com este e-mail. Inicia sessão."
-
 msgid "Invalid token."
 msgstr "Token inválido."
 
@@ -1900,13 +1907,6 @@ msgstr "Consulta o teu e-mail para confirmares a tua presença"
 
 msgid "This event requires login to purchase tickets."
 msgstr "Este evento requer início de sessão para comprar bilhetes."
-
-msgid ""
-"Your cart is too large for guest checkout. Please log in or split your "
-"purchase."
-msgstr ""
-"O teu carrinho é demasiado grande para a compra como convidado. Inicia "
-"sessão ou divide a tua compra."
 
 msgid "Please check your email to confirm your ticket purchase"
 msgstr "Consulta o teu e-mail para confirmares a compra do bilhete"
@@ -5389,3 +5389,9 @@ msgstr "Conta do Telegram banida ligada"
 
 msgid "Django site admin"
 msgstr "Administração do site Django"
+
+msgid ""
+"Wallet pass generation is temporarily unavailable. Please try again later."
+msgstr ""
+"A geração do passe para a Wallet está temporariamente indisponível. Tenta "
+"novamente mais tarde."

--- a/src/wallet/apple/generator.py
+++ b/src/wallet/apple/generator.py
@@ -18,7 +18,6 @@ from zoneinfo import ZoneInfo
 
 import structlog
 from django.conf import settings
-from django.utils import timezone
 
 from events.models import HeldSeriesPass, OrganizationMember, Ticket
 from events.utils import get_event_timezone, get_organization_timezone
@@ -45,6 +44,7 @@ from wallet.apple.images import (
 )
 from wallet.apple.signer import ApplePassSigner, ApplePassSignerError
 from wallet.pricing import resolve_ticket_price
+from wallet.resolution import resolve_series_window, resolve_ticket_location
 
 logger = structlog.get_logger(__name__)
 
@@ -282,58 +282,41 @@ class ApplePassGenerator:
         """Build PassData from a HeldSeriesPass model.
 
         A series pass has no single covered event, so event-shaped fields are
-        derived from the covered events as a whole: ``event_start``/
-        ``relevant_date`` use the soonest upcoming covered event (falling back
-        to the most recent past one once all events have elapsed), while
-        ``event_end``/``expiration_date`` use the latest-ending covered event
-        so the pass stays valid until the series is fully over. Branding
-        (logo) and address use the same representative event, mirroring
-        ``_build_pass_data``'s per-event resolution.
+        derived from the covered events as a whole by
+        :func:`wallet.resolution.resolve_series_window` (shared with the Google
+        rail): ``event_start``/``relevant_date`` use the soonest upcoming
+        covered event (falling back to the most recent past one once all events
+        have elapsed), while ``event_end``/``expiration_date`` use the
+        latest-ending covered event so the pass stays valid until the series is
+        fully over. Only the logo is rail-specific — Apple embeds the bytes.
         """
         series_pass = held_pass.series_pass
         event_series = series_pass.event_series
         org = event_series.organization
 
-        events = [link.event for link in series_pass.tier_links.select_related("event").all()]
-        now = timezone.now()
-        upcoming = sorted((event for event in events if event.end >= now), key=lambda event: event.start)
-        representative_event = upcoming[0] if upcoming else (max(events, key=lambda event: event.start, default=None))
-
-        if representative_event is not None:
-            logo_image = resolve_cover_art(representative_event) or generate_fallback_logo(org)
-            venue = representative_event.venue
-            address = (venue.full_address() if venue else None) or representative_event.address or None
-            venue_name = venue.name if venue else None
-            event_tz = get_event_timezone(representative_event)
-            event_start = representative_event.start
-        else:
-            # Defensive fallback: a purchasable series pass always covers at least
-            # two events, so this only guards against an edge case with none.
-            logo_image = generate_fallback_logo(org)
-            address = None
-            venue_name = None
-            event_tz = get_organization_timezone(org)
-            event_start = held_pass.created_at
-
-        event_end = max((event.end for event in events), default=event_start)
+        window = resolve_series_window(held_pass)
+        representative_event = window.representative_event
+        logo_image = (resolve_cover_art(representative_event) if representative_event else None) or (
+            generate_fallback_logo(org)
+        )
 
         return PassData(
             serial_number=str(held_pass.id),
             description=f"Series Pass for {event_series.name}",
             organization_name=org.name,
             event_name=series_pass.name,
-            event_start=event_start,
-            event_end=event_end,
-            event_tz=event_tz,
-            address=address,
+            event_start=window.start,
+            event_end=window.end,
+            event_tz=window.tz,
+            address=window.address,
             ticket_tier="Series Pass",
             ticket_price=format_price(held_pass.price_paid, series_pass.currency),
             colors=get_theme_colors(),
             logo_image=logo_image,
             barcode_message=held_pass.qr_payload,
-            relevant_date=event_start,
-            expiration_date=event_end + PASS_EXPIRATION_GRACE_PERIOD,
-            venue_name=venue_name,
+            relevant_date=window.start,
+            expiration_date=window.end + PASS_EXPIRATION_GRACE_PERIOD,
+            venue_name=window.venue_name,
         )
 
     def _build_pass_data(self, ticket: Ticket) -> PassData:
@@ -349,27 +332,9 @@ class ApplePassGenerator:
         # 2. ticket.payment.amount (online Stripe payment)
         # 3. the seat's category price, else tier.price (see resolve_ticket_price)
         price, currency = resolve_ticket_price(ticket)
-        ticket_price = format_price(price, currency) if price > 0 else "Free"
 
-        # Extract venue (from tier's venue, ticket's venue, or event's venue)
-        venue = None
-        if ticket.tier.venue:
-            venue = ticket.tier.venue
-        elif ticket.venue:
-            venue = ticket.venue
-        elif event.venue:
-            venue = event.venue
-        venue_name = venue.name if venue else None
-
-        # Extract sector name (from tier's sector or ticket's sector)
-        sector_name: str | None = None
-        if ticket.tier.sector:
-            sector_name = ticket.tier.sector.name
-        elif ticket.sector:
-            sector_name = ticket.sector.name
-
-        # Extract seat label
-        seat_label = ticket.seat.label if ticket.seat else None
+        # Venue, sector and seat resolution is shared with the Google rail.
+        location = resolve_ticket_location(ticket)
 
         return PassData(
             serial_number=str(ticket.id),
@@ -379,18 +344,18 @@ class ApplePassGenerator:
             event_start=event.start,
             event_end=event.end,
             event_tz=get_event_timezone(event),
-            address=(venue.full_address() if venue else None) or event.address or None,
+            address=location.address,
             ticket_tier=ticket.tier.name,
-            ticket_price=ticket_price,
+            ticket_price=format_price(price, currency),
             colors=get_theme_colors(),
             logo_image=logo_image,
             barcode_message=str(ticket.id),
             relevant_date=event.start,
             expiration_date=event.end + PASS_EXPIRATION_GRACE_PERIOD,
             guest_name=ticket.guest_name,
-            venue_name=venue_name,
-            sector_name=sector_name,
-            seat_label=seat_label,
+            venue_name=location.venue_name,
+            sector_name=location.sector.name if location.sector else None,
+            seat_label=location.seat_label,
         )
 
     def _generate_files(self, pass_json: bytes, colors: PassColors, logo_image: bytes) -> dict[str, bytes]:

--- a/src/wallet/apps.py
+++ b/src/wallet/apps.py
@@ -9,3 +9,9 @@ class WalletConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "wallet"
     verbose_name = "Wallet Passes"
+
+    def ready(self) -> None:
+        """Register the per-app exception handlers on the global Ninja API."""
+        from wallet.exception_handlers import register as register_exception_handlers
+
+        register_exception_handlers()

--- a/src/wallet/controllers.py
+++ b/src/wallet/controllers.py
@@ -19,7 +19,7 @@ from events.service import ticket_file_service
 from events.service.ticket_file_service import get_apple_pass_generator
 from events.utils import create_membership_pdf
 from wallet.google import service as google_wallet_service
-from wallet.schema import GoogleWalletSaveUrlSchema
+from wallet.schema import GoogleWalletSaveUrlSchema, WalletPassErrorSchema
 
 
 @api_controller("/tickets", tags=["Tickets - Wallet"], auth=I18nJWTAuth())
@@ -38,7 +38,7 @@ class TicketWalletController(UserAwareController):
         url_name="ticket_apple_wallet_pass",
         summary="Download Apple Wallet pass",
         description="Generate and download an Apple Wallet pass (.pkpass) for a ticket.",
-        response={200: None, 404: None, 503: None},
+        response={200: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
     )
     def download_apple_pass(self, ticket_id: UUID) -> HttpResponse:
         """Download an Apple Wallet pass for a ticket.
@@ -68,7 +68,7 @@ class TicketWalletController(UserAwareController):
         description="Redirects to a signed 'save to Google Wallet' link for a ticket. "
         "Pass ?format=json to receive the link as JSON instead — browser clients cannot "
         "follow the cross-origin redirect.",
-        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: None},
+        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
     )
     def google_wallet_save_link(
         self,
@@ -96,7 +96,7 @@ class TicketWalletController(UserAwareController):
         summary="Download Apple Wallet pass via signed link",
         description="Auth-free pkpass download guarded by an HMAC signature and expiry; "
         "used by the Add to Apple Wallet badge in ticket emails.",
-        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: None},
+        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: WalletPassErrorSchema | ErrorDetail},
         auth=None,
     )
     def download_apple_pass_signed(
@@ -192,7 +192,7 @@ class MembershipWalletController(UserAwareController):
         "/wallet/apple",
         url_name="me_membership_apple_wallet_pass",
         summary="Download Apple Wallet membership card",
-        response={200: None, 404: None, 503: None},
+        response={200: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
     )
     def download_apple_pass(self, slug: str) -> HttpResponse:
         """Generate and download the caller's membership card (.pkpass)."""
@@ -209,7 +209,7 @@ class MembershipWalletController(UserAwareController):
         "/wallet/google",
         url_name="me_membership_google_wallet_pass",
         summary="Add membership card to Google Wallet",
-        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: None},
+        response={200: GoogleWalletSaveUrlSchema, 302: None, 404: None, 503: WalletPassErrorSchema | ErrorDetail},
     )
     def google_wallet_save_link(
         self,
@@ -253,7 +253,7 @@ class MembershipWalletSignedController(UserAwareController):
         summary="Download Apple Wallet membership card via signed link",
         description="Auth-free pkpass download guarded by an HMAC signature and expiry; "
         "used by the Add to Apple Wallet badge in membership emails.",
-        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: None},
+        response={200: None, 403: ErrorDetail, 404: None, 410: None, 503: WalletPassErrorSchema | ErrorDetail},
         auth=None,
     )
     def download_apple_pass_signed(

--- a/src/wallet/exception_handlers.py
+++ b/src/wallet/exception_handlers.py
@@ -1,0 +1,84 @@
+"""Wallet exception handlers.
+
+Registered on the global ``NinjaExtraAPI`` from
+:meth:`wallet.apps.WalletConfig.ready`. Signing and generation failures are
+infrastructure faults (an unreadable certificate, a service-account key the
+container cannot open), not caller mistakes, so they answer 503 — the status
+the wallet routes already declare for "this rail is unavailable" — instead of
+falling through to the generic 500 handler.
+
+``ApplePassGeneratorError`` also wraps genuinely unexpected failures inside the
+generator, so mapping it here trades a loud 500 for a "try again later". The
+error log below keeps those diagnosable: it is the same signal that made the
+container certificate-permissions incident traceable in Loki.
+
+The reusable handler factories and the registration loop live in
+:mod:`common.exception_handlers`. A static message is deliberate — ``str(exc)``
+carries filesystem paths (``Certificate not found: /app/certs/pass.pem``).
+"""
+
+import typing as t
+
+import structlog
+from django.http import HttpRequest
+from django.utils.translation import gettext_lazy as _
+from ninja.responses import Response
+
+from common.exception_handlers import ExceptionHandler, register_handlers
+from wallet.apple.generator import ApplePassGeneratorError
+from wallet.apple.signer import ApplePassSignerError
+from wallet.google.signer import GooglePassSignerError
+from wallet.schema import WalletPassErrorCode, WalletPassErrorSchema
+
+logger = structlog.get_logger(__name__)
+
+PASS_UNAVAILABLE_MESSAGE = _("Wallet pass generation is temporarily unavailable. Please try again later.")
+
+
+def handle_pass_unavailable(request: HttpRequest, exc: Exception | t.Type[Exception]) -> Response:
+    """Render a wallet signer/generator failure as a 503, and log it with its traceback.
+
+    The body carries a stable ``code``: the same 503 status is already used for
+    the un-``code``d "Wallet is not configured" refusal, and the frontend cannot
+    key on the translated ``detail`` to tell the two apart (#905 precedent).
+
+    Args:
+        request: The current HTTP request.
+        exc: The raised wallet error (its message stays in the logs only).
+
+    Returns:
+        Response: A 503 response shaped like ``WalletPassErrorSchema``.
+    """
+    logger.error(
+        "wallet_pass_unavailable",
+        exc_info=exc,
+        path=request.path,
+        exception_type=type(exc).__name__,
+        exception_message=str(exc),
+    )
+    return Response(
+        status=503,
+        data=WalletPassErrorSchema(
+            detail=str(PASS_UNAVAILABLE_MESSAGE),
+            code=WalletPassErrorCode.PASS_UNAVAILABLE,
+        ).model_dump(mode="json"),
+    )
+
+
+# Single source of truth for the exception → status mapping.
+HANDLERS: dict[type[Exception], ExceptionHandler] = {
+    ApplePassSignerError: handle_pass_unavailable,
+    ApplePassGeneratorError: handle_pass_unavailable,
+    GooglePassSignerError: handle_pass_unavailable,
+}
+
+
+def register() -> None:
+    """Install wallet exception handlers on the global Ninja API.
+
+    Called from :meth:`wallet.apps.WalletConfig.ready`. Imports the global
+    ``api`` lazily to avoid AppConfig import-cycle issues.
+    """
+    from api.api import api
+
+    register_handlers(api, HANDLERS)

--- a/src/wallet/google/builder.py
+++ b/src/wallet/google/builder.py
@@ -14,13 +14,13 @@ from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils import timezone
 
 from events.models import Event, HeldSeriesPass, Organization, OrganizationMember, Ticket
 from events.utils import get_event_timezone, get_organization_timezone
 from wallet.apple.formatting import format_iso_date, format_price, get_theme_hex_background
 from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD, POWERED_BY_URL
 from wallet.pricing import resolve_ticket_price
+from wallet.resolution import resolve_series_window, resolve_ticket_location
 
 
 def _pass_id(kind: str, entity_id: t.Any) -> str:
@@ -111,8 +111,10 @@ def _build_class(
 def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
     """Build the fat-JWT payload for a ticket.
 
-    Field resolution (venue, sector, seat, price) mirrors
-    ``ApplePassGenerator._build_pass_data`` so both rails show the same data.
+    Venue, sector and seat come from :func:`wallet.resolution.resolve_ticket_location`
+    and the price from :func:`wallet.pricing.resolve_ticket_price` — the same
+    helpers ``ApplePassGenerator._build_pass_data`` uses, so both rails show the
+    same data (pinned by ``wallet/tests/test_cross_rail_parity.py``).
 
     Args:
         ticket: The ticket to build a payload for.
@@ -124,23 +126,7 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
     org = event.organization
     tz = get_event_timezone(event)
 
-    venue = None
-    if ticket.tier.venue:
-        venue = ticket.tier.venue
-    elif ticket.venue:
-        venue = ticket.venue
-    elif event.venue:
-        venue = event.venue
-    venue_name = venue.name if venue else None
-    address = (venue.full_address() if venue else None) or event.address or None
-
-    sector = None
-    if ticket.tier.sector:
-        sector = ticket.tier.sector
-    elif ticket.sector:
-        sector = ticket.sector
-    seat_label = ticket.seat.label if ticket.seat else None
-
+    location = resolve_ticket_location(ticket)
     price, currency = resolve_ticket_price(ticket)
 
     cls = _build_class(
@@ -150,8 +136,8 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
         start=event.start,
         end=event.end,
         tz=tz,
-        venue_name=venue_name,
-        address=address,
+        venue_name=location.venue_name,
+        address=location.address,
         logo_url=_org_logo_url(org),
         hero_url=_event_cover_url(event),
     )
@@ -169,10 +155,10 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
     if ticket.guest_name:
         obj["ticketHolderName"] = ticket.guest_name
     seat_info: dict[str, t.Any] = {}
-    if sector:
-        seat_info["section"] = _localized(sector.name)
-    if seat_label:
-        seat_info["seat"] = _localized(seat_label)
+    if location.sector:
+        seat_info["section"] = _localized(location.sector.name)
+    if location.seat_label:
+        seat_info["seat"] = _localized(location.seat_label)
     if seat_info:
         obj["seatInfo"] = seat_info
 
@@ -182,10 +168,12 @@ def build_ticket_payload(ticket: Ticket) -> dict[str, t.Any]:
 def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
     """Build the fat-JWT payload for a held series pass.
 
-    Event-shaped fields are derived from the covered events as a whole,
-    mirroring ``ApplePassGenerator._build_series_pass_data``: the soonest
-    upcoming covered event is the representative (falling back to the most
-    recent past one), and the pass stays valid until the latest covered end.
+    Event-shaped fields are derived from the covered events as a whole by
+    :func:`wallet.resolution.resolve_series_window`, shared with
+    ``ApplePassGenerator._build_series_pass_data``: the soonest upcoming covered
+    event is the representative (falling back to the most recent past one), and
+    the pass stays valid until the latest covered end. Only the hero image is
+    rail-specific (Google fetches a URL, Apple embeds bytes).
 
     Args:
         held_pass: The held series pass to build a payload for.
@@ -194,39 +182,20 @@ def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
         ``{"eventTicketClasses": [...], "eventTicketObjects": [...]}``
     """
     series_pass = held_pass.series_pass
-    event_series = series_pass.event_series
-    org = event_series.organization
+    org = series_pass.event_series.organization
 
-    events = [link.event for link in series_pass.tier_links.select_related("event").all()]
-    now = timezone.now()
-    upcoming = sorted((event for event in events if event.end >= now), key=lambda event: event.start)
-    representative = upcoming[0] if upcoming else (max(events, key=lambda event: event.start, default=None))
-
-    if representative is not None:
-        venue = representative.venue
-        venue_name = venue.name if venue else None
-        address = (venue.full_address() if venue else None) or representative.address or None
-        tz = get_event_timezone(representative)
-        event_start = representative.start
-        hero_url = _event_cover_url(representative)
-    else:
-        venue_name = None
-        address = None
-        tz = get_organization_timezone(org)
-        event_start = held_pass.created_at
-        hero_url = None
-
-    event_end = max((event.end for event in events), default=event_start)
+    window = resolve_series_window(held_pass)
+    hero_url = _event_cover_url(window.representative_event) if window.representative_event else None
 
     cls = _build_class(
         class_id=_pass_id("series", series_pass.id),
         issuer_name=org.name,
         event_name=series_pass.name,
-        start=event_start,
-        end=event_end,
-        tz=tz,
-        venue_name=venue_name,
-        address=address,
+        start=window.start,
+        end=window.end,
+        tz=window.tz,
+        venue_name=window.venue_name,
+        address=window.address,
         logo_url=_org_logo_url(org),
         hero_url=hero_url,
     )
@@ -237,7 +206,9 @@ def build_series_pass_payload(held_pass: HeldSeriesPass) -> dict[str, t.Any]:
         "state": "ACTIVE",
         "barcode": {"type": "QR_CODE", "value": held_pass.qr_payload},
         "ticketType": _localized("Series Pass"),
-        "validTimeInterval": {"end": {"date": format_iso_date(event_end + PASS_EXPIRATION_GRACE_PERIOD, tz=tz)}},
+        "validTimeInterval": {
+            "end": {"date": format_iso_date(window.end + PASS_EXPIRATION_GRACE_PERIOD, tz=window.tz)}
+        },
         "textModulesData": [
             {"id": "price", "header": "Price", "body": format_price(held_pass.price_paid, series_pass.currency)}
         ],

--- a/src/wallet/resolution.py
+++ b/src/wallet/resolution.py
@@ -1,0 +1,123 @@
+"""Shared field resolution for wallet passes (Apple and Google rails).
+
+Both rails answer the same two questions before they can render a pass — *where
+is this ticket* and *what window does this series pass cover* — and both used to
+answer them with textually duplicated blocks, so a fix to one rail silently
+missed the other. They live here instead, as pure functions over already-loaded
+relations (same shape as :mod:`wallet.pricing`).
+
+Imagery deliberately stays with each rail: Apple embeds image *bytes* in the
+archive, Google emits *URLs* its servers fetch. Only the representative event is
+resolved here; each rail derives its own artwork from it.
+"""
+
+import typing as t
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from django.utils import timezone
+
+from events.models import Event, HeldSeriesPass, Ticket, Venue, VenueSector
+from events.utils import get_event_timezone, get_organization_timezone
+
+
+class TicketLocation(t.NamedTuple):
+    """Where a ticket sits: venue, sector and seat, with the display strings."""
+
+    venue: Venue | None
+    venue_name: str | None
+    address: str | None
+    sector: VenueSector | None
+    seat_label: str | None
+
+
+def resolve_ticket_location(ticket: Ticket) -> TicketLocation:
+    """Resolve a ticket's venue, sector and seat.
+
+    Priority (most specific first): the tier's venue, then the ticket's own
+    venue, then the event's; the tier's sector, then the ticket's. The address
+    prefers the resolved venue's full address and falls back to the event's
+    free-text address.
+
+    Every input is already loaded on the pass-generating paths
+    (``Ticket.objects.full()`` selects ``tier``, ``seat`` and ``event``), so this
+    is a pure function over them — no extra query per pass.
+
+    Args:
+        ticket: The ticket to locate.
+
+    Returns:
+        TicketLocation: The resolved venue/sector/seat, with ``None`` for
+        whatever the ticket does not carry.
+    """
+    event = ticket.event
+    venue = ticket.tier.venue or ticket.venue or event.venue
+    sector = ticket.tier.sector or ticket.sector
+
+    return TicketLocation(
+        venue=venue,
+        venue_name=venue.name if venue else None,
+        address=(venue.full_address() if venue else None) or event.address or None,
+        sector=sector,
+        seat_label=ticket.seat.label if ticket.seat else None,
+    )
+
+
+class SeriesWindow(t.NamedTuple):
+    """The event-shaped fields a series pass borrows from its covered events."""
+
+    representative_event: Event | None
+    venue: Venue | None
+    venue_name: str | None
+    address: str | None
+    tz: ZoneInfo
+    start: datetime
+    end: datetime
+
+
+def resolve_series_window(held_pass: HeldSeriesPass) -> SeriesWindow:
+    """Resolve the representative event and validity window of a held series pass.
+
+    A series pass has no single event, so the pass borrows: the representative
+    is the soonest covered event that has not yet ended, falling back to the
+    latest-starting past one once the series is over. ``start`` follows the
+    representative; ``end`` is the latest end across *all* covered events, so the
+    pass stays valid until the series is fully over.
+
+    Args:
+        held_pass: The held series pass to resolve a window for.
+
+    Returns:
+        SeriesWindow: The representative event (``None`` only for the defensive
+        case of a pass covering no events, where the window collapses to the
+        pass's creation time) with its venue, timezone and window.
+    """
+    events = [link.event for link in held_pass.series_pass.tier_links.select_related("event").all()]
+    now = timezone.now()
+    upcoming = sorted((event for event in events if event.end >= now), key=lambda event: event.start)
+    representative = upcoming[0] if upcoming else max(events, key=lambda event: event.start, default=None)
+
+    if representative is None:
+        # Defensive fallback: a purchasable series pass always covers at least
+        # two events, so this only guards against an edge case with none.
+        start = held_pass.created_at
+        return SeriesWindow(
+            representative_event=None,
+            venue=None,
+            venue_name=None,
+            address=None,
+            tz=get_organization_timezone(held_pass.series_pass.event_series.organization),
+            start=start,
+            end=start,
+        )
+
+    venue = representative.venue
+    return SeriesWindow(
+        representative_event=representative,
+        venue=venue,
+        venue_name=venue.name if venue else None,
+        address=(venue.full_address() if venue else None) or representative.address or None,
+        tz=get_event_timezone(representative),
+        start=representative.start,
+        end=max(event.end for event in events),
+    )

--- a/src/wallet/schema.py
+++ b/src/wallet/schema.py
@@ -1,5 +1,7 @@
 """Schemas for wallet pass endpoints."""
 
+import enum
+
 from ninja import Schema
 
 
@@ -7,3 +9,29 @@ class GoogleWalletSaveUrlSchema(Schema):
     """JSON shape of the Google Wallet save link (``?format=json``)."""
 
     save_url: str
+
+
+class WalletPassErrorCode(str, enum.Enum):
+    """Stable discriminators for wallet 503s.
+
+    Both rails answer 503 for two different situations: the deployment has no
+    wallet credentials at all (a plain ``HttpError``, no ``code``), and the
+    credentials are there but the pass could not be signed or built. The
+    frontend renders "not configured" for the former, so the latter needs a
+    machine-readable marker — renaming a value is a breaking change, rewording
+    the message is always safe.
+    """
+
+    PASS_UNAVAILABLE = "wallet_pass_unavailable"
+
+
+class WalletPassErrorSchema(Schema):
+    """503 body for a wallet pass that could not be signed or generated.
+
+    ``detail`` is translated and must never be matched on; ``code`` is the
+    discriminator the frontend keys on to tell a transient generation failure
+    apart from the un-``code``d "Wallet is not configured" 503.
+    """
+
+    detail: str
+    code: WalletPassErrorCode

--- a/src/wallet/tests/conftest.py
+++ b/src/wallet/tests/conftest.py
@@ -425,3 +425,147 @@ def google_wallet_not_configured(settings: t.Any) -> None:
     """Clear Google Wallet settings for tests."""
     settings.GOOGLE_WALLET_ISSUER_ID = ""
     settings.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY_PATH = ""
+
+
+# --- Seating Fixtures (shared by the Apple and Google rail tests) ---
+
+
+@pytest.fixture
+def seated_venue(organization: t.Any) -> t.Any:
+    """A venue with an address, for testing venue/sector/seat resolution."""
+    from events.models import Venue
+
+    return Venue.objects.create(organization=organization, name="Teatro Grande", address="1 Teatro Street")
+
+
+@pytest.fixture
+def seated_sector(seated_venue: t.Any) -> t.Any:
+    """The sector the seated tier sells."""
+    from events.models import VenueSector
+
+    return VenueSector.objects.create(venue=seated_venue, name="Platea")
+
+
+@pytest.fixture
+def seated_seat(seated_sector: t.Any) -> t.Any:
+    """A materialized seat in the sector."""
+    from events.models import VenueSeat
+
+    return VenueSeat.objects.create(sector=seated_sector, label="A-7", row_label="A", number=7)
+
+
+@pytest.fixture
+def seated_tier(event: t.Any, seated_venue: t.Any, seated_sector: t.Any) -> t.Any:
+    """A tier wired to the venue/sector, for user-choice seat assignment."""
+    from decimal import Decimal
+
+    from events.models import TicketTier
+
+    return TicketTier.objects.create(
+        event=event,
+        name="Platea Tier",
+        price=Decimal("10.00"),
+        currency="EUR",
+        payment_method=TicketTier.PaymentMethod.OFFLINE,
+        venue=seated_venue,
+        sector=seated_sector,
+        seat_assignment_mode=TicketTier.SeatAssignmentMode.USER_CHOICE,
+    )
+
+
+@pytest.fixture
+def seated_ticket(event: t.Any, member_user: t.Any, seated_tier: t.Any, seated_seat: t.Any) -> t.Any:
+    """A ticket for the seated tier, with a materialized seat assigned."""
+    from events.models import Ticket
+
+    return Ticket.objects.create(
+        event=event,
+        user=member_user,
+        tier=seated_tier,
+        seat=seated_seat,
+        status=Ticket.TicketStatus.ACTIVE,
+        guest_name=member_user.get_display_name(),
+    )
+
+
+# --- Series Pass Fixtures (shared by the Apple and Google rail tests) ---
+
+
+@pytest.fixture
+def event_series(organization: t.Any) -> t.Any:
+    """Event series for wallet series pass tests."""
+    from events.models import EventSeries
+
+    return EventSeries.objects.create(organization=organization, name="Wallet Series", slug="wallet-series")
+
+
+@pytest.fixture
+def series_pass(event_series: t.Any) -> t.Any:
+    """Series pass product for wallet tests."""
+    from decimal import Decimal
+
+    from events.models import SeriesPass, TicketTier
+
+    return SeriesPass.objects.create(
+        event_series=event_series,
+        name="Wallet Season Pass",
+        price=Decimal("60.00"),
+        pro_rata_discount=Decimal("10.00"),
+        currency="EUR",
+        payment_method=TicketTier.PaymentMethod.FREE,
+    )
+
+
+def make_covered_event(
+    organization: t.Any,
+    event_series: t.Any,
+    series_pass: t.Any,
+    name: str,
+    slug: str,
+    start_delta: timedelta,
+) -> t.Any:
+    """Create an OPEN covered event with a linked tier."""
+    from django.utils import timezone
+
+    from events.models import Event, SeriesPassTierLink, TicketTier
+
+    now = timezone.now()
+    covered = Event.objects.create(
+        organization=organization,
+        event_series=event_series,
+        name=name,
+        slug=slug,
+        start=now + start_delta,
+        end=now + start_delta + timedelta(hours=2),
+        requires_ticket=True,
+        status=Event.EventStatus.OPEN,
+    )
+    tier = TicketTier.objects.create(
+        event=covered, name=f"{name} Tier", price=10, currency="EUR", payment_method=TicketTier.PaymentMethod.FREE
+    )
+    SeriesPassTierLink.objects.create(series_pass=series_pass, event=covered, tier=tier)
+    return covered
+
+
+@pytest.fixture
+def covered_events(organization: t.Any, event_series: t.Any, series_pass: t.Any) -> list[t.Any]:
+    """Two future covered events (7 and 14 days out)."""
+    return [
+        make_covered_event(organization, event_series, series_pass, "Covered One", "covered-one", timedelta(days=7)),
+        make_covered_event(organization, event_series, series_pass, "Covered Two", "covered-two", timedelta(days=14)),
+    ]
+
+
+@pytest.fixture
+def held_pass(series_pass: t.Any, member_user: t.Any, covered_events: list[t.Any]) -> t.Any:
+    """An active held series pass covering two future events."""
+    from decimal import Decimal
+
+    from events.models import HeldSeriesPass
+
+    return HeldSeriesPass.objects.create(
+        series_pass=series_pass,
+        user=member_user,
+        status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
+        price_paid=Decimal("50.00"),
+    )

--- a/src/wallet/tests/test_cross_rail_parity.py
+++ b/src/wallet/tests/test_cross_rail_parity.py
@@ -1,0 +1,184 @@
+"""Drift guard: the Apple and Google rails must describe the same pass.
+
+Both builders' docstrings claim their venue/sector/seat/price and series-window
+resolution mirrors the other rail's, but nothing enforced it — the two code
+paths were textually duplicated. They now share :mod:`wallet.resolution`; this
+test pins the claim so a future change to one rail cannot silently diverge from
+the other (same idea as ``polls/tests/test_controller_drift.py``).
+"""
+
+import typing as t
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from events.models import Event, HeldSeriesPass, Ticket
+from events.utils import get_event_timezone
+from wallet.apple.formatting import format_iso_date
+from wallet.apple.generator import ApplePassGenerator
+from wallet.google.builder import build_series_pass_payload, build_ticket_payload
+from wallet.tests.conftest import make_covered_event
+
+pytestmark = pytest.mark.django_db
+
+
+def _google_venue(cls: dict[str, t.Any]) -> tuple[str | None, str | None]:
+    """Unwrap Google's EventVenue into ``(name, address)``."""
+    venue = cls.get("venue")
+    if venue is None:
+        return None, None
+    return venue["name"]["defaultValue"]["value"], venue["address"]["defaultValue"]["value"]
+
+
+def _google_seat_info(obj: dict[str, t.Any]) -> tuple[str | None, str | None]:
+    """Unwrap Google's seatInfo into ``(section, seat)``."""
+    seat_info = obj.get("seatInfo", {})
+    section = seat_info.get("section")
+    seat = seat_info.get("seat")
+    return (
+        section["defaultValue"]["value"] if section else None,
+        seat["defaultValue"]["value"] if seat else None,
+    )
+
+
+def _google_price(obj: dict[str, t.Any]) -> str:
+    """Read the price text module off a Google object."""
+    return str(next(module["body"] for module in obj["textModulesData"] if module["id"] == "price"))
+
+
+class TestTicketParity:
+    """Both rails report the same venue, sector, seat and price for one ticket."""
+
+    def test_seated_ticket_matches_across_rails(
+        self,
+        google_wallet_configured_settings: None,
+        seated_ticket: Ticket,
+        mock_signer: MagicMock,
+    ) -> None:
+        """Tier venue/sector + assigned seat resolve identically on both rails."""
+        apple = ApplePassGenerator(signer=mock_signer)._build_pass_data(seated_ticket)
+        payload = build_ticket_payload(seated_ticket)
+        cls, obj = payload["eventTicketClasses"][0], payload["eventTicketObjects"][0]
+
+        google_venue_name, google_address = _google_venue(cls)
+        google_section, google_seat = _google_seat_info(obj)
+
+        assert apple.venue_name == google_venue_name == "Teatro Grande"
+        assert apple.address == google_address == "1 Teatro Street"
+        assert apple.sector_name == google_section == "Platea"
+        assert apple.seat_label == google_seat == "A-7"
+        assert apple.ticket_price == _google_price(obj) == "EUR 10.00"
+
+    def test_ticket_venue_falls_back_to_the_event_address_on_both_rails(
+        self,
+        google_wallet_configured_settings: None,
+        ticket: Ticket,
+        mock_signer: MagicMock,
+    ) -> None:
+        """No venue anywhere: both rails fall back to ``event.address``, and report no seat."""
+        apple = ApplePassGenerator(signer=mock_signer)._build_pass_data(ticket)
+        payload = build_ticket_payload(ticket)
+        cls, obj = payload["eventTicketClasses"][0], payload["eventTicketObjects"][0]
+
+        _, google_address = _google_venue(cls)
+        google_section, google_seat = _google_seat_info(obj)
+
+        assert apple.venue_name is None
+        assert apple.address == google_address == ticket.event.address
+        assert apple.sector_name == google_section is None
+        assert apple.seat_label == google_seat is None
+
+    def test_free_ticket_price_matches_across_rails(
+        self,
+        google_wallet_configured_settings: None,
+        ticket: Ticket,
+        mock_signer: MagicMock,
+    ) -> None:
+        """A zero-price ticket reads "Free" on both rails (no rail-local special case)."""
+        ticket.tier.price = 0
+        ticket.tier.save()
+
+        apple = ApplePassGenerator(signer=mock_signer)._build_pass_data(ticket)
+        obj = build_ticket_payload(ticket)["eventTicketObjects"][0]
+
+        assert apple.ticket_price == _google_price(obj) == "Free"
+
+
+class TestSeriesPassParity:
+    """Both rails derive the same representative event and validity window."""
+
+    def test_series_window_matches_across_rails(
+        self,
+        google_wallet_configured_settings: None,
+        held_pass: HeldSeriesPass,
+        covered_events: list[Event],
+        mock_signer: MagicMock,
+    ) -> None:
+        """The soonest upcoming covered event drives start; the latest end drives expiry."""
+        representative = covered_events[0]
+        representative.venue = None
+        representative.address = "9 Series Street"
+        representative.save()
+
+        apple = ApplePassGenerator(signer=mock_signer)._build_series_pass_data(held_pass)
+        payload = build_series_pass_payload(held_pass)
+        cls, obj = payload["eventTicketClasses"][0], payload["eventTicketObjects"][0]
+
+        _, google_address = _google_venue(cls)
+        tz = get_event_timezone(representative)
+
+        assert apple.address == google_address == "9 Series Street"
+        assert cls["dateTime"]["start"] == format_iso_date(apple.event_start, tz=tz)
+        assert cls["dateTime"]["end"] == format_iso_date(apple.event_end, tz=tz)
+        assert apple.event_start == representative.start
+        assert apple.event_end == max(event.end for event in covered_events)
+        assert apple.ticket_price == _google_price(obj) == "EUR 50.00"
+
+    def test_past_series_representative_matches_across_rails(
+        self,
+        google_wallet_configured_settings: None,
+        organization: t.Any,
+        event_series: t.Any,
+        series_pass: t.Any,
+        member_user: t.Any,
+        mock_signer: MagicMock,
+    ) -> None:
+        """Once every covered event has ended, both rails pick the latest-starting past one."""
+        make_covered_event(organization, event_series, series_pass, "Old One", "old-one", timedelta(days=-14))
+        latest = make_covered_event(organization, event_series, series_pass, "Old Two", "old-two", timedelta(days=-7))
+        held = HeldSeriesPass.objects.create(
+            series_pass=series_pass,
+            user=member_user,
+            status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
+            price_paid=0,
+        )
+
+        apple = ApplePassGenerator(signer=mock_signer)._build_series_pass_data(held)
+        cls = build_series_pass_payload(held)["eventTicketClasses"][0]
+
+        assert apple.event_start == latest.start
+        assert cls["dateTime"]["start"] == format_iso_date(apple.event_start, tz=get_event_timezone(latest))
+
+    def test_series_pass_without_covered_events_matches_across_rails(
+        self,
+        google_wallet_configured_settings: None,
+        series_pass: t.Any,
+        member_user: t.Any,
+        mock_signer: MagicMock,
+    ) -> None:
+        """Defensive: with no covered events both rails fall back to ``created_at`` and no venue."""
+        held = HeldSeriesPass.objects.create(
+            series_pass=series_pass,
+            user=member_user,
+            status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
+            price_paid=0,
+        )
+
+        apple = ApplePassGenerator(signer=mock_signer)._build_series_pass_data(held)
+        cls = build_series_pass_payload(held)["eventTicketClasses"][0]
+
+        assert apple.event_start == apple.event_end == held.created_at
+        assert apple.venue_name is None
+        assert apple.address is None
+        assert "venue" not in cls

--- a/src/wallet/tests/test_exception_handlers.py
+++ b/src/wallet/tests/test_exception_handlers.py
@@ -1,0 +1,151 @@
+"""Wallet signer/generator failures answer 503, not an opaque 500.
+
+Covers both the handler table itself (status, body, log) and the wiring from
+:meth:`wallet.apps.WalletConfig.ready` — a handler nobody registers is dead code.
+"""
+
+import typing as t
+from unittest.mock import patch
+
+import orjson
+import pytest
+from django.test import RequestFactory
+from django.test.client import Client
+from django.urls import reverse
+from structlog.testing import capture_logs
+
+from events.models import Ticket
+from wallet.apple.generator import ApplePassGeneratorError
+from wallet.apple.signer import ApplePassSignerError
+from wallet.exception_handlers import HANDLERS, PASS_UNAVAILABLE_MESSAGE
+from wallet.google.signer import GooglePassSignerError
+from wallet.schema import WalletPassErrorCode
+
+WALLET_ERRORS: list[type[Exception]] = [ApplePassSignerError, ApplePassGeneratorError, GooglePassSignerError]
+
+
+@pytest.mark.parametrize("exc_type", WALLET_ERRORS)
+def test_handler_renders_static_503_with_a_stable_code(exc_type: type[Exception]) -> None:
+    """Each wallet error renders the fixed message plus the machine-readable code.
+
+    The un-``code``d 503 on the same routes means "Wallet is not configured";
+    the frontend tells the two apart on ``code``, never on ``detail``.
+    """
+    response = HANDLERS[exc_type](RequestFactory().get("/"), exc_type("boom"))
+
+    assert response.status_code == 503
+    body = orjson.loads(response.content)
+    assert body == {"detail": str(PASS_UNAVAILABLE_MESSAGE), "code": "wallet_pass_unavailable"}
+    assert body["code"] == WalletPassErrorCode.PASS_UNAVAILABLE.value
+
+
+@pytest.mark.parametrize("exc_type", WALLET_ERRORS)
+def test_handler_does_not_leak_the_exception_message(exc_type: type[Exception]) -> None:
+    """``str(exc)`` carries filesystem paths — the body must be static instead."""
+    exc = exc_type("Certificate not found: /app/certs/pass.pem")
+
+    response = HANDLERS[exc_type](RequestFactory().get("/"), exc)
+
+    assert "/app/certs" not in response.content.decode()
+
+
+@pytest.mark.parametrize("exc_type", WALLET_ERRORS)
+def test_handler_logs_the_failure_with_traceback(exc_type: type[Exception]) -> None:
+    """The 503 must stay diagnosable in Loki (the cert-permissions incident)."""
+    exc = exc_type("Certificate not found: /app/certs/pass.pem")
+
+    with capture_logs() as logs:
+        HANDLERS[exc_type](RequestFactory().get("/wallet/apple"), exc)
+
+    assert len(logs) == 1
+    entry = logs[0]
+    assert entry["event"] == "wallet_pass_unavailable"
+    assert entry["log_level"] == "error"
+    assert entry["exception_type"] == exc_type.__name__
+    assert entry["path"] == "/wallet/apple"
+    assert entry["exc_info"] is exc
+
+
+def test_every_wallet_error_is_registered_on_the_api() -> None:
+    """WalletConfig.ready must have installed the table on the global API."""
+    from api.api import api
+
+    for exc_type in WALLET_ERRORS:
+        assert api._exception_handlers[exc_type] is HANDLERS[exc_type]
+
+
+@pytest.mark.django_db
+def test_apple_pass_generation_failure_returns_503(
+    apple_wallet_configured: None,
+    member_client: Client,
+    ticket: Ticket,
+) -> None:
+    """A signing/generation failure is a 503, not a 500."""
+    url = reverse("api:ticket_apple_wallet_pass", kwargs={"ticket_id": ticket.id})
+
+    with patch(
+        "events.service.ticket_file_service.get_or_generate_pkpass",
+        side_effect=ApplePassGeneratorError("Failed to generate pass: [Errno 13] /app/certs/pass.pem"),
+    ):
+        response = member_client.get(url)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": str(PASS_UNAVAILABLE_MESSAGE), "code": "wallet_pass_unavailable"}
+
+
+@pytest.mark.django_db
+def test_google_save_link_signer_failure_returns_503(
+    google_wallet_configured_settings: None,
+    member_client: Client,
+    ticket: Ticket,
+) -> None:
+    """An unreadable service-account key is a 503, not a 500."""
+    url = reverse("api:ticket_google_wallet_pass", kwargs={"ticket_id": ticket.id})
+
+    with patch(
+        "wallet.google.service.ticket_save_url",
+        side_effect=GooglePassSignerError("Cannot load Google Wallet service account key: [Errno 13]"),
+    ):
+        response = member_client.get(url, {"format": "json"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": str(PASS_UNAVAILABLE_MESSAGE), "code": "wallet_pass_unavailable"}
+
+
+@pytest.mark.django_db
+def test_membership_pass_generation_failure_returns_503(
+    apple_wallet_configured: None,
+    member_client: Client,
+    member: t.Any,
+) -> None:
+    """The membership rail shares the mapping (same generator, same errors)."""
+    url = reverse("api:me_membership_apple_wallet_pass", kwargs={"slug": member.organization.slug})
+
+    with patch(
+        "wallet.controllers.get_apple_pass_generator",
+        side_effect=ApplePassSignerError("Certificate not found: /app/certs/pass.pem"),
+    ):
+        response = member_client.get(url)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": str(PASS_UNAVAILABLE_MESSAGE), "code": "wallet_pass_unavailable"}
+
+
+@pytest.mark.django_db
+def test_not_configured_503_carries_no_code(
+    apple_wallet_not_configured: None,
+    member_client: Client,
+    ticket: Ticket,
+) -> None:
+    """The other 503 on the same route stays un-``code``d.
+
+    The frontend renders "Wallet is not configured" for that one and a
+    try-again message for the coded one, so the two bodies must stay
+    distinguishable without reading the translated ``detail``.
+    """
+    url = reverse("api:ticket_apple_wallet_pass", kwargs={"ticket_id": ticket.id})
+
+    response = member_client.get(url)
+
+    assert response.status_code == 503
+    assert "code" not in response.json()

--- a/src/wallet/tests/test_generator_series_pass.py
+++ b/src/wallet/tests/test_generator_series_pass.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
-from django.utils import timezone
 
 from accounts.models import RevelUser
 from events.models import (
@@ -18,81 +17,11 @@ from events.models import (
     HeldSeriesPass,
     Organization,
     SeriesPass,
-    SeriesPassTierLink,
-    TicketTier,
 )
 from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD, ApplePassGenerator
+from wallet.tests.conftest import make_covered_event
 
 pytestmark = pytest.mark.django_db
-
-
-# --- Fixtures ---
-
-
-@pytest.fixture
-def event_series(organization: Organization) -> EventSeries:
-    """Event series for wallet series pass tests."""
-    return EventSeries.objects.create(organization=organization, name="Wallet Series", slug="wallet-series")
-
-
-@pytest.fixture
-def series_pass(event_series: EventSeries) -> SeriesPass:
-    """Series pass product for wallet tests."""
-    return SeriesPass.objects.create(
-        event_series=event_series,
-        name="Wallet Season Pass",
-        price=Decimal("60.00"),
-        pro_rata_discount=Decimal("10.00"),
-        currency="EUR",
-        payment_method=TicketTier.PaymentMethod.FREE,
-    )
-
-
-def _covered_event(
-    organization: Organization,
-    event_series: EventSeries,
-    series_pass: SeriesPass,
-    name: str,
-    slug: str,
-    start_delta: timedelta,
-) -> Event:
-    """Create an OPEN covered event with a linked tier."""
-    now = timezone.now()
-    covered = Event.objects.create(
-        organization=organization,
-        event_series=event_series,
-        name=name,
-        slug=slug,
-        start=now + start_delta,
-        end=now + start_delta + timedelta(hours=2),
-        requires_ticket=True,
-        status=Event.EventStatus.OPEN,
-    )
-    tier = TicketTier.objects.create(
-        event=covered, name=f"{name} Tier", price=10, currency="EUR", payment_method=TicketTier.PaymentMethod.FREE
-    )
-    SeriesPassTierLink.objects.create(series_pass=series_pass, event=covered, tier=tier)
-    return covered
-
-
-@pytest.fixture
-def covered_events(organization: Organization, event_series: EventSeries, series_pass: SeriesPass) -> list[Event]:
-    """Two future covered events (7 and 14 days out)."""
-    return [
-        _covered_event(organization, event_series, series_pass, "Covered One", "covered-one", timedelta(days=7)),
-        _covered_event(organization, event_series, series_pass, "Covered Two", "covered-two", timedelta(days=14)),
-    ]
-
-
-@pytest.fixture
-def held_pass(series_pass: SeriesPass, member_user: RevelUser, covered_events: list[Event]) -> HeldSeriesPass:
-    """An active held series pass covering two future events."""
-    return HeldSeriesPass.objects.create(
-        series_pass=series_pass,
-        user=member_user,
-        status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
-        price_paid=Decimal("50.00"),
-    )
 
 
 class TestBuildSeriesPassData:
@@ -131,8 +60,10 @@ class TestBuildSeriesPassData:
         mock_signer: MagicMock,
     ) -> None:
         """Should skip already-ended events when picking the representative event."""
-        past = _covered_event(organization, event_series, series_pass, "Past Show", "past-show", timedelta(days=-7))
-        upcoming = _covered_event(organization, event_series, series_pass, "Next Show", "next-show", timedelta(days=3))
+        past = make_covered_event(organization, event_series, series_pass, "Past Show", "past-show", timedelta(days=-7))
+        upcoming = make_covered_event(
+            organization, event_series, series_pass, "Next Show", "next-show", timedelta(days=3)
+        )
         held = HeldSeriesPass.objects.create(
             series_pass=series_pass,
             user=member_user,
@@ -155,8 +86,8 @@ class TestBuildSeriesPassData:
         mock_signer: MagicMock,
     ) -> None:
         """Should fall back to the most recent past event once the series is over."""
-        _covered_event(organization, event_series, series_pass, "Old One", "old-one", timedelta(days=-14))
-        latest = _covered_event(organization, event_series, series_pass, "Old Two", "old-two", timedelta(days=-7))
+        make_covered_event(organization, event_series, series_pass, "Old One", "old-one", timedelta(days=-14))
+        latest = make_covered_event(organization, event_series, series_pass, "Old Two", "old-two", timedelta(days=-7))
         held = HeldSeriesPass.objects.create(
             series_pass=series_pass,
             user=member_user,

--- a/src/wallet/tests/test_google_builder.py
+++ b/src/wallet/tests/test_google_builder.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 import pytest
 from django.core.files.base import ContentFile
-from django.utils import timezone
 
 from accounts.models import RevelUser
 from events.models import (
@@ -15,15 +14,11 @@ from events.models import (
     HeldSeriesPass,
     Organization,
     SeriesPass,
-    SeriesPassTierLink,
     Ticket,
-    TicketTier,
-    Venue,
-    VenueSeat,
-    VenueSector,
 )
 from wallet.apple.formatting import get_theme_hex_background
 from wallet.google.builder import build_ticket_payload
+from wallet.tests.conftest import make_covered_event
 
 pytestmark = pytest.mark.django_db
 
@@ -74,52 +69,6 @@ def test_ticket_payload_address_only_event(google_wallet_configured_settings: No
     cls = payload["eventTicketClasses"][0]
     assert cls["venue"]["name"]["defaultValue"]["value"] == "123 Test Street"
     assert cls["venue"]["address"]["defaultValue"]["value"] == "123 Test Street"
-
-
-@pytest.fixture
-def seated_venue(organization: Organization) -> Venue:
-    """A venue with an address, for testing venue/sector/seat resolution."""
-    return Venue.objects.create(organization=organization, name="Teatro Grande", address="1 Teatro Street")
-
-
-@pytest.fixture
-def seated_sector(seated_venue: Venue) -> VenueSector:
-    """The sector the seated tier sells."""
-    return VenueSector.objects.create(venue=seated_venue, name="Platea")
-
-
-@pytest.fixture
-def seated_seat(seated_sector: VenueSector) -> VenueSeat:
-    """A materialized seat in the sector."""
-    return VenueSeat.objects.create(sector=seated_sector, label="A-7", row_label="A", number=7)
-
-
-@pytest.fixture
-def seated_tier(event: Event, seated_venue: Venue, seated_sector: VenueSector) -> TicketTier:
-    """A tier wired to the venue/sector, for user-choice seat assignment."""
-    return TicketTier.objects.create(
-        event=event,
-        name="Platea Tier",
-        price=Decimal("10.00"),
-        currency="EUR",
-        payment_method=TicketTier.PaymentMethod.OFFLINE,
-        venue=seated_venue,
-        sector=seated_sector,
-        seat_assignment_mode=TicketTier.SeatAssignmentMode.USER_CHOICE,
-    )
-
-
-@pytest.fixture
-def seated_ticket(event: Event, member_user: RevelUser, seated_tier: TicketTier, seated_seat: VenueSeat) -> Ticket:
-    """A ticket for the seated tier, with a materialized seat assigned."""
-    return Ticket.objects.create(
-        event=event,
-        user=member_user,
-        tier=seated_tier,
-        seat=seated_seat,
-        status=Ticket.TicketStatus.ACTIVE,
-        guest_name=member_user.get_display_name(),
-    )
 
 
 def test_ticket_payload_venue_sector_seat(google_wallet_configured_settings: None, seated_ticket: Ticket) -> None:
@@ -187,122 +136,38 @@ def test_ticket_payload_valid_time_interval(google_wallet_configured_settings: N
     assert end.startswith(expected_year)
 
 
-# --- Series pass fixtures (minimal setup replicated from
-# wallet/tests/test_generator_series_pass.py; not imported since that file's
-# fixtures aren't shared via a conftest) ---
-
-
-@pytest.fixture
-def google_event_series(organization: Organization) -> EventSeries:
-    """Event series for the Google Wallet series-pass test."""
-    return EventSeries.objects.create(organization=organization, name="Google Wallet Series", slug="gwallet-series")
-
-
-@pytest.fixture
-def google_series_pass(google_event_series: EventSeries) -> SeriesPass:
-    """Series pass product for the Google Wallet series-pass test."""
-    return SeriesPass.objects.create(
-        event_series=google_event_series,
-        name="Google Wallet Season Pass",
-        price=Decimal("60.00"),
-        pro_rata_discount=Decimal("10.00"),
-        currency="EUR",
-        payment_method=TicketTier.PaymentMethod.FREE,
-    )
-
-
-def _covered_event(
-    organization: Organization,
-    event_series: EventSeries,
-    series_pass: SeriesPass,
-    name: str,
-    slug: str,
-    start_delta: timedelta,
-) -> Event:
-    """Create an OPEN covered event with a linked tier."""
-    now = timezone.now()
-    covered = Event.objects.create(
-        organization=organization,
-        event_series=event_series,
-        name=name,
-        slug=slug,
-        start=now + start_delta,
-        end=now + start_delta + timedelta(hours=2),
-        requires_ticket=True,
-        status=Event.EventStatus.OPEN,
-    )
-    tier = TicketTier.objects.create(
-        event=covered, name=f"{name} Tier", price=10, currency="EUR", payment_method=TicketTier.PaymentMethod.FREE
-    )
-    SeriesPassTierLink.objects.create(series_pass=series_pass, event=covered, tier=tier)
-    return covered
-
-
-@pytest.fixture
-def google_covered_events(
-    organization: Organization, google_event_series: EventSeries, google_series_pass: SeriesPass
-) -> list[Event]:
-    """Two future covered events (7 and 14 days out)."""
-    return [
-        _covered_event(
-            organization, google_event_series, google_series_pass, "GW Covered One", "gw-covered-one", timedelta(days=7)
-        ),
-        _covered_event(
-            organization,
-            google_event_series,
-            google_series_pass,
-            "GW Covered Two",
-            "gw-covered-two",
-            timedelta(days=14),
-        ),
-    ]
-
-
-@pytest.fixture
-def held_series_pass(
-    google_series_pass: SeriesPass, member_user: RevelUser, google_covered_events: list[Event]
-) -> HeldSeriesPass:
-    """An active held series pass covering two future events."""
-    return HeldSeriesPass.objects.create(
-        series_pass=google_series_pass,
-        user=member_user,
-        status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
-        price_paid=Decimal("50.00"),
-    )
-
-
 def test_series_pass_payload(
-    google_wallet_configured_settings: None, held_series_pass: t.Any, google_covered_events: list[Event]
+    google_wallet_configured_settings: None, held_pass: t.Any, covered_events: list[Event]
 ) -> None:
     from wallet.apple.generator import PASS_EXPIRATION_GRACE_PERIOD
     from wallet.google.builder import build_series_pass_payload
 
-    payload = build_series_pass_payload(held_series_pass)
+    payload = build_series_pass_payload(held_pass)
     cls = payload["eventTicketClasses"][0]
     obj = payload["eventTicketObjects"][0]
 
-    series_pass = held_series_pass.series_pass
+    series_pass = held_pass.series_pass
     assert cls["id"] == f"3388000000012345678.test.series.{series_pass.id}"
     assert cls["eventName"]["defaultValue"]["value"] == series_pass.name
-    assert obj["id"] == f"3388000000012345678.test.pass.{held_series_pass.id}"
-    assert obj["barcode"] == {"type": "QR_CODE", "value": held_series_pass.qr_payload}
+    assert obj["id"] == f"3388000000012345678.test.pass.{held_pass.id}"
+    assert obj["barcode"] == {"type": "QR_CODE", "value": held_pass.qr_payload}
     assert obj["ticketType"]["defaultValue"]["value"] == "Series Pass"
 
     # Latest-ending covered event (the 14-days-out one) plus the grace period.
-    latest_end = max(event.end for event in google_covered_events)
+    latest_end = max(event.end for event in covered_events)
     end = obj["validTimeInterval"]["end"]["date"]
     assert end.startswith(str((latest_end + PASS_EXPIRATION_GRACE_PERIOD).year))
 
     price_modules = [m for m in obj["textModulesData"] if m["id"] == "price"]
     assert len(price_modules) == 1
-    assert price_modules[0]["body"] == "EUR 50.00"  # held_series_pass fixture price_paid
+    assert price_modules[0]["body"] == "EUR 50.00"  # held_pass fixture price_paid
 
 
 def test_series_pass_falls_back_to_latest_past_event(
     google_wallet_configured_settings: None,
     organization: Organization,
-    google_event_series: EventSeries,
-    google_series_pass: SeriesPass,
+    event_series: EventSeries,
+    series_pass: SeriesPass,
     member_user: RevelUser,
 ) -> None:
     """Once every covered event has ended, the representative is the latest-starting past one."""
@@ -310,14 +175,10 @@ def test_series_pass_falls_back_to_latest_past_event(
     from wallet.apple.formatting import format_iso_date
     from wallet.google.builder import build_series_pass_payload
 
-    _covered_event(
-        organization, google_event_series, google_series_pass, "GW Old One", "gw-old-one", timedelta(days=-14)
-    )
-    latest = _covered_event(
-        organization, google_event_series, google_series_pass, "GW Old Two", "gw-old-two", timedelta(days=-7)
-    )
+    make_covered_event(organization, event_series, series_pass, "GW Old One", "gw-old-one", timedelta(days=-14))
+    latest = make_covered_event(organization, event_series, series_pass, "GW Old Two", "gw-old-two", timedelta(days=-7))
     held = HeldSeriesPass.objects.create(
-        series_pass=google_series_pass,
+        series_pass=series_pass,
         user=member_user,
         status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
         price_paid=Decimal("30"),
@@ -334,14 +195,14 @@ def test_series_pass_falls_back_to_latest_past_event(
 
 def test_series_pass_no_covered_events_falls_back_to_created_at(
     google_wallet_configured_settings: None,
-    google_series_pass: SeriesPass,
+    series_pass: SeriesPass,
     member_user: RevelUser,
 ) -> None:
     """Defensive: a pass with no tier links still builds a valid payload from held_pass.created_at."""
     from wallet.google.builder import build_series_pass_payload
 
     held = HeldSeriesPass.objects.create(
-        series_pass=google_series_pass,
+        series_pass=series_pass,
         user=member_user,
         status=HeldSeriesPass.HeldSeriesPassStatus.ACTIVE,
         price_paid=Decimal("0"),
@@ -357,12 +218,12 @@ def test_series_pass_no_covered_events_falls_back_to_created_at(
 def test_payload_objects_carry_powered_by_link(
     google_wallet_configured_settings: None,
     ticket: Ticket,
-    held_series_pass: t.Any,
-    google_covered_events: list[Event],
+    held_pass: t.Any,
+    covered_events: list[Event],
 ) -> None:
     """Ticket and series-pass objects carry the platform attribution link (mirrors the Apple back field)."""
     from wallet.google.builder import build_series_pass_payload
 
     expected = {"uris": [{"id": "powered_by", "uri": "https://letsrevel.io", "description": "Powered by Revel"}]}
     assert build_ticket_payload(ticket)["eventTicketObjects"][0]["linksModuleData"] == expected
-    assert build_series_pass_payload(held_series_pass)["eventTicketObjects"][0]["linksModuleData"] == expected
+    assert build_series_pass_payload(held_pass)["eventTicketObjects"][0]["linksModuleData"] == expected


### PR DESCRIPTION
Tech-debt sweep findings 15 and 20.

Finding 15: wallet had no per-app exception handlers, so every
ApplePassSignerError / ApplePassGeneratorError / GooglePassSignerError fell
through to the generic handler and answered 500, even though every wallet
route already declares 503 for "this rail is unavailable" (the container
cert-permissions incident surfaced as an opaque 500). Adds
wallet/exception_handlers.py mapping the three to a static, translatable 503
(str(exc) carries filesystem paths, so it must not be echoed), wired from
WalletConfig.ready like polls/events/questionnaires.

Tradeoff: ApplePassGeneratorError also wraps genuinely unexpected generator
failures, so a real bug now reads as "try again later" instead of a loud 500.
The handler therefore logs `wallet_pass_unavailable` at error level with
exc_info before returning, preserving the Loki traceback that made the cert
incident diagnosable.

Both wallet rails already answered 503 for "not configured", and the frontend
maps every wallet 503 to that message, so the new transient failure would have
been shown as "not configured". Following #952, the handler now renders
WalletPassErrorSchema {detail, code} with code="wallet_pass_unavailable"
(WalletPassErrorCode enum, so the generated client narrows it), and all eight
wallet routes (six in wallet/controllers.py, two series-pass routes in
events/controllers/series_pass.py) declare
503: WalletPassErrorSchema | ErrorDetail instead of the previous (already
inaccurate) 503: None. The un-coded "... is not configured" HttpError bodies
are unchanged; a test pins that they carry no `code`, which is what the
frontend branches on (revel-frontend#916).

Finding 20: the Apple generator and the Google builder resolved a ticket's
venue/sector/seat and a series pass's representative event/window with
textually identical blocks, and both docstrings claimed parity with nothing
enforcing it. Adds wallet/resolution.py (resolve_ticket_location /
resolve_series_window, pure functions over loaded relations, same shape as
wallet/pricing.py) and calls it from all four sites. Imagery stays
rail-specific (Apple embeds bytes, Google emits URLs). Also drops the dead
`if price > 0 else "Free"` on the Apple rail: format_price already returns
"Free" at 0.

Tests: test_exception_handlers.py (503 body and code, no path leak, error log
emitted, registration on the API, endpoints end-to-end), an OpenAPI test
pinning the 503 shapes on all eight paths, and test_cross_rail_parity.py (drift
guard: both rails report the same venue, address, sector, seat, price and
series window). The seating and series-pass fixtures move into
wallet/tests/conftest.py so both rails' tests and the parity test share one set.

**Merge note:** this PR and the i18n PR both add entries to the five `.po` catalogs. Whichever merges second needs a rebase: keep both sides of the catalog hunks (pure insertions), keep a blank line before each `msgid`, then `make i18n-check`. Frontend follow-up: letsrevel/revel-frontend#916. Related tech-debt PRs: #961–#972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
