### PR TITLE
feat(i18n): translate user-facing error messages and guard against regressions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,9 @@ jobs:
       - name: Check Celery tasks declare explicit names
         run: uv run python scripts/check_task_names.py src
 
+      - name: Check user-facing error messages are translated
+        run: uv run python scripts/check_i18n_literals.py src
+
       - name: Check for missing migrations
         working-directory: src
         run: uv run manage.py makemigrations --check --dry-run --no-input

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ This project uses a comprehensive Makefile.
 - `make setup` — One-time setup: venv, deps, Docker services, server.
 - `make run` — Start Django dev server (generates test JWTs first).
 - `make jwt EMAIL=user@example.com` — Get JWT access/refresh tokens for a user.
-- `make check` — All quality checks (format, lint, mypy, migration-check, i18n-check, file-length, task-names).
+- `make check` — All quality checks (format, lint, mypy, migration-check, i18n-check, i18n-literals, file-length, task-names).
 - `make test` — Parallel pytest with coverage; on failure saves the failures section to `.tests.output`.
 - `make test-linear` — Sequential tests (single process, for debugging).
 - `make test-failed` — Re-run only failed tests.
@@ -336,6 +336,12 @@ def list_items(self) -> QuerySet[Item]:
   a deploy. Enforced by `make task-names` (in `make check` **and** CI). When moving an existing
   task, keep its current name verbatim. To catch beat rows pointing at a now-missing task (e.g.
   manually-created ones), run `python manage.py check_orphaned_beat_tasks`.
+- **User-facing error messages must be marked for translation**: any message that reaches the
+  client — `raise HttpError(<status>, msg)`, or `raise <AppError>(msg)` for an exception mapped
+  with `make_simple_handler` (subclasses included, dispatch is by MRO) — uses
+  `str(_("..."))`. For interpolation, translate **first** and then `.format(...)`
+  (`str(_("Unknown event {}.").format(event_id))`); f-strings are invisible to `xgettext` and are
+  rejected. Enforced by `make i18n-literals` (in `make check` **and** CI).
 - Use Django Ninja's automatic OpenAPI docs. Use the **context7 MCP** to look up library docs.
 
 > ⚠️ **Deep production gotchas** — Celery `transaction.on_commit` / `ATOMIC_REQUESTS`, and

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,10 @@ audit:
 .PHONY: deps-check
 deps-check: licensecheck audit
 
-# Combined command: Runs format, lint, mypy, migration-check, i18n-check, file-length, and task-names in sequence
+# Combined command: Runs format, lint, mypy, migration-check, i18n-check,
+# i18n-literals, file-length, and task-names in sequence
 .PHONY: check
-check: format lint mypy migration-check i18n-check file-length task-names
+check: format lint mypy migration-check i18n-check i18n-literals file-length task-names
 
 .PHONY: file-length
 file-length:
@@ -99,6 +100,10 @@ file-length:
 .PHONY: task-names
 task-names:
 	@uv run python scripts/check_task_names.py src
+
+.PHONY: i18n-literals
+i18n-literals:
+	@uv run python scripts/check_i18n_literals.py src
 
 .PHONY: migration-check
 migration-check:

--- a/scripts/check_i18n_literals.py
+++ b/scripts/check_i18n_literals.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Assert that user-facing error messages are marked for translation.
+
+Two rendering paths put a raised message straight into the HTTP response body:
+
+1. ``raise HttpError(<status>, <message>)`` — Ninja renders ``<message>`` as the
+   ``detail`` of the error body.
+2. ``raise <AppError>(<message>)`` where ``<AppError>`` is registered in some
+   app's ``exception_handlers.HANDLERS`` map with ``make_simple_handler`` — that
+   factory renders ``str(exc)`` as the ``detail`` (see
+   ``common/exception_handlers.py``). Ninja Extra dispatches by MRO, so
+   *subclasses* of a registered class are covered too, and its
+   ``PermissionDenied`` behaves the same way.
+
+A bare string literal (or an f-string, which ``xgettext`` cannot extract at all)
+in either position ships untranslated English to every locale. This check
+enforces the house idiom at ``make check`` time via the source AST — no imports,
+no DB::
+
+    raise HttpError(400, str(_("Something went wrong.")))
+    raise PollValidationError(str(_("Unknown event {}.").format(event_id)))
+
+Interpolation must translate *first* and then ``.format(...)``; f-strings are
+invisible to the extractor and are therefore rejected outright.
+
+Usage: ``python scripts/check_i18n_literals.py [src_dir]``  (default: ``src``)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Exception classes rendered to the client outside the per-app HANDLERS maps.
+_EXTRA_RENDERED_EXCEPTIONS = {"HttpError", "PermissionDenied"}
+
+# Directory names whose contents are never user-facing API responses.
+_SKIPPED_DIRS = {"migrations", "tests"}
+
+
+def _simple_handler_exceptions(src_dir: Path) -> set[str]:
+    """Collect exception class names mapped with ``make_simple_handler``.
+
+    Parses every ``<app>/exception_handlers.py`` and reads the ``HANDLERS``
+    dict literal. Only ``make_simple_handler`` entries matter: those render
+    ``str(exc)``, so the raise site's message reaches the client.
+    ``make_static_handler`` entries ignore the raised message entirely.
+    """
+    names: set[str] = set(_EXTRA_RENDERED_EXCEPTIONS)
+    for file in sorted(src_dir.glob("*/exception_handlers.py")):
+        tree = ast.parse(file.read_text(encoding="utf-8"), filename=str(file))
+        for node in ast.walk(tree):
+            mapping = _handlers_dict(node)
+            if mapping is not None:
+                names |= _simple_handler_keys(mapping)
+    return names
+
+
+def _handlers_dict(node: ast.AST) -> ast.Dict | None:
+    """The dict literal assigned to the name ``HANDLERS``, if ``node`` is that assignment."""
+    if not isinstance(node, ast.AnnAssign | ast.Assign):
+        return None
+    targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets
+    if not any(isinstance(tgt, ast.Name) and tgt.id == "HANDLERS" for tgt in targets):
+        return None
+    return node.value if isinstance(node.value, ast.Dict) else None
+
+
+def _simple_handler_keys(mapping: ast.Dict) -> set[str]:
+    """Names of the exception classes mapped with ``make_simple_handler``."""
+    names: set[str] = set()
+    for key, value in zip(mapping.keys, mapping.values, strict=True):
+        if not isinstance(key, ast.Name) or not isinstance(value, ast.Call):
+            continue
+        if isinstance(value.func, ast.Name) and value.func.id == "make_simple_handler":
+            names.add(key.id)
+    return names
+
+
+def _expand_with_subclasses(names: set[str], src_dir: Path) -> set[str]:
+    """Grow ``names`` with every class in ``src`` that inherits from one of them.
+
+    Ninja Extra dispatches exception handlers by MRO, so a subclass of a
+    registered class is rendered by the same handler (e.g. the questionnaires
+    ``File*Error`` family, all registered once via ``FileValidationError``).
+    Bases are matched by bare name — good enough for a source-level lint.
+    """
+    bases_by_name: dict[str, set[str]] = {}
+    for file in sorted(src_dir.rglob("*.py")):
+        if _SKIPPED_DIRS & set(file.parts):
+            continue
+        try:
+            tree = ast.parse(file.read_text(encoding="utf-8"), filename=str(file))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                bases = {b.id for b in node.bases if isinstance(b, ast.Name)}
+                bases_by_name.setdefault(node.name, set()).update(bases)
+    resolved = set(names)
+    changed = True
+    while changed:
+        changed = False
+        for name, bases in bases_by_name.items():
+            if name not in resolved and bases & resolved:
+                resolved.add(name)
+                changed = True
+    return resolved
+
+
+def _offending_argument(call: ast.Call, rendered: set[str]) -> ast.expr | None:
+    """Return the literal message argument of ``call``, or ``None`` if it is fine."""
+    func = call.func
+    name = func.id if isinstance(func, ast.Name) else func.attr if isinstance(func, ast.Attribute) else None
+    if name not in rendered:
+        return None
+    # HttpError's message is the SECOND positional argument; app exceptions take it first.
+    index = 1 if name == "HttpError" else 0
+    if len(call.args) <= index:
+        return None
+    arg = call.args[index]
+    if isinstance(arg, ast.JoinedStr):
+        return arg
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg
+    return None
+
+
+def find_violations(src_dir: Path) -> list[tuple[Path, int, str]]:
+    """Return ``(file, lineno, reason)`` for every unmarked user-facing message."""
+    rendered = _expand_with_subclasses(_simple_handler_exceptions(src_dir), src_dir)
+    violations: list[tuple[Path, int, str]] = []
+    for file in sorted(src_dir.rglob("*.py")):
+        if _SKIPPED_DIRS & set(file.parts):
+            continue
+        try:
+            tree = ast.parse(file.read_text(encoding="utf-8"), filename=str(file))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+                continue
+            arg = _offending_argument(node.exc, rendered)
+            if arg is None:
+                continue
+            func = node.exc.func
+            exc_name = func.id if isinstance(func, ast.Name) else t_attr(func)
+            kind = "f-string" if isinstance(arg, ast.JoinedStr) else "bare literal"
+            violations.append((file, arg.lineno, f"{exc_name}(...) — {kind}"))
+    return violations
+
+
+def t_attr(func: ast.expr) -> str:
+    """Best-effort dotted name for an attribute callee (for the report only)."""
+    return func.attr if isinstance(func, ast.Attribute) else "<expr>"
+
+
+def main() -> int:
+    """Print any unmarked user-facing messages and return a non-zero exit code."""
+    src_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "src").resolve()
+    violations = find_violations(src_dir)
+    if not violations:
+        sys.stdout.write("✅ Every user-facing error message is marked for translation.\n")
+        return 0
+
+    lines = ["❌ Found user-facing error message(s) that bypass gettext:"]
+    for file, lineno, reason in violations:
+        rel = file.relative_to(src_dir.parent)
+        lines.append(f"  - {rel}:{lineno}  {reason}")
+    lines.append(
+        '\nWrap the message: raise HttpError(400, str(_("...")))  — and for interpolation '
+        'translate first, then format: str(_("... {}").format(value)). '
+        "See revel-backend/CLAUDE.md and scripts/check_i18n_literals.py."
+    )
+    sys.stderr.write("\n".join(lines) + "\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/accounts/controllers/otp.py
+++ b/src/accounts/controllers/otp.py
@@ -3,6 +3,7 @@
 import pyotp
 import structlog
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 from ninja_extra import (
     api_controller,
@@ -39,7 +40,7 @@ class OtpController(UserAwareController):
         """
         user = self.user()
         if user.totp_active:
-            raise HttpError(400, "OTP is already enabled.")
+            raise HttpError(400, str(_("OTP is already enabled.")))
         provisioning_uri = pyotp.totp.TOTP(user.totp_secret).provisioning_uri(
             name=user.email,
             issuer_name=settings.TOTP_ISSUER_NAME,
@@ -61,7 +62,7 @@ class OtpController(UserAwareController):
         user = self.user()
         totp = pyotp.TOTP(user.totp_secret)
         if not totp.verify(payload.otp):
-            raise HttpError(status.HTTP_403_FORBIDDEN, "Invalid OTP")
+            raise HttpError(status.HTTP_403_FORBIDDEN, str(_("Invalid OTP")))
         user.totp_active = True
         user.save()
         return user
@@ -81,7 +82,7 @@ class OtpController(UserAwareController):
         user = self.user()
         totp = pyotp.TOTP(user.totp_secret)
         if not totp.verify(payload.otp):
-            raise HttpError(status.HTTP_403_FORBIDDEN, "Invalid OTP")
+            raise HttpError(status.HTTP_403_FORBIDDEN, str(_("Invalid OTP")))
         user.totp_active = False
         user.save()
         return user

--- a/src/accounts/jwt.py
+++ b/src/accounts/jwt.py
@@ -7,6 +7,7 @@ import jwt
 import structlog
 from django.conf import settings
 from django.db import transaction
+from django.utils.translation import gettext_lazy as _
 from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 from ninja.errors import HttpError
 from ninja_extra.exceptions import AuthenticationFailed
@@ -15,6 +16,10 @@ from ninja_jwt.utils import datetime_from_epoch
 from pydantic import UUID4, BaseModel, ConfigDict, TypeAdapter, field_serializer
 
 logger = structlog.get_logger(__file__)
+
+# Module constant: the raise site in ``consume_one_shot_token`` shadows ``_``
+# with a throwaway unpack target, so the message cannot be marked inline.
+_TOKEN_BLACKLISTED_MESSAGE: str = _("Token is blacklisted.")  # type: ignore[assignment]
 
 
 class _BaseJWTPayload(BaseModel):
@@ -141,7 +146,7 @@ def create_token(payload: dict[str, t.Any], secret: str, algorithm: str) -> str:
 def check_blacklist(jti: str) -> None:
     """Checks if this token is present in the token blacklist.  Raises `HttpError` if so."""
     if BlacklistedToken.objects.filter(token__jti=jti).exists():
-        raise HttpError(401, "Token is blacklisted.")
+        raise HttpError(401, str(_TOKEN_BLACKLISTED_MESSAGE))
 
 
 def blacklist_user_tokens(user: t.Any) -> int:
@@ -192,7 +197,7 @@ def consume_one_shot_token(token: str) -> None:
     _, created = _blacklist(token)
     if not created:
         logger.warning("one_shot_token_already_consumed")
-        raise HttpError(401, "Token is blacklisted.")
+        raise HttpError(401, str(_TOKEN_BLACKLISTED_MESSAGE))
 
 
 @transaction.atomic

--- a/src/accounts/service/billing_profile_service.py
+++ b/src/accounts/service/billing_profile_service.py
@@ -6,6 +6,7 @@ Thin wrappers around the generic billing operations in ``common.service.vies_ser
 import typing as t
 
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
 from common.service.vies_service import VIESValidationResult, validate_and_update_vat_entity
@@ -35,7 +36,7 @@ def create_billing_profile(user: "RevelUser", data: dict[str, t.Any]) -> "UserBi
         defaults={"user": user, **data},
     )
     if not created:
-        raise HttpError(409, "Billing profile already exists.")
+        raise HttpError(409, str(_("Billing profile already exists.")))
     return profile
 
 

--- a/src/accounts/service/impersonation.py
+++ b/src/accounts/service/impersonation.py
@@ -93,7 +93,7 @@ def create_impersonation_request(
             target_email=target.email,
             reason=error,
         )
-        raise HttpError(403, error or "Impersonation not allowed.")
+        raise HttpError(403, error or str(_("Impersonation not allowed.")))
 
     # Generate unique JTI for tracking
     jti = uuid4().hex
@@ -179,7 +179,7 @@ def redeem_impersonation_token(token: str) -> ImpersonationResult:
             target_id=str(log.target_user.id),
             reason=error,
         )
-        raise HttpError(403, error or "Impersonation no longer allowed.")
+        raise HttpError(403, error or str(_("Impersonation no longer allowed.")))
 
     # Consume the request token: refuses the loser of two concurrent redemptions.
     consume_one_shot_token(token)

--- a/src/events/controllers/event_admin/waitlist_offers.py
+++ b/src/events/controllers/event_admin/waitlist_offers.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from ninja import Body
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -135,12 +136,12 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
             models.WaitlistOffer.WaitlistOfferStatus.EXPIRED,
             models.WaitlistOffer.WaitlistOfferStatus.REVOKED,
         }:
-            raise HttpError(404, "Offer not found.")
+            raise HttpError(404, str(_("Offer not found.")))
         payload_expires_at = payload.expires_at if payload else None
         if event.waitlist_time_window is None and payload_expires_at is None:
             raise HttpError(
                 400,
-                "Waitlist time window is not configured for this event. Provide expires_at in the payload.",
+                str(_("Waitlist time window is not configured for this event. Provide expires_at in the payload.")),
             )
         conflict = (
             models.WaitlistOffer.objects.filter(
@@ -152,7 +153,7 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
             .exists()
         )
         if conflict:
-            raise HttpError(409, "User already has a pending offer for this event.")
+            raise HttpError(409, str(_("User already has a pending offer for this event.")))
 
         if payload_expires_at is not None:
             expires_at = payload_expires_at
@@ -165,13 +166,13 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
             if str(exc) == "capacity":
                 raise HttpError(
                     409,
-                    "Event is at capacity. Revoke an existing pending offer to make room.",
+                    str(_("Event is at capacity. Revoke an existing pending offer to make room.")),
                 ) from exc
             raise
         except IntegrityError as exc:
             # Lost the race: another writer landed a PENDING offer for this
             # (event, user) between the conflict check above and the save.
-            raise HttpError(409, "User already has a pending offer for this event.") from exc
+            raise HttpError(409, str(_("User already has a pending offer for this event."))) from exc
         offer_id_str = str(offer.id)
         transaction.on_commit(lambda: send_waitlist_offer_notification_task.delay(offer_id_str))
         return offer
@@ -203,7 +204,7 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
         if event.waitlist_time_window is None and payload.expires_at is None:
             raise HttpError(
                 400,
-                "Waitlist time window is not configured for this event. Provide expires_at in the payload.",
+                str(_("Waitlist time window is not configured for this event. Provide expires_at in the payload.")),
             )
         entry = get_object_or_404(models.EventWaitList, pk=payload.waitlist_entry_id, event=event)
         already_pending = models.WaitlistOffer.objects.filter(
@@ -212,7 +213,7 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
             status=models.WaitlistOffer.WaitlistOfferStatus.PENDING,
         ).exists()
         if already_pending:
-            raise HttpError(409, "User already has a pending offer for this event.")
+            raise HttpError(409, str(_("User already has a pending offer for this event.")))
 
         if payload.expires_at is not None:
             expires_at = payload.expires_at
@@ -225,13 +226,13 @@ class EventAdminWaitlistOffersController(EventAdminBaseController):
             if str(exc) == "capacity":
                 raise HttpError(
                     409,
-                    "Event is at capacity. Revoke an existing pending offer to make room.",
+                    str(_("Event is at capacity. Revoke an existing pending offer to make room.")),
                 ) from exc
             raise
         except IntegrityError as exc:
             # Lost the race: another writer (manual create, periodic processor)
             # landed a PENDING offer between the existence check and our create.
-            raise HttpError(409, "User already has a pending offer for this event.") from exc
+            raise HttpError(409, str(_("User already has a pending offer for this event."))) from exc
         offer_id_str = str(offer.id)
         transaction.on_commit(lambda: send_waitlist_offer_notification_task.delay(offer_id_str))
         return 201, offer

--- a/src/events/controllers/event_public/seating.py
+++ b/src/events/controllers/event_public/seating.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from ninja import Body
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -73,7 +74,7 @@ class EventPublicSeatingController(EventPublicBaseController):
         """Return the render-ready seating chart (sectors, seats, price categories) for the event's venue."""
         event = self.get_one(event_id)
         if not event.venue_id:
-            raise HttpError(404, "This event has no venue.")
+            raise HttpError(404, str(_("This event has no venue.")))
         # build_chart does its own prefetch (sectors, seats, price categories) — pass a plain venue.
         venue = models.Venue.objects.get(pk=event.venue_id)
         return chart_service.build_chart(venue)

--- a/src/events/controllers/organization.py
+++ b/src/events/controllers/organization.py
@@ -472,7 +472,7 @@ class OrganizationController(UserAwareController):
         if not fuzzy_matches:
             from ninja.errors import HttpError
 
-            raise HttpError(400, "No matching blacklist entries found.")
+            raise HttpError(400, str(_("No matching blacklist entries found.")))
 
         # Extract blacklist entries from matches
         matched_entries = [entry for entry, _ in fuzzy_matches]

--- a/src/events/controllers/organization_admin/recurring_events.py
+++ b/src/events/controllers/organization_admin/recurring_events.py
@@ -4,6 +4,7 @@ import typing as t
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from ninja import Body
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -200,7 +201,7 @@ class OrganizationAdminRecurringEventsController(OrganizationAdminBaseController
         """
         series = self._get_series(slug, series_id)
         if not series.template_event_id:
-            raise HttpError(404, "Series has no template event.")
+            raise HttpError(404, str(_("Series has no template event.")))
         return get_object_or_404(models.Event.objects.full(), pk=series.template_event_id)
 
     @route.post(

--- a/src/events/controllers/organization_admin/revenue.py
+++ b/src/events/controllers/organization_admin/revenue.py
@@ -5,6 +5,7 @@ import typing as t
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from ninja import Query
 from ninja_extra import api_controller, route
 
@@ -46,7 +47,7 @@ class OrganizationAdminRevenueController(OrganizationAdminBaseController):
         date_from = payload.date_from or today.replace(month=1, day=1)
         date_to = payload.date_to or today
         if date_from > date_to:
-            raise InvalidPeriodError("date_from must be on or before date_to.")
+            raise InvalidPeriodError(str(_("date_from must be on or before date_to.")))
         scope = revenue_report_service.ReportScope(
             org=org,
             event_id=payload.event_id,

--- a/src/events/controllers/permissions.py
+++ b/src/events/controllers/permissions.py
@@ -104,7 +104,7 @@ class IsOrganizationOwner(RootPermission):
         """Can edit organization."""
         if obj.owner_id == request.user.id:
             return True
-        raise PermissionDenied("You must be the owner of this organization.")
+        raise PermissionDenied(str(_("You must be the owner of this organization.")))
 
 
 class IsOrganizationStaff(RootPermission):
@@ -121,7 +121,7 @@ class IsOrganizationStaff(RootPermission):
         """Can edit organization."""
         if obj.is_owner_or_staff(t.cast(RevelUser, request.user)):
             return True
-        raise PermissionDenied("You must be the owner or a staff member of this organization.")
+        raise PermissionDenied(str(_("You must be the owner or a staff member of this organization.")))
 
 
 class CanDuplicateEvent(RootPermission):
@@ -206,7 +206,7 @@ class CanPurchaseTicket(RootPermission):
         if obj.sales_paused:
             raise PermissionDenied(str(_("Ticket sales are paused.")))
         if not obj.can_purchase():
-            raise PermissionDenied("You're outside of the sale window.")
+            raise PermissionDenied(str(_("You're outside of the sale window.")))
         if obj.purchasable_by == models.TicketTier.PurchasableBy.PUBLIC:
             return True
         if obj.event.organization.is_owner_or_staff(user):
@@ -224,7 +224,7 @@ class CanPurchaseTicket(RootPermission):
         if obj.purchasable_by in [PB.INVITED, PB.INVITED_AND_MEMBERS] and self._check_invited(obj, user.id):
             return True
 
-        raise PermissionDenied(f"The ticket can be purchased by {obj.get_purchasable_by_display()}")
+        raise PermissionDenied(str(_("The ticket can be purchased by {}").format(obj.get_purchasable_by_display())))
 
 
 @api_controller("/permissions", auth=I18nJWTAuth(), tags=["Permissions"])

--- a/src/events/controllers/series_pass.py
+++ b/src/events/controllers/series_pass.py
@@ -238,7 +238,7 @@ class SeriesPassController(UserAwareController):
         )
 
         if not apple_wallet_configured():
-            raise HttpError(503, "Apple Wallet is not configured")
+            raise HttpError(503, str(_("Apple Wallet is not configured")))
 
         pkpass_bytes = series_pass_file_service.get_or_generate_pass_pkpass(held_pass)
 
@@ -272,7 +272,7 @@ class SeriesPassController(UserAwareController):
         )
 
         if not google_wallet_configured():
-            raise HttpError(503, "Google Wallet is not configured")
+            raise HttpError(503, str(_("Google Wallet is not configured")))
 
         save_url = google_wallet_service.series_pass_save_url(held_pass)
         if format == "json":

--- a/src/events/service/announcement_service.py
+++ b/src/events/service/announcement_service.py
@@ -11,6 +11,7 @@ import structlog
 from django.db import transaction
 from django.db.models import F, QuerySet
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from accounts.models import RevelUser
 from common.models import SiteSettings
@@ -30,7 +31,7 @@ from notifications.service.dispatcher import NotificationData, bulk_create_notif
 logger = structlog.get_logger(__name__)
 
 # Error messages
-_ERR_EVENT_NOT_FOUND = "Event not found or does not belong to this organization"
+_ERR_EVENT_NOT_FOUND: str = _("Event not found or does not belong to this organization")  # type: ignore[assignment]
 
 
 def _validate_announcement_has_targeting(announcement: Announcement) -> None:
@@ -52,8 +53,12 @@ def _validate_announcement_has_targeting(announcement: Announcement) -> None:
     )
     if not has_targeting:
         raise ValueError(
-            "Announcement must have at least one targeting option: "
-            "event, target_all_members, target_tiers, or target_staff_only"
+            str(
+                _(
+                    "Announcement must have at least one targeting option: "
+                    "event, target_all_members, target_tiers, or target_staff_only"
+                )
+            )
         )
 
 
@@ -167,7 +172,7 @@ def update_announcement(
     """
     editable = (Announcement.AnnouncementStatus.DRAFT, Announcement.AnnouncementStatus.SCHEDULED)
     if announcement.status not in editable:
-        raise ValueError("Only draft or scheduled announcements can be updated")
+        raise ValueError(str(_("Only draft or scheduled announcements can be updated")))
 
     update_data = payload.model_dump(exclude_unset=True)
 
@@ -192,10 +197,10 @@ def update_announcement(
             setattr(announcement, field, value)
 
     if announcement.resend_to_new_signups and announcement.event_id is None:
-        raise ValueError("Re-sending to new sign-ups requires an event-targeted announcement")
+        raise ValueError(str(_("Re-sending to new sign-ups requires an event-targeted announcement")))
 
     if announcement.schedule_anchor is not None and announcement.event_id is None:
-        raise ValueError("Relative scheduling requires an event-targeted announcement")
+        raise ValueError(str(_("Relative scheduling requires an event-targeted announcement")))
 
     # Validate that at least one targeting option remains
     _validate_announcement_has_targeting(announcement)
@@ -236,7 +241,7 @@ def schedule_announcement(
         ValueError: If not a draft, the schedule is unresolvable, or it is in the past.
     """
     if announcement.status != Announcement.AnnouncementStatus.DRAFT:
-        raise ValueError("Only draft announcements can be scheduled")
+        raise ValueError(str(_("Only draft announcements can be scheduled")))
 
     announcement.scheduled_at = scheduled_at
     announcement.schedule_anchor = schedule_anchor
@@ -244,13 +249,13 @@ def schedule_announcement(
 
     is_relative = announcement.schedule_anchor is not None or announcement.schedule_offset_minutes is not None
     if is_relative and (announcement.schedule_anchor is None or announcement.schedule_offset_minutes is None):
-        raise ValueError("Relative scheduling requires both an anchor and an offset")
+        raise ValueError(str(_("Relative scheduling requires both an anchor and an offset")))
 
     resolved = announcement.effective_send_at
     if resolved is None:
-        raise ValueError("Could not resolve a scheduled time (relative scheduling requires an event)")
+        raise ValueError(str(_("Could not resolve a scheduled time (relative scheduling requires an event)")))
     if resolved <= timezone.now():
-        raise ValueError("Scheduled time must be in the future")
+        raise ValueError(str(_("Scheduled time must be in the future")))
 
     announcement.status = Announcement.AnnouncementStatus.SCHEDULED
     announcement.save()
@@ -271,7 +276,7 @@ def unschedule_announcement(announcement: Announcement) -> Announcement:
         ValueError: If the announcement is not scheduled.
     """
     if announcement.status != Announcement.AnnouncementStatus.SCHEDULED:
-        raise ValueError("Only scheduled announcements can be unscheduled")
+        raise ValueError(str(_("Only scheduled announcements can be unscheduled")))
 
     announcement.status = Announcement.AnnouncementStatus.DRAFT
     announcement.scheduled_at = None
@@ -437,7 +442,7 @@ def send_announcement(announcement: Announcement) -> int:
 
     sendable = (Announcement.AnnouncementStatus.DRAFT, Announcement.AnnouncementStatus.SCHEDULED)
     if announcement.status not in sendable:
-        raise ValueError("Only draft or scheduled announcements can be sent")
+        raise ValueError(str(_("Only draft or scheduled announcements can be sent")))
 
     recipients = list(get_recipients(announcement).select_related("notification_preferences"))
     recipient_count = len(recipients)
@@ -478,9 +483,9 @@ def resend_to_new_recipients(announcement: Announcement) -> int:
 
     announcement = Announcement.objects.select_related("organization").select_for_update().get(pk=announcement.pk)
     if announcement.status != Announcement.AnnouncementStatus.SENT:
-        raise ValueError("Only sent announcements can be resent")
+        raise ValueError(str(_("Only sent announcements can be resent")))
     if not announcement.resend_to_new_signups:
-        raise ValueError("Announcement is not configured for resending")
+        raise ValueError(str(_("Announcement is not configured for resending")))
 
     now = timezone.now()
     if announcement.event is not None and announcement.event.end <= now:

--- a/src/events/service/attendee_invoice_service.py
+++ b/src/events/service/attendee_invoice_service.py
@@ -11,6 +11,7 @@ import structlog
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
 from common.constants import EU_MEMBER_STATES
@@ -45,16 +46,16 @@ def validate_invoicing_prerequisites(org: Organization) -> None:
     missing: list[str] = []
 
     if not org.vat_country_code or org.vat_country_code not in EU_MEMBER_STATES:
-        missing.append("Organization must be EU-based (valid EU VAT country code required)")
+        missing.append(str(_("Organization must be EU-based (valid EU VAT country code required)")))
 
     if not org.vat_id_validated:
-        missing.append("VAT ID must be validated via VIES")
+        missing.append(str(_("VAT ID must be validated via VIES")))
 
     if not org.billing_name:
-        missing.append("Billing name (legal entity name) is required")
+        missing.append(str(_("Billing name (legal entity name) is required")))
 
     if not org.billing_address:
-        missing.append("Billing address is required")
+        missing.append(str(_("Billing address is required")))
 
     if missing:
         raise HttpError(422, "; ".join(missing))

--- a/src/events/service/attendee_vat_service.py
+++ b/src/events/service/attendee_vat_service.py
@@ -511,13 +511,13 @@ def calculate_vat_preview(
     for item in items:
         tier = TicketTier.objects.filter(pk=item.tier_id, event=event).first()
         if not tier:
-            raise HttpError(404, "Ticket tier not found.")
+            raise HttpError(404, str(_("Ticket tier not found.")))
 
         # Validate consistent currency across all tiers
         if not currency:
             currency = tier.currency
         elif tier.currency != currency:
-            raise HttpError(400, "All tiers must use the same currency.")
+            raise HttpError(400, str(_("All tiers must use the same currency.")))
 
         seats = _resolve_preview_seats(tier, item)
         pricing = _resolve_line_pricing(tier, org, seats, price_per_ticket, discount_code)

--- a/src/events/service/event_questionnaire_service.py
+++ b/src/events/service/event_questionnaire_service.py
@@ -441,7 +441,7 @@ def update_organization_questionnaire(
         if not has_free_text:
             has_free_text = any(section.freetextquestion_questions.exists() for section in questionnaire.sections.all())
         if has_free_text:
-            raise HttpError(400, "LLM evaluation is not available.")
+            raise HttpError(400, str(_("LLM evaluation is not available.")))
 
     # Extract questionnaire-specific fields with type conversions
     questionnaire_kwargs = {}

--- a/src/events/service/follow_service.py
+++ b/src/events/service/follow_service.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from django.db import IntegrityError, transaction
 from django.db.models import Model, QuerySet
+from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 
 from accounts.models import RevelUser
@@ -116,7 +117,7 @@ def follow_organization(
         HttpError: If the organization is not visible to the user
     """
     if not Organization.objects.for_user(user).filter(pk=organization.pk).exists():
-        raise HttpError(404, "Organization not found")
+        raise HttpError(404, str(_("Organization not found")))
 
     follow = _get_or_reactivate_follow(
         model=OrganizationFollow,
@@ -124,7 +125,7 @@ def follow_organization(
         target_field="organization",
         target=organization,
         defaults={"notify_new_events": notify_new_events, "notify_announcements": notify_announcements},
-        already_following_message="Already following this organization",
+        already_following_message=str(_("Already following this organization")),
     )
 
     # Ensure organization is attached for schema serialization
@@ -172,7 +173,7 @@ def unfollow_organization(user: RevelUser, organization: Organization) -> None:
         user=user,
         target_field="organization",
         target=organization,
-        not_following_message="Not following this organization",
+        not_following_message=str(_("Not following this organization")),
     )
 
 
@@ -205,7 +206,7 @@ def update_organization_follow_preferences(
     try:
         follow = OrganizationFollow.objects.get(user=user, organization=organization, is_archived=False)
     except OrganizationFollow.DoesNotExist:
-        raise HttpError(400, "Not following this organization")
+        raise HttpError(400, str(_("Not following this organization")))
 
     update_fields: list[str] = []
     if notify_new_events is not None:
@@ -244,7 +245,7 @@ def follow_event_series(
         HttpError: If the event series is not visible to the user
     """
     if not EventSeries.objects.for_user(user).filter(pk=event_series.pk).exists():
-        raise HttpError(404, "Event series not found")
+        raise HttpError(404, str(_("Event series not found")))
 
     follow = _get_or_reactivate_follow(
         model=EventSeriesFollow,
@@ -252,7 +253,7 @@ def follow_event_series(
         target_field="event_series",
         target=event_series,
         defaults={"notify_new_events": notify_new_events},
-        already_following_message="Already following this series",
+        already_following_message=str(_("Already following this series")),
     )
 
     # Ensure event_series is attached for schema serialization
@@ -303,7 +304,7 @@ def unfollow_event_series(user: RevelUser, event_series: EventSeries) -> None:
         user=user,
         target_field="event_series",
         target=event_series,
-        not_following_message="Not following this series",
+        not_following_message=str(_("Not following this series")),
     )
 
 
@@ -334,7 +335,7 @@ def update_event_series_follow_preferences(
     try:
         follow = EventSeriesFollow.objects.get(user=user, event_series=event_series, is_archived=False)
     except EventSeriesFollow.DoesNotExist:
-        raise HttpError(400, "Not following this series")
+        raise HttpError(400, str(_("Not following this series")))
 
     if notify_new_events is not None:
         follow.notify_new_events = notify_new_events

--- a/src/events/service/revenue_aggregation.py
+++ b/src/events/service/revenue_aggregation.py
@@ -15,6 +15,8 @@ from decimal import Decimal
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+from django.utils.translation import gettext_lazy as _
+
 if t.TYPE_CHECKING:
     from events.models import Event
 
@@ -150,7 +152,7 @@ def resolve_period(
     from events.exceptions import InvalidPeriodError
 
     if month is not None and quarter is not None:
-        raise InvalidPeriodError("Specify either month or quarter, not both.")
+        raise InvalidPeriodError(str(_("Specify either month or quarter, not both.")))
     today = datetime.now(tz).date()
     if year is None and month is None and quarter is None and default_all_time:
         return date.min, today

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -44,36 +45,42 @@ msgid "Requeue failed payouts"
 msgstr "Fehlgeschlagene Auszahlungen erneut einreihen"
 
 #, python-format
+
 msgid "Requeued %d failed payout."
 msgid_plural "Requeued %d failed payouts."
 msgstr[0] "%d fehlgeschlagene Auszahlung erneut eingereiht."
 msgstr[1] "%d fehlgeschlagene Auszahlungen erneut eingereiht."
 
 #, python-format
+
 msgid "Skipped %d payout (not in failed status)."
 msgid_plural "Skipped %d payouts (not in failed status)."
 msgstr[0] "%d Auszahlung übersprungen (Status nicht fehlgeschlagen)."
 msgstr[1] "%d Auszahlungen übersprungen (Status nicht fehlgeschlagen)."
 
 #, python-format
+
 msgid "Verification email sent to %d user."
 msgid_plural "Verification emails sent to %d users."
 msgstr[0] "Bestätigungs-E-Mail an %d Anwender:in gesendet."
 msgstr[1] "Bestätigungs-E-Mails an %d Anwender:innen gesendet."
 
 #, python-format
+
 msgid "Skipped %d user (already verified)."
 msgid_plural "Skipped %d users (already verified)."
 msgstr[0] "%d Anwender:in übersprungen (bereits verifiziert)."
 msgstr[1] "%d Anwender:innen übersprungen (bereits verifiziert)."
 
 #, python-format
+
 msgid "Password reset email sent to %d user."
 msgid_plural "Password reset emails sent to %d users."
 msgstr[0] "Passwort-Zurücksetzungs-E-Mail an %d Anwender:in gesendet."
 msgstr[1] "Passwort-Zurücksetzungs-E-Mails an %d Anwender:innen gesendet."
 
 #, python-format
+
 msgid "Skipped %d user (Google SSO or not found)."
 msgid_plural "Skipped %d users (Google SSO or not found)."
 msgstr[0] "%d Anwender:in übersprungen (Google SSO oder nicht gefunden)."
@@ -86,12 +93,14 @@ msgid "Violation of terms of service"
 msgstr "Verstoß gegen die Nutzungsbedingungen"
 
 #, python-format
+
 msgid "Banned %d user."
 msgid_plural "Banned %d users."
 msgstr[0] "%d Anwender:in gesperrt."
 msgstr[1] "%d Anwender:innen gesperrt."
 
 #, python-format
+
 msgid "Skipped %d user (staff/superuser or already banned)."
 msgid_plural "Skipped %d users (staff/superuser or already banned)."
 msgstr[0] ""
@@ -142,6 +151,12 @@ msgstr "Du hast bereits eine Einschränkung für dieses Lebensmittel."
 msgid "You have already added this dietary preference."
 msgstr "Du hast diese Ernährungspräferenz bereits hinzugefügt."
 
+msgid "OTP is already enabled."
+msgstr "OTP ist bereits aktiviert."
+
+msgid "Invalid OTP"
+msgstr "Ungültiges OTP"
+
 msgid "Invalid or inactive referral code."
 msgstr "Ungültiger oder inaktiver Empfehlungs-Code."
 
@@ -155,6 +170,7 @@ msgid "Only active referrers can connect a Stripe account."
 msgstr "Nur aktive Referrers können ein Stripe-Konto verbinden."
 
 #, python-format
+
 msgid ""
 "Deleting your account will permanently forfeit %(count)s unpaid referral "
 "payout(s) totalling %(total)s %(currency)s, of which %(failed)s %(currency)s "
@@ -168,6 +184,9 @@ msgstr ""
 "möchten, oder senden Sie die Anfrage mit force=true erneut, um trotzdem zu "
 "löschen."
 
+msgid "Token is blacklisted."
+msgstr "Der Token steht auf der Sperrliste."
+
 msgid "Global Ban"
 msgstr "Globale Sperre"
 
@@ -175,6 +194,7 @@ msgid "Global Bans"
 msgstr "Globale Sperren"
 
 #, python-format
+
 msgid "Password must be at least %(min_length)d characters long."
 msgstr "Das Passwort muss mindestens %(min_length)d Zeichen lang sein."
 
@@ -195,6 +215,7 @@ msgstr ""
 "<>)[]=."
 
 #, python-format
+
 msgid ""
 "Your password must be at least %(min_length)d characters long, contain at "
 "least one uppercase letter, one lowercase letter, one digit, and one special "
@@ -237,11 +258,15 @@ msgid "Token has expired."
 msgstr "Der Token ist abgelaufen."
 
 #, python-brace-format
+
 msgid "Invalid token: {error}"
 msgstr "Ungültiger Token: {error}"
 
 msgid "Invalid token type."
 msgstr "Ungültiger Token-Typ."
+
+msgid "Billing profile already exists."
+msgstr "Es existiert bereits ein Rechnungsprofil."
 
 msgid "Registration is not available."
 msgstr "Die Registrierung ist nicht verfügbar."
@@ -261,10 +286,17 @@ msgstr "Du kannst dich nicht als Staff-Mitglied anmelden."
 msgid "Cannot impersonate inactive users."
 msgstr "Du kannst dich nicht als inaktive:r Anwender:in anmelden."
 
+msgid "Impersonation not allowed."
+msgstr "Identitätsübernahme ist nicht erlaubt."
+
+msgid "Impersonation no longer allowed."
+msgstr "Identitätsübernahme ist nicht mehr erlaubt."
+
 msgid "Set a password before unlinking your only sign-in method."
 msgstr "Lege ein Passwort fest, bevor du deine einzige Anmeldemethode trennst."
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s (%(currency)s)"
 msgstr "Empfehlungsvergütung %(document_number)s (%(currency)s)"
 
@@ -327,6 +359,7 @@ msgstr ""
 "und alle damit verbundenen Daten dauerhaft gelöscht."
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account immediately</a>."
@@ -350,6 +383,7 @@ msgid "Confirm Account Deletion"
 msgstr "Kontolöschung bestätigen"
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at\n"
@@ -369,6 +403,7 @@ msgid "Confirm Account Deletion."
 msgstr "Kontolöschung bestätigen."
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at %(frontend_base_url)s."
@@ -392,10 +427,12 @@ msgid "Please investigate this issue as soon as possible."
 msgstr "Bitte untersuche dieses Problem so schnell wie möglich."
 
 #, python-format
+
 msgid "User: %(user.email)s"
 msgstr "Anwender:in: %(user.email)s"
 
 #, python-format
+
 msgid "Error: %(error_message)s"
 msgstr "Fehler: %(error_message)s"
 
@@ -406,6 +443,7 @@ msgid "Data Export Failed"
 msgstr "Anwender:innen-Datenexport fehlgeschlagen"
 
 #, python-format
+
 msgid "Hi %(user.first_name)s,"
 msgstr "Hi %(user.first_name)s,"
 
@@ -439,6 +477,7 @@ msgid "Your Data Export is Ready"
 msgstr "Dein Datenexport ist bereit"
 
 #, python-format
+
 msgid "Hi %(user.username)s,"
 msgstr "Hi %(user.username)s,"
 
@@ -477,6 +516,7 @@ msgid "Your Revel email address has been changed"
 msgstr "Deine Revel-E-Mail-Adresse wurde geändert"
 
 #, python-format
+
 msgid ""
 "This address (<strong>%(new_email)s</strong>) is now the primary email on "
 "your Revel account. The previous address (<strong>%(old_email)s</strong>) "
@@ -498,6 +538,7 @@ msgid "Your Revel email address has been changed."
 msgstr "Deine Revel-E-Mail-Adresse wurde geändert."
 
 #, python-format
+
 msgid ""
 "This address (%(new_email)s) is now the primary email on your Revel account. "
 "The previous address (%(old_email)s) has been removed and can no longer be "
@@ -508,6 +549,7 @@ msgstr ""
 "nicht mehr zur Anmeldung verwendet werden."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from <strong>%(old_email)s</strong> to <strong>%(new_email)s</"
@@ -525,6 +567,7 @@ msgstr ""
 "von nun an mit deiner neuen E-Mail-Adresse an."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from %(old_email)s to %(new_email)s."
@@ -576,6 +619,7 @@ msgid "An email change was requested on your account"
 msgstr "Eine Änderung der E-Mail-Adresse wurde für dein Konto beantragt"
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "<strong>%(masked_new_email)s</strong>. The change is not active yet — it "
@@ -606,6 +650,7 @@ msgid "An email change was requested on your account."
 msgstr "Eine Änderung der E-Mail-Adresse wurde für dein Konto beantragt."
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "%(masked_new_email)s. The change is not active yet — it will only take "
@@ -616,6 +661,7 @@ msgstr ""
 "erst wirksam, wenn die neue E-Mail-Adresse bestätigt wird."
 
 #, python-format
+
 msgid ""
 "If this wasn't you, change your password immediately at "
 "%(frontend_base_url)s/account/password-reset and contact support."
@@ -653,6 +699,7 @@ msgid "Verify Email Now"
 msgstr "Jetzt E-Mail verifizieren"
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account</a>."
@@ -723,15 +770,18 @@ msgstr ""
 "Buchhaltungszwecken aufbewahrt."
 
 #, python-format
+
 msgid "User: %(user_email)s (%(user_id)s)"
 msgstr "Anwender:in: %(user_email)s (%(user_id)s)"
 
 #, python-format
+
 msgid "Forfeited: %(unpaid_count)s payout(s), %(unpaid_total)s %(currency)s"
 msgstr ""
 "Verfallen: %(unpaid_count)s Vergütung(en), %(unpaid_total)s %(currency)s"
 
 #, python-format
+
 msgid "Of which failed transfers: %(failed_total)s %(currency)s"
 msgstr ""
 "Davon aus fehlgeschlagenen Überweisungen: %(failed_total)s %(currency)s"
@@ -740,14 +790,17 @@ msgid "Referral payouts forfeited by an account deletion"
 msgstr "Durch eine Kontolöschung verfallene Empfehlungsvergütungen"
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s"
 msgstr "Empfehlungsvergütung %(document_number)s"
 
 #, python-format
+
 msgid "Referral Payout Statement %(document_number)s"
 msgstr "Empfehlungsvergütung %(document_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached your referral payout statement %(document_number)s for "
 "the period %(period_start)s to %(period_end)s."
@@ -771,6 +824,7 @@ msgid "Users"
 msgstr "Anwender:innen"
 
 #, python-format
+
 msgid "You are about to impersonate the user \"%(username)s\"."
 msgstr "Du bist im Begriff, dich als Anwender:in „%(username)s“ anzumelden."
 
@@ -853,6 +907,7 @@ msgstr ""
 "wurde gespeichert. Bitte versuche es später noch einmal."
 
 #, python-format
+
 msgid "Country code must match the VAT ID prefix (%(prefix)s)."
 msgstr ""
 "Der Ländercode muss mit dem USt-IdNr.-Präfix übereinstimmen (%(prefix)s)."
@@ -935,6 +990,24 @@ msgstr "refund_tickets ist nur beim Abbrechen des Events gültig."
 msgid "Invitation not found."
 msgstr "Einladung nicht gefunden."
 
+msgid "Offer not found."
+msgstr "Angebot nicht gefunden."
+
+msgid ""
+"Waitlist time window is not configured for this event. Provide expires_at in "
+"the payload."
+msgstr ""
+"Für dieses Event ist kein Wartelisten-Zeitfenster konfiguriert. Gib "
+"expires_at im Payload an."
+
+msgid "User already has a pending offer for this event."
+msgstr "Diese:r Anwender:in hat bereits ein offenes Angebot für dieses Event."
+
+msgid "Event is at capacity. Revoke an existing pending offer to make room."
+msgstr ""
+"Das Event ist ausgelastet. Widerrufe ein bestehendes offenes Angebot, um "
+"Platz zu schaffen."
+
 msgid "This event does not have an open waitlist."
 msgstr "Dieses Event hat keine offene Warteliste."
 
@@ -989,15 +1062,20 @@ msgstr "Eine oder mehrere Ticketkategorien wurden nicht gefunden."
 msgid "No pending reservation found."
 msgstr "Keine ausstehende Reservierung gefunden."
 
+msgid "This event has no venue."
+msgstr "Dieses Event hat keinen Veranstaltungsort."
+
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Verwende den Endpunkt /checkout/pwyc für \"Zahl-was-du-kannst\"-Tickets"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at least {min_amount}"
 msgstr "Der PWYC-Betrag muss mindestens {min_amount} betragen"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at most {max_amount}"
 msgstr "Der PWYC-Betrag darf höchstens {max_amount} betragen"
 
@@ -1034,6 +1112,9 @@ msgstr "Das Erstellen von Organisationen ist auf dieser Instanz deaktiviert."
 msgid "Message sent."
 msgstr "Nachricht gesendet."
 
+msgid "No matching blacklist entries found."
+msgstr "Keine passenden Blacklist-Einträge gefunden."
+
 msgid "Token does not match this organization."
 msgstr "Dieses Token gehört nicht zu dieser Organisation."
 
@@ -1042,6 +1123,12 @@ msgstr "Nur der:die Organisationsinhaber:in kann Staff-Mitglieder erstellen."
 
 msgid "Only the organization owner can change staff permissions."
 msgstr "Nur der:die Organisationsinhaber:in kann Staff-Berechtigungen ändern."
+
+msgid "Series has no template event."
+msgstr "Die Serie hat kein Vorlagen-Event."
+
+msgid "date_from must be on or before date_to."
+msgstr "date_from muss vor oder gleich date_to liegen."
 
 msgid ""
 "ONLINE plans must be subscribed to by the member directly. Send them to the "
@@ -1078,8 +1165,26 @@ msgstr "Das Rechnungs-PDF wurde noch nicht erstellt."
 msgid "Invoice PDF could not be generated."
 msgstr "Rechnungs-PDF konnte nicht erstellt werden."
 
+msgid "You must be the owner of this organization."
+msgstr "Du musst Inhaber:in dieser Organisation sein."
+
+msgid "You must be the owner or a staff member of this organization."
+msgstr "Du musst Inhaber:in oder Staff-Mitglied dieser Organisation sein."
+
 msgid "Ticket sales are paused."
 msgstr "Der Ticketverkauf ist pausiert."
+
+msgid "You're outside of the sale window."
+msgstr "Du befindest dich außerhalb des Verkaufszeitraums."
+
+msgid "The ticket can be purchased by {}"
+msgstr "Das Ticket kann gekauft werden von {}"
+
+msgid "Apple Wallet is not configured"
+msgstr "Apple Wallet ist nicht konfiguriert"
+
+msgid "Google Wallet is not configured"
+msgstr "Google Wallet ist nicht konfiguriert"
 
 msgid ""
 "Your payment went through. We're still confirming your subscription — check "
@@ -1561,7 +1666,62 @@ msgstr ""
 msgid "This member has no ticket for this event."
 msgstr "Dieses Mitglied hat kein Ticket für dieses Event."
 
+msgid "Event not found or does not belong to this organization"
+msgstr "Event nicht gefunden oder gehört nicht zu dieser Organisation"
+
+msgid ""
+"Announcement must have at least one targeting option: event, "
+"target_all_members, target_tiers, or target_staff_only"
+msgstr ""
+"Die Ankündigung muss mindestens eine Zielgruppen-Option haben: event, "
+"target_all_members, target_tiers oder target_staff_only"
+
+msgid "Only draft or scheduled announcements can be updated"
+msgstr ""
+"Nur Ankündigungen im Entwurf oder geplante Ankündigungen können bearbeitet "
+"werden"
+
+msgid "Re-sending to new sign-ups requires an event-targeted announcement"
+msgstr ""
+"Das erneute Senden an neue Anmeldungen erfordert eine auf ein Event "
+"gerichtete Ankündigung"
+
+msgid "Relative scheduling requires an event-targeted announcement"
+msgstr ""
+"Die relative Planung erfordert eine auf ein Event gerichtete Ankündigung"
+
+msgid "Only draft announcements can be scheduled"
+msgstr "Nur Ankündigungen im Entwurf können geplant werden"
+
+msgid "Relative scheduling requires both an anchor and an offset"
+msgstr ""
+"Die relative Planung erfordert sowohl einen Anker als auch einen Versatz"
+
+msgid ""
+"Could not resolve a scheduled time (relative scheduling requires an event)"
+msgstr ""
+"Der geplante Zeitpunkt konnte nicht ermittelt werden (die relative Planung "
+"erfordert ein Event)"
+
+msgid "Scheduled time must be in the future"
+msgstr "Der geplante Zeitpunkt muss in der Zukunft liegen"
+
+msgid "Only scheduled announcements can be unscheduled"
+msgstr "Nur geplante Ankündigungen können wieder entplant werden"
+
+msgid "Only draft or scheduled announcements can be sent"
+msgstr ""
+"Nur Ankündigungen im Entwurf oder geplante Ankündigungen können gesendet "
+"werden"
+
+msgid "Only sent announcements can be resent"
+msgstr "Nur gesendete Ankündigungen können erneut gesendet werden"
+
+msgid "Announcement is not configured for resending"
+msgstr "Die Ankündigung ist nicht für erneutes Senden konfiguriert"
+
 #, python-brace-format
+
 msgid "Invoice totals do not reconcile with its line items: {details}"
 msgstr ""
 "Die Rechnungssummen stimmen nicht mit den Rechnungspositionen überein: "
@@ -1571,10 +1731,12 @@ msgid "Only draft invoices can be edited."
 msgstr "Nur Rechnungsentwürfe können bearbeitet werden."
 
 #, python-brace-format
+
 msgid "Cannot edit fields: {fields}"
 msgstr "Diese Felder können nicht bearbeitet werden: {fields}"
 
 #, python-brace-format
+
 msgid "Fields cannot be null: {fields}"
 msgstr "Diese Felder dürfen nicht null sein: {fields}"
 
@@ -1583,6 +1745,20 @@ msgstr "Stornierte Rechnungen können nicht ausgestellt werden."
 
 msgid "Only draft invoices can be deleted."
 msgstr "Nur Rechnungsentwürfe können gelöscht werden."
+
+msgid "Organization must be EU-based (valid EU VAT country code required)"
+msgstr ""
+"Die Organisation muss in der EU ansässig sein (gültiger EU-Ländercode für "
+"die USt-IdNr. erforderlich)"
+
+msgid "VAT ID must be validated via VIES"
+msgstr "Die USt-IdNr. muss über VIES validiert werden"
+
+msgid "Billing name (legal entity name) is required"
+msgstr "Der Rechnungsname (Name der juristischen Person) ist erforderlich"
+
+msgid "Billing address is required"
+msgstr "Die Rechnungsadresse ist erforderlich"
 
 msgid "Provide either seat_ids or price_category_id, not both."
 msgstr "Gib entweder seat_ids oder price_category_id an, nicht beides."
@@ -1602,10 +1778,17 @@ msgstr ""
 "Ein oder mehrere ausgewählte Sitzplätze sind ungültig oder befinden sich "
 "nicht im richtigen Sektor."
 
+msgid "Ticket tier not found."
+msgstr "Ticket-Stufe nicht gefunden."
+
+msgid "All tiers must use the same currency."
+msgstr "Alle Ticket-Stufen müssen dieselbe Währung verwenden."
+
 msgid "This ticket tier is sold out."
 msgstr "Diese Ticket-Kategorie ist ausverkauft."
 
 #, python-brace-format
+
 msgid "Only {available} ticket(s) remaining for this tier."
 msgstr "Es sind nur noch {available} Tickets für diese Kategorie verbleibend."
 
@@ -1613,6 +1796,7 @@ msgid "This event is sold out."
 msgstr "Dieses Event ist ausverkauft."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining for this event."
 msgstr "Es sind nur noch {available} Plätze für dieses Event verbleibend."
 
@@ -1620,6 +1804,7 @@ msgid "This sector is full."
 msgstr "Dieser Sektor ist voll."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining in this sector."
 msgstr "Es sind nur noch {available} Plätze in diesem Sektor verbleibend."
 
@@ -1645,9 +1830,6 @@ msgstr "Jede Kategorie darf pro Checkout nur einmal vorkommen."
 msgid "The same seat cannot be purchased twice."
 msgstr "Derselbe Sitzplatz kann nicht zweimal gekauft werden."
 
-msgid "You're outside of the sale window."
-msgstr "Du befindest dich außerhalb des Verkaufszeitraums."
-
 msgid "You are not allowed to purchase from this tier."
 msgstr "Du darfst Tickets dieser Kategorie nicht kaufen."
 
@@ -1655,6 +1837,7 @@ msgid "You have reached the maximum number of tickets for this event."
 msgstr "Du hast die maximale Anzahl an Tickets für dieses Event erreicht."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this event."
 msgstr ""
 "Du kannst nur noch {remaining} weitere Tickets für dieses Event erwerben."
@@ -1663,6 +1846,7 @@ msgid "You have reached the maximum number of tickets for this tier."
 msgstr "Du hast die maximale Anzahl an Tickets für diese Kategorie erreicht."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this tier."
 msgstr ""
 "Du kannst nur noch {remaining} weitere Tickets für diese Kategorie erwerben."
@@ -1720,10 +1904,12 @@ msgid "Check-in is not currently open for this event."
 msgstr "Der Check-in ist für dieses Event derzeit nicht geöffnet."
 
 #, python-brace-format
+
 msgid "Check-in is not open yet. It will open at {opens_at}."
 msgstr "Der Check-in ist noch nicht geöffnet. Er öffnet um {opens_at}."
 
 #, python-brace-format
+
 msgid "Check-in has closed for this event. It ended at {ended_at}."
 msgstr ""
 "Der Check-in für dieses Event ist geschlossen. Er endete um {ended_at}."
@@ -1738,6 +1924,7 @@ msgid "This ticket is pending payment confirmation."
 msgstr "Dieses Ticket wartet auf Zahlungsbestätigung."
 
 #, python-brace-format
+
 msgid "Invalid ticket status: {status}"
 msgstr "Ungültiger Ticket-Status: {status}"
 
@@ -1785,6 +1972,7 @@ msgid "This discount code is not valid for this currency."
 msgstr "Dieser Rabattcode ist für diese Währung nicht gültig."
 
 #, python-brace-format
+
 msgid "Minimum purchase amount of {amount} required to use this discount code."
 msgstr ""
 "Mindestens ein Kaufbetrag von {amount} ist erforderlich, um diesen "
@@ -1827,6 +2015,7 @@ msgid "Waiting for questionnaire evaluation."
 msgstr "Warten auf die Fragebogen-Bewertung."
 
 #, python-brace-format
+
 msgid ""
 "Questionnaire evaluation was insufficient. You can try again in {retry_on}."
 msgstr ""
@@ -1900,6 +2089,7 @@ msgid "You have reached the maximum number of attempts."
 msgstr "Du hast die maximale Anzahl an Versuchen erreicht."
 
 #, python-format
+
 msgid "You can retry after %(retry_on)s."
 msgstr "Du kannst es nach %(retry_on)s erneut versuchen."
 
@@ -1910,6 +2100,9 @@ msgstr ""
 
 msgid "Feedback questionnaires cannot require evaluation."
 msgstr "Feedback-Fragebögen können keine Bewertung erfordern."
+
+msgid "LLM evaluation is not available."
+msgstr "Die LLM-Bewertung ist nicht verfügbar."
 
 msgid "One or more events do not exist or belong to this organization."
 msgstr ""
@@ -1944,6 +2137,24 @@ msgstr "Du hast bereits Feedback für dieses Event abgegeben."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Feedback-Fragebögen können nicht bewertet werden."
 
+msgid "Organization not found"
+msgstr "Organisation nicht gefunden"
+
+msgid "Already following this organization"
+msgstr "Du folgst dieser Organisation bereits"
+
+msgid "Not following this organization"
+msgstr "Du folgst dieser Organisation nicht"
+
+msgid "Event series not found"
+msgstr "Event-Serie nicht gefunden"
+
+msgid "Already following this series"
+msgstr "Du folgst dieser Serie bereits"
+
+msgid "Not following this series"
+msgstr "Du folgst dieser Serie nicht"
+
 msgid "Invalid token."
 msgstr "Ungültiger Token."
 
@@ -1966,6 +2177,7 @@ msgid "Invalid token type"
 msgstr "Ungültiger Token-Typ"
 
 #, python-format
+
 msgid "Ticket tiers not found: %(ids)s"
 msgstr "Ticket-Stufen nicht gefunden: %(ids)s"
 
@@ -2069,6 +2281,7 @@ msgstr ""
 "Mitgliedschafts-Abonnementrichtlinie ändern."
 
 #, python-format
+
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "
 "name."
@@ -2204,6 +2417,7 @@ msgid "This payment is already fully refunded."
 msgstr "Diese Zahlung wurde bereits vollständig erstattet."
 
 #, python-format
+
 msgid ""
 "Refund amount must be between 0 and the remaining refundable amount "
 "(%(amount)s)."
@@ -2216,6 +2430,9 @@ msgstr "Für dieses Ticket gibt es keine Zahlung zu erstatten."
 
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "Eine Datei muss bereitgestellt werden, wenn resource_type 'file' ist."
+
+msgid "Specify either month or quarter, not both."
+msgstr "Gib entweder einen Monat oder ein Quartal an, nicht beides."
 
 msgid "This seat is not available for this event."
 msgstr "Dieser Sitzplatz ist für dieses Event nicht verfügbar."
@@ -2272,10 +2489,12 @@ msgstr ""
 "kontaktiere den:die Veranstalter:in."
 
 #, python-brace-format
+
 msgid "Select one of this ticket tier's zones: {zones}."
 msgstr "Wähle eine der Zonen dieser Ticket-Kategorie: {zones}."
 
 #, python-brace-format
+
 msgid ""
 "Seat {seat} is in the \"{category}\" price category, which this ticket tier "
 "does not sell."
@@ -2302,6 +2521,7 @@ msgid "This pass has no upcoming events to purchase."
 msgstr "Dieser Pass hat keine bevorstehenden Veranstaltungen zum Kauf."
 
 #, python-brace-format
+
 msgid "Event {name} is sold out."
 msgstr "Event {name} ist ausverkauft."
 
@@ -2322,18 +2542,22 @@ msgid "Series passes are not supported on recurring series."
 msgstr "Serienpässe werden für wiederkehrende Serien nicht unterstützt."
 
 #, python-format
+
 msgid "Event '%s' does not belong to this series."
 msgstr "Event '%s' gehört nicht zu dieser Serie."
 
 #, python-format
+
 msgid "Event '%s' is not open."
 msgstr "Event '%s' ist nicht geöffnet."
 
 #, python-format
+
 msgid "Event '%s' does not require a ticket."
 msgstr "Event '%s' erfordert kein Ticket."
 
 #, python-format
+
 msgid ""
 "Event '%s' is invitation-only or members-only and cannot be covered by a "
 "series pass."
@@ -2352,6 +2576,7 @@ msgid "One or more events do not exist."
 msgstr "Ein oder mehrere Events existieren nicht."
 
 #, python-format
+
 msgid "Event '%s' is already covered by this pass via a different tier."
 msgstr ""
 "Event '%s' wird von diesem Pass bereits über eine andere Kategorie abgedeckt."
@@ -2618,6 +2843,7 @@ msgid "Cannot refund a ticket that was never paid."
 msgstr "Ein Ticket, das nie bezahlt wurde, kann nicht erstattet werden."
 
 #, python-format
+
 msgid "Refund amount must be between 0 and the amount paid (%(amount)s)."
 msgstr ""
 "Der Erstattungsbetrag muss zwischen 0 und dem gezahlten Betrag liegen "
@@ -2629,6 +2855,7 @@ msgstr ""
 "Sitzplätze."
 
 #, python-brace-format
+
 msgid ""
 "This price category is used by one or more ticket tiers and cannot be "
 "deleted: {tiers}. Remove it from those tiers' category prices first."
@@ -2695,18 +2922,22 @@ msgid "Only approved requests can be removed from whitelist."
 msgstr "Nur genehmigte Anfragen können von der Whitelist entfernt werden."
 
 #, python-format
+
 msgid "Confirm your RSVP to %(event_name)s"
 msgstr "Bestätige deine RSVP für %(event_name)s"
 
 #, python-format
+
 msgid "Confirm your ticket for %(event_name)s"
 msgstr "Bestätige dein Ticket für %(event_name)s"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s (%(currency)s)"
 msgstr "Plattformgebühren-Rechnung %(invoice_number)s (%(currency)s)"
 
 #, python-format
+
 msgid "Verify contact email for %(organization_name)s"
 msgstr "Verifiziere die Kontakt-E-Mail-Adresse für %(organization_name)s"
 
@@ -2717,6 +2948,7 @@ msgid "Confirm your RSVP"
 msgstr "Bestätige deine RSVP"
 
 #, python-format
+
 msgid "You've indicated your interest in attending %(event_name)s."
 msgstr "Du hast dein Interesse an der Teilnahme an %(event_name)s bekundet."
 
@@ -2743,6 +2975,7 @@ msgid "Confirm your ticket purchase"
 msgstr "Bestätige deinen Ticketkauf"
 
 #, python-format
+
 msgid "You've requested a ticket for %(event_name)s (%(tier_name)s)."
 msgstr "Du hast ein Ticket für %(event_name)s (%(tier_name)s) angefragt."
 
@@ -2758,14 +2991,17 @@ msgstr ""
 "Um deinen Ticketkauf zu bestätigen, klicke bitte auf den folgenden Link:"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s"
 msgstr "Plattformgebühren-Rechnung %(invoice_number)s"
 
 #, python-format
+
 msgid "Platform Fee Invoice %(invoice_number)s"
 msgstr "Plattformgebühren-Rechnung %(invoice_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached the platform fee invoice %(invoice_number)s for "
 "%(currency)s transactions in the period %(period_start)s to %(period_end)s."
@@ -2803,19 +3039,23 @@ msgstr ""
 "sein."
 
 #, python-brace-format
+
 msgid "'{key}' is not a valid price category id."
 msgstr "'{key}' ist keine gültige Preiskategorie-ID."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a decimal string."
 msgstr ""
 "Der Preis für die Kategorie {category} muss eine Dezimalzeichenfolge sein."
 
 #, python-brace-format
+
 msgid "'{value}' is not a valid price for category {category}."
 msgstr "'{value}' ist kein gültiger Preis für die Kategorie {category}."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a non-negative number."
 msgstr ""
 "Der Preis für die Kategorie {category} muss eine nicht negative Zahl sein."
@@ -2832,6 +3072,7 @@ msgstr ""
 "Kategorie bepreist, niemals beides."
 
 #, python-brace-format
+
 msgid ""
 "Online tiers require every category price to be at least 1: {categories}."
 msgstr ""
@@ -2839,6 +3080,7 @@ msgstr ""
 "betragen: {categories}."
 
 #, python-brace-format
+
 msgid "These price categories do not belong to the tier's venue: {categories}."
 msgstr ""
 "Diese Preiskategorien gehören nicht zum Veranstaltungsort der Ticket-"
@@ -2892,6 +3134,7 @@ msgid "The import failed unexpectedly."
 msgstr "Der Import ist unerwartet fehlgeschlagen."
 
 #, python-format
+
 msgid "Ticket class %(name)s could not be imported."
 msgstr "Die Ticketklasse %(name)s konnte nicht importiert werden."
 
@@ -3030,6 +3273,7 @@ msgid "Read more..."
 msgstr "Weiterlesen..."
 
 #, python-format
+
 msgid "%(counter)s new notification"
 msgid_plural "%(counter)s new notifications"
 msgstr[0] "%(counter)s neue Benachrichtigung"
@@ -3042,94 +3286,117 @@ msgid "Revel - Your account has been suspended"
 msgstr "Revel - Dein Konto wurde gesperrt"
 
 #, python-format
+
 msgid "New Event: %(event)s"
 msgstr "Neues Event: %(event)s"
 
 #, python-format
+
 msgid "%(org)s has published a new event"
 msgstr "%(org)s hat ein neues Event veröffentlicht"
 
 #, python-format
+
 msgid "Reminder: %(event)s is tomorrow!"
 msgstr "Erinnerung: %(event)s ist morgen!"
 
 #, python-format
+
 msgid "Reminder: %(event)s in %(days)d days"
 msgstr "Erinnerung: %(event)s in %(days)d Tagen"
 
 #, python-format
+
 msgid "Tomorrow: %(event)s"
 msgstr "Morgen: %(event)s"
 
 #, python-format
+
 msgid "Event Updated: %(event)s"
 msgstr "Event aktualisiert: %(event)s"
 
 #, python-format
+
 msgid "Important Update: %(event)s"
 msgstr "Wichtiges Update: %(event)s"
 
 #, python-format
+
 msgid "Event Cancelled: %(event)s"
 msgstr "Event abgesagt: %(event)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s"
 msgstr "%(follower)s folgt jetzt %(org)s"
 
 #, python-format
+
 msgid "New follower - %(org)s"
 msgstr "Neue:r Follower:in - %(org)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s"
 msgstr "%(follower)s folgt jetzt %(series)s"
 
 #, python-format
+
 msgid "New follower - %(series)s"
 msgstr "Neue:r Follower:in - %(series)s"
 
 #, python-format
+
 msgid "%(org)s created %(event)s"
 msgstr "%(org)s hat %(event)s erstellt"
 
 #, python-format
+
 msgid "New event from %(org)s"
 msgstr "Neues Event von %(org)s"
 
 #, python-format
+
 msgid "New event in %(series)s: %(event)s"
 msgstr "Neues Event in %(series)s: %(event)s"
 
 #, python-format
+
 msgid "New event in %(series)s"
 msgstr "Neues Event in %(series)s"
 
 #, python-format
+
 msgid "You're invited to %(event)s"
 msgstr "Du bist zu %(event)s eingeladen"
 
 #, python-format
+
 msgid "You're invited: %(event)s"
 msgstr "Du bist eingeladen: %(event)s"
 
 #, python-format
+
 msgid "%(email)s requested invitation to %(event)s"
 msgstr "%(email)s hat eine Einladung für %(event)s angefragt"
 
 #, python-format
+
 msgid "New invitation request: %(event)s"
 msgstr "Neue Einladungsanfrage: %(event)s"
 
 #, python-format
+
 msgid "You're now a %(role)s of %(org)s"
 msgstr "Du bist jetzt %(role)s von %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s"
 msgstr "Willkommen bei %(org)s"
 
 #, python-format
+
 msgid "Your membership card was updated: %(org)s"
 msgstr "Deine Mitgliedskarte wurde aktualisiert: %(org)s"
 
@@ -3137,268 +3404,333 @@ msgid "Your membership card was updated"
 msgstr "Deine Mitgliedskarte wurde aktualisiert"
 
 #, python-format
+
 msgid "You've been promoted to %(role)s in %(org)s"
 msgstr "Du wurdest in %(org)s zu %(role)s befördert"
 
 #, python-format
+
 msgid "Role Updated: %(role)s - %(org)s"
 msgstr "Rolle aktualisiert: %(role)s - %(org)s"
 
 #, python-format
+
 msgid "Membership Removed: %(org)s"
 msgstr "Mitgliedschaft entfernt: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Approved: %(org)s"
 msgstr "Mitgliedschaftsantrag genehmigt: %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s - Request Approved"
 msgstr "Willkommen bei %(org)s – Antrag genehmigt"
 
 #, python-format
+
 msgid "%(user)s requested to join %(org)s"
 msgstr "Anfrage von %(user)s, %(org)s beizutreten"
 
 #, python-format
+
 msgid "New membership request: %(org)s"
 msgstr "Neuer Mitgliedschaftsantrag: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Declined: %(org)s"
 msgstr "Mitgliedschaftsantrag abgelehnt: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Update: %(org)s"
 msgstr "Mitgliedschaftsantrag-Update: %(org)s"
 
 #, python-format
+
 msgid "%(org)s: %(title)s"
 msgstr "%(org)s: %(title)s"
 
 #, python-format
+
 msgid "%(org)s - %(title)s"
 msgstr "%(org)s - %(title)s"
 
 #, python-format
+
 msgid "New contact message for %(org)s from %(sender)s"
 msgstr "Neue Kontaktnachricht für %(org)s von %(sender)s"
 
 #, python-format
+
 msgid "New contact message: %(org)s"
 msgstr "Neue Kontaktnachricht: %(org)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s"
 msgstr "%(actor)s hat %(item)s hinzugefügt"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s"
 msgstr "%(actor)s hat %(item)s hinzugefügt und beansprucht"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s"
 msgstr "%(actor)s hat %(item)s beansprucht"
 
 #, python-format
+
 msgid "New Potluck Item: %(item)s"
 msgstr "Neuer Mitbringsel: %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item Claimed: %(item)s"
 msgstr "Neuer Mitbringsel beansprucht: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Claimed: %(item)s"
 msgstr "Mitbringsel beansprucht: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Available: %(item)s"
 msgstr "Mitbringsel verfügbar: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Removed: %(item)s"
 msgstr "Mitbringsel entfernt: %(item)s"
 
 #, python-format
+
 msgid "Potluck Update: %(item)s"
 msgstr "Aktualisierung der Mitbringliste: %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s - %(event)s"
 msgstr "%(actor)s hat %(item)s hinzugefügt – %(event)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s - %(event)s"
 msgstr "%(actor)s hat %(item)s hinzugefügt und beansprucht - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s - %(event)s"
 msgstr "%(actor)s hat %(item)s beansprucht – %(event)s"
 
 #, python-format
+
 msgid "Potluck Item Removed - %(event)s"
 msgstr "Mitbringsel entfernt - %(event)s"
 
 #, python-format
+
 msgid "Potluck Update - %(event)s"
 msgstr "Aktualisierung der Mitbringliste - %(event)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission: %(name)s"
 msgstr "Neuer Fragebogen eingegangen: %(name)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission - %(name)s"
 msgstr "Neuer Fragebogen eingegangen: %(name)s"
 
 #, python-format
+
 msgid "✅ Questionnaire Approved: %(name)s"
 msgstr "✅ Fragebogen genehmigt: %(name)s"
 
 #, python-format
+
 msgid "❌ Questionnaire Not Approved: %(name)s"
 msgstr "❌ Fragebogen nicht genehmigt: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation: %(name)s"
 msgstr "Fragebogen-Bewertung: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation Result - %(name)s"
 msgstr "Fragebogen-Bewertung: %(name)s"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s: %(response)s)"
 msgstr "RSVP bestätigt: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(response)s)"
 msgstr "RSVP bestätigt: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s)"
 msgstr "RSVP bestätigt: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s"
 msgstr "RSVP bestätigt: %(event)s"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(response)s)"
 msgstr "RSVP aktualisiert: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(response)s)"
 msgstr "RSVP aktualisiert: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(new_response)s)"
 msgstr "RSVP aktualisiert: %(event)s (%(user)s: %(new_response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s"
 msgstr "RSVP aktualisiert: %(event)s"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s (%(user)s)"
 msgstr "RSVP storniert: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s"
 msgstr "RSVP storniert: %(event)s"
 
 #, python-format
+
 msgid "Series pass purchased: %(pass)s (%(series)s)"
 msgstr "Pass gekauft: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass purchased - %(pass)s"
 msgstr "Pass gekauft - %(pass)s"
 
 #, python-format
+
 msgid "%(pass)s now covers %(count)d new event"
 msgid_plural "%(pass)s now covers %(count)d new events"
 msgstr[0] "%(pass)s deckt jetzt %(count)d neues Event ab"
 msgstr[1] "%(pass)s deckt jetzt %(count)d neue Events ab"
 
 #, python-format
+
 msgid "Your series pass has new events - %(pass)s"
 msgstr "Dein Pass hat neue Events - %(pass)s"
 
 #, python-format
+
 msgid "Series pass cancelled: %(pass)s (%(series)s)"
 msgstr "Pass storniert: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass cancelled - %(pass)s"
 msgstr "Pass storniert - %(pass)s"
 
 #, python-format
+
 msgid "%(count)d new event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "%(count)d neues Event für %(series)s geplant"
 msgstr[1] "%(count)d neue Events für %(series)s geplant"
 
 #, python-format
+
 msgid "New event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "Neues Event für %(series)s geplant"
 msgstr[1] "%(count)d neue Events für %(series)s geplant"
 
 #, python-format
+
 msgid "Membership renewed: %(org)s"
 msgstr "Mitgliedschaft verlängert: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership was renewed"
 msgstr "Deine %(org)s-Mitgliedschaft wurde verlängert"
 
 #, python-format
+
 msgid "Payment failed: %(org)s membership"
 msgstr "Zahlung fehlgeschlagen: %(org)s-Mitgliedschaft"
 
 #, python-format
+
 msgid "Action needed: payment failed for %(org)s"
 msgstr "Handlung erforderlich: Zahlung für %(org)s fehlgeschlagen"
 
 #, python-format
+
 msgid "Membership expired: %(org)s"
 msgstr "Mitgliedschaft abgelaufen: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has expired"
 msgstr "Deine %(org)s-Mitgliedschaft ist abgelaufen"
 
 #, python-format
+
 msgid "Membership cancelled: %(org)s"
 msgstr "Mitgliedschaft gekündigt: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has been cancelled"
 msgstr "Deine %(org)s-Mitgliedschaft wurde gekündigt"
 
 #, python-format
+
 msgid "Membership renews soon: %(org)s"
 msgstr "Mitgliedschaft wird bald verlängert: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership renews soon"
 msgstr "Deine %(org)s-Mitgliedschaft wird bald verlängert"
 
 #, python-format
+
 msgid "Price change: %(org)s membership"
 msgstr "Preisänderung: %(org)s-Mitgliedschaft"
 
 #, python-format
+
 msgid "Upcoming price change for your %(org)s membership"
 msgstr "Bevorstehende Preisänderung für deine %(org)s-Mitgliedschaft"
 
 #, python-format
+
 msgid "Complete your membership renewal: %(org)s"
 msgstr "Schließe die Verlängerung deiner Mitgliedschaft ab: %(org)s"
 
 #, python-format
+
 msgid "Complete your %(org)s membership renewal"
 msgstr "Schließe die Verlängerung deiner %(org)s-Mitgliedschaft ab"
 
@@ -3406,38 +3738,47 @@ msgid "System Announcement"
 msgstr "Systemankündigung"
 
 #, python-format
+
 msgid "Revel - %(title)s"
 msgstr "Revel - %(title)s"
 
 #, python-format
+
 msgid "New Ticket: %(holder)s - %(event)s"
 msgstr "Neues Ticket: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending for %(event)s"
 msgstr "Ticket ausstehend für %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed for %(event)s"
 msgstr "Ticket bestätigt für %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending - %(event)s"
 msgstr "Ticket ausstehend - %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed - %(event)s"
 msgstr "Ticket bestätigt - %(event)s"
 
 #, python-format
+
 msgid "Ticket %(action)s: %(holder)s - %(event)s"
 msgstr "Ticket %(action)s: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Update for %(event)s"
 msgstr "Ticket-Update für %(event)s"
 
 #, python-format
+
 msgid "Ticket Update - %(event)s"
 msgstr "Ticket-Update - %(event)s"
 
@@ -3445,14 +3786,17 @@ msgid "Payment Confirmation"
 msgstr "Zahlungsbestätigung"
 
 #, python-format
+
 msgid "Payment Confirmation - %(event)s"
 msgstr "Zahlungsbestätigung - %(event)s"
 
 #, python-format
+
 msgid "Checked in for %(event)s"
 msgstr "Eingecheckt für %(event)s"
 
 #, python-format
+
 msgid "Checked in - %(event)s"
 msgstr "Eingecheckt - %(event)s"
 
@@ -3460,48 +3804,59 @@ msgid "Refund could not be matched to a ticket"
 msgstr "Rückerstattung konnte keinem Ticket zugeordnet werden"
 
 #, python-format
+
 msgid "Action needed: unmatched refund - %(org)s"
 msgstr "Handlungsbedarf: nicht zugeordnete Rückerstattung - %(org)s"
 
 #, python-format
+
 msgid "Refund sweep finished - %(event)s"
 msgstr "Erstattungslauf abgeschlossen - %(event)s"
 
 #, python-format
+
 msgid "Spot available for %(event)s!"
 msgstr "Freier Platz für %(event)s!"
 
 #, python-format
+
 msgid "%d spot available for %s!"
 msgid_plural "%d spots available for %s!"
 msgstr[0] "%d freier Platz für %s!"
 msgstr[1] "%d freie Plätze für %s!"
 
 #, python-format
+
 msgid "Spot Available: %(event)s"
 msgstr "Freier Platz: %(event)s"
 
 #, python-format
+
 msgid "%(user)s requested verification for %(org)s"
 msgstr "Verifizierungsanfrage von %(user)s für %(org)s"
 
 #, python-format
+
 msgid "New verification request: %(org)s"
 msgstr "Neue Verifizierungsanfrage: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved: %(org)s"
 msgstr "Verifizierung genehmigt: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved - %(org)s"
 msgstr "Verifizierung genehmigt - %(org)s"
 
 #, python-format
+
 msgid "Verification Declined: %(org)s"
 msgstr "Verifizierung abgelehnt: %(org)s"
 
 #, python-format
+
 msgid "Verification Update: %(org)s"
 msgstr "Verifizierungs-Update: %(org)s"
 
@@ -3509,6 +3864,7 @@ msgid "Event details have been updated."
 msgstr "Die Event-Details wurden aktualisiert."
 
 #, python-format
+
 msgid "You're invited: %(event_name)s"
 msgstr "Du bist eingeladen: %(event_name)s"
 
@@ -3577,6 +3933,7 @@ msgid "Hello"
 msgstr "Hallo"
 
 #, python-format
+
 msgid ""
 "We regret to inform you that <strong>%(event)s</strong> has been cancelled."
 msgstr ""
@@ -3596,6 +3953,7 @@ msgid "We apologize for any inconvenience this may cause."
 msgstr "Wir entschuldigen uns für eventuelle Unannehmlichkeiten."
 
 #, python-format
+
 msgid "We regret to inform you that %(event)s has been cancelled."
 msgstr "Wir bedauern, dir mitteilen zu müssen, dass %(event)s abgesagt wurde."
 
@@ -3612,6 +3970,7 @@ msgid "Alternative event:"
 msgstr "Alternatives Event:"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has published a new event: <strong>%(event)s</"
 "strong>!"
@@ -3632,6 +3991,7 @@ msgid "View Event & Register"
 msgstr "Event anzeigen & registrieren"
 
 #, python-format
+
 msgid "%(org)s has published a new event: %(event)s!"
 msgstr "%(org)s hat ein neues Event veröffentlicht: %(event)s!"
 
@@ -3639,10 +3999,12 @@ msgid "View event details and register:"
 msgstr "Event-Details anzeigen und registrieren:"
 
 #, python-format
+
 msgid "Refund sweep for %(event)s finished"
 msgstr "Erstattungslauf für %(event)s abgeschlossen"
 
 #, python-format
+
 msgid ""
 "%(cancelled)s tickets cancelled, %(refunded)s refunds issued, %(failed)s "
 "refunds failed."
@@ -3651,6 +4013,7 @@ msgstr ""
 "%(failed)s Erstattungen fehlgeschlagen."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent "
 "&mdash; check the event's ticket admin."
@@ -3659,6 +4022,7 @@ msgstr ""
 "storniert &mdash; bitte in der Ticketverwaltung des Events prüfen."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent - "
 "check the event's ticket admin."
@@ -3667,10 +4031,12 @@ msgstr ""
 "storniert - bitte in der Ticketverwaltung des Events prüfen."
 
 #, python-format
+
 msgid "Reminder: <strong>%(event)s</strong> is tomorrow!"
 msgstr "Erinnerung: <strong>%(event)s</strong> ist morgen!"
 
 #, python-format
+
 msgid ""
 "Reminder: <strong>%(event)s</strong> is in <strong>%(days)s days</strong>"
 msgstr ""
@@ -3692,6 +4058,7 @@ msgid "See you there!"
 msgstr "Wir sehen uns dort!"
 
 #, python-format
+
 msgid "Reminder: %(event)s is in %(days)s days"
 msgstr "Erinnerung: %(event)s ist in %(days)s Tagen"
 
@@ -3702,6 +4069,7 @@ msgid "View event details:"
 msgstr "Event-Details ansehen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(series)s</strong>."
 msgstr "<strong>%(follower)s</strong> folgt jetzt <strong>%(series)s</strong>."
@@ -3719,6 +4087,7 @@ msgid "Series:"
 msgstr "Eventreihe:"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s."
 msgstr "%(follower)s folgt jetzt %(series)s."
 
@@ -3726,6 +4095,7 @@ msgid "Follower Details:"
 msgstr "Details zu:r Follower:in:"
 
 #, python-format
+
 msgid "Important update about <strong>%(event)s</strong>"
 msgstr "Wichtiges Update zu <strong>%(event)s</strong>"
 
@@ -3739,6 +4109,7 @@ msgid "View Updated Event"
 msgstr "Aktualisiertes Event ansehen"
 
 #, python-format
+
 msgid "Important update about %(event)s"
 msgstr "Wichtiges Update zu %(event)s"
 
@@ -3761,6 +4132,7 @@ msgid "New Invitation Request"
 msgstr "Neue Einladungsanfrage"
 
 #, python-format
+
 msgid ""
 "<strong>%(email)s</strong> has requested an invitation to <strong>%(event)s</"
 "strong>."
@@ -3782,6 +4154,7 @@ msgstr ""
 "Dies ist eine automatische Benachrichtigung deines Event-Management-Systems."
 
 #, python-format
+
 msgid "%(email)s has requested an invitation to %(event)s."
 msgstr "%(email)s hat eine Einladung für %(event)s angefragt."
 
@@ -3789,6 +4162,7 @@ msgid "View and manage this request:"
 msgstr "Diese Anfrage ansehen und verwalten:"
 
 #, python-format
+
 msgid ""
 "Your membership tier in <strong>%(org)s</strong> changed to "
 "<strong>%(tier)s</strong>."
@@ -3807,6 +4181,7 @@ msgid "View Organization"
 msgstr "Organisation ansehen"
 
 #, python-format
+
 msgid "Your membership tier in %(org)s changed to %(tier)s."
 msgstr "Deine Mitgliedschaftsstufe in %(org)s wurde auf %(tier)s geändert."
 
@@ -3820,6 +4195,7 @@ msgid "View organization:"
 msgstr "Organisation ansehen:"
 
 #, python-format
+
 msgid "You are now a <strong>%(role)s</strong> of <strong>%(org)s</strong>!"
 msgstr "Du bist jetzt <strong>%(role)s</strong> von <strong>%(org)s</strong>!"
 
@@ -3836,6 +4212,7 @@ msgid "Connect with other members"
 msgstr "Dich mit anderen Mitgliedern vernetzen"
 
 #, python-format
+
 msgid "You are now a %(role)s of %(org)s!"
 msgstr "Du bist jetzt %(role)s von %(org)s!"
 
@@ -3855,6 +4232,7 @@ msgid "New Membership Request"
 msgstr "Neuer Mitgliedschaftsantrag"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested to join <strong>%(org)s</strong>."
 msgstr ""
@@ -3868,6 +4246,7 @@ msgstr ""
 "Systems."
 
 #, python-format
+
 msgid "%(name)s has requested to join %(org)s."
 msgstr "%(name)s hat beantragt, %(org)s beizutreten."
 
@@ -3875,6 +4254,7 @@ msgid "Request Declined"
 msgstr "Antrag abgelehnt"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> created a new event: <strong>%(event)s</strong>"
 msgstr ""
@@ -3900,6 +4280,7 @@ msgid "View Event"
 msgstr "Zum Event"
 
 #, python-format
+
 msgid "%(org)s created a new event: %(event)s"
 msgstr "%(org)s hat ein neues Event erstellt: %(event)s"
 
@@ -3907,6 +4288,7 @@ msgid "View the event:"
 msgstr "Zum Event:"
 
 #, python-format
+
 msgid "New event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 msgstr "Neues Event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 
@@ -3917,6 +4299,7 @@ msgid "New Contact Message"
 msgstr "Neue Kontaktnachricht"
 
 #, python-format
+
 msgid "<strong>%(sender)s</strong> sent a message to <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(sender)s</strong> hat eine Nachricht an <strong>%(org)s</strong> "
@@ -3929,6 +4312,7 @@ msgid "View Message"
 msgstr "Nachricht anzeigen"
 
 #, python-format
+
 msgid "%(sender)s sent a message to %(org)s."
 msgstr "%(sender)s hat eine Nachricht an %(org)s gesendet."
 
@@ -3936,15 +4320,18 @@ msgid "View this message:"
 msgstr "Diese Nachricht anzeigen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(org)s</strong>."
 msgstr "<strong>%(follower)s</strong> folgt jetzt <strong>%(org)s</strong>."
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s."
 msgstr "%(follower)s folgt jetzt %(org)s."
 
 #, python-format
+
 msgid ""
 "Thank you! Your payment for <strong>%(event)s</strong> has been confirmed. 🎉"
 msgstr ""
@@ -3973,6 +4360,7 @@ msgstr ""
 "Eingang des Events vor."
 
 #, python-format
+
 msgid "Thank you! Your payment for %(event)s has been confirmed. 🎉"
 msgstr "Vielen Dank! Deine Zahlung für %(event)s wurde bestätigt. 🎉"
 
@@ -3993,6 +4381,7 @@ msgid "Sign up to accept this invitation:"
 msgstr "Registriere dich, um diese Einladung anzunehmen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> claimed <strong>\"%(item)s\"</strong> for "
 "<strong>%(event)s</strong>."
@@ -4001,6 +4390,7 @@ msgstr ""
 "<strong>%(event)s</strong> beansprucht."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been claimed for <strong>%(event)s</"
 "strong>."
@@ -4027,10 +4417,12 @@ msgid "View Potluck List"
 msgstr "Mitbringliste ansehen"
 
 #, python-format
+
 msgid "%(actor)s claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s hat \"%(item)s\" für %(event)s beansprucht."
 
 #, python-format
+
 msgid "\"%(item)s\" has been claimed for %(event)s."
 msgstr "\"%(item)s\" wurde für %(event)s beansprucht."
 
@@ -4041,6 +4433,7 @@ msgid "View potluck list:"
 msgstr "Mitbringliste ansehen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added <strong>\"%(item)s\"</strong> to the "
 "potluck for <strong>%(event)s</strong>."
@@ -4049,6 +4442,7 @@ msgstr ""
 "Mitbringliste für <strong>%(event)s</strong> hinzugefügt."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added to "
 "<strong>%(event)s</strong>."
@@ -4063,11 +4457,13 @@ msgid "Claim Item"
 msgstr "Mitbringsel beanspruchen"
 
 #, python-format
+
 msgid "%(actor)s added \"%(item)s\" to the potluck for %(event)s."
 msgstr ""
 "%(actor)s hat \"%(item)s\" zur Mitbringliste für %(event)s hinzugefügt."
 
 #, python-format
+
 msgid "A new potluck item \"%(item)s\" has been added to %(event)s."
 msgstr "Ein neues Mitbringsel \"%(item)s\" wurde zu %(event)s hinzugefügt."
 
@@ -4075,6 +4471,7 @@ msgid "Claim this item or view the potluck list:"
 msgstr "Beanspruche dieses Mitbringsel oder sieh dir die Mitbringliste an:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added and claimed <strong>\"%(item)s\"</strong> "
 "for <strong>%(event)s</strong>."
@@ -4083,6 +4480,7 @@ msgstr ""
 "<strong>%(event)s</strong> hinzugefügt und beansprucht."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added and claimed "
 "for <strong>%(event)s</strong>."
@@ -4094,10 +4492,12 @@ msgid "Added and claimed by:"
 msgstr "Hinzugefügt und beansprucht von:"
 
 #, python-format
+
 msgid "%(actor)s added and claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s hat \"%(item)s\" für %(event)s hinzugefügt und beansprucht."
 
 #, python-format
+
 msgid ""
 "A new potluck item \"%(item)s\" has been added and claimed for %(event)s."
 msgstr ""
@@ -4105,6 +4505,7 @@ msgstr ""
 "beansprucht."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been removed from the potluck for "
 "<strong>%(event)s</strong>."
@@ -4113,10 +4514,12 @@ msgstr ""
 "<strong>%(event)s</strong> entfernt."
 
 #, python-format
+
 msgid "\"%(item)s\" has been removed from the potluck for %(event)s."
 msgstr "\"%(item)s\" wurde von der Mitbringliste für %(event)s entfernt."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> is now available for <strong>%(event)s</"
 "strong>."
@@ -4125,6 +4528,7 @@ msgstr ""
 "verfügbar."
 
 #, python-format
+
 msgid "\"%(item)s\" is now available for %(event)s."
 msgstr "\"%(item)s\" ist jetzt für %(event)s verfügbar."
 
@@ -4132,6 +4536,7 @@ msgid "Claim this item:"
 msgstr "Dieses Mitbringsel beanspruchen:"
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been updated for <strong>%(event)s</"
 "strong>."
@@ -4140,10 +4545,12 @@ msgstr ""
 "aktualisiert."
 
 #, python-format
+
 msgid "\"%(item)s\" has been updated for %(event)s."
 msgstr "\"%(item)s\" wurde für %(event)s aktualisiert."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(event)s</strong> has been approved."
@@ -4152,6 +4559,7 @@ msgstr ""
 "<strong>%(event)s</strong> wurde genehmigt."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(org)s</strong> has been approved."
@@ -4160,6 +4568,7 @@ msgstr ""
 "<strong>%(org)s</strong> wurde genehmigt."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(event)s</"
 "strong> was not approved."
@@ -4168,6 +4577,7 @@ msgstr ""
 "strong> wurde nicht genehmigt."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(org)s</"
 "strong> was not approved."
@@ -4214,18 +4624,22 @@ msgid "RSVP Now"
 msgstr "Jetzt zusagen"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s has been approved!"
 msgstr "Dein Fragebogen %(questionnaire)s für %(event)s wurde genehmigt!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s has been approved!"
 msgstr "Dein Fragebogen %(questionnaire)s wurde genehmigt!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s was not approved."
 msgstr "Dein Fragebogen %(questionnaire)s für %(event)s wurde nicht genehmigt."
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s was not approved."
 msgstr "Dein Fragebogen %(questionnaire)s wurde nicht genehmigt."
 
@@ -4239,6 +4653,7 @@ msgid "RSVP now:"
 msgstr "Jetzt zusagen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has submitted the questionnaire "
 "<strong>%(questionnaire)s</strong>."
@@ -4256,6 +4671,7 @@ msgid "Review Submission"
 msgstr "Fragebogen prüfen"
 
 #, python-format
+
 msgid "%(name)s has submitted the questionnaire %(questionnaire)s."
 msgstr "%(name)s hat den Fragebogen %(questionnaire)s ausgefüllt."
 
@@ -4266,6 +4682,7 @@ msgid "Review the submission:"
 msgstr "Fragebogen prüfen:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s arrived from Stripe on payment "
 "%(intent)s, but Revel could not tell which ticket it belongs to. No ticket "
@@ -4280,6 +4697,7 @@ msgid "It could apply to any of these tickets:"
 msgstr "Sie könnte zu einem dieser Tickets gehören:"
 
 #, python-format
+
 msgid "seat %(seat)s"
 msgstr "Platz %(seat)s"
 
@@ -4298,6 +4716,7 @@ msgid "Refund ID:"
 msgstr "Rückerstattungs-ID:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has cancelled their RSVP for <strong>%(event)s</"
 "strong>."
@@ -4309,6 +4728,7 @@ msgid "Cancellation Details"
 msgstr "Stornierungsdetails"
 
 #, python-format
+
 msgid "Your RSVP for <strong>%(event)s</strong> has been cancelled."
 msgstr "Deine RSVP für <strong>%(event)s</strong> wurde storniert."
 
@@ -4316,6 +4736,7 @@ msgid "You can RSVP again anytime if you change your mind."
 msgstr "Du kannst jederzeit erneut zusagen, wenn du deine Meinung änderst."
 
 #, python-format
+
 msgid "%(user)s has cancelled their RSVP for %(event)s."
 msgstr "%(user)s hat die RSVP für %(event)s storniert."
 
@@ -4323,10 +4744,12 @@ msgid "Cancellation Details:"
 msgstr "Stornierungsdetails:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been cancelled."
 msgstr "Deine RSVP für %(event)s wurde storniert."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has RSVP'd <strong>%(response)s</strong> for "
 "<strong>%(event)s</strong>."
@@ -4344,6 +4767,7 @@ msgid "Note:"
 msgstr "Notiz:"
 
 #, python-format
+
 msgid ""
 "Your RSVP (<strong>%(response)s</strong>) for <strong>%(event)s</strong> has "
 "been confirmed! ✅"
@@ -4361,6 +4785,7 @@ msgid "Dietary restrictions:"
 msgstr "Ernährungseinschränkungen:"
 
 #, python-format
+
 msgid "%(user)s has RSVP'd %(response)s for %(event)s."
 msgstr "Zusage von %(user)s mit %(response)s für %(event)s."
 
@@ -4368,6 +4793,7 @@ msgid "RSVP Details:"
 msgstr "Zusagedetails (RSVP):"
 
 #, python-format
+
 msgid "Your RSVP (%(response)s) for %(event)s has been confirmed! ✅"
 msgstr "Deine RSVP (%(response)s) für %(event)s wurde bestätigt! ✅"
 
@@ -4375,6 +4801,7 @@ msgid "Your Response:"
 msgstr "Deine Antwort:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has changed their RSVP from <strong>%(old)s</"
 "strong> to <strong>%(new)s</strong> for <strong>%(event)s</strong>."
@@ -4383,6 +4810,7 @@ msgstr ""
 "<strong>%(new)s</strong> für <strong>%(event)s</strong> geändert."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> updated their RSVP note for <strong>%(event)s</"
 "strong>."
@@ -4400,6 +4828,7 @@ msgid "New Response:"
 msgstr "Neue Antwort:"
 
 #, python-format
+
 msgid ""
 "Your RSVP for <strong>%(event)s</strong> has been updated from "
 "<strong>%(old)s</strong> to <strong>%(new)s</strong>."
@@ -4411,11 +4840,13 @@ msgid "Updated Response"
 msgstr "Aktualisierte Antwort"
 
 #, python-format
+
 msgid "%(user)s has changed their RSVP from %(old)s to %(new)s for %(event)s."
 msgstr ""
 "RSVP von %(user)s wurde von %(old)s auf %(new)s für %(event)s geändert."
 
 #, python-format
+
 msgid "%(user)s updated their RSVP note for %(event)s."
 msgstr "%(user)s hat die RSVP-Notiz für %(event)s aktualisiert."
 
@@ -4423,6 +4854,7 @@ msgid "Updated RSVP Details:"
 msgstr "Zusagedetails (RSVP) aktualisiert:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been updated from %(old)s to %(new)s."
 msgstr "Deine RSVP für %(event)s wurde von %(old)s auf %(new)s geändert."
 
@@ -4430,6 +4862,7 @@ msgid "Updated Response:"
 msgstr "Aktualisierte Antwort:"
 
 #, python-format
+
 msgid ""
 "<strong>%(counter)s</strong> new event has been scheduled for "
 "<strong>%(series)s</strong>."
@@ -4450,6 +4883,7 @@ msgid "View Series"
 msgstr "Serie ansehen"
 
 #, python-format
+
 msgid "%(counter)s new event has been scheduled for %(series)s."
 msgid_plural "%(counter)s new events have been scheduled for %(series)s."
 msgstr[0] "%(counter)s neues Event wurde für %(series)s geplant."
@@ -4459,6 +4893,7 @@ msgid "View the series:"
 msgstr "Zur Serie:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> has been cancelled."
@@ -4473,6 +4908,7 @@ msgid "Tickets cancelled:"
 msgstr "Stornierte Tickets:"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "pass holder."
@@ -4481,6 +4917,7 @@ msgstr ""
 "den Passinhaber ausgestellt."
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> will be processed to "
 "your original payment method within 5-10 business days."
@@ -4490,16 +4927,19 @@ msgstr ""
 "abgewickelt."
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s has been cancelled."
 msgstr "Dein Pass %(pass_name)s für %(series)s wurde storniert."
 
 #, python-format
+
 msgid "A refund of %(amount)s %(currency)s has been issued to the pass holder."
 msgstr ""
 "Eine Rückerstattung von %(amount)s %(currency)s wurde an den Passinhaber "
 "ausgestellt."
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s will be processed to your original "
 "payment method within 5-10 business days."
@@ -4508,6 +4948,7 @@ msgstr ""
 "Werktagen über deine ursprüngliche Zahlungsmethode abgewickelt."
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> now covers <strong>%(counter)s</strong> new event."
@@ -4525,6 +4966,7 @@ msgid "New Events"
 msgstr "Neue Events"
 
 #, python-format
+
 msgid ""
 "Your series pass %(pass_name)s for %(series)s now covers %(counter)s new "
 "event."
@@ -4542,6 +4984,7 @@ msgid "New Events:"
 msgstr "Neue Events:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> is now active."
@@ -4559,6 +5002,7 @@ msgid "Price paid:"
 msgstr "Bezahlter Preis:"
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s is now active."
 msgstr "Dein Pass %(pass_name)s für %(series)s ist jetzt aktiv."
 
@@ -4569,6 +5013,7 @@ msgid "Subscription Cancelled"
 msgstr "Abonnement gekündigt"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> has "
 "been cancelled effective immediately."
@@ -4577,6 +5022,7 @@ msgstr ""
 "mit sofortiger Wirkung gekündigt."
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> will "
 "end on %(date)s."
@@ -4594,6 +5040,7 @@ msgid "We hope to see you again in the future."
 msgstr "Wir hoffen, dich in Zukunft wiederzusehen."
 
 #, python-format
+
 msgid ""
 "Your %(plan)s subscription at %(org)s has been cancelled effective "
 "immediately."
@@ -4601,6 +5048,7 @@ msgstr ""
 "Dein %(plan)s-Abonnement bei %(org)s wurde mit sofortiger Wirkung gekündigt."
 
 #, python-format
+
 msgid "Your %(plan)s subscription at %(org)s will end on %(date)s."
 msgstr "Dein %(plan)s-Abonnement bei %(org)s endet am %(date)s."
 
@@ -4608,6 +5056,7 @@ msgid "Membership Ended"
 msgstr "Mitgliedschaft beendet"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> ended "
 "on %(date)s."
@@ -4619,12 +5068,14 @@ msgid "Ended on:"
 msgstr "Beendet am:"
 
 #, python-format
+
 msgid "You can reactivate your membership until <strong>%(date)s</strong>."
 msgstr ""
 "Du kannst deine Mitgliedschaft bis zum <strong>%(date)s</strong> "
 "reaktivieren."
 
 #, python-format
+
 msgid "Reactivate by %(date)s"
 msgstr "Bis zum %(date)s reaktivieren"
 
@@ -4635,10 +5086,12 @@ msgstr ""
 "starten."
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s ended on %(date)s."
 msgstr "Deine %(plan)s-Mitgliedschaft bei %(org)s endete am %(date)s."
 
 #, python-format
+
 msgid "You can reactivate your membership until %(date)s."
 msgstr "Du kannst deine Mitgliedschaft bis zum %(date)s reaktivieren."
 
@@ -4649,6 +5102,7 @@ msgid "Payment Failed"
 msgstr "Zahlung fehlgeschlagen"
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your <strong>%(plan)s</strong> "
 "membership at <strong>%(org)s</strong>."
@@ -4663,6 +5117,7 @@ msgid "Grace period ends:"
 msgstr "Kulanzfrist endet:"
 
 #, python-format
+
 msgid ""
 "Please resolve this before <strong>%(date)s</strong> to keep your membership "
 "active."
@@ -4674,6 +5129,7 @@ msgid "Update Payment Method"
 msgstr "Zahlungsmethode aktualisieren"
 
 #, python-format
+
 msgid ""
 "Please <a href=\"%(url)s\">contact %(org)s</a> to renew your membership."
 msgstr ""
@@ -4681,6 +5137,7 @@ msgstr ""
 "zu verlängern."
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your %(plan)s membership at %(org)s."
 msgstr ""
@@ -4688,6 +5145,7 @@ msgstr ""
 "einziehen."
 
 #, python-format
+
 msgid "Please resolve this before %(date)s to keep your membership active."
 msgstr ""
 "Bitte behebe dies vor dem %(date)s, um deine Mitgliedschaft aktiv zu halten."
@@ -4696,6 +5154,7 @@ msgid "Update payment method:"
 msgstr "Zahlungsmethode aktualisieren:"
 
 #, python-format
+
 msgid "Contact %(org)s to renew:"
 msgstr "%(org)s kontaktieren, um zu verlängern:"
 
@@ -4703,6 +5162,7 @@ msgid "Subscription Price Update"
 msgstr "Aktualisierung des Abonnementpreises"
 
 #, python-format
+
 msgid ""
 "The price for your <strong>%(plan)s</strong> subscription at "
 "<strong>%(org)s</strong> is changing."
@@ -4723,10 +5183,12 @@ msgid "Effective from:"
 msgstr "Gültig ab:"
 
 #, python-format
+
 msgid "Your subscription will move from %(old)s to %(new)s starting %(date)s."
 msgstr "Dein Abonnement wechselt ab dem %(date)s von %(old)s zu %(new)s."
 
 #, python-format
+
 msgid "The price for your %(plan)s subscription at %(org)s is changing."
 msgstr "Der Preis für dein %(plan)s-Abonnement bei %(org)s ändert sich."
 
@@ -4734,6 +5196,7 @@ msgid "Membership Renewing Soon"
 msgstr "Mitgliedschaft wird bald verlängert"
 
 #, python-format
+
 msgid ""
 "Heads up — your <strong>%(plan)s</strong> membership at <strong>%(org)s</"
 "strong> renews on %(date)s for <strong>%(amount)s</strong>."
@@ -4752,6 +5215,7 @@ msgid "Manage Billing"
 msgstr "Abrechnung verwalten"
 
 #, python-format
+
 msgid ""
 "If you don't want to renew, please <a href=\"%(url)s\">contact %(org)s</a> "
 "before the renewal date."
@@ -4760,6 +5224,7 @@ msgstr ""
 "a> bitte vor dem Verlängerungsdatum."
 
 #, python-format
+
 msgid ""
 "Heads up — your %(plan)s membership at %(org)s renews on %(date)s for "
 "%(amount)s."
@@ -4771,6 +5236,7 @@ msgid "Manage billing:"
 msgstr "Abrechnung verwalten:"
 
 #, python-format
+
 msgid "If you don't want to renew, please contact %(org)s:"
 msgstr "Wenn du nicht verlängern möchtest, kontaktiere bitte %(org)s:"
 
@@ -4778,6 +5244,7 @@ msgid "Membership Renewed"
 msgstr "Mitgliedschaft verlängert"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> has "
 "been successfully renewed."
@@ -4795,6 +5262,7 @@ msgid "Next renewal:"
 msgstr "Nächste Verlängerung:"
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s has been successfully renewed."
 msgstr ""
 "Deine %(plan)s-Mitgliedschaft bei %(org)s wurde erfolgreich verlängert."
@@ -4803,6 +5271,7 @@ msgid "Renew Your Membership"
 msgstr "Verlängere deine Mitgliedschaft"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has set up the renewal of your <strong>%(plan)s</"
 "strong> membership. Complete the payment to reactivate it."
@@ -4822,6 +5291,7 @@ msgstr ""
 "kannst du die Verlängerung über deine Mitgliedschaftsseite neu starten."
 
 #, python-format
+
 msgid ""
 "%(org)s has set up the renewal of your %(plan)s membership. Complete the "
 "payment to reactivate it."
@@ -4839,6 +5309,7 @@ msgid "Read more:"
 msgstr "Mehr lesen:"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> cancelled their ticket for <strong>%(event)s</"
 "strong>."
@@ -4847,6 +5318,7 @@ msgstr ""
 "strong> storniert."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> was "
 "refunded via the Stripe dashboard."
@@ -4855,6 +5327,7 @@ msgstr ""
 "wurde über das Stripe-Dashboard erstattet."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "cancelled."
@@ -4863,16 +5336,19 @@ msgstr ""
 "wurde storniert."
 
 #, python-format
+
 msgid "You cancelled your ticket for <strong>%(event)s</strong>."
 msgstr "Du hast dein Ticket für <strong>%(event)s</strong> storniert."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been cancelled and refunded."
 msgstr ""
 "Dein Ticket für <strong>%(event)s</strong> wurde storniert und erstattet."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> has been cancelled."
 msgstr "Dein Ticket für <strong>%(event)s</strong> wurde storniert."
 
@@ -4883,6 +5359,7 @@ msgid "Cancelled Ticket"
 msgstr "Storniertes Ticket"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "ticket holder."
@@ -4891,10 +5368,12 @@ msgstr ""
 "den Ticketinhaber ausgestellt."
 
 #, python-format
+
 msgid "%(holder)s cancelled their ticket for %(event)s."
 msgstr "%(holder)s hat das eigene Ticket für %(event)s storniert."
 
 #, python-format
+
 msgid ""
 "%(holder)s's ticket for %(event)s was refunded via the Stripe dashboard."
 msgstr ""
@@ -4902,6 +5381,7 @@ msgstr ""
 "erstattet."
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been cancelled."
 msgstr "Das Ticket von %(holder)s für %(event)s wurde storniert."
 
@@ -4909,14 +5389,17 @@ msgid "Ticket Holder:"
 msgstr "Ticketinhaber:"
 
 #, python-format
+
 msgid "You cancelled your ticket for %(event)s."
 msgstr "Du hast dein Ticket für %(event)s storniert."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled and refunded."
 msgstr "Dein Ticket für %(event)s wurde storniert und erstattet."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled."
 msgstr "Dein Ticket für %(event)s wurde storniert."
 
@@ -4924,6 +5407,7 @@ msgid "Cancelled Ticket:"
 msgstr "Storniertes Ticket:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s has been issued to the ticket holder."
 msgstr ""
@@ -4931,6 +5415,7 @@ msgstr ""
 "ausgestellt."
 
 #, python-format
+
 msgid "You have been checked in for <strong>%(event)s</strong>!"
 msgstr "Du wurdest für <strong>%(event)s</strong> eingecheckt!"
 
@@ -4938,10 +5423,12 @@ msgid "Enjoy the event!"
 msgstr "Viel Spaß beim Event!"
 
 #, python-format
+
 msgid "You have been checked in for %(event)s!"
 msgstr "Du wurdest für %(event)s eingecheckt!"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> has registered for <strong>%(event)s</strong>."
 msgstr ""
@@ -4955,6 +5442,7 @@ msgid "Holder:"
 msgstr "Ticketinhaber:in:"
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> is pending payment confirmation."
 msgstr ""
@@ -4973,10 +5461,12 @@ msgstr ""
 "Dein Ticket erhältst du per E-Mail, sobald deine Zahlung bestätigt ist."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> is confirmed! 🎉"
 msgstr "Dein Ticket für <strong>%(event)s</strong> ist bestätigt! 🎉"
 
 #, python-format
+
 msgid "%(holder)s has registered for %(event)s."
 msgstr "%(holder)s hat sich für %(event)s registriert."
 
@@ -4984,6 +5474,7 @@ msgid "Ticket Details:"
 msgstr "Ticket-Details:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is pending payment confirmation."
 msgstr "Dein Ticket für %(event)s wartet auf die Zahlungsbestätigung."
 
@@ -4991,10 +5482,12 @@ msgid "Payment Instructions:"
 msgstr "Zahlungsanweisungen:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is confirmed! 🎉"
 msgstr "Dein Ticket für %(event)s ist bestätigt! 🎉"
 
 #, python-format
+
 msgid "Your ticket refund for <strong>%(event)s</strong> has been processed."
 msgstr ""
 "Die Rückerstattung deines Tickets für <strong>%(event)s</strong> wurde "
@@ -5009,6 +5502,7 @@ msgstr ""
 "deinem Kartenanbieter."
 
 #, python-format
+
 msgid "Your ticket refund for %(event)s has been processed."
 msgstr "Die Rückerstattung deines Tickets für %(event)s wurde verarbeitet."
 
@@ -5021,6 +5515,7 @@ msgstr ""
 "deinem Kartenanbieter."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "<strong>%(action)s</strong>."
@@ -5029,6 +5524,7 @@ msgstr ""
 "wurde <strong>%(action)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been <strong>%(action)s</"
 "strong>."
@@ -5039,10 +5535,12 @@ msgid "Updated Ticket Information"
 msgstr "Aktualisierte Ticket-Informationen"
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been %(action)s."
 msgstr "Das Ticket von %(holder)s für %(event)s wurde %(action)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been confirmed! 🎉"
 msgstr "Dein Ticket für %(event)s ist bestätigt! 🎉"
 
@@ -5050,6 +5548,7 @@ msgid "Your payment has been confirmed. Your ticket is now active!"
 msgstr "Deine Zahlung wurde bestätigt. Dein Ticket ist jetzt aktiv!"
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been updated."
 msgstr "Dein Ticket für %(event)s wurde aktualisiert."
 
@@ -5057,6 +5556,7 @@ msgid "Updated Ticket Information:"
 msgstr "Aktualisierte Ticket-Informationen:"
 
 #, python-format
+
 msgid "A spot just opened up for <strong>%(event)s</strong>!"
 msgstr "Ein Platz ist frei geworden für <strong>%(event)s</strong>!"
 
@@ -5083,6 +5583,7 @@ msgid "Claim your spot:"
 msgstr "Beanspruche deinen Platz:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> has been approved. "
 "You now have full access to view and participate in their events."
@@ -5094,6 +5595,7 @@ msgid "Verification Approved"
 msgstr "Verifizierung genehmigt"
 
 #, python-format
+
 msgid ""
 "Your verification request for %(org)s has been approved. You now have full "
 "access to view and participate in their events."
@@ -5105,6 +5607,7 @@ msgid "New Verification Request"
 msgstr "Neue Verifizierungsanfrage"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested verification for <strong>%(org)s</"
 "strong>."
@@ -5126,6 +5629,7 @@ msgstr ""
 "bittet um Verifizierung, um auf deine Organisation zuzugreifen."
 
 #, python-format
+
 msgid "%(name)s has requested verification for %(org)s."
 msgstr "%(name)s hat eine Verifizierung für %(org)s beantragt."
 
@@ -5133,6 +5637,7 @@ msgid "Review this request:"
 msgstr "Anfrage prüfen:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> was not approved at "
 "this time."
@@ -5150,6 +5655,7 @@ msgid "Verification Update"
 msgstr "Verifizierungs-Update"
 
 #, python-format
+
 msgid "Your verification request for %(org)s was not approved at this time."
 msgstr "Deine Verifizierungsanfrage für %(org)s wurde derzeit nicht genehmigt."
 
@@ -5170,6 +5676,12 @@ msgstr "Benachrichtigungs-Digest"
 
 msgid "View all notifications:"
 msgstr "Alle Benachrichtigungen anzeigen:"
+
+msgid "You are not allowed to see this poll."
+msgstr "Du darfst diese Umfrage nicht sehen."
+
+msgid "You are not allowed to see the results for this poll."
+msgstr "Du darfst die Ergebnisse dieser Umfrage nicht sehen."
 
 msgid "Anonymity flags are immutable after a poll is created."
 msgstr ""
@@ -5205,12 +5717,102 @@ msgstr ""
 "public_anonymous muss True sein, wenn result_visibility PUBLIC oder UNLISTED "
 "ist."
 
+msgid "Only the organization owner can perform this action."
+msgstr "Nur der:die Organisationsinhaber:in kann diese Aktion ausführen."
+
+msgid "Unknown event {} or it does not belong to this organization."
+msgstr "Unbekanntes Event {} oder es gehört nicht zu dieser Organisation."
+
+msgid "Unknown or cross-organization membership_tier ids: {}"
+msgstr "Unbekannte oder organisationsfremde membership_tier-IDs: {}"
+
+msgid "Only DRAFT polls can be opened directly. Use reopen for CLOSED polls."
+msgstr ""
+"Nur Umfragen im Status DRAFT können direkt geöffnet werden. Nutze reopen für "
+"Umfragen im Status CLOSED."
+
+msgid "Only OPEN polls can be closed."
+msgstr "Nur Umfragen im Status OPEN können geschlossen werden."
+
+msgid "Only CLOSED polls can be reopened."
+msgstr "Nur Umfragen im Status CLOSED können wieder geöffnet werden."
+
+msgid "closes_at must be in the future."
+msgstr "closes_at muss in der Zukunft liegen."
+
+msgid "Cannot reopen: provide a future closes_at or set clear_closes_at=True."
+msgstr ""
+"Wiederöffnen nicht möglich: Gib ein zukünftiges closes_at an oder setze "
+"clear_closes_at=True."
+
+msgid "Unknown multiple-choice question id: {}"
+msgstr "Unbekannte ID einer Multiple-Choice-Frage: {}"
+
+msgid "Unknown multiple-choice option id: {}"
+msgstr "Unbekannte ID einer Multiple-Choice-Option: {}"
+
+msgid "Unknown free-text question id: {}"
+msgstr "Unbekannte ID einer Freitext-Frage: {}"
+
+msgid "Unknown file-upload question id: {}"
+msgstr "Unbekannte ID einer Datei-Upload-Frage: {}"
+
+msgid "Unknown or other-user file_upload ids: {}"
+msgstr "Unbekannte oder anderen Anwender:innen gehörende file_upload-IDs: {}"
+
 msgid "You submitted answers refer to a different questionnaire."
 msgstr ""
 "Deine eingesendeten Antworten beziehen sich auf einen anderen Fragebogen."
 
 msgid "You are missing mandatory answers."
 msgstr "Dir fehlen Pflichtantworten."
+
+msgid "File exceeds maximum upload size of {}MB."
+msgstr "Die Datei überschreitet die maximale Upload-Größe von {} MB."
+
+msgid ""
+"File type '{}' is not allowed. Allowed types: documents, images, audio, "
+"video, and archives."
+msgstr ""
+"Der Dateityp '{}' ist nicht erlaubt. Erlaubte Typen: Dokumente, Bilder, "
+"Audio, Video und Archive."
+
+msgid "Section ID in payload does not match the provided section."
+msgstr ""
+"Die Abschnitts-ID im Payload stimmt nicht mit dem angegebenen Abschnitt "
+"überein."
+
+msgid "Section does not exist or does not belong to this questionnaire."
+msgstr "Der Abschnitt existiert nicht oder gehört nicht zu diesem Fragebogen."
+
+msgid "Option does not exist or does not belong to this questionnaire."
+msgstr "Die Option existiert nicht oder gehört nicht zu diesem Fragebogen."
+
+msgid "Question does not belong to this questionnaire."
+msgstr "Die Frage gehört nicht zu diesem Fragebogen."
+
+msgid "Some files do not exist or do not belong to you."
+msgstr "Einige Dateien existieren nicht oder gehören dir nicht."
+
+msgid "Too many files. Maximum allowed: {}."
+msgstr "Zu viele Dateien. Maximal erlaubt: {}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' has type '{mime_type}' which is not allowed. Allowed "
+"types: {allowed_types}."
+msgstr ""
+"Die Datei '{filename}' hat den Typ '{mime_type}', der nicht erlaubt ist. "
+"Erlaubte Typen: {allowed_types}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes."
+msgstr ""
+"Die Datei '{filename}' ({size} Bytes) überschreitet die maximale Größe von "
+"{max_size} Bytes."
 
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -5506,8 +6108,17 @@ msgstr "Gruppen"
 msgid "Telegram integration is not enabled."
 msgstr "Die Telegram-Integration ist nicht aktiviert."
 
+msgid "Your account is already connected to Telegram."
+msgstr "Dein Konto ist bereits mit Telegram verbunden."
+
+msgid "Invalid or expired OTP code."
+msgstr "Ungültiger oder abgelaufener OTP-Code."
+
 msgid "Connected banned Telegram account"
 msgstr "Gesperrtes Telegram-Konto verbunden"
+
+msgid "No Telegram account is linked to your account."
+msgstr "Mit deinem Konto ist kein Telegram-Konto verknüpft."
 
 msgid "Django site admin"
 msgstr "Django-Website-Admin"
@@ -5517,3 +6128,9 @@ msgid ""
 msgstr ""
 "Die Erstellung des Wallet-Passes ist vorübergehend nicht verfügbar. Bitte "
 "versuche es später erneut."
+
+msgid "Invalid link"
+msgstr "Ungültiger Link"
+
+msgid "Link expired"
+msgstr "Link abgelaufen"

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -44,36 +45,42 @@ msgid "Requeue failed payouts"
 msgstr "Reencolar pagos fallidos"
 
 #, python-format
+
 msgid "Requeued %d failed payout."
 msgid_plural "Requeued %d failed payouts."
 msgstr[0] "%d pago fallido reencolado."
 msgstr[1] "%d pagos fallidos reencolados."
 
 #, python-format
+
 msgid "Skipped %d payout (not in failed status)."
 msgid_plural "Skipped %d payouts (not in failed status)."
 msgstr[0] "%d pago omitido (no está en estado fallido)."
 msgstr[1] "%d pagos omitidos (no están en estado fallido)."
 
 #, python-format
+
 msgid "Verification email sent to %d user."
 msgid_plural "Verification emails sent to %d users."
 msgstr[0] "Correo de verificación enviado a %d usuario."
 msgstr[1] "Correos de verificación enviados a %d usuarios."
 
 #, python-format
+
 msgid "Skipped %d user (already verified)."
 msgid_plural "Skipped %d users (already verified)."
 msgstr[0] "%d usuario omitido (ya verificado)."
 msgstr[1] "%d usuarios omitidos (ya verificados)."
 
 #, python-format
+
 msgid "Password reset email sent to %d user."
 msgid_plural "Password reset emails sent to %d users."
 msgstr[0] "Correo de restablecimiento de contraseña enviado a %d usuario."
 msgstr[1] "Correos de restablecimiento de contraseña enviados a %d usuarios."
 
 #, python-format
+
 msgid "Skipped %d user (Google SSO or not found)."
 msgid_plural "Skipped %d users (Google SSO or not found)."
 msgstr[0] "%d usuario omitido (SSO de Google o no encontrado)."
@@ -87,12 +94,14 @@ msgid "Violation of terms of service"
 msgstr "Violación de los términos del servicio"
 
 #, python-format
+
 msgid "Banned %d user."
 msgid_plural "Banned %d users."
 msgstr[0] "%d usuario bloqueado."
 msgstr[1] "%d usuarios bloqueados."
 
 #, python-format
+
 msgid "Skipped %d user (staff/superuser or already banned)."
 msgid_plural "Skipped %d users (staff/superuser or already banned)."
 msgstr[0] "%d usuario omitido (staff/superusuario o ya bloqueado)."
@@ -142,6 +151,12 @@ msgstr "Ya tienes una restricción para este alimento."
 msgid "You have already added this dietary preference."
 msgstr "Ya has añadido esta preferencia alimentaria."
 
+msgid "OTP is already enabled."
+msgstr "El OTP ya está activado."
+
+msgid "Invalid OTP"
+msgstr "OTP no válido"
+
 msgid "Invalid or inactive referral code."
 msgstr "Código de referido no válido o inactivo."
 
@@ -155,6 +170,7 @@ msgid "Only active referrers can connect a Stripe account."
 msgstr "Solo los referidores activos pueden conectar una cuenta de Stripe."
 
 #, python-format
+
 msgid ""
 "Deleting your account will permanently forfeit %(count)s unpaid referral "
 "payout(s) totalling %(total)s %(currency)s, of which %(failed)s %(currency)s "
@@ -167,6 +183,9 @@ msgstr ""
 "en contacto con soporte antes de eliminarla si quieres cobrarlos, o vuelve a "
 "enviar la solicitud con force=true para eliminarla de todas formas."
 
+msgid "Token is blacklisted."
+msgstr "El token está en la lista negra."
+
 msgid "Global Ban"
 msgstr "Bloqueo global"
 
@@ -174,6 +193,7 @@ msgid "Global Bans"
 msgstr "Bloqueos globales"
 
 #, python-format
+
 msgid "Password must be at least %(min_length)d characters long."
 msgstr "La contraseña debe tener al menos %(min_length)d caracteres."
 
@@ -194,6 +214,7 @@ msgstr ""
 "{}|<>)[]=."
 
 #, python-format
+
 msgid ""
 "Your password must be at least %(min_length)d characters long, contain at "
 "least one uppercase letter, one lowercase letter, one digit, and one special "
@@ -236,11 +257,15 @@ msgid "Token has expired."
 msgstr "El token ha caducado."
 
 #, python-brace-format
+
 msgid "Invalid token: {error}"
 msgstr "Token no válido: {error}"
 
 msgid "Invalid token type."
 msgstr "Tipo de token no válido."
+
+msgid "Billing profile already exists."
+msgstr "El perfil de facturación ya existe."
 
 msgid "Registration is not available."
 msgstr "El registro no está disponible."
@@ -260,12 +285,19 @@ msgstr "No puedes suplantar a miembros del staff."
 msgid "Cannot impersonate inactive users."
 msgstr "No puedes suplantar a usuarios inactivos."
 
+msgid "Impersonation not allowed."
+msgstr "La suplantación de identidad no está permitida."
+
+msgid "Impersonation no longer allowed."
+msgstr "La suplantación de identidad ya no está permitida."
+
 msgid "Set a password before unlinking your only sign-in method."
 msgstr ""
 "Establece una contraseña antes de desvincular tu único método de inicio de "
 "sesión."
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s (%(currency)s)"
 msgstr "Extracto de pago de referidos %(document_number)s (%(currency)s)"
 
@@ -326,6 +358,7 @@ msgstr ""
 "eliminarán definitivamente."
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account immediately</a>."
@@ -348,6 +381,7 @@ msgid "Confirm Account Deletion"
 msgstr "Confirmar la eliminación de la cuenta"
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at\n"
@@ -367,6 +401,7 @@ msgid "Confirm Account Deletion."
 msgstr "Confirmar la eliminación de la cuenta."
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at %(frontend_base_url)s."
@@ -390,10 +425,12 @@ msgid "Please investigate this issue as soon as possible."
 msgstr "Por favor, investiga este problema lo antes posible."
 
 #, python-format
+
 msgid "User: %(user.email)s"
 msgstr "Usuario: %(user.email)s"
 
 #, python-format
+
 msgid "Error: %(error_message)s"
 msgstr "Error: %(error_message)s"
 
@@ -404,6 +441,7 @@ msgid "Data Export Failed"
 msgstr "Error en la exportación de datos de usuario"
 
 #, python-format
+
 msgid "Hi %(user.first_name)s,"
 msgstr "Hola %(user.first_name)s,"
 
@@ -437,6 +475,7 @@ msgid "Your Data Export is Ready"
 msgstr "Tu exportación de datos está lista"
 
 #, python-format
+
 msgid "Hi %(user.username)s,"
 msgstr "Hola %(user.username)s,"
 
@@ -474,6 +513,7 @@ msgid "Your Revel email address has been changed"
 msgstr "Tu dirección de correo electrónico de Revel ha cambiado"
 
 #, python-format
+
 msgid ""
 "This address (<strong>%(new_email)s</strong>) is now the primary email on "
 "your Revel account. The previous address (<strong>%(old_email)s</strong>) "
@@ -496,6 +536,7 @@ msgid "Your Revel email address has been changed."
 msgstr "Tu dirección de correo electrónico de Revel ha cambiado."
 
 #, python-format
+
 msgid ""
 "This address (%(new_email)s) is now the primary email on your Revel account. "
 "The previous address (%(old_email)s) has been removed and can no longer be "
@@ -506,6 +547,7 @@ msgstr ""
 "ya no puede usarse para iniciar sesión."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from <strong>%(old_email)s</strong> to <strong>%(new_email)s</"
@@ -523,6 +565,7 @@ msgstr ""
 "de ahora, inicia sesión con tu nueva dirección."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from %(old_email)s to %(new_email)s."
@@ -575,6 +618,7 @@ msgid "An email change was requested on your account"
 msgstr "Se ha solicitado un cambio de correo electrónico en tu cuenta"
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "<strong>%(masked_new_email)s</strong>. The change is not active yet — it "
@@ -604,6 +648,7 @@ msgid "An email change was requested on your account."
 msgstr "Se ha solicitado un cambio de correo electrónico en tu cuenta."
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "%(masked_new_email)s. The change is not active yet — it will only take "
@@ -614,6 +659,7 @@ msgstr ""
 "solo surtirá efecto cuando se confirme la nueva dirección."
 
 #, python-format
+
 msgid ""
 "If this wasn't you, change your password immediately at "
 "%(frontend_base_url)s/account/password-reset and contact support."
@@ -650,6 +696,7 @@ msgid "Verify Email Now"
 msgstr "Verificar correo electrónico ahora"
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account</a>."
@@ -716,14 +763,17 @@ msgstr ""
 "Los pagos ya abonados y sus extractos se han conservado con fines contables."
 
 #, python-format
+
 msgid "User: %(user_email)s (%(user_id)s)"
 msgstr "Usuario: %(user_email)s (%(user_id)s)"
 
 #, python-format
+
 msgid "Forfeited: %(unpaid_count)s payout(s), %(unpaid_total)s %(currency)s"
 msgstr "Perdidos: %(unpaid_count)s pago(s), %(unpaid_total)s %(currency)s"
 
 #, python-format
+
 msgid "Of which failed transfers: %(failed_total)s %(currency)s"
 msgstr "De los cuales, transferencias fallidas: %(failed_total)s %(currency)s"
 
@@ -731,14 +781,17 @@ msgid "Referral payouts forfeited by an account deletion"
 msgstr "Pagos de referidos perdidos por la eliminación de una cuenta"
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s"
 msgstr "Extracto de pago de referidos %(document_number)s"
 
 #, python-format
+
 msgid "Referral Payout Statement %(document_number)s"
 msgstr "Extracto de pago de referidos %(document_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached your referral payout statement %(document_number)s for "
 "the period %(period_start)s to %(period_end)s."
@@ -761,6 +814,7 @@ msgid "Users"
 msgstr "Usuarios"
 
 #, python-format
+
 msgid "You are about to impersonate the user \"%(username)s\"."
 msgstr "Estás a punto de suplantar al usuario \"%(username)s\"."
 
@@ -843,6 +897,7 @@ msgstr ""
 "de IVA se ha guardado. Inténtalo de nuevo más tarde."
 
 #, python-format
+
 msgid "Country code must match the VAT ID prefix (%(prefix)s)."
 msgstr ""
 "El código de país debe coincidir con el prefijo del número de IVA "
@@ -925,6 +980,24 @@ msgstr "refund_tickets solo es válido al cancelar el evento."
 msgid "Invitation not found."
 msgstr "Invitación no encontrada."
 
+msgid "Offer not found."
+msgstr "Oferta no encontrada."
+
+msgid ""
+"Waitlist time window is not configured for this event. Provide expires_at in "
+"the payload."
+msgstr ""
+"Este evento no tiene configurada una ventana de tiempo para la lista de "
+"espera. Indica expires_at en el payload."
+
+msgid "User already has a pending offer for this event."
+msgstr "Esta persona ya tiene una oferta pendiente para este evento."
+
+msgid "Event is at capacity. Revoke an existing pending offer to make room."
+msgstr ""
+"El evento está al máximo de su capacidad. Revoca una oferta pendiente para "
+"hacer sitio."
+
 msgid "This event does not have an open waitlist."
 msgstr "Este evento no tiene una lista de espera abierta."
 
@@ -978,15 +1051,20 @@ msgstr "No se encontraron uno o más tipos de entrada."
 msgid "No pending reservation found."
 msgstr "No se ha encontrado ninguna reserva pendiente."
 
+msgid "This event has no venue."
+msgstr "Este evento no tiene lugar asignado."
+
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Usa el endpoint /checkout/pwyc para las entradas de aportación voluntaria"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at least {min_amount}"
 msgstr "El importe PWYC debe ser al menos {min_amount}"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at most {max_amount}"
 msgstr "El importe PWYC debe ser como máximo {max_amount}"
 
@@ -1022,6 +1100,9 @@ msgstr "La creación de organizaciones está deshabilitada en esta instancia."
 msgid "Message sent."
 msgstr "Mensaje enviado."
 
+msgid "No matching blacklist entries found."
+msgstr "No se han encontrado entradas coincidentes en la lista negra."
+
 msgid "Token does not match this organization."
 msgstr "El token no corresponde a esta organización."
 
@@ -1031,6 +1112,12 @@ msgstr "Solo el propietario de la organización puede crear miembros del staff."
 msgid "Only the organization owner can change staff permissions."
 msgstr ""
 "Solo el propietario de la organización puede cambiar los permisos del staff."
+
+msgid "Series has no template event."
+msgstr "La serie no tiene evento plantilla."
+
+msgid "date_from must be on or before date_to."
+msgstr "date_from debe ser anterior o igual a date_to."
 
 msgid ""
 "ONLINE plans must be subscribed to by the member directly. Send them to the "
@@ -1067,8 +1154,26 @@ msgstr "El PDF de la factura aún no se ha generado."
 msgid "Invoice PDF could not be generated."
 msgstr "No se ha podido generar el PDF de la factura."
 
+msgid "You must be the owner of this organization."
+msgstr "Debes ser propietario/a de esta organización."
+
+msgid "You must be the owner or a staff member of this organization."
+msgstr "Debes ser propietario/a o miembro del staff de esta organización."
+
 msgid "Ticket sales are paused."
 msgstr "La venta de entradas está pausada."
+
+msgid "You're outside of the sale window."
+msgstr "Estás fuera de la ventana de venta."
+
+msgid "The ticket can be purchased by {}"
+msgstr "La entrada puede ser comprada por {}"
+
+msgid "Apple Wallet is not configured"
+msgstr "Apple Wallet no está configurado"
+
+msgid "Google Wallet is not configured"
+msgstr "Google Wallet no está configurado"
 
 msgid ""
 "Your payment went through. We're still confirming your subscription — check "
@@ -1543,7 +1648,55 @@ msgstr ""
 msgid "This member has no ticket for this event."
 msgstr "Este miembro no tiene ninguna entrada para este evento."
 
+msgid "Event not found or does not belong to this organization"
+msgstr "Evento no encontrado o no pertenece a esta organización"
+
+msgid ""
+"Announcement must have at least one targeting option: event, "
+"target_all_members, target_tiers, or target_staff_only"
+msgstr ""
+"El anuncio debe tener al menos una opción de segmentación: event, "
+"target_all_members, target_tiers o target_staff_only"
+
+msgid "Only draft or scheduled announcements can be updated"
+msgstr "Solo se pueden actualizar los anuncios en borrador o programados"
+
+msgid "Re-sending to new sign-ups requires an event-targeted announcement"
+msgstr ""
+"Reenviar a nuevas inscripciones requiere un anuncio dirigido a un evento"
+
+msgid "Relative scheduling requires an event-targeted announcement"
+msgstr "La programación relativa requiere un anuncio dirigido a un evento"
+
+msgid "Only draft announcements can be scheduled"
+msgstr "Solo se pueden programar los anuncios en borrador"
+
+msgid "Relative scheduling requires both an anchor and an offset"
+msgstr "La programación relativa requiere tanto un ancla como un desfase"
+
+msgid ""
+"Could not resolve a scheduled time (relative scheduling requires an event)"
+msgstr ""
+"No se ha podido determinar la hora programada (la programación relativa "
+"requiere un evento)"
+
+msgid "Scheduled time must be in the future"
+msgstr "La hora programada debe estar en el futuro"
+
+msgid "Only scheduled announcements can be unscheduled"
+msgstr "Solo se puede cancelar la programación de los anuncios programados"
+
+msgid "Only draft or scheduled announcements can be sent"
+msgstr "Solo se pueden enviar los anuncios en borrador o programados"
+
+msgid "Only sent announcements can be resent"
+msgstr "Solo se pueden reenviar los anuncios ya enviados"
+
+msgid "Announcement is not configured for resending"
+msgstr "El anuncio no está configurado para el reenvío"
+
 #, python-brace-format
+
 msgid "Invoice totals do not reconcile with its line items: {details}"
 msgstr "Los totales de la factura no cuadran con sus líneas: {details}"
 
@@ -1551,10 +1704,12 @@ msgid "Only draft invoices can be edited."
 msgstr "Solo se pueden editar las facturas en borrador."
 
 #, python-brace-format
+
 msgid "Cannot edit fields: {fields}"
 msgstr "No se pueden editar los campos: {fields}"
 
 #, python-brace-format
+
 msgid "Fields cannot be null: {fields}"
 msgstr "Estos campos no pueden ser nulos: {fields}"
 
@@ -1563,6 +1718,20 @@ msgstr "Las facturas canceladas no se pueden emitir."
 
 msgid "Only draft invoices can be deleted."
 msgstr "Solo se pueden eliminar las facturas en borrador."
+
+msgid "Organization must be EU-based (valid EU VAT country code required)"
+msgstr ""
+"La organización debe estar radicada en la UE (se requiere un código de país "
+"de IVA de la UE válido)"
+
+msgid "VAT ID must be validated via VIES"
+msgstr "El número de IVA debe validarse mediante VIES"
+
+msgid "Billing name (legal entity name) is required"
+msgstr "El nombre de facturación (razón social) es obligatorio"
+
+msgid "Billing address is required"
+msgstr "La dirección de facturación es obligatoria"
 
 msgid "Provide either seat_ids or price_category_id, not both."
 msgstr "Proporciona seat_ids o price_category_id, no ambos."
@@ -1582,10 +1751,17 @@ msgstr ""
 "Uno o más asientos seleccionados no son válidos o no están en el sector "
 "correcto."
 
+msgid "Ticket tier not found."
+msgstr "Tipo de entrada no encontrado."
+
+msgid "All tiers must use the same currency."
+msgstr "Todos los tipos de entrada deben usar la misma moneda."
+
 msgid "This ticket tier is sold out."
 msgstr "Este tipo de entrada está agotado."
 
 #, python-brace-format
+
 msgid "Only {available} ticket(s) remaining for this tier."
 msgstr "Solo quedan {available} entrada(s) de este tipo."
 
@@ -1593,6 +1769,7 @@ msgid "This event is sold out."
 msgstr "Este evento está agotado."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining for this event."
 msgstr "Solo quedan {available} plaza(s) para este evento."
 
@@ -1600,6 +1777,7 @@ msgid "This sector is full."
 msgstr "Este sector está completo."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining in this sector."
 msgstr "Solo quedan {available} plaza(s) en este sector."
 
@@ -1625,9 +1803,6 @@ msgstr "Cada tipo de entrada solo puede aparecer una vez por compra."
 msgid "The same seat cannot be purchased twice."
 msgstr "El mismo asiento no se puede comprar dos veces."
 
-msgid "You're outside of the sale window."
-msgstr "Estás fuera de la ventana de venta."
-
 msgid "You are not allowed to purchase from this tier."
 msgstr "No puedes comprar entradas de este tipo."
 
@@ -1635,6 +1810,7 @@ msgid "You have reached the maximum number of tickets for this event."
 msgstr "Has alcanzado el número máximo de entradas para este evento."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this event."
 msgstr "Solo puedes comprar {remaining} entrada(s) más para este evento."
 
@@ -1642,6 +1818,7 @@ msgid "You have reached the maximum number of tickets for this tier."
 msgstr "Has alcanzado el número máximo de entradas para este tipo."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this tier."
 msgstr "Solo puedes comprar {remaining} entrada(s) más de este tipo."
 
@@ -1693,10 +1870,12 @@ msgid "Check-in is not currently open for this event."
 msgstr "El check-in no está abierto actualmente para este evento."
 
 #, python-brace-format
+
 msgid "Check-in is not open yet. It will open at {opens_at}."
 msgstr "El check-in aún no está abierto. Abrirá a las {opens_at}."
 
 #, python-brace-format
+
 msgid "Check-in has closed for this event. It ended at {ended_at}."
 msgstr "El check-in de este evento ha cerrado. Terminó a las {ended_at}."
 
@@ -1710,6 +1889,7 @@ msgid "This ticket is pending payment confirmation."
 msgstr "Esta entrada está pendiente de confirmación del pago."
 
 #, python-brace-format
+
 msgid "Invalid ticket status: {status}"
 msgstr "Estado de la entrada no válido: {status}"
 
@@ -1758,6 +1938,7 @@ msgid "This discount code is not valid for this currency."
 msgstr "Este código de descuento no es válido para esta moneda."
 
 #, python-brace-format
+
 msgid "Minimum purchase amount of {amount} required to use this discount code."
 msgstr ""
 "Se necesita un importe mínimo de compra de {amount} para usar este código de "
@@ -1801,6 +1982,7 @@ msgid "Waiting for questionnaire evaluation."
 msgstr "Esperando la evaluación del cuestionario."
 
 #, python-brace-format
+
 msgid ""
 "Questionnaire evaluation was insufficient. You can try again in {retry_on}."
 msgstr ""
@@ -1874,6 +2056,7 @@ msgid "You have reached the maximum number of attempts."
 msgstr "Has alcanzado el número máximo de intentos."
 
 #, python-format
+
 msgid "You can retry after %(retry_on)s."
 msgstr "Puedes volver a intentarlo después de %(retry_on)s."
 
@@ -1882,6 +2065,9 @@ msgstr "No se puede filtrar por event_id y event_series_id a la vez."
 
 msgid "Feedback questionnaires cannot require evaluation."
 msgstr "Los cuestionarios de feedback no pueden requerir evaluación."
+
+msgid "LLM evaluation is not available."
+msgstr "La evaluación con LLM no está disponible."
 
 msgid "One or more events do not exist or belong to this organization."
 msgstr "Uno o más eventos no existen o no pertenecen a esta organización."
@@ -1914,6 +2100,24 @@ msgstr "Ya has enviado feedback para este evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Los cuestionarios de feedback no se pueden evaluar."
 
+msgid "Organization not found"
+msgstr "Organización no encontrada"
+
+msgid "Already following this organization"
+msgstr "Ya sigues esta organización"
+
+msgid "Not following this organization"
+msgstr "No sigues esta organización"
+
+msgid "Event series not found"
+msgstr "Serie de eventos no encontrada"
+
+msgid "Already following this series"
+msgstr "Ya sigues esta serie"
+
+msgid "Not following this series"
+msgstr "No sigues esta serie"
+
 msgid "Invalid token."
 msgstr "Token no válido."
 
@@ -1936,6 +2140,7 @@ msgid "Invalid token type"
 msgstr "Tipo de token no válido"
 
 #, python-format
+
 msgid "Ticket tiers not found: %(ids)s"
 msgstr "Tipos de entrada no encontrados: %(ids)s"
 
@@ -2041,6 +2246,7 @@ msgstr ""
 "cambiar la política de suscripción de las membresías."
 
 #, python-format
+
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "
 "name."
@@ -2173,6 +2379,7 @@ msgid "This payment is already fully refunded."
 msgstr "Este pago ya ha sido reembolsado en su totalidad."
 
 #, python-format
+
 msgid ""
 "Refund amount must be between 0 and the remaining refundable amount "
 "(%(amount)s)."
@@ -2185,6 +2392,9 @@ msgstr "Esta entrada no tiene ningún pago que reembolsar."
 
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "Debes proporcionar un archivo cuando resource_type es 'file'."
+
+msgid "Specify either month or quarter, not both."
+msgstr "Indica un mes o un trimestre, pero no ambos."
 
 msgid "This seat is not available for this event."
 msgstr "Este asiento no está disponible para este evento."
@@ -2242,10 +2452,12 @@ msgstr ""
 "organización."
 
 #, python-brace-format
+
 msgid "Select one of this ticket tier's zones: {zones}."
 msgstr "Selecciona una de las zonas de este tipo de entrada: {zones}."
 
 #, python-brace-format
+
 msgid ""
 "Seat {seat} is in the \"{category}\" price category, which this ticket tier "
 "does not sell."
@@ -2272,6 +2484,7 @@ msgid "This pass has no upcoming events to purchase."
 msgstr "Este pase no tiene eventos próximos que comprar."
 
 #, python-brace-format
+
 msgid "Event {name} is sold out."
 msgstr "El evento {name} está agotado."
 
@@ -2291,18 +2504,22 @@ msgid "Series passes are not supported on recurring series."
 msgstr "Los pases de serie no son compatibles con las series recurrentes."
 
 #, python-format
+
 msgid "Event '%s' does not belong to this series."
 msgstr "El evento '%s' no pertenece a esta serie."
 
 #, python-format
+
 msgid "Event '%s' is not open."
 msgstr "El evento '%s' no está abierto."
 
 #, python-format
+
 msgid "Event '%s' does not require a ticket."
 msgstr "El evento '%s' no requiere entrada."
 
 #, python-format
+
 msgid ""
 "Event '%s' is invitation-only or members-only and cannot be covered by a "
 "series pass."
@@ -2321,6 +2538,7 @@ msgid "One or more events do not exist."
 msgstr "Uno o más eventos no existen."
 
 #, python-format
+
 msgid "Event '%s' is already covered by this pass via a different tier."
 msgstr ""
 "El evento '%s' ya está cubierto por este pase mediante otro tipo de entrada."
@@ -2580,6 +2798,7 @@ msgid "Cannot refund a ticket that was never paid."
 msgstr "No se puede reembolsar una entrada que nunca se pagó."
 
 #, python-format
+
 msgid "Refund amount must be between 0 and the amount paid (%(amount)s)."
 msgstr ""
 "El importe del reembolso debe estar entre 0 y el importe pagado (%(amount)s)."
@@ -2589,6 +2808,7 @@ msgstr ""
 "La categoría de precio debe pertenecer al mismo espacio que los asientos."
 
 #, python-brace-format
+
 msgid ""
 "This price category is used by one or more ticket tiers and cannot be "
 "deleted: {tiers}. Remove it from those tiers' category prices first."
@@ -2653,18 +2873,22 @@ msgid "Only approved requests can be removed from whitelist."
 msgstr "Solo se pueden quitar de la lista blanca las solicitudes aprobadas."
 
 #, python-format
+
 msgid "Confirm your RSVP to %(event_name)s"
 msgstr "Confirma tu asistencia a %(event_name)s"
 
 #, python-format
+
 msgid "Confirm your ticket for %(event_name)s"
 msgstr "Confirma tu entrada para %(event_name)s"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s (%(currency)s)"
 msgstr "Factura de comisiones de plataforma %(invoice_number)s (%(currency)s)"
 
 #, python-format
+
 msgid "Verify contact email for %(organization_name)s"
 msgstr "Verifica el correo de contacto de %(organization_name)s"
 
@@ -2675,6 +2899,7 @@ msgid "Confirm your RSVP"
 msgstr "Confirma tu asistencia"
 
 #, python-format
+
 msgid "You've indicated your interest in attending %(event_name)s."
 msgstr "Has indicado tu interés en asistir a %(event_name)s."
 
@@ -2698,6 +2923,7 @@ msgid "Confirm your ticket purchase"
 msgstr "Confirma la compra de tu entrada"
 
 #, python-format
+
 msgid "You've requested a ticket for %(event_name)s (%(tier_name)s)."
 msgstr "Has solicitado una entrada para %(event_name)s (%(tier_name)s)."
 
@@ -2712,14 +2938,17 @@ msgstr ""
 "Para confirmar la compra de tu entrada, haz clic en el enlace de abajo:"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s"
 msgstr "Factura de comisiones de plataforma %(invoice_number)s"
 
 #, python-format
+
 msgid "Platform Fee Invoice %(invoice_number)s"
 msgstr "Factura de comisiones de plataforma %(invoice_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached the platform fee invoice %(invoice_number)s for "
 "%(currency)s transactions in the period %(period_start)s to %(period_end)s."
@@ -2757,18 +2986,22 @@ msgstr ""
 "categoría de precio y el precio."
 
 #, python-brace-format
+
 msgid "'{key}' is not a valid price category id."
 msgstr "'{key}' no es un id de categoría de precio válido."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a decimal string."
 msgstr "El precio de la categoría {category} debe ser una cadena decimal."
 
 #, python-brace-format
+
 msgid "'{value}' is not a valid price for category {category}."
 msgstr "'{value}' no es un precio válido para la categoría {category}."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a non-negative number."
 msgstr "El precio de la categoría {category} debe ser un número no negativo."
 
@@ -2784,6 +3017,7 @@ msgstr ""
 "ambas cosas."
 
 #, python-brace-format
+
 msgid ""
 "Online tiers require every category price to be at least 1: {categories}."
 msgstr ""
@@ -2791,6 +3025,7 @@ msgstr ""
 "menos 1: {categories}."
 
 #, python-brace-format
+
 msgid "These price categories do not belong to the tier's venue: {categories}."
 msgstr ""
 "Estas categorías de precio no pertenecen al espacio del tipo de entrada: "
@@ -2842,6 +3077,7 @@ msgid "The import failed unexpectedly."
 msgstr "La importación falló de forma inesperada."
 
 #, python-format
+
 msgid "Ticket class %(name)s could not be imported."
 msgstr "La clase de entrada %(name)s no se pudo importar."
 
@@ -2979,6 +3215,7 @@ msgid "Read more..."
 msgstr "Leer más..."
 
 #, python-format
+
 msgid "%(counter)s new notification"
 msgid_plural "%(counter)s new notifications"
 msgstr[0] "%(counter)s notificación nueva"
@@ -2991,94 +3228,117 @@ msgid "Revel - Your account has been suspended"
 msgstr "Revel - Tu cuenta ha sido suspendida"
 
 #, python-format
+
 msgid "New Event: %(event)s"
 msgstr "Nuevo evento: %(event)s"
 
 #, python-format
+
 msgid "%(org)s has published a new event"
 msgstr "%(org)s ha publicado un nuevo evento"
 
 #, python-format
+
 msgid "Reminder: %(event)s is tomorrow!"
 msgstr "Recordatorio: ¡%(event)s es mañana!"
 
 #, python-format
+
 msgid "Reminder: %(event)s in %(days)d days"
 msgstr "Recordatorio: %(event)s dentro de %(days)d días"
 
 #, python-format
+
 msgid "Tomorrow: %(event)s"
 msgstr "Mañana: %(event)s"
 
 #, python-format
+
 msgid "Event Updated: %(event)s"
 msgstr "Evento actualizado: %(event)s"
 
 #, python-format
+
 msgid "Important Update: %(event)s"
 msgstr "Actualización importante: %(event)s"
 
 #, python-format
+
 msgid "Event Cancelled: %(event)s"
 msgstr "Evento cancelado: %(event)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s"
 msgstr "%(follower)s ha empezado a seguir a %(org)s"
 
 #, python-format
+
 msgid "New follower - %(org)s"
 msgstr "Nuevo seguidor - %(org)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s"
 msgstr "%(follower)s ha empezado a seguir a %(series)s"
 
 #, python-format
+
 msgid "New follower - %(series)s"
 msgstr "Nuevo seguidor - %(series)s"
 
 #, python-format
+
 msgid "%(org)s created %(event)s"
 msgstr "%(org)s ha creado %(event)s"
 
 #, python-format
+
 msgid "New event from %(org)s"
 msgstr "Nuevo evento de %(org)s"
 
 #, python-format
+
 msgid "New event in %(series)s: %(event)s"
 msgstr "Nuevo evento en %(series)s: %(event)s"
 
 #, python-format
+
 msgid "New event in %(series)s"
 msgstr "Nuevo evento en %(series)s"
 
 #, python-format
+
 msgid "You're invited to %(event)s"
 msgstr "Te han invitado a %(event)s"
 
 #, python-format
+
 msgid "You're invited: %(event)s"
 msgstr "Te han invitado: %(event)s"
 
 #, python-format
+
 msgid "%(email)s requested invitation to %(event)s"
 msgstr "%(email)s ha solicitado una invitación para %(event)s"
 
 #, python-format
+
 msgid "New invitation request: %(event)s"
 msgstr "Nueva solicitud de invitación: %(event)s"
 
 #, python-format
+
 msgid "You're now a %(role)s of %(org)s"
 msgstr "Ahora eres %(role)s de %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s"
 msgstr "Te damos la bienvenida a %(org)s"
 
 #, python-format
+
 msgid "Your membership card was updated: %(org)s"
 msgstr "Tu tarjeta de membresía se actualizó: %(org)s"
 
@@ -3086,268 +3346,333 @@ msgid "Your membership card was updated"
 msgstr "Tu tarjeta de membresía se actualizó"
 
 #, python-format
+
 msgid "You've been promoted to %(role)s in %(org)s"
 msgstr "Te han ascendido a %(role)s en %(org)s"
 
 #, python-format
+
 msgid "Role Updated: %(role)s - %(org)s"
 msgstr "Rol actualizado: %(role)s - %(org)s"
 
 #, python-format
+
 msgid "Membership Removed: %(org)s"
 msgstr "Membresía eliminada: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Approved: %(org)s"
 msgstr "Solicitud de membresía aprobada: %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s - Request Approved"
 msgstr "Te damos la bienvenida a %(org)s - Solicitud aprobada"
 
 #, python-format
+
 msgid "%(user)s requested to join %(org)s"
 msgstr "%(user)s ha solicitado unirse a %(org)s"
 
 #, python-format
+
 msgid "New membership request: %(org)s"
 msgstr "Nueva solicitud de membresía: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Declined: %(org)s"
 msgstr "Solicitud de membresía rechazada: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Update: %(org)s"
 msgstr "Actualización de la solicitud de membresía: %(org)s"
 
 #, python-format
+
 msgid "%(org)s: %(title)s"
 msgstr "%(org)s: %(title)s"
 
 #, python-format
+
 msgid "%(org)s - %(title)s"
 msgstr "%(org)s - %(title)s"
 
 #, python-format
+
 msgid "New contact message for %(org)s from %(sender)s"
 msgstr "Nuevo mensaje de contacto para %(org)s de %(sender)s"
 
 #, python-format
+
 msgid "New contact message: %(org)s"
 msgstr "Nuevo mensaje de contacto: %(org)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s"
 msgstr "%(actor)s ha añadido %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s"
 msgstr "%(actor)s ha añadido y reservado %(item)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s"
 msgstr "%(actor)s ha reservado %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item: %(item)s"
 msgstr "Nueva aportación: %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item Claimed: %(item)s"
 msgstr "Nueva aportación reservada: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Claimed: %(item)s"
 msgstr "Aportación reservada: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Available: %(item)s"
 msgstr "Aportación disponible: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Removed: %(item)s"
 msgstr "Aportación retirada: %(item)s"
 
 #, python-format
+
 msgid "Potluck Update: %(item)s"
 msgstr "Actualización de aportaciones: %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s - %(event)s"
 msgstr "%(actor)s ha añadido %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s - %(event)s"
 msgstr "%(actor)s ha añadido y reservado %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s - %(event)s"
 msgstr "%(actor)s ha reservado %(item)s - %(event)s"
 
 #, python-format
+
 msgid "Potluck Item Removed - %(event)s"
 msgstr "Aportación retirada - %(event)s"
 
 #, python-format
+
 msgid "Potluck Update - %(event)s"
 msgstr "Actualización de aportaciones - %(event)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission: %(name)s"
 msgstr "Nuevo cuestionario recibido: %(name)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission - %(name)s"
 msgstr "Nuevo cuestionario recibido - %(name)s"
 
 #, python-format
+
 msgid "✅ Questionnaire Approved: %(name)s"
 msgstr "✅ Cuestionario aprobado: %(name)s"
 
 #, python-format
+
 msgid "❌ Questionnaire Not Approved: %(name)s"
 msgstr "❌ Cuestionario no aprobado: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation: %(name)s"
 msgstr "Evaluación del cuestionario: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation Result - %(name)s"
 msgstr "Resultado de la evaluación del cuestionario - %(name)s"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s: %(response)s)"
 msgstr "Asistencia confirmada: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(response)s)"
 msgstr "Asistencia confirmada: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s)"
 msgstr "Asistencia confirmada: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s"
 msgstr "Asistencia confirmada: %(event)s"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(response)s)"
 msgstr "Asistencia actualizada: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(response)s)"
 msgstr "Asistencia actualizada: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(new_response)s)"
 msgstr "Asistencia actualizada: %(event)s (%(user)s: %(new_response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s"
 msgstr "Asistencia actualizada: %(event)s"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s (%(user)s)"
 msgstr "Asistencia cancelada: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s"
 msgstr "Asistencia cancelada: %(event)s"
 
 #, python-format
+
 msgid "Series pass purchased: %(pass)s (%(series)s)"
 msgstr "Pase de serie comprado: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass purchased - %(pass)s"
 msgstr "Pase de serie comprado - %(pass)s"
 
 #, python-format
+
 msgid "%(pass)s now covers %(count)d new event"
 msgid_plural "%(pass)s now covers %(count)d new events"
 msgstr[0] "%(pass)s ahora cubre %(count)d evento nuevo"
 msgstr[1] "%(pass)s ahora cubre %(count)d eventos nuevos"
 
 #, python-format
+
 msgid "Your series pass has new events - %(pass)s"
 msgstr "Tu pase de serie tiene eventos nuevos - %(pass)s"
 
 #, python-format
+
 msgid "Series pass cancelled: %(pass)s (%(series)s)"
 msgstr "Pase de serie cancelado: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass cancelled - %(pass)s"
 msgstr "Pase de serie cancelado - %(pass)s"
 
 #, python-format
+
 msgid "%(count)d new event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "%(count)d evento nuevo programado para %(series)s"
 msgstr[1] "%(count)d eventos nuevos programados para %(series)s"
 
 #, python-format
+
 msgid "New event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "Nuevo evento programado para %(series)s"
 msgstr[1] "%(count)d eventos nuevos programados para %(series)s"
 
 #, python-format
+
 msgid "Membership renewed: %(org)s"
 msgstr "Membresía renovada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership was renewed"
 msgstr "Tu membresía de %(org)s se ha renovado"
 
 #, python-format
+
 msgid "Payment failed: %(org)s membership"
 msgstr "Pago fallido: membresía de %(org)s"
 
 #, python-format
+
 msgid "Action needed: payment failed for %(org)s"
 msgstr "Acción necesaria: el pago de %(org)s ha fallado"
 
 #, python-format
+
 msgid "Membership expired: %(org)s"
 msgstr "Membresía caducada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has expired"
 msgstr "Tu membresía de %(org)s ha caducado"
 
 #, python-format
+
 msgid "Membership cancelled: %(org)s"
 msgstr "Membresía cancelada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has been cancelled"
 msgstr "Tu membresía de %(org)s ha sido cancelada"
 
 #, python-format
+
 msgid "Membership renews soon: %(org)s"
 msgstr "Tu membresía se renueva pronto: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership renews soon"
 msgstr "Tu membresía de %(org)s se renueva pronto"
 
 #, python-format
+
 msgid "Price change: %(org)s membership"
 msgstr "Cambio de precio: membresía de %(org)s"
 
 #, python-format
+
 msgid "Upcoming price change for your %(org)s membership"
 msgstr "Próximo cambio de precio en tu membresía de %(org)s"
 
 #, python-format
+
 msgid "Complete your membership renewal: %(org)s"
 msgstr "Completa la renovación de tu membresía: %(org)s"
 
 #, python-format
+
 msgid "Complete your %(org)s membership renewal"
 msgstr "Completa la renovación de tu membresía de %(org)s"
 
@@ -3355,38 +3680,47 @@ msgid "System Announcement"
 msgstr "Anuncio del sistema"
 
 #, python-format
+
 msgid "Revel - %(title)s"
 msgstr "Revel - %(title)s"
 
 #, python-format
+
 msgid "New Ticket: %(holder)s - %(event)s"
 msgstr "Nueva entrada: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending for %(event)s"
 msgstr "Entrada pendiente para %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed for %(event)s"
 msgstr "Entrada confirmada para %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending - %(event)s"
 msgstr "Entrada pendiente - %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed - %(event)s"
 msgstr "Entrada confirmada - %(event)s"
 
 #, python-format
+
 msgid "Ticket %(action)s: %(holder)s - %(event)s"
 msgstr "Entrada %(action)s: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Update for %(event)s"
 msgstr "Actualización de entrada para %(event)s"
 
 #, python-format
+
 msgid "Ticket Update - %(event)s"
 msgstr "Actualización de entrada - %(event)s"
 
@@ -3394,14 +3728,17 @@ msgid "Payment Confirmation"
 msgstr "Confirmación de pago"
 
 #, python-format
+
 msgid "Payment Confirmation - %(event)s"
 msgstr "Confirmación de pago - %(event)s"
 
 #, python-format
+
 msgid "Checked in for %(event)s"
 msgstr "Check-in realizado para %(event)s"
 
 #, python-format
+
 msgid "Checked in - %(event)s"
 msgstr "Check-in realizado - %(event)s"
 
@@ -3409,48 +3746,59 @@ msgid "Refund could not be matched to a ticket"
 msgstr "No se ha podido asociar el reembolso a ninguna entrada"
 
 #, python-format
+
 msgid "Action needed: unmatched refund - %(org)s"
 msgstr "Acción necesaria: reembolso sin asociar - %(org)s"
 
 #, python-format
+
 msgid "Refund sweep finished - %(event)s"
 msgstr "Barrido de reembolsos finalizado - %(event)s"
 
 #, python-format
+
 msgid "Spot available for %(event)s!"
 msgstr "¡Plaza disponible para %(event)s!"
 
 #, python-format
+
 msgid "%d spot available for %s!"
 msgid_plural "%d spots available for %s!"
 msgstr[0] "¡%d plaza disponible para %s!"
 msgstr[1] "¡%d plazas disponibles para %s!"
 
 #, python-format
+
 msgid "Spot Available: %(event)s"
 msgstr "Plaza disponible: %(event)s"
 
 #, python-format
+
 msgid "%(user)s requested verification for %(org)s"
 msgstr "%(user)s ha solicitado la verificación de %(org)s"
 
 #, python-format
+
 msgid "New verification request: %(org)s"
 msgstr "Nueva solicitud de verificación: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved: %(org)s"
 msgstr "Verificación aprobada: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved - %(org)s"
 msgstr "Verificación aprobada - %(org)s"
 
 #, python-format
+
 msgid "Verification Declined: %(org)s"
 msgstr "Verificación rechazada: %(org)s"
 
 #, python-format
+
 msgid "Verification Update: %(org)s"
 msgstr "Actualización de la verificación: %(org)s"
 
@@ -3458,6 +3806,7 @@ msgid "Event details have been updated."
 msgstr "Los detalles del evento se han actualizado."
 
 #, python-format
+
 msgid "You're invited: %(event_name)s"
 msgstr "Te han invitado: %(event_name)s"
 
@@ -3524,6 +3873,7 @@ msgid "Hello"
 msgstr "Hola"
 
 #, python-format
+
 msgid ""
 "We regret to inform you that <strong>%(event)s</strong> has been cancelled."
 msgstr ""
@@ -3542,6 +3892,7 @@ msgid "We apologize for any inconvenience this may cause."
 msgstr "Sentimos las molestias que esto pueda ocasionar."
 
 #, python-format
+
 msgid "We regret to inform you that %(event)s has been cancelled."
 msgstr "Lamentamos informarte de que %(event)s se ha cancelado."
 
@@ -3558,6 +3909,7 @@ msgid "Alternative event:"
 msgstr "Evento alternativo:"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has published a new event: <strong>%(event)s</"
 "strong>!"
@@ -3578,6 +3930,7 @@ msgid "View Event & Register"
 msgstr "Ver evento e inscribirse"
 
 #, python-format
+
 msgid "%(org)s has published a new event: %(event)s!"
 msgstr "¡%(org)s ha publicado un nuevo evento: %(event)s!"
 
@@ -3585,10 +3938,12 @@ msgid "View event details and register:"
 msgstr "Consulta los detalles del evento e inscríbete:"
 
 #, python-format
+
 msgid "Refund sweep for %(event)s finished"
 msgstr "El barrido de reembolsos para %(event)s ha finalizado"
 
 #, python-format
+
 msgid ""
 "%(cancelled)s tickets cancelled, %(refunded)s refunds issued, %(failed)s "
 "refunds failed."
@@ -3597,6 +3952,7 @@ msgstr ""
 "%(failed)s reembolsos fallidos."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent "
 "&mdash; check the event's ticket admin."
@@ -3605,6 +3961,7 @@ msgstr ""
 "&mdash; revisa la administración de entradas del evento."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent - "
 "check the event's ticket admin."
@@ -3613,10 +3970,12 @@ msgstr ""
 "revisa la administración de entradas del evento."
 
 #, python-format
+
 msgid "Reminder: <strong>%(event)s</strong> is tomorrow!"
 msgstr "¡Recordatorio: <strong>%(event)s</strong> es mañana!"
 
 #, python-format
+
 msgid ""
 "Reminder: <strong>%(event)s</strong> is in <strong>%(days)s days</strong>"
 msgstr ""
@@ -3639,6 +3998,7 @@ msgid "See you there!"
 msgstr "¡Nos vemos allí!"
 
 #, python-format
+
 msgid "Reminder: %(event)s is in %(days)s days"
 msgstr "Recordatorio: %(event)s es dentro de %(days)s días"
 
@@ -3649,6 +4009,7 @@ msgid "View event details:"
 msgstr "Ver los detalles del evento:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(series)s</strong>."
 msgstr ""
@@ -3668,6 +4029,7 @@ msgid "Series:"
 msgstr "Serie:"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s."
 msgstr "%(follower)s ha empezado a seguir %(series)s."
 
@@ -3675,6 +4037,7 @@ msgid "Follower Details:"
 msgstr "Detalles de la persona seguidora:"
 
 #, python-format
+
 msgid "Important update about <strong>%(event)s</strong>"
 msgstr "Actualización importante sobre <strong>%(event)s</strong>"
 
@@ -3688,6 +4051,7 @@ msgid "View Updated Event"
 msgstr "Ver evento actualizado"
 
 #, python-format
+
 msgid "Important update about %(event)s"
 msgstr "Actualización importante sobre %(event)s"
 
@@ -3710,6 +4074,7 @@ msgid "New Invitation Request"
 msgstr "Nueva solicitud de invitación"
 
 #, python-format
+
 msgid ""
 "<strong>%(email)s</strong> has requested an invitation to <strong>%(event)s</"
 "strong>."
@@ -3731,6 +4096,7 @@ msgstr ""
 "Esta es una notificación automática de tu sistema de gestión de eventos."
 
 #, python-format
+
 msgid "%(email)s has requested an invitation to %(event)s."
 msgstr "%(email)s ha solicitado una invitación para %(event)s."
 
@@ -3738,6 +4104,7 @@ msgid "View and manage this request:"
 msgstr "Ver y gestionar esta solicitud:"
 
 #, python-format
+
 msgid ""
 "Your membership tier in <strong>%(org)s</strong> changed to "
 "<strong>%(tier)s</strong>."
@@ -3756,6 +4123,7 @@ msgid "View Organization"
 msgstr "Ver organización"
 
 #, python-format
+
 msgid "Your membership tier in %(org)s changed to %(tier)s."
 msgstr "Tu nivel de membresía en %(org)s cambió a %(tier)s."
 
@@ -3769,6 +4137,7 @@ msgid "View organization:"
 msgstr "Ver organización:"
 
 #, python-format
+
 msgid "You are now a <strong>%(role)s</strong> of <strong>%(org)s</strong>!"
 msgstr "¡Ahora eres <strong>%(role)s</strong> de <strong>%(org)s</strong>!"
 
@@ -3785,6 +4154,7 @@ msgid "Connect with other members"
 msgstr "Conectar con otros miembros"
 
 #, python-format
+
 msgid "You are now a %(role)s of %(org)s!"
 msgstr "¡Ahora eres %(role)s de %(org)s!"
 
@@ -3804,6 +4174,7 @@ msgid "New Membership Request"
 msgstr "Nueva solicitud de membresía"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested to join <strong>%(org)s</strong>."
 msgstr ""
@@ -3816,6 +4187,7 @@ msgstr ""
 "organizaciones."
 
 #, python-format
+
 msgid "%(name)s has requested to join %(org)s."
 msgstr "%(name)s ha solicitado unirse a %(org)s."
 
@@ -3823,6 +4195,7 @@ msgid "Request Declined"
 msgstr "Solicitud rechazada"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> created a new event: <strong>%(event)s</strong>"
 msgstr ""
@@ -3848,6 +4221,7 @@ msgid "View Event"
 msgstr "Ver evento"
 
 #, python-format
+
 msgid "%(org)s created a new event: %(event)s"
 msgstr "%(org)s ha creado un nuevo evento: %(event)s"
 
@@ -3855,6 +4229,7 @@ msgid "View the event:"
 msgstr "Ver el evento:"
 
 #, python-format
+
 msgid "New event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 msgstr ""
 "Nuevo evento en <strong>%(series)s</strong>: <strong>%(event)s</strong>"
@@ -3866,6 +4241,7 @@ msgid "New Contact Message"
 msgstr "Nuevo mensaje de contacto"
 
 #, python-format
+
 msgid "<strong>%(sender)s</strong> sent a message to <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(sender)s</strong> ha enviado un mensaje a <strong>%(org)s</strong>."
@@ -3877,6 +4253,7 @@ msgid "View Message"
 msgstr "Ver mensaje"
 
 #, python-format
+
 msgid "%(sender)s sent a message to %(org)s."
 msgstr "%(sender)s ha enviado un mensaje a %(org)s."
 
@@ -3884,16 +4261,19 @@ msgid "View this message:"
 msgstr "Ver este mensaje:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(follower)s</strong> ha empezado a seguir <strong>%(org)s</strong>."
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s."
 msgstr "%(follower)s ha empezado a seguir %(org)s."
 
 #, python-format
+
 msgid ""
 "Thank you! Your payment for <strong>%(event)s</strong> has been confirmed. 🎉"
 msgstr ""
@@ -3922,6 +4302,7 @@ msgstr ""
 "al evento."
 
 #, python-format
+
 msgid "Thank you! Your payment for %(event)s has been confirmed. 🎉"
 msgstr "¡Gracias! Tu pago para %(event)s ha sido confirmado. 🎉"
 
@@ -3941,6 +4322,7 @@ msgid "Sign up to accept this invitation:"
 msgstr "Regístrate para aceptar esta invitación:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> claimed <strong>\"%(item)s\"</strong> for "
 "<strong>%(event)s</strong>."
@@ -3949,6 +4331,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been claimed for <strong>%(event)s</"
 "strong>."
@@ -3975,10 +4358,12 @@ msgid "View Potluck List"
 msgstr "Ver lista de aportaciones"
 
 #, python-format
+
 msgid "%(actor)s claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s ha reservado \"%(item)s\" para %(event)s."
 
 #, python-format
+
 msgid "\"%(item)s\" has been claimed for %(event)s."
 msgstr "\"%(item)s\" se ha reservado para %(event)s."
 
@@ -3989,6 +4374,7 @@ msgid "View potluck list:"
 msgstr "Ver la lista de aportaciones:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added <strong>\"%(item)s\"</strong> to the "
 "potluck for <strong>%(event)s</strong>."
@@ -3997,6 +4383,7 @@ msgstr ""
 "aportaciones de <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added to "
 "<strong>%(event)s</strong>."
@@ -4011,10 +4398,12 @@ msgid "Claim Item"
 msgstr "Reservar artículo"
 
 #, python-format
+
 msgid "%(actor)s added \"%(item)s\" to the potluck for %(event)s."
 msgstr "%(actor)s ha añadido \"%(item)s\" a las aportaciones de %(event)s."
 
 #, python-format
+
 msgid "A new potluck item \"%(item)s\" has been added to %(event)s."
 msgstr "Se ha añadido la nueva aportación \"%(item)s\" a %(event)s."
 
@@ -4022,6 +4411,7 @@ msgid "Claim this item or view the potluck list:"
 msgstr "Reserva este artículo o consulta la lista de aportaciones:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added and claimed <strong>\"%(item)s\"</strong> "
 "for <strong>%(event)s</strong>."
@@ -4030,6 +4420,7 @@ msgstr ""
 "strong> para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added and claimed "
 "for <strong>%(event)s</strong>."
@@ -4041,16 +4432,19 @@ msgid "Added and claimed by:"
 msgstr "Añadido y reservado por:"
 
 #, python-format
+
 msgid "%(actor)s added and claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s ha añadido y reservado \"%(item)s\" para %(event)s."
 
 #, python-format
+
 msgid ""
 "A new potluck item \"%(item)s\" has been added and claimed for %(event)s."
 msgstr ""
 "Se ha añadido y reservado la nueva aportación \"%(item)s\" para %(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been removed from the potluck for "
 "<strong>%(event)s</strong>."
@@ -4059,10 +4453,12 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been removed from the potluck for %(event)s."
 msgstr "\"%(item)s\" se ha eliminado de las aportaciones de %(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> is now available for <strong>%(event)s</"
 "strong>."
@@ -4071,6 +4467,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" is now available for %(event)s."
 msgstr "\"%(item)s\" ya está disponible para %(event)s."
 
@@ -4078,6 +4475,7 @@ msgid "Claim this item:"
 msgstr "Reserva este artículo:"
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been updated for <strong>%(event)s</"
 "strong>."
@@ -4086,10 +4484,12 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been updated for %(event)s."
 msgstr "\"%(item)s\" se ha actualizado para %(event)s."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(event)s</strong> has been approved."
@@ -4098,6 +4498,7 @@ msgstr ""
 "<strong>%(event)s</strong> ha sido aprobado."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(org)s</strong> has been approved."
@@ -4106,6 +4507,7 @@ msgstr ""
 "<strong>%(org)s</strong> ha sido aprobado."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(event)s</"
 "strong> was not approved."
@@ -4114,6 +4516,7 @@ msgstr ""
 "strong> no ha sido aprobado."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(org)s</"
 "strong> was not approved."
@@ -4160,18 +4563,22 @@ msgid "RSVP Now"
 msgstr "Confirmar asistencia"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s has been approved!"
 msgstr "¡Tu cuestionario %(questionnaire)s para %(event)s ha sido aprobado!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s has been approved!"
 msgstr "¡Tu cuestionario %(questionnaire)s ha sido aprobado!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s was not approved."
 msgstr "Tu cuestionario %(questionnaire)s para %(event)s no ha sido aprobado."
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s was not approved."
 msgstr "Tu cuestionario %(questionnaire)s no ha sido aprobado."
 
@@ -4185,6 +4592,7 @@ msgid "RSVP now:"
 msgstr "Confirmar asistencia:"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has submitted the questionnaire "
 "<strong>%(questionnaire)s</strong>."
@@ -4202,6 +4610,7 @@ msgid "Review Submission"
 msgstr "Revisar cuestionario"
 
 #, python-format
+
 msgid "%(name)s has submitted the questionnaire %(questionnaire)s."
 msgstr "%(name)s ha enviado el cuestionario %(questionnaire)s."
 
@@ -4212,6 +4621,7 @@ msgid "Review the submission:"
 msgstr "Revisa el cuestionario:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s arrived from Stripe on payment "
 "%(intent)s, but Revel could not tell which ticket it belongs to. No ticket "
@@ -4225,6 +4635,7 @@ msgid "It could apply to any of these tickets:"
 msgstr "Podría corresponder a alguna de estas entradas:"
 
 #, python-format
+
 msgid "seat %(seat)s"
 msgstr "asiento %(seat)s"
 
@@ -4243,6 +4654,7 @@ msgid "Refund ID:"
 msgstr "ID del reembolso:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has cancelled their RSVP for <strong>%(event)s</"
 "strong>."
@@ -4254,6 +4666,7 @@ msgid "Cancellation Details"
 msgstr "Detalles de la cancelación"
 
 #, python-format
+
 msgid "Your RSVP for <strong>%(event)s</strong> has been cancelled."
 msgstr ""
 "Tu confirmación de asistencia a <strong>%(event)s</strong> ha sido cancelada."
@@ -4264,6 +4677,7 @@ msgstr ""
 "opinión."
 
 #, python-format
+
 msgid "%(user)s has cancelled their RSVP for %(event)s."
 msgstr "%(user)s ha cancelado su confirmación de asistencia a %(event)s."
 
@@ -4271,10 +4685,12 @@ msgid "Cancellation Details:"
 msgstr "Detalles de la cancelación:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been cancelled."
 msgstr "Tu confirmación de asistencia a %(event)s ha sido cancelada."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has RSVP'd <strong>%(response)s</strong> for "
 "<strong>%(event)s</strong>."
@@ -4292,6 +4708,7 @@ msgid "Note:"
 msgstr "Nota:"
 
 #, python-format
+
 msgid ""
 "Your RSVP (<strong>%(response)s</strong>) for <strong>%(event)s</strong> has "
 "been confirmed! ✅"
@@ -4309,6 +4726,7 @@ msgid "Dietary restrictions:"
 msgstr "Restricciones alimentarias:"
 
 #, python-format
+
 msgid "%(user)s has RSVP'd %(response)s for %(event)s."
 msgstr "%(user)s ha respondido %(response)s para %(event)s."
 
@@ -4316,6 +4734,7 @@ msgid "RSVP Details:"
 msgstr "Detalles de la respuesta:"
 
 #, python-format
+
 msgid "Your RSVP (%(response)s) for %(event)s has been confirmed! ✅"
 msgstr "¡Tu respuesta (%(response)s) para %(event)s ha sido confirmada! ✅"
 
@@ -4323,6 +4742,7 @@ msgid "Your Response:"
 msgstr "Tu respuesta:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has changed their RSVP from <strong>%(old)s</"
 "strong> to <strong>%(new)s</strong> for <strong>%(event)s</strong>."
@@ -4331,6 +4751,7 @@ msgstr ""
 "strong> a <strong>%(new)s</strong> para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> updated their RSVP note for <strong>%(event)s</"
 "strong>."
@@ -4348,6 +4769,7 @@ msgid "New Response:"
 msgstr "Nueva respuesta:"
 
 #, python-format
+
 msgid ""
 "Your RSVP for <strong>%(event)s</strong> has been updated from "
 "<strong>%(old)s</strong> to <strong>%(new)s</strong>."
@@ -4359,10 +4781,12 @@ msgid "Updated Response"
 msgstr "Respuesta actualizada"
 
 #, python-format
+
 msgid "%(user)s has changed their RSVP from %(old)s to %(new)s for %(event)s."
 msgstr "%(user)s ha cambiado su respuesta de %(old)s a %(new)s para %(event)s."
 
 #, python-format
+
 msgid "%(user)s updated their RSVP note for %(event)s."
 msgstr "%(user)s ha actualizado la nota de su respuesta para %(event)s."
 
@@ -4370,6 +4794,7 @@ msgid "Updated RSVP Details:"
 msgstr "Detalles de la respuesta actualizados:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been updated from %(old)s to %(new)s."
 msgstr "Tu respuesta para %(event)s se ha actualizado de %(old)s a %(new)s."
 
@@ -4377,6 +4802,7 @@ msgid "Updated Response:"
 msgstr "Respuesta actualizada:"
 
 #, python-format
+
 msgid ""
 "<strong>%(counter)s</strong> new event has been scheduled for "
 "<strong>%(series)s</strong>."
@@ -4397,6 +4823,7 @@ msgid "View Series"
 msgstr "Ver serie"
 
 #, python-format
+
 msgid "%(counter)s new event has been scheduled for %(series)s."
 msgid_plural "%(counter)s new events have been scheduled for %(series)s."
 msgstr[0] "%(counter)s nuevo evento se ha programado para %(series)s."
@@ -4406,6 +4833,7 @@ msgid "View the series:"
 msgstr "Ver la serie:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> has been cancelled."
@@ -4420,6 +4848,7 @@ msgid "Tickets cancelled:"
 msgstr "Entradas canceladas:"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "pass holder."
@@ -4428,6 +4857,7 @@ msgstr ""
 "persona titular del pase."
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> will be processed to "
 "your original payment method within 5-10 business days."
@@ -4436,15 +4866,18 @@ msgstr ""
 "método de pago original en un plazo de 5 a 10 días laborables."
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s has been cancelled."
 msgstr "Tu pase de serie %(pass_name)s para %(series)s ha sido cancelado."
 
 #, python-format
+
 msgid "A refund of %(amount)s %(currency)s has been issued to the pass holder."
 msgstr ""
 "Se ha emitido un reembolso de %(amount)s %(currency)s al titular del pase."
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s will be processed to your original "
 "payment method within 5-10 business days."
@@ -4453,6 +4886,7 @@ msgstr ""
 "original en un plazo de 5 a 10 días laborables."
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> now covers <strong>%(counter)s</strong> new event."
@@ -4470,6 +4904,7 @@ msgid "New Events"
 msgstr "Nuevos eventos"
 
 #, python-format
+
 msgid ""
 "Your series pass %(pass_name)s for %(series)s now covers %(counter)s new "
 "event."
@@ -4487,6 +4922,7 @@ msgid "New Events:"
 msgstr "Nuevos eventos:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> is now active."
@@ -4504,6 +4940,7 @@ msgid "Price paid:"
 msgstr "Precio pagado:"
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s is now active."
 msgstr "Tu pase de serie %(pass_name)s para %(series)s ya está activo."
 
@@ -4514,6 +4951,7 @@ msgid "Subscription Cancelled"
 msgstr "Suscripción cancelada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> has "
 "been cancelled effective immediately."
@@ -4522,6 +4960,7 @@ msgstr ""
 "cancelada con efecto inmediato."
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> will "
 "end on %(date)s."
@@ -4539,6 +4978,7 @@ msgid "We hope to see you again in the future."
 msgstr "Esperamos volver a verte en el futuro."
 
 #, python-format
+
 msgid ""
 "Your %(plan)s subscription at %(org)s has been cancelled effective "
 "immediately."
@@ -4546,6 +4986,7 @@ msgstr ""
 "Tu suscripción %(plan)s en %(org)s ha sido cancelada con efecto inmediato."
 
 #, python-format
+
 msgid "Your %(plan)s subscription at %(org)s will end on %(date)s."
 msgstr "Tu suscripción %(plan)s en %(org)s finalizará el %(date)s."
 
@@ -4553,6 +4994,7 @@ msgid "Membership Ended"
 msgstr "Membresía finalizada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> ended "
 "on %(date)s."
@@ -4564,10 +5006,12 @@ msgid "Ended on:"
 msgstr "Finalizó el:"
 
 #, python-format
+
 msgid "You can reactivate your membership until <strong>%(date)s</strong>."
 msgstr "Puedes reactivar tu membresía hasta el <strong>%(date)s</strong>."
 
 #, python-format
+
 msgid "Reactivate by %(date)s"
 msgstr "Reactivar antes del %(date)s"
 
@@ -4578,10 +5022,12 @@ msgstr ""
 "momento."
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s ended on %(date)s."
 msgstr "Tu membresía %(plan)s en %(org)s finalizó el %(date)s."
 
 #, python-format
+
 msgid "You can reactivate your membership until %(date)s."
 msgstr "Puedes reactivar tu membresía hasta el %(date)s."
 
@@ -4592,6 +5038,7 @@ msgid "Payment Failed"
 msgstr "Pago fallido"
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your <strong>%(plan)s</strong> "
 "membership at <strong>%(org)s</strong>."
@@ -4606,6 +5053,7 @@ msgid "Grace period ends:"
 msgstr "El periodo de gracia termina:"
 
 #, python-format
+
 msgid ""
 "Please resolve this before <strong>%(date)s</strong> to keep your membership "
 "active."
@@ -4617,6 +5065,7 @@ msgid "Update Payment Method"
 msgstr "Actualizar método de pago"
 
 #, python-format
+
 msgid ""
 "Please <a href=\"%(url)s\">contact %(org)s</a> to renew your membership."
 msgstr ""
@@ -4624,11 +5073,13 @@ msgstr ""
 "membresía."
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your %(plan)s membership at %(org)s."
 msgstr "No hemos podido cobrar el pago de tu membresía %(plan)s en %(org)s."
 
 #, python-format
+
 msgid "Please resolve this before %(date)s to keep your membership active."
 msgstr "Resuélvelo antes del %(date)s para mantener tu membresía activa."
 
@@ -4636,6 +5087,7 @@ msgid "Update payment method:"
 msgstr "Actualizar método de pago:"
 
 #, python-format
+
 msgid "Contact %(org)s to renew:"
 msgstr "Contacta con %(org)s para renovar:"
 
@@ -4643,6 +5095,7 @@ msgid "Subscription Price Update"
 msgstr "Actualización del precio de la suscripción"
 
 #, python-format
+
 msgid ""
 "The price for your <strong>%(plan)s</strong> subscription at "
 "<strong>%(org)s</strong> is changing."
@@ -4663,10 +5116,12 @@ msgid "Effective from:"
 msgstr "En vigor desde:"
 
 #, python-format
+
 msgid "Your subscription will move from %(old)s to %(new)s starting %(date)s."
 msgstr "Tu suscripción pasará de %(old)s a %(new)s a partir del %(date)s."
 
 #, python-format
+
 msgid "The price for your %(plan)s subscription at %(org)s is changing."
 msgstr "El precio de tu suscripción %(plan)s en %(org)s va a cambiar."
 
@@ -4674,6 +5129,7 @@ msgid "Membership Renewing Soon"
 msgstr "Membresía a punto de renovarse"
 
 #, python-format
+
 msgid ""
 "Heads up — your <strong>%(plan)s</strong> membership at <strong>%(org)s</"
 "strong> renews on %(date)s for <strong>%(amount)s</strong>."
@@ -4692,6 +5148,7 @@ msgid "Manage Billing"
 msgstr "Gestionar facturación"
 
 #, python-format
+
 msgid ""
 "If you don't want to renew, please <a href=\"%(url)s\">contact %(org)s</a> "
 "before the renewal date."
@@ -4700,6 +5157,7 @@ msgstr ""
 "la fecha de renovación."
 
 #, python-format
+
 msgid ""
 "Heads up — your %(plan)s membership at %(org)s renews on %(date)s for "
 "%(amount)s."
@@ -4711,6 +5169,7 @@ msgid "Manage billing:"
 msgstr "Gestionar facturación:"
 
 #, python-format
+
 msgid "If you don't want to renew, please contact %(org)s:"
 msgstr "Si no quieres renovar, contacta con %(org)s:"
 
@@ -4718,6 +5177,7 @@ msgid "Membership Renewed"
 msgstr "Membresía renovada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> has "
 "been successfully renewed."
@@ -4735,6 +5195,7 @@ msgid "Next renewal:"
 msgstr "Próxima renovación:"
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s has been successfully renewed."
 msgstr "Tu membresía %(plan)s en %(org)s se ha renovado correctamente."
 
@@ -4742,6 +5203,7 @@ msgid "Renew Your Membership"
 msgstr "Renueva tu membresía"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has set up the renewal of your <strong>%(plan)s</"
 "strong> membership. Complete the payment to reactivate it."
@@ -4760,6 +5222,7 @@ msgstr ""
 "reiniciar la renovación desde la página de tu membresía."
 
 #, python-format
+
 msgid ""
 "%(org)s has set up the renewal of your %(plan)s membership. Complete the "
 "payment to reactivate it."
@@ -4777,6 +5240,7 @@ msgid "Read more:"
 msgstr "Leer más:"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> cancelled their ticket for <strong>%(event)s</"
 "strong>."
@@ -4785,6 +5249,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> was "
 "refunded via the Stripe dashboard."
@@ -4793,6 +5258,7 @@ msgstr ""
 "sido reembolsada desde el panel de Stripe."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "cancelled."
@@ -4801,16 +5267,19 @@ msgstr ""
 "sido cancelada."
 
 #, python-format
+
 msgid "You cancelled your ticket for <strong>%(event)s</strong>."
 msgstr "Has cancelado tu entrada para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been cancelled and refunded."
 msgstr ""
 "Tu entrada para <strong>%(event)s</strong> ha sido cancelada y reembolsada."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> has been cancelled."
 msgstr "Tu entrada para <strong>%(event)s</strong> ha sido cancelada."
 
@@ -4821,6 +5290,7 @@ msgid "Cancelled Ticket"
 msgstr "Entrada cancelada"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "ticket holder."
@@ -4829,10 +5299,12 @@ msgstr ""
 "titular de la entrada."
 
 #, python-format
+
 msgid "%(holder)s cancelled their ticket for %(event)s."
 msgstr "%(holder)s ha cancelado su entrada para %(event)s."
 
 #, python-format
+
 msgid ""
 "%(holder)s's ticket for %(event)s was refunded via the Stripe dashboard."
 msgstr ""
@@ -4840,6 +5312,7 @@ msgstr ""
 "de Stripe."
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been cancelled."
 msgstr "La entrada de %(holder)s para %(event)s ha sido cancelada."
 
@@ -4847,14 +5320,17 @@ msgid "Ticket Holder:"
 msgstr "Titular de la entrada:"
 
 #, python-format
+
 msgid "You cancelled your ticket for %(event)s."
 msgstr "Has cancelado tu entrada para %(event)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled and refunded."
 msgstr "Tu entrada para %(event)s ha sido cancelada y reembolsada."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled."
 msgstr "Tu entrada para %(event)s ha sido cancelada."
 
@@ -4862,6 +5338,7 @@ msgid "Cancelled Ticket:"
 msgstr "Entrada cancelada:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s has been issued to the ticket holder."
 msgstr ""
@@ -4869,6 +5346,7 @@ msgstr ""
 "entrada."
 
 #, python-format
+
 msgid "You have been checked in for <strong>%(event)s</strong>!"
 msgstr "¡Has hecho el check-in en <strong>%(event)s</strong>!"
 
@@ -4876,10 +5354,12 @@ msgid "Enjoy the event!"
 msgstr "¡Disfruta del evento!"
 
 #, python-format
+
 msgid "You have been checked in for %(event)s!"
 msgstr "¡Has hecho el check-in en %(event)s!"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> has registered for <strong>%(event)s</strong>."
 msgstr ""
@@ -4892,6 +5372,7 @@ msgid "Holder:"
 msgstr "Titular:"
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> is pending payment confirmation."
 msgstr ""
@@ -4909,10 +5390,12 @@ msgstr ""
 "Recibirás tu entrada por correo electrónico en cuanto se confirme tu pago."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> is confirmed! 🎉"
 msgstr "¡Tu entrada para <strong>%(event)s</strong> está confirmada! 🎉"
 
 #, python-format
+
 msgid "%(holder)s has registered for %(event)s."
 msgstr "%(holder)s se ha registrado para %(event)s."
 
@@ -4920,6 +5403,7 @@ msgid "Ticket Details:"
 msgstr "Detalles de la entrada:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is pending payment confirmation."
 msgstr "Tu entrada para %(event)s está pendiente de confirmación del pago."
 
@@ -4927,10 +5411,12 @@ msgid "Payment Instructions:"
 msgstr "Instrucciones de pago:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is confirmed! 🎉"
 msgstr "¡Tu entrada para %(event)s está confirmada! 🎉"
 
 #, python-format
+
 msgid "Your ticket refund for <strong>%(event)s</strong> has been processed."
 msgstr ""
 "Se ha procesado el reembolso de tu entrada para <strong>%(event)s</strong>."
@@ -4944,6 +5430,7 @@ msgstr ""
 "tarjeta."
 
 #, python-format
+
 msgid "Your ticket refund for %(event)s has been processed."
 msgstr "Se ha procesado el reembolso de tu entrada para %(event)s."
 
@@ -4955,6 +5442,7 @@ msgstr ""
 "días laborables, según tu banco o el emisor de la tarjeta."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "<strong>%(action)s</strong>."
@@ -4963,6 +5451,7 @@ msgstr ""
 "sido <strong>%(action)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been <strong>%(action)s</"
 "strong>."
@@ -4974,10 +5463,12 @@ msgid "Updated Ticket Information"
 msgstr "Información actualizada de la entrada"
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been %(action)s."
 msgstr "La entrada de %(holder)s para %(event)s ha sido %(action)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been confirmed! 🎉"
 msgstr "¡Tu entrada para %(event)s ha sido confirmada! 🎉"
 
@@ -4985,6 +5476,7 @@ msgid "Your payment has been confirmed. Your ticket is now active!"
 msgstr "Tu pago se ha confirmado. ¡Tu entrada ya está activa!"
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been updated."
 msgstr "Tu entrada para %(event)s se ha actualizado."
 
@@ -4992,6 +5484,7 @@ msgid "Updated Ticket Information:"
 msgstr "Información actualizada de la entrada:"
 
 #, python-format
+
 msgid "A spot just opened up for <strong>%(event)s</strong>!"
 msgstr "¡Se ha liberado una plaza para <strong>%(event)s</strong>!"
 
@@ -5019,6 +5512,7 @@ msgid "Claim your spot:"
 msgstr "Reserva tu plaza:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> has been approved. "
 "You now have full access to view and participate in their events."
@@ -5030,6 +5524,7 @@ msgid "Verification Approved"
 msgstr "Verificación aprobada"
 
 #, python-format
+
 msgid ""
 "Your verification request for %(org)s has been approved. You now have full "
 "access to view and participate in their events."
@@ -5041,6 +5536,7 @@ msgid "New Verification Request"
 msgstr "Nueva solicitud de verificación"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested verification for <strong>%(org)s</"
 "strong>."
@@ -5062,6 +5558,7 @@ msgstr ""
 "verificación para acceder a tu organización."
 
 #, python-format
+
 msgid "%(name)s has requested verification for %(org)s."
 msgstr "%(name)s ha solicitado la verificación para %(org)s."
 
@@ -5069,6 +5566,7 @@ msgid "Review this request:"
 msgstr "Revisar esta solicitud:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> was not approved at "
 "this time."
@@ -5085,6 +5583,7 @@ msgid "Verification Update"
 msgstr "Actualización de la verificación"
 
 #, python-format
+
 msgid "Your verification request for %(org)s was not approved at this time."
 msgstr ""
 "Tu solicitud de verificación para %(org)s no ha sido aprobada por el momento."
@@ -5106,6 +5605,12 @@ msgstr "Tu resumen de notificaciones"
 
 msgid "View all notifications:"
 msgstr "Ver todas las notificaciones:"
+
+msgid "You are not allowed to see this poll."
+msgstr "No tienes permiso para ver esta encuesta."
+
+msgid "You are not allowed to see the results for this poll."
+msgstr "No tienes permiso para ver los resultados de esta encuesta."
 
 msgid "Anonymity flags are immutable after a poll is created."
 msgstr ""
@@ -5139,12 +5644,101 @@ msgid ""
 msgstr ""
 "public_anonymous debe ser True cuando result_visibility es PUBLIC o UNLISTED."
 
+msgid "Only the organization owner can perform this action."
+msgstr ""
+"Solo el/la propietario/a de la organización puede realizar esta acción."
+
+msgid "Unknown event {} or it does not belong to this organization."
+msgstr "Evento {} desconocido o no pertenece a esta organización."
+
+msgid "Unknown or cross-organization membership_tier ids: {}"
+msgstr "IDs de membership_tier desconocidos o de otra organización: {}"
+
+msgid "Only DRAFT polls can be opened directly. Use reopen for CLOSED polls."
+msgstr ""
+"Solo las encuestas en estado DRAFT pueden abrirse directamente. Usa reopen "
+"para las encuestas en estado CLOSED."
+
+msgid "Only OPEN polls can be closed."
+msgstr "Solo se pueden cerrar las encuestas en estado OPEN."
+
+msgid "Only CLOSED polls can be reopened."
+msgstr "Solo se pueden reabrir las encuestas en estado CLOSED."
+
+msgid "closes_at must be in the future."
+msgstr "closes_at debe estar en el futuro."
+
+msgid "Cannot reopen: provide a future closes_at or set clear_closes_at=True."
+msgstr ""
+"No se puede reabrir: indica un closes_at futuro o establece "
+"clear_closes_at=True."
+
+msgid "Unknown multiple-choice question id: {}"
+msgstr "ID de pregunta de opción múltiple desconocido: {}"
+
+msgid "Unknown multiple-choice option id: {}"
+msgstr "ID de opción de respuesta múltiple desconocido: {}"
+
+msgid "Unknown free-text question id: {}"
+msgstr "ID de pregunta de texto libre desconocido: {}"
+
+msgid "Unknown file-upload question id: {}"
+msgstr "ID de pregunta de subida de archivo desconocido: {}"
+
+msgid "Unknown or other-user file_upload ids: {}"
+msgstr "IDs de file_upload desconocidos o pertenecientes a otra persona: {}"
+
 msgid "You submitted answers refer to a different questionnaire."
 msgstr ""
 "Las respuestas que has enviado corresponden a un cuestionario diferente."
 
 msgid "You are missing mandatory answers."
 msgstr "Faltan respuestas obligatorias."
+
+msgid "File exceeds maximum upload size of {}MB."
+msgstr "El archivo supera el tamaño máximo de subida de {} MB."
+
+msgid ""
+"File type '{}' is not allowed. Allowed types: documents, images, audio, "
+"video, and archives."
+msgstr ""
+"El tipo de archivo '{}' no está permitido. Tipos permitidos: documentos, "
+"imágenes, audio, vídeo y archivos comprimidos."
+
+msgid "Section ID in payload does not match the provided section."
+msgstr "El ID de sección del payload no coincide con la sección indicada."
+
+msgid "Section does not exist or does not belong to this questionnaire."
+msgstr "La sección no existe o no pertenece a este cuestionario."
+
+msgid "Option does not exist or does not belong to this questionnaire."
+msgstr "La opción no existe o no pertenece a este cuestionario."
+
+msgid "Question does not belong to this questionnaire."
+msgstr "La pregunta no pertenece a este cuestionario."
+
+msgid "Some files do not exist or do not belong to you."
+msgstr "Algunos archivos no existen o no te pertenecen."
+
+msgid "Too many files. Maximum allowed: {}."
+msgstr "Demasiados archivos. Máximo permitido: {}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' has type '{mime_type}' which is not allowed. Allowed "
+"types: {allowed_types}."
+msgstr ""
+"El archivo '{filename}' tiene el tipo '{mime_type}', que no está permitido. "
+"Tipos permitidos: {allowed_types}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes."
+msgstr ""
+"El archivo '{filename}' ({size} bytes) supera el tamaño máximo de {max_size} "
+"bytes."
 
 msgid "Dashboard"
 msgstr "Panel de control"
@@ -5440,8 +6034,17 @@ msgstr "Grupos"
 msgid "Telegram integration is not enabled."
 msgstr "La integración con Telegram no está habilitada."
 
+msgid "Your account is already connected to Telegram."
+msgstr "Tu cuenta ya está conectada a Telegram."
+
+msgid "Invalid or expired OTP code."
+msgstr "Código OTP no válido o caducado."
+
 msgid "Connected banned Telegram account"
 msgstr "Cuenta de Telegram bloqueada conectada"
+
+msgid "No Telegram account is linked to your account."
+msgstr "No hay ninguna cuenta de Telegram vinculada a tu cuenta."
 
 msgid "Django site admin"
 msgstr "Administración del sitio Django"
@@ -5451,3 +6054,9 @@ msgid ""
 msgstr ""
 "La generación del pase para Wallet no está disponible temporalmente. "
 "Inténtalo de nuevo más tarde."
+
+msgid "Invalid link"
+msgstr "Enlace no válido"
+
+msgid "Link expired"
+msgstr "Enlace caducado"

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -44,30 +45,35 @@ msgid "Requeue failed payouts"
 msgstr "Remettre en file les versements échoués"
 
 #, python-format
+
 msgid "Requeued %d failed payout."
 msgid_plural "Requeued %d failed payouts."
 msgstr[0] "%d versement échoué remis en file."
 msgstr[1] "%d versements échoués remis en file."
 
 #, python-format
+
 msgid "Skipped %d payout (not in failed status)."
 msgid_plural "Skipped %d payouts (not in failed status)."
 msgstr[0] "%d versement ignoré (pas au statut échoué)."
 msgstr[1] "%d versements ignorés (pas au statut échoué)."
 
 #, python-format
+
 msgid "Verification email sent to %d user."
 msgid_plural "Verification emails sent to %d users."
 msgstr[0] "E-mail de vérification envoyé à %d utilisateur·rice."
 msgstr[1] "E-mails de vérification envoyés à %d utilisateur·rice·s."
 
 #, python-format
+
 msgid "Skipped %d user (already verified)."
 msgid_plural "Skipped %d users (already verified)."
 msgstr[0] "%d utilisateur·rice ignoré·e (déjà vérifié·e)."
 msgstr[1] "%d utilisateur·rice·s ignoré·e·s (déjà vérifié·e·s)."
 
 #, python-format
+
 msgid "Password reset email sent to %d user."
 msgid_plural "Password reset emails sent to %d users."
 msgstr[0] ""
@@ -76,6 +82,7 @@ msgstr[1] ""
 "E-mails de réinitialisation de mot de passe envoyés à %d utilisateur·rice·s."
 
 #, python-format
+
 msgid "Skipped %d user (Google SSO or not found)."
 msgid_plural "Skipped %d users (Google SSO or not found)."
 msgstr[0] "%d utilisateur·rice ignoré·e (SSO Google ou introuvable)."
@@ -90,12 +97,14 @@ msgid "Violation of terms of service"
 msgstr "Violation des conditions d'utilisation"
 
 #, python-format
+
 msgid "Banned %d user."
 msgid_plural "Banned %d users."
 msgstr[0] "%d utilisateur·rice banni·e."
 msgstr[1] "%d utilisateur·rice·s banni·e·s."
 
 #, python-format
+
 msgid "Skipped %d user (staff/superuser or already banned)."
 msgid_plural "Skipped %d users (staff/superuser or already banned)."
 msgstr[0] ""
@@ -146,6 +155,12 @@ msgstr "Tu as déjà une restriction pour cet aliment."
 msgid "You have already added this dietary preference."
 msgstr "Tu as déjà ajouté cette préférence alimentaire."
 
+msgid "OTP is already enabled."
+msgstr "L'OTP est déjà activé."
+
+msgid "Invalid OTP"
+msgstr "OTP invalide"
+
 msgid "Invalid or inactive referral code."
 msgstr "Code de parrainage invalide ou inactif."
 
@@ -160,6 +175,7 @@ msgstr ""
 "Seuls les profils de parrainage actifs peuvent connecter un compte Stripe."
 
 #, python-format
+
 msgid ""
 "Deleting your account will permanently forfeit %(count)s unpaid referral "
 "payout(s) totalling %(total)s %(currency)s, of which %(failed)s %(currency)s "
@@ -172,6 +188,9 @@ msgstr ""
 "Contactez l'assistance avant la suppression si vous souhaitez les percevoir, "
 "ou renvoyez la demande avec force=true pour supprimer malgré tout."
 
+msgid "Token is blacklisted."
+msgstr "Le jeton est sur la liste noire."
+
 msgid "Global Ban"
 msgstr "Bannissement global"
 
@@ -179,6 +198,7 @@ msgid "Global Bans"
 msgstr "Bannissements globaux"
 
 #, python-format
+
 msgid "Password must be at least %(min_length)d characters long."
 msgstr "Le mot de passe doit contenir au moins %(min_length)d caractères."
 
@@ -199,6 +219,7 @@ msgstr ""
 "{}|<>)."
 
 #, python-format
+
 msgid ""
 "Your password must be at least %(min_length)d characters long, contain at "
 "least one uppercase letter, one lowercase letter, one digit, and one special "
@@ -241,11 +262,15 @@ msgid "Token has expired."
 msgstr "Le jeton a expiré."
 
 #, python-brace-format
+
 msgid "Invalid token: {error}"
 msgstr "Jeton invalide : {error}"
 
 msgid "Invalid token type."
 msgstr "Type de jeton invalide."
+
+msgid "Billing profile already exists."
+msgstr "Le profil de facturation existe déjà."
 
 msgid "Registration is not available."
 msgstr "L'inscription n'est pas disponible."
@@ -267,11 +292,18 @@ msgstr "Impossible d'emprunter l'identité de membres du staff."
 msgid "Cannot impersonate inactive users."
 msgstr "Impossible d'emprunter l'identité d'utilisateur·rice·s inactif·ve·s."
 
+msgid "Impersonation not allowed."
+msgstr "L'usurpation d'identité n'est pas autorisée."
+
+msgid "Impersonation no longer allowed."
+msgstr "L'usurpation d'identité n'est plus autorisée."
+
 msgid "Set a password before unlinking your only sign-in method."
 msgstr ""
 "Définis un mot de passe avant de dissocier ta seule méthode de connexion."
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s (%(currency)s)"
 msgstr "Relevé de versement de parrainage %(document_number)s (%(currency)s)"
 
@@ -331,6 +363,7 @@ msgstr ""
 "associées seront définitivement supprimés."
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account immediately</a>."
@@ -354,6 +387,7 @@ msgid "Confirm Account Deletion"
 msgstr "Confirmer la suppression du compte"
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at\n"
@@ -373,6 +407,7 @@ msgid "Confirm Account Deletion."
 msgstr "Confirmer la suppression du compte."
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at %(frontend_base_url)s."
@@ -396,10 +431,12 @@ msgid "Please investigate this issue as soon as possible."
 msgstr "Merci d'examiner ce problème dès que possible."
 
 #, python-format
+
 msgid "User: %(user.email)s"
 msgstr "Utilisateur·rice : %(user.email)s"
 
 #, python-format
+
 msgid "Error: %(error_message)s"
 msgstr "Erreur : %(error_message)s"
 
@@ -410,6 +447,7 @@ msgid "Data Export Failed"
 msgstr "Échec de l'exportation des données d'utilisateur·rice"
 
 #, python-format
+
 msgid "Hi %(user.first_name)s,"
 msgstr "Salut %(user.first_name)s,"
 
@@ -444,6 +482,7 @@ msgid "Your Data Export is Ready"
 msgstr "L'exportation de tes données est prête"
 
 #, python-format
+
 msgid "Hi %(user.username)s,"
 msgstr "Salut %(user.username)s,"
 
@@ -481,6 +520,7 @@ msgid "Your Revel email address has been changed"
 msgstr "Ton adresse e-mail Revel a été modifiée"
 
 #, python-format
+
 msgid ""
 "This address (<strong>%(new_email)s</strong>) is now the primary email on "
 "your Revel account. The previous address (<strong>%(old_email)s</strong>) "
@@ -503,6 +543,7 @@ msgid "Your Revel email address has been changed."
 msgstr "Ton adresse e-mail Revel a été modifiée."
 
 #, python-format
+
 msgid ""
 "This address (%(new_email)s) is now the primary email on your Revel account. "
 "The previous address (%(old_email)s) has been removed and can no longer be "
@@ -513,6 +554,7 @@ msgstr ""
 "peut plus être utilisée pour se connecter."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from <strong>%(old_email)s</strong> to <strong>%(new_email)s</"
@@ -529,6 +571,7 @@ msgstr ""
 "partir de maintenant, connecte-toi avec ta nouvelle adresse."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from %(old_email)s to %(new_email)s."
@@ -581,6 +624,7 @@ msgid "An email change was requested on your account"
 msgstr "Une modification d'adresse e-mail a été demandée sur ton compte"
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "<strong>%(masked_new_email)s</strong>. The change is not active yet — it "
@@ -610,6 +654,7 @@ msgid "An email change was requested on your account."
 msgstr "Une modification d'adresse e-mail a été demandée sur ton compte."
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "%(masked_new_email)s. The change is not active yet — it will only take "
@@ -620,6 +665,7 @@ msgstr ""
 "effet que lorsque la nouvelle adresse sera confirmée."
 
 #, python-format
+
 msgid ""
 "If this wasn't you, change your password immediately at "
 "%(frontend_base_url)s/account/password-reset and contact support."
@@ -657,6 +703,7 @@ msgid "Verify Email Now"
 msgstr "Vérifier l'e-mail maintenant"
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account</a>."
@@ -725,14 +772,17 @@ msgstr ""
 "comptables."
 
 #, python-format
+
 msgid "User: %(user_email)s (%(user_id)s)"
 msgstr "Utilisateur·rice : %(user_email)s (%(user_id)s)"
 
 #, python-format
+
 msgid "Forfeited: %(unpaid_count)s payout(s), %(unpaid_total)s %(currency)s"
 msgstr "Perdus : %(unpaid_count)s versement(s), %(unpaid_total)s %(currency)s"
 
 #, python-format
+
 msgid "Of which failed transfers: %(failed_total)s %(currency)s"
 msgstr "Dont transferts échoués : %(failed_total)s %(currency)s"
 
@@ -741,14 +791,17 @@ msgstr ""
 "Versements de parrainage perdus à la suite de la suppression d'un compte"
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s"
 msgstr "Relevé de versement de parrainage %(document_number)s"
 
 #, python-format
+
 msgid "Referral Payout Statement %(document_number)s"
 msgstr "Relevé de versement de parrainage %(document_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached your referral payout statement %(document_number)s for "
 "the period %(period_start)s to %(period_end)s."
@@ -772,6 +825,7 @@ msgid "Users"
 msgstr "Utilisateur·rice·s"
 
 #, python-format
+
 msgid "You are about to impersonate the user \"%(username)s\"."
 msgstr ""
 "Tu es sur le point d'usurper l'identité de l'utilisateur·rice "
@@ -856,6 +910,7 @@ msgstr ""
 "TVA a été enregistré. Réessaie plus tard."
 
 #, python-format
+
 msgid "Country code must match the VAT ID prefix (%(prefix)s)."
 msgstr ""
 "Le code pays doit correspondre au préfixe du numéro de TVA (%(prefix)s)."
@@ -937,6 +992,23 @@ msgstr "refund_tickets n'est valide que lors de l'annulation de l'événement."
 msgid "Invitation not found."
 msgstr "Invitation non trouvée."
 
+msgid "Offer not found."
+msgstr "Offre non trouvée."
+
+msgid ""
+"Waitlist time window is not configured for this event. Provide expires_at in "
+"the payload."
+msgstr ""
+"Aucune fenêtre de temps de liste d'attente n'est configurée pour cet "
+"événement. Indique expires_at dans le payload."
+
+msgid "User already has a pending offer for this event."
+msgstr "Cette personne a déjà une offre en attente pour cet événement."
+
+msgid "Event is at capacity. Revoke an existing pending offer to make room."
+msgstr ""
+"L'événement est complet. Révoque une offre en attente pour libérer une place."
+
 msgid "This event does not have an open waitlist."
 msgstr "Cet événement n'a pas de liste d'attente ouverte."
 
@@ -995,16 +1067,21 @@ msgstr "Une ou plusieurs catégories de billets sont introuvables."
 msgid "No pending reservation found."
 msgstr "Aucune réservation en attente trouvée."
 
+msgid "This event has no venue."
+msgstr "Cet événement n'a pas de lieu."
+
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Utilise le point d'accès /checkout/pwyc pour les tickets avec tarif libre "
 "(paie ce que tu peux)"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at least {min_amount}"
 msgstr "Le montant du tarif libre doit être d'au moins {min_amount}"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at most {max_amount}"
 msgstr "Le montant du tarif libre doit être d'au plus {max_amount}"
 
@@ -1040,6 +1117,9 @@ msgstr "La création d'organisations est désactivée sur cette instance."
 msgid "Message sent."
 msgstr "Message envoyé."
 
+msgid "No matching blacklist entries found."
+msgstr "Aucune entrée correspondante dans la liste noire."
+
 msgid "Token does not match this organization."
 msgstr "Le jeton ne correspond pas à cette organisation."
 
@@ -1051,6 +1131,12 @@ msgid "Only the organization owner can change staff permissions."
 msgstr ""
 "Seul·e le·la propriétaire de l'organisation peut modifier les permissions du "
 "staff."
+
+msgid "Series has no template event."
+msgstr "La série n'a pas d'événement modèle."
+
+msgid "date_from must be on or before date_to."
+msgstr "date_from doit être antérieure ou égale à date_to."
 
 msgid ""
 "ONLINE plans must be subscribed to by the member directly. Send them to the "
@@ -1087,8 +1173,26 @@ msgstr "Le PDF de la facture n'est pas encore généré."
 msgid "Invoice PDF could not be generated."
 msgstr "Le PDF de la facture n'a pas pu être généré."
 
+msgid "You must be the owner of this organization."
+msgstr "Tu dois être propriétaire de cette organisation."
+
+msgid "You must be the owner or a staff member of this organization."
+msgstr "Tu dois être propriétaire ou membre du staff de cette organisation."
+
 msgid "Ticket sales are paused."
 msgstr "La vente des billets est suspendue."
+
+msgid "You're outside of the sale window."
+msgstr "Tu es en dehors de la période de vente."
+
+msgid "The ticket can be purchased by {}"
+msgstr "Le billet peut être acheté par {}"
+
+msgid "Apple Wallet is not configured"
+msgstr "Apple Wallet n'est pas configuré"
+
+msgid "Google Wallet is not configured"
+msgstr "Google Wallet n'est pas configuré"
 
 msgid ""
 "Your payment went through. We're still confirming your subscription — check "
@@ -1568,7 +1672,56 @@ msgstr ""
 msgid "This member has no ticket for this event."
 msgstr "Ce membre n'a pas de ticket pour cet événement."
 
+msgid "Event not found or does not belong to this organization"
+msgstr "Événement introuvable ou n'appartenant pas à cette organisation"
+
+msgid ""
+"Announcement must have at least one targeting option: event, "
+"target_all_members, target_tiers, or target_staff_only"
+msgstr ""
+"L'annonce doit avoir au moins une option de ciblage : event, "
+"target_all_members, target_tiers ou target_staff_only"
+
+msgid "Only draft or scheduled announcements can be updated"
+msgstr "Seules les annonces en brouillon ou planifiées peuvent être modifiées"
+
+msgid "Re-sending to new sign-ups requires an event-targeted announcement"
+msgstr ""
+"Le renvoi aux nouvelles inscriptions nécessite une annonce ciblant un "
+"événement"
+
+msgid "Relative scheduling requires an event-targeted announcement"
+msgstr "La planification relative nécessite une annonce ciblant un événement"
+
+msgid "Only draft announcements can be scheduled"
+msgstr "Seules les annonces en brouillon peuvent être planifiées"
+
+msgid "Relative scheduling requires both an anchor and an offset"
+msgstr "La planification relative nécessite à la fois une ancre et un décalage"
+
+msgid ""
+"Could not resolve a scheduled time (relative scheduling requires an event)"
+msgstr ""
+"Impossible de déterminer l'heure planifiée (la planification relative "
+"nécessite un événement)"
+
+msgid "Scheduled time must be in the future"
+msgstr "L'heure planifiée doit être dans le futur"
+
+msgid "Only scheduled announcements can be unscheduled"
+msgstr "Seules les annonces planifiées peuvent être déplanifiées"
+
+msgid "Only draft or scheduled announcements can be sent"
+msgstr "Seules les annonces en brouillon ou planifiées peuvent être envoyées"
+
+msgid "Only sent announcements can be resent"
+msgstr "Seules les annonces déjà envoyées peuvent être renvoyées"
+
+msgid "Announcement is not configured for resending"
+msgstr "L'annonce n'est pas configurée pour le renvoi"
+
 #, python-brace-format
+
 msgid "Invoice totals do not reconcile with its line items: {details}"
 msgstr "Les totaux de la facture ne concordent pas avec ses lignes : {details}"
 
@@ -1576,10 +1729,12 @@ msgid "Only draft invoices can be edited."
 msgstr "Seules les factures au statut de brouillon peuvent être modifiées."
 
 #, python-brace-format
+
 msgid "Cannot edit fields: {fields}"
 msgstr "Impossible de modifier les champs : {fields}"
 
 #, python-brace-format
+
 msgid "Fields cannot be null: {fields}"
 msgstr "Ces champs ne peuvent pas être nuls : {fields}"
 
@@ -1588,6 +1743,20 @@ msgstr "Les factures annulées ne peuvent pas être émises."
 
 msgid "Only draft invoices can be deleted."
 msgstr "Seules les factures au statut de brouillon peuvent être supprimées."
+
+msgid "Organization must be EU-based (valid EU VAT country code required)"
+msgstr ""
+"L'organisation doit être établie dans l'UE (un code pays de TVA de l'UE "
+"valide est requis)"
+
+msgid "VAT ID must be validated via VIES"
+msgstr "Le numéro de TVA doit être validé via VIES"
+
+msgid "Billing name (legal entity name) is required"
+msgstr "Le nom de facturation (dénomination sociale) est requis"
+
+msgid "Billing address is required"
+msgstr "L'adresse de facturation est requise"
 
 msgid "Provide either seat_ids or price_category_id, not both."
 msgstr "Fournis soit seat_ids, soit price_category_id, pas les deux."
@@ -1607,10 +1776,17 @@ msgstr ""
 "Un ou plusieurs sièges sélectionnés sont invalides ou ne se trouvent pas "
 "dans le bon secteur."
 
+msgid "Ticket tier not found."
+msgstr "Catégorie de billet introuvable."
+
+msgid "All tiers must use the same currency."
+msgstr "Toutes les catégories de billets doivent utiliser la même devise."
+
 msgid "This ticket tier is sold out."
 msgstr "Cette catégorie de tickets est épuisée."
 
 #, python-brace-format
+
 msgid "Only {available} ticket(s) remaining for this tier."
 msgstr "Seulement {available} ticket·s restant·s pour cette catégorie."
 
@@ -1618,6 +1794,7 @@ msgid "This event is sold out."
 msgstr "Cet événement est complet."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining for this event."
 msgstr "Seulement {available} place·s restante·s pour cet événement."
 
@@ -1625,6 +1802,7 @@ msgid "This sector is full."
 msgstr "Ce secteur est complet."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining in this sector."
 msgstr "Seulement {available} place·s restante·s dans ce secteur."
 
@@ -1650,9 +1828,6 @@ msgstr "Chaque catégorie ne peut apparaître qu'une seule fois par achat."
 msgid "The same seat cannot be purchased twice."
 msgstr "Le même siège ne peut pas être acheté deux fois."
 
-msgid "You're outside of the sale window."
-msgstr "Tu es en dehors de la période de vente."
-
 msgid "You are not allowed to purchase from this tier."
 msgstr "Tu n'es pas autorisé·e à acheter des tickets de cette catégorie."
 
@@ -1660,6 +1835,7 @@ msgid "You have reached the maximum number of tickets for this event."
 msgstr "Tu as atteint le nombre maximum de tickets pour cet événement."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this event."
 msgstr ""
 "Tu ne peux acheter que {remaining} ticket·s supplémentaire·s pour cet "
@@ -1669,6 +1845,7 @@ msgid "You have reached the maximum number of tickets for this tier."
 msgstr "Tu as atteint le nombre maximum de tickets pour cette catégorie."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this tier."
 msgstr ""
 "Tu ne peux acheter que {remaining} ticket·s supplémentaire·s pour cette "
@@ -1721,10 +1898,12 @@ msgid "Check-in is not currently open for this event."
 msgstr "L'enregistrement n'est pas ouvert pour cet événement actuellement."
 
 #, python-brace-format
+
 msgid "Check-in is not open yet. It will open at {opens_at}."
 msgstr "L'enregistrement n'est pas encore ouvert. Il ouvrira à {opens_at}."
 
 #, python-brace-format
+
 msgid "Check-in has closed for this event. It ended at {ended_at}."
 msgstr ""
 "L'enregistrement est fermé pour cet événement. Il s'est terminé à {ended_at}."
@@ -1739,6 +1918,7 @@ msgid "This ticket is pending payment confirmation."
 msgstr "Ce ticket est en attente de confirmation du paiement."
 
 #, python-brace-format
+
 msgid "Invalid ticket status: {status}"
 msgstr "Statut du ticket invalide : {status}"
 
@@ -1787,6 +1967,7 @@ msgid "This discount code is not valid for this currency."
 msgstr "Ce code de réduction n'est pas valide pour cette devise."
 
 #, python-brace-format
+
 msgid "Minimum purchase amount of {amount} required to use this discount code."
 msgstr ""
 "Un montant d'achat minimum de {amount} est requis pour utiliser ce code de "
@@ -1830,6 +2011,7 @@ msgid "Waiting for questionnaire evaluation."
 msgstr "En attente de l'évaluation du questionnaire."
 
 #, python-brace-format
+
 msgid ""
 "Questionnaire evaluation was insufficient. You can try again in {retry_on}."
 msgstr ""
@@ -1904,6 +2086,7 @@ msgid "You have reached the maximum number of attempts."
 msgstr "Tu as atteint le nombre maximum de tentatives."
 
 #, python-format
+
 msgid "You can retry after %(retry_on)s."
 msgstr "Tu peux réessayer après %(retry_on)s."
 
@@ -1914,6 +2097,9 @@ msgid "Feedback questionnaires cannot require evaluation."
 msgstr ""
 "Les questionnaires de retour d'expérience ne peuvent pas nécessiter "
 "d'évaluation."
+
+msgid "LLM evaluation is not available."
+msgstr "L'évaluation par LLM n'est pas disponible."
 
 msgid "One or more events do not exist or belong to this organization."
 msgstr ""
@@ -1951,6 +2137,24 @@ msgstr "Tu as déjà soumis un retour d'expérience pour cet événement."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Les questionnaires de retour d'expérience ne peuvent pas être évalués."
 
+msgid "Organization not found"
+msgstr "Organisation non trouvée"
+
+msgid "Already following this organization"
+msgstr "Tu suis déjà cette organisation"
+
+msgid "Not following this organization"
+msgstr "Tu ne suis pas cette organisation"
+
+msgid "Event series not found"
+msgstr "Série d'événements non trouvée"
+
+msgid "Already following this series"
+msgstr "Tu suis déjà cette série"
+
+msgid "Not following this series"
+msgstr "Tu ne suis pas cette série"
+
 msgid "Invalid token."
 msgstr "Jeton invalide."
 
@@ -1973,6 +2177,7 @@ msgid "Invalid token type"
 msgstr "Type de jeton invalide"
 
 #, python-format
+
 msgid "Ticket tiers not found: %(ids)s"
 msgstr "Catégories de billets introuvables : %(ids)s"
 
@@ -2076,6 +2281,7 @@ msgstr ""
 "politique d'abonnement des membres."
 
 #, python-format
+
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "
 "name."
@@ -2208,6 +2414,7 @@ msgid "This payment is already fully refunded."
 msgstr "Ce paiement a déjà été intégralement remboursé."
 
 #, python-format
+
 msgid ""
 "Refund amount must be between 0 and the remaining refundable amount "
 "(%(amount)s)."
@@ -2222,6 +2429,9 @@ msgid "A file must be provided when resource_type is 'file'."
 msgstr ""
 "Un fichier doit être fourni lorsque le type de ressource (resource_type) est "
 "'file'."
+
+msgid "Specify either month or quarter, not both."
+msgstr "Indique soit un mois, soit un trimestre, mais pas les deux."
 
 msgid "This seat is not available for this event."
 msgstr "Ce siège n'est pas disponible pour cet événement."
@@ -2278,10 +2488,12 @@ msgstr ""
 "l'organisateur·rice."
 
 #, python-brace-format
+
 msgid "Select one of this ticket tier's zones: {zones}."
 msgstr "Choisis une des zones de cette catégorie de tickets : {zones}."
 
 #, python-brace-format
+
 msgid ""
 "Seat {seat} is in the \"{category}\" price category, which this ticket tier "
 "does not sell."
@@ -2308,6 +2520,7 @@ msgid "This pass has no upcoming events to purchase."
 msgstr "Ce pass n'a aucun événement à venir à acheter."
 
 #, python-brace-format
+
 msgid "Event {name} is sold out."
 msgstr "L'événement {name} est complet."
 
@@ -2329,18 +2542,22 @@ msgstr ""
 "Les pass de série ne sont pas pris en charge pour les séries récurrentes."
 
 #, python-format
+
 msgid "Event '%s' does not belong to this series."
 msgstr "L'événement '%s' n'appartient pas à cette série."
 
 #, python-format
+
 msgid "Event '%s' is not open."
 msgstr "L'événement '%s' n'est pas ouvert."
 
 #, python-format
+
 msgid "Event '%s' does not require a ticket."
 msgstr "L'événement '%s' ne nécessite pas de billet."
 
 #, python-format
+
 msgid ""
 "Event '%s' is invitation-only or members-only and cannot be covered by a "
 "series pass."
@@ -2359,6 +2576,7 @@ msgid "One or more events do not exist."
 msgstr "Un ou plusieurs événements n'existent pas."
 
 #, python-format
+
 msgid "Event '%s' is already covered by this pass via a different tier."
 msgstr ""
 "L'événement '%s' est déjà couvert par ce pass via une catégorie différente."
@@ -2619,6 +2837,7 @@ msgid "Cannot refund a ticket that was never paid."
 msgstr "Impossible de rembourser un billet qui n'a jamais été payé."
 
 #, python-format
+
 msgid "Refund amount must be between 0 and the amount paid (%(amount)s)."
 msgstr ""
 "Le montant du remboursement doit être compris entre 0 et le montant payé "
@@ -2628,6 +2847,7 @@ msgid "Price category must belong to the same venue as the seats."
 msgstr "La catégorie tarifaire doit appartenir au même lieu que les sièges."
 
 #, python-brace-format
+
 msgid ""
 "This price category is used by one or more ticket tiers and cannot be "
 "deleted: {tiers}. Remove it from those tiers' category prices first."
@@ -2692,18 +2912,22 @@ msgstr ""
 "Seules les demandes approuvées peuvent être retirées de la liste blanche."
 
 #, python-format
+
 msgid "Confirm your RSVP to %(event_name)s"
 msgstr "Confirme ta réponse à l'invitation pour %(event_name)s"
 
 #, python-format
+
 msgid "Confirm your ticket for %(event_name)s"
 msgstr "Confirme ton ticket pour %(event_name)s"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s (%(currency)s)"
 msgstr "Facture des frais de plateforme %(invoice_number)s (%(currency)s)"
 
 #, python-format
+
 msgid "Verify contact email for %(organization_name)s"
 msgstr "Vérifie l'adresse e-mail de contact pour %(organization_name)s"
 
@@ -2714,6 +2938,7 @@ msgid "Confirm your RSVP"
 msgstr "Confirme ta réponse à l'invitation"
 
 #, python-format
+
 msgid "You've indicated your interest in attending %(event_name)s."
 msgstr "Tu as manifesté ton intérêt pour participer à %(event_name)s."
 
@@ -2740,6 +2965,7 @@ msgid "Confirm your ticket purchase"
 msgstr "Confirme ton achat de ticket"
 
 #, python-format
+
 msgid "You've requested a ticket for %(event_name)s (%(tier_name)s)."
 msgstr "Tu as demandé un ticket pour %(event_name)s (%(tier_name)s)."
 
@@ -2753,14 +2979,17 @@ msgid "To confirm your ticket purchase, please click the link below:"
 msgstr "Pour confirmer ton achat de ticket, clique sur le lien ci-dessous :"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s"
 msgstr "Facture des frais de plateforme %(invoice_number)s"
 
 #, python-format
+
 msgid "Platform Fee Invoice %(invoice_number)s"
 msgstr "Facture des frais de plateforme %(invoice_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached the platform fee invoice %(invoice_number)s for "
 "%(currency)s transactions in the period %(period_start)s to %(period_end)s."
@@ -2798,18 +3027,22 @@ msgstr ""
 "catégorie tarifaire et le prix."
 
 #, python-brace-format
+
 msgid "'{key}' is not a valid price category id."
 msgstr "« {key} » n'est pas un id de catégorie tarifaire valide."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a decimal string."
 msgstr "Le prix de la catégorie {category} doit être une chaîne décimale."
 
 #, python-brace-format
+
 msgid "'{value}' is not a valid price for category {category}."
 msgstr "« {value} » n'est pas un prix valide pour la catégorie {category}."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a non-negative number."
 msgstr "Le prix de la catégorie {category} doit être un nombre positif ou nul."
 
@@ -2825,6 +3058,7 @@ msgstr ""
 "jamais les deux."
 
 #, python-brace-format
+
 msgid ""
 "Online tiers require every category price to be at least 1: {categories}."
 msgstr ""
@@ -2832,6 +3066,7 @@ msgstr ""
 "catégorie soit d'au moins 1 : {categories}."
 
 #, python-brace-format
+
 msgid "These price categories do not belong to the tier's venue: {categories}."
 msgstr ""
 "Ces catégories tarifaires n'appartiennent pas au lieu de la catégorie de "
@@ -2882,6 +3117,7 @@ msgid "The import failed unexpectedly."
 msgstr "L'importation a échoué de manière inattendue."
 
 #, python-format
+
 msgid "Ticket class %(name)s could not be imported."
 msgstr "La catégorie de billets %(name)s n'a pas pu être importée."
 
@@ -3023,6 +3259,7 @@ msgid "Read more..."
 msgstr "Lire la suite..."
 
 #, python-format
+
 msgid "%(counter)s new notification"
 msgid_plural "%(counter)s new notifications"
 msgstr[0] "%(counter)s nouvelle notification"
@@ -3035,94 +3272,117 @@ msgid "Revel - Your account has been suspended"
 msgstr "Revel - Ton compte a été suspendu"
 
 #, python-format
+
 msgid "New Event: %(event)s"
 msgstr "Nouvel événement : %(event)s"
 
 #, python-format
+
 msgid "%(org)s has published a new event"
 msgstr "%(org)s a publié un nouvel événement"
 
 #, python-format
+
 msgid "Reminder: %(event)s is tomorrow!"
 msgstr "Rappel : %(event)s est demain !"
 
 #, python-format
+
 msgid "Reminder: %(event)s in %(days)d days"
 msgstr "Rappel : %(event)s dans %(days)d jours"
 
 #, python-format
+
 msgid "Tomorrow: %(event)s"
 msgstr "Demain : %(event)s"
 
 #, python-format
+
 msgid "Event Updated: %(event)s"
 msgstr "Événement mis à jour : %(event)s"
 
 #, python-format
+
 msgid "Important Update: %(event)s"
 msgstr "Mise à jour importante : %(event)s"
 
 #, python-format
+
 msgid "Event Cancelled: %(event)s"
 msgstr "Événement annulé : %(event)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s"
 msgstr "%(follower)s a commencé à suivre %(org)s"
 
 #, python-format
+
 msgid "New follower - %(org)s"
 msgstr "Nouvel·le abonné·e - %(org)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s"
 msgstr "%(follower)s a commencé à suivre %(series)s"
 
 #, python-format
+
 msgid "New follower - %(series)s"
 msgstr "Nouvel·le abonné·e - %(series)s"
 
 #, python-format
+
 msgid "%(org)s created %(event)s"
 msgstr "%(org)s a créé %(event)s"
 
 #, python-format
+
 msgid "New event from %(org)s"
 msgstr "Nouvel événement de %(org)s"
 
 #, python-format
+
 msgid "New event in %(series)s: %(event)s"
 msgstr "Nouvel événement dans %(series)s : %(event)s"
 
 #, python-format
+
 msgid "New event in %(series)s"
 msgstr "Nouvel événement dans %(series)s"
 
 #, python-format
+
 msgid "You're invited to %(event)s"
 msgstr "Tu es invité·e à %(event)s"
 
 #, python-format
+
 msgid "You're invited: %(event)s"
 msgstr "Tu es invité·e : %(event)s"
 
 #, python-format
+
 msgid "%(email)s requested invitation to %(event)s"
 msgstr "%(email)s a demandé une invitation pour %(event)s"
 
 #, python-format
+
 msgid "New invitation request: %(event)s"
 msgstr "Nouvelle demande d'invitation : %(event)s"
 
 #, python-format
+
 msgid "You're now a %(role)s of %(org)s"
 msgstr "Tu es maintenant %(role)s de %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s"
 msgstr "Bienvenue chez %(org)s"
 
 #, python-format
+
 msgid "Your membership card was updated: %(org)s"
 msgstr "Ta carte d'adhésion a été mise à jour : %(org)s"
 
@@ -3130,268 +3390,333 @@ msgid "Your membership card was updated"
 msgstr "Ta carte d'adhésion a été mise à jour"
 
 #, python-format
+
 msgid "You've been promoted to %(role)s in %(org)s"
 msgstr "Tu as été promu·e %(role)s dans %(org)s"
 
 #, python-format
+
 msgid "Role Updated: %(role)s - %(org)s"
 msgstr "Rôle mis à jour : %(role)s - %(org)s"
 
 #, python-format
+
 msgid "Membership Removed: %(org)s"
 msgstr "Adhésion supprimée : %(org)s"
 
 #, python-format
+
 msgid "Membership Request Approved: %(org)s"
 msgstr "Demande d'adhésion approuvée : %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s - Request Approved"
 msgstr "Bienvenue chez %(org)s - Demande approuvée"
 
 #, python-format
+
 msgid "%(user)s requested to join %(org)s"
 msgstr "%(user)s a demandé à rejoindre %(org)s"
 
 #, python-format
+
 msgid "New membership request: %(org)s"
 msgstr "Nouvelle demande d'adhésion : %(org)s"
 
 #, python-format
+
 msgid "Membership Request Declined: %(org)s"
 msgstr "Demande d'adhésion refusée : %(org)s"
 
 #, python-format
+
 msgid "Membership Request Update: %(org)s"
 msgstr "Mise à jour de la demande d'adhésion : %(org)s"
 
 #, python-format
+
 msgid "%(org)s: %(title)s"
 msgstr "%(org)s : %(title)s"
 
 #, python-format
+
 msgid "%(org)s - %(title)s"
 msgstr "%(org)s - %(title)s"
 
 #, python-format
+
 msgid "New contact message for %(org)s from %(sender)s"
 msgstr "Nouveau message de contact pour %(org)s de la part de %(sender)s"
 
 #, python-format
+
 msgid "New contact message: %(org)s"
 msgstr "Nouveau message de contact : %(org)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s"
 msgstr "%(actor)s a ajouté %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s"
 msgstr "%(actor)s a ajouté et réservé %(item)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s"
 msgstr "%(actor)s a réservé %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item: %(item)s"
 msgstr "Nouvelle contribution : %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item Claimed: %(item)s"
 msgstr "Nouvelle contribution réservée : %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Claimed: %(item)s"
 msgstr "Contribution réservée : %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Available: %(item)s"
 msgstr "Contribution disponible : %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Removed: %(item)s"
 msgstr "Contribution retirée : %(item)s"
 
 #, python-format
+
 msgid "Potluck Update: %(item)s"
 msgstr "Mise à jour des contributions : %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s - %(event)s"
 msgstr "%(actor)s a ajouté %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s - %(event)s"
 msgstr "%(actor)s a ajouté et réservé %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s - %(event)s"
 msgstr "%(actor)s a réservé %(item)s - %(event)s"
 
 #, python-format
+
 msgid "Potluck Item Removed - %(event)s"
 msgstr "Contribution retirée - %(event)s"
 
 #, python-format
+
 msgid "Potluck Update - %(event)s"
 msgstr "Mise à jour des contributions - %(event)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission: %(name)s"
 msgstr "Nouvelle soumission de questionnaire : %(name)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission - %(name)s"
 msgstr "Nouvelle soumission de questionnaire - %(name)s"
 
 #, python-format
+
 msgid "✅ Questionnaire Approved: %(name)s"
 msgstr "✅ Questionnaire approuvé : %(name)s"
 
 #, python-format
+
 msgid "❌ Questionnaire Not Approved: %(name)s"
 msgstr "❌ Questionnaire non approuvé : %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation: %(name)s"
 msgstr "Évaluation du questionnaire : %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation Result - %(name)s"
 msgstr "Résultat de l'évaluation du questionnaire - %(name)s"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s: %(response)s)"
 msgstr "Réponse confirmée : %(event)s (%(user)s : %(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(response)s)"
 msgstr "Réponse confirmée : %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s)"
 msgstr "Réponse confirmée : %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s"
 msgstr "Réponse confirmée : %(event)s"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(response)s)"
 msgstr "Réponse mise à jour : %(event)s (%(user)s : %(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(response)s)"
 msgstr "Réponse mise à jour : %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(new_response)s)"
 msgstr "Réponse mise à jour : %(event)s (%(user)s : %(new_response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s"
 msgstr "Réponse mise à jour : %(event)s"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s (%(user)s)"
 msgstr "Réponse annulée : %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s"
 msgstr "Réponse annulée : %(event)s"
 
 #, python-format
+
 msgid "Series pass purchased: %(pass)s (%(series)s)"
 msgstr "Pass de série acheté : %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass purchased - %(pass)s"
 msgstr "Pass de série acheté - %(pass)s"
 
 #, python-format
+
 msgid "%(pass)s now covers %(count)d new event"
 msgid_plural "%(pass)s now covers %(count)d new events"
 msgstr[0] "%(pass)s couvre désormais %(count)d nouvel événement"
 msgstr[1] "%(pass)s couvre désormais %(count)d nouveaux événements"
 
 #, python-format
+
 msgid "Your series pass has new events - %(pass)s"
 msgstr "Ton pass de série a de nouveaux événements - %(pass)s"
 
 #, python-format
+
 msgid "Series pass cancelled: %(pass)s (%(series)s)"
 msgstr "Pass de série annulé : %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass cancelled - %(pass)s"
 msgstr "Pass de série annulé - %(pass)s"
 
 #, python-format
+
 msgid "%(count)d new event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "%(count)d nouvel événement programmé pour %(series)s"
 msgstr[1] "%(count)d nouveaux événements programmés pour %(series)s"
 
 #, python-format
+
 msgid "New event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "Nouvel événement programmé pour %(series)s"
 msgstr[1] "%(count)d nouveaux événements programmés pour %(series)s"
 
 #, python-format
+
 msgid "Membership renewed: %(org)s"
 msgstr "Adhésion renouvelée : %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership was renewed"
 msgstr "Ton adhésion à %(org)s a été renouvelée"
 
 #, python-format
+
 msgid "Payment failed: %(org)s membership"
 msgstr "Paiement échoué : adhésion %(org)s"
 
 #, python-format
+
 msgid "Action needed: payment failed for %(org)s"
 msgstr "Action requise : le paiement pour %(org)s a échoué"
 
 #, python-format
+
 msgid "Membership expired: %(org)s"
 msgstr "Adhésion expirée : %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has expired"
 msgstr "Ton adhésion à %(org)s a expiré"
 
 #, python-format
+
 msgid "Membership cancelled: %(org)s"
 msgstr "Adhésion annulée : %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has been cancelled"
 msgstr "Ton adhésion à %(org)s a été annulée"
 
 #, python-format
+
 msgid "Membership renews soon: %(org)s"
 msgstr "Ton adhésion se renouvelle bientôt : %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership renews soon"
 msgstr "Ton adhésion à %(org)s se renouvelle bientôt"
 
 #, python-format
+
 msgid "Price change: %(org)s membership"
 msgstr "Changement de prix : adhésion %(org)s"
 
 #, python-format
+
 msgid "Upcoming price change for your %(org)s membership"
 msgstr "Changement de prix à venir pour ton adhésion %(org)s"
 
 #, python-format
+
 msgid "Complete your membership renewal: %(org)s"
 msgstr "Finalise le renouvellement de ton adhésion : %(org)s"
 
 #, python-format
+
 msgid "Complete your %(org)s membership renewal"
 msgstr "Finalise le renouvellement de ton adhésion %(org)s"
 
@@ -3399,38 +3724,47 @@ msgid "System Announcement"
 msgstr "Annonce système"
 
 #, python-format
+
 msgid "Revel - %(title)s"
 msgstr "Revel - %(title)s"
 
 #, python-format
+
 msgid "New Ticket: %(holder)s - %(event)s"
 msgstr "Nouveau ticket : %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending for %(event)s"
 msgstr "Ticket en attente pour %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed for %(event)s"
 msgstr "Ticket confirmé pour %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending - %(event)s"
 msgstr "Ticket en attente - %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed - %(event)s"
 msgstr "Ticket confirmé - %(event)s"
 
 #, python-format
+
 msgid "Ticket %(action)s: %(holder)s - %(event)s"
 msgstr "Ticket %(action)s : %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Update for %(event)s"
 msgstr "Mise à jour du ticket pour %(event)s"
 
 #, python-format
+
 msgid "Ticket Update - %(event)s"
 msgstr "Mise à jour du ticket - %(event)s"
 
@@ -3438,14 +3772,17 @@ msgid "Payment Confirmation"
 msgstr "Confirmation de paiement"
 
 #, python-format
+
 msgid "Payment Confirmation - %(event)s"
 msgstr "Confirmation de paiement - %(event)s"
 
 #, python-format
+
 msgid "Checked in for %(event)s"
 msgstr "Enregistré·e pour %(event)s"
 
 #, python-format
+
 msgid "Checked in - %(event)s"
 msgstr "Enregistré·e - %(event)s"
 
@@ -3453,48 +3790,59 @@ msgid "Refund could not be matched to a ticket"
 msgstr "Le remboursement n'a pas pu être associé à un billet"
 
 #, python-format
+
 msgid "Action needed: unmatched refund - %(org)s"
 msgstr "Action requise : remboursement non associé - %(org)s"
 
 #, python-format
+
 msgid "Refund sweep finished - %(event)s"
 msgstr "Vague de remboursements terminée - %(event)s"
 
 #, python-format
+
 msgid "Spot available for %(event)s!"
 msgstr "Place disponible pour %(event)s !"
 
 #, python-format
+
 msgid "%d spot available for %s!"
 msgid_plural "%d spots available for %s!"
 msgstr[0] "%d place disponible pour %s !"
 msgstr[1] "%d places disponibles pour %s !"
 
 #, python-format
+
 msgid "Spot Available: %(event)s"
 msgstr "Place disponible : %(event)s"
 
 #, python-format
+
 msgid "%(user)s requested verification for %(org)s"
 msgstr "%(user)s a demandé une vérification pour %(org)s"
 
 #, python-format
+
 msgid "New verification request: %(org)s"
 msgstr "Nouvelle demande de vérification : %(org)s"
 
 #, python-format
+
 msgid "Verification Approved: %(org)s"
 msgstr "Vérification approuvée : %(org)s"
 
 #, python-format
+
 msgid "Verification Approved - %(org)s"
 msgstr "Vérification approuvée - %(org)s"
 
 #, python-format
+
 msgid "Verification Declined: %(org)s"
 msgstr "Vérification refusée : %(org)s"
 
 #, python-format
+
 msgid "Verification Update: %(org)s"
 msgstr "Mise à jour de la vérification : %(org)s"
 
@@ -3502,6 +3850,7 @@ msgid "Event details have been updated."
 msgstr "Les détails de l'événement ont été mis à jour."
 
 #, python-format
+
 msgid "You're invited: %(event_name)s"
 msgstr "Tu es invité·e : %(event_name)s"
 
@@ -3568,6 +3917,7 @@ msgid "Hello"
 msgstr "Bonjour"
 
 #, python-format
+
 msgid ""
 "We regret to inform you that <strong>%(event)s</strong> has been cancelled."
 msgstr ""
@@ -3587,6 +3937,7 @@ msgid "We apologize for any inconvenience this may cause."
 msgstr "Nous te prions de nous excuser pour la gêne occasionnée."
 
 #, python-format
+
 msgid "We regret to inform you that %(event)s has been cancelled."
 msgstr "Nous avons le regret de t'informer que %(event)s a été annulé."
 
@@ -3603,6 +3954,7 @@ msgid "Alternative event:"
 msgstr "Événement alternatif :"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has published a new event: <strong>%(event)s</"
 "strong>!"
@@ -3623,6 +3975,7 @@ msgid "View Event & Register"
 msgstr "Voir l'événement et s'inscrire"
 
 #, python-format
+
 msgid "%(org)s has published a new event: %(event)s!"
 msgstr "%(org)s a publié un nouvel événement : %(event)s !"
 
@@ -3630,10 +3983,12 @@ msgid "View event details and register:"
 msgstr "Voir les détails de l'événement et s'inscrire :"
 
 #, python-format
+
 msgid "Refund sweep for %(event)s finished"
 msgstr "La vague de remboursements pour %(event)s est terminée"
 
 #, python-format
+
 msgid ""
 "%(cancelled)s tickets cancelled, %(refunded)s refunds issued, %(failed)s "
 "refunds failed."
@@ -3642,6 +3997,7 @@ msgstr ""
 "%(failed)s remboursements échoués."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent "
 "&mdash; check the event's ticket admin."
@@ -3650,6 +4006,7 @@ msgstr ""
 "résumé &mdash; vérifiez l'administration des billets de l'événement."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent - "
 "check the event's ticket admin."
@@ -3658,10 +4015,12 @@ msgstr ""
 "résumé - vérifiez l'administration des billets de l'événement."
 
 #, python-format
+
 msgid "Reminder: <strong>%(event)s</strong> is tomorrow!"
 msgstr "Rappel : <strong>%(event)s</strong> a lieu demain !"
 
 #, python-format
+
 msgid ""
 "Reminder: <strong>%(event)s</strong> is in <strong>%(days)s days</strong>"
 msgstr ""
@@ -3684,6 +4043,7 @@ msgid "See you there!"
 msgstr "À bientôt !"
 
 #, python-format
+
 msgid "Reminder: %(event)s is in %(days)s days"
 msgstr "Rappel : %(event)s a lieu dans %(days)s jours"
 
@@ -3694,6 +4054,7 @@ msgid "View event details:"
 msgstr "Voir les détails de l'événement :"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(series)s</strong>."
 msgstr ""
@@ -3713,6 +4074,7 @@ msgid "Series:"
 msgstr "Série d'événements :"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s."
 msgstr "%(follower)s a commencé à suivre %(series)s."
 
@@ -3720,6 +4082,7 @@ msgid "Follower Details:"
 msgstr "Détails de l'abonné·e :"
 
 #, python-format
+
 msgid "Important update about <strong>%(event)s</strong>"
 msgstr "Mise à jour importante concernant <strong>%(event)s</strong>"
 
@@ -3733,6 +4096,7 @@ msgid "View Updated Event"
 msgstr "Voir l'événement mis à jour"
 
 #, python-format
+
 msgid "Important update about %(event)s"
 msgstr "Mise à jour importante concernant %(event)s"
 
@@ -3755,6 +4119,7 @@ msgid "New Invitation Request"
 msgstr "Nouvelle demande d'invitation"
 
 #, python-format
+
 msgid ""
 "<strong>%(email)s</strong> has requested an invitation to <strong>%(event)s</"
 "strong>."
@@ -3776,6 +4141,7 @@ msgstr ""
 "Ceci est une notification automatique de ton système de gestion d'événements."
 
 #, python-format
+
 msgid "%(email)s has requested an invitation to %(event)s."
 msgstr "%(email)s a demandé une invitation pour %(event)s."
 
@@ -3783,6 +4149,7 @@ msgid "View and manage this request:"
 msgstr "Voir et gérer cette demande :"
 
 #, python-format
+
 msgid ""
 "Your membership tier in <strong>%(org)s</strong> changed to "
 "<strong>%(tier)s</strong>."
@@ -3801,6 +4168,7 @@ msgid "View Organization"
 msgstr "Voir l'organisation"
 
 #, python-format
+
 msgid "Your membership tier in %(org)s changed to %(tier)s."
 msgstr "Ton niveau d'adhésion dans %(org)s est passé à %(tier)s."
 
@@ -3814,6 +4182,7 @@ msgid "View organization:"
 msgstr "Voir l'organisation :"
 
 #, python-format
+
 msgid "You are now a <strong>%(role)s</strong> of <strong>%(org)s</strong>!"
 msgstr ""
 "Tu es maintenant <strong>%(role)s</strong> de <strong>%(org)s</strong> !"
@@ -3831,6 +4200,7 @@ msgid "Connect with other members"
 msgstr "Te connecter avec d'autres membres"
 
 #, python-format
+
 msgid "You are now a %(role)s of %(org)s!"
 msgstr "Tu es maintenant %(role)s de %(org)s !"
 
@@ -3850,6 +4220,7 @@ msgid "New Membership Request"
 msgstr "Nouvelle demande d'adhésion"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested to join <strong>%(org)s</strong>."
 msgstr ""
@@ -3862,6 +4233,7 @@ msgstr ""
 "d'organisation."
 
 #, python-format
+
 msgid "%(name)s has requested to join %(org)s."
 msgstr "%(name)s a demandé à rejoindre %(org)s."
 
@@ -3869,6 +4241,7 @@ msgid "Request Declined"
 msgstr "Demande déclinée"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> created a new event: <strong>%(event)s</strong>"
 msgstr ""
@@ -3894,6 +4267,7 @@ msgid "View Event"
 msgstr "Voir l'événement"
 
 #, python-format
+
 msgid "%(org)s created a new event: %(event)s"
 msgstr "%(org)s a créé un nouvel événement : %(event)s"
 
@@ -3901,6 +4275,7 @@ msgid "View the event:"
 msgstr "Voir l'événement :"
 
 #, python-format
+
 msgid "New event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 msgstr ""
 "Nouvel événement dans <strong>%(series)s</strong> : <strong>%(event)s</"
@@ -3913,6 +4288,7 @@ msgid "New Contact Message"
 msgstr "Nouveau message de contact"
 
 #, python-format
+
 msgid "<strong>%(sender)s</strong> sent a message to <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(sender)s</strong> a envoyé un message à <strong>%(org)s</strong>."
@@ -3924,6 +4300,7 @@ msgid "View Message"
 msgstr "Voir le message"
 
 #, python-format
+
 msgid "%(sender)s sent a message to %(org)s."
 msgstr "%(sender)s a envoyé un message à %(org)s."
 
@@ -3931,16 +4308,19 @@ msgid "View this message:"
 msgstr "Voir ce message :"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(follower)s</strong> a commencé à suivre <strong>%(org)s</strong>."
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s."
 msgstr "%(follower)s a commencé à suivre %(org)s."
 
 #, python-format
+
 msgid ""
 "Thank you! Your payment for <strong>%(event)s</strong> has been confirmed. 🎉"
 msgstr ""
@@ -3969,6 +4349,7 @@ msgstr ""
 "l'entrée de l'événement."
 
 #, python-format
+
 msgid "Thank you! Your payment for %(event)s has been confirmed. 🎉"
 msgstr "Merci beaucoup ! Ton paiement pour %(event)s a été confirmé. 🎉"
 
@@ -3989,6 +4370,7 @@ msgid "Sign up to accept this invitation:"
 msgstr "Inscris-toi pour accepter cette invitation :"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> claimed <strong>\"%(item)s\"</strong> for "
 "<strong>%(event)s</strong>."
@@ -3997,6 +4379,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been claimed for <strong>%(event)s</"
 "strong>."
@@ -4022,10 +4405,12 @@ msgid "View Potluck List"
 msgstr "Voir la liste des contributions"
 
 #, python-format
+
 msgid "%(actor)s claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s a réservé \"%(item)s\" pour %(event)s."
 
 #, python-format
+
 msgid "\"%(item)s\" has been claimed for %(event)s."
 msgstr "\"%(item)s\" a été réservée pour %(event)s."
 
@@ -4036,6 +4421,7 @@ msgid "View potluck list:"
 msgstr "Voir la liste des contributions :"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added <strong>\"%(item)s\"</strong> to the "
 "potluck for <strong>%(event)s</strong>."
@@ -4044,6 +4430,7 @@ msgstr ""
 "contributions pour <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added to "
 "<strong>%(event)s</strong>."
@@ -4058,10 +4445,12 @@ msgid "Claim Item"
 msgstr "Réserver la contribution"
 
 #, python-format
+
 msgid "%(actor)s added \"%(item)s\" to the potluck for %(event)s."
 msgstr "%(actor)s a ajouté \"%(item)s\" aux contributions pour %(event)s."
 
 #, python-format
+
 msgid "A new potluck item \"%(item)s\" has been added to %(event)s."
 msgstr "Une nouvelle contribution \"%(item)s\" a été ajoutée à %(event)s."
 
@@ -4069,6 +4458,7 @@ msgid "Claim this item or view the potluck list:"
 msgstr "Réserve cette contribution ou consulte la liste des contributions :"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added and claimed <strong>\"%(item)s\"</strong> "
 "for <strong>%(event)s</strong>."
@@ -4077,6 +4467,7 @@ msgstr ""
 "pour <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added and claimed "
 "for <strong>%(event)s</strong>."
@@ -4088,10 +4479,12 @@ msgid "Added and claimed by:"
 msgstr "Ajoutée et réservée par :"
 
 #, python-format
+
 msgid "%(actor)s added and claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s a ajouté et réservé \"%(item)s\" pour %(event)s."
 
 #, python-format
+
 msgid ""
 "A new potluck item \"%(item)s\" has been added and claimed for %(event)s."
 msgstr ""
@@ -4099,6 +4492,7 @@ msgstr ""
 "%(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been removed from the potluck for "
 "<strong>%(event)s</strong>."
@@ -4107,10 +4501,12 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been removed from the potluck for %(event)s."
 msgstr "\"%(item)s\" a été retirée des contributions pour %(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> is now available for <strong>%(event)s</"
 "strong>."
@@ -4119,6 +4515,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" is now available for %(event)s."
 msgstr "\"%(item)s\" est maintenant disponible pour %(event)s."
 
@@ -4126,6 +4523,7 @@ msgid "Claim this item:"
 msgstr "Réserve cette contribution :"
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been updated for <strong>%(event)s</"
 "strong>."
@@ -4134,10 +4532,12 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been updated for %(event)s."
 msgstr "\"%(item)s\" a été mise à jour pour %(event)s."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(event)s</strong> has been approved."
@@ -4146,6 +4546,7 @@ msgstr ""
 "<strong>%(event)s</strong> a été approuvé."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(org)s</strong> has been approved."
@@ -4154,6 +4555,7 @@ msgstr ""
 "<strong>%(org)s</strong> a été approuvé."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(event)s</"
 "strong> was not approved."
@@ -4162,6 +4564,7 @@ msgstr ""
 "strong> n'a pas été approuvé."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(org)s</"
 "strong> was not approved."
@@ -4208,19 +4611,23 @@ msgid "RSVP Now"
 msgstr "Répondre à l'invitation"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s has been approved!"
 msgstr "Ton questionnaire %(questionnaire)s pour %(event)s a été approuvé !"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s has been approved!"
 msgstr "Ton questionnaire %(questionnaire)s a été approuvé !"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s was not approved."
 msgstr ""
 "Ton questionnaire %(questionnaire)s pour %(event)s n'a pas été approuvé."
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s was not approved."
 msgstr "Ton questionnaire %(questionnaire)s n'a pas été approuvé."
 
@@ -4234,6 +4641,7 @@ msgid "RSVP now:"
 msgstr "Répondre à l'invitation :"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has submitted the questionnaire "
 "<strong>%(questionnaire)s</strong>."
@@ -4251,6 +4659,7 @@ msgid "Review Submission"
 msgstr "Vérifier la soumission"
 
 #, python-format
+
 msgid "%(name)s has submitted the questionnaire %(questionnaire)s."
 msgstr "%(name)s a soumis le questionnaire %(questionnaire)s."
 
@@ -4261,6 +4670,7 @@ msgid "Review the submission:"
 msgstr "Examiner la soumission :"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s arrived from Stripe on payment "
 "%(intent)s, but Revel could not tell which ticket it belongs to. No ticket "
@@ -4274,6 +4684,7 @@ msgid "It could apply to any of these tickets:"
 msgstr "Il pourrait correspondre à l'un de ces billets :"
 
 #, python-format
+
 msgid "seat %(seat)s"
 msgstr "place %(seat)s"
 
@@ -4292,6 +4703,7 @@ msgid "Refund ID:"
 msgstr "ID du remboursement :"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has cancelled their RSVP for <strong>%(event)s</"
 "strong>."
@@ -4303,6 +4715,7 @@ msgid "Cancellation Details"
 msgstr "Détails de l'annulation"
 
 #, python-format
+
 msgid "Your RSVP for <strong>%(event)s</strong> has been cancelled."
 msgstr ""
 "Ta réponse à l'invitation pour <strong>%(event)s</strong> a été annulée."
@@ -4312,6 +4725,7 @@ msgstr ""
 "Tu peux à nouveau répondre à l'invitation à tout moment si tu changes d'avis."
 
 #, python-format
+
 msgid "%(user)s has cancelled their RSVP for %(event)s."
 msgstr "%(user)s a annulé sa réponse à l'invitation pour %(event)s."
 
@@ -4319,10 +4733,12 @@ msgid "Cancellation Details:"
 msgstr "Détails de l'annulation :"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been cancelled."
 msgstr "Ta réponse à l'invitation pour %(event)s a été annulée."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has RSVP'd <strong>%(response)s</strong> for "
 "<strong>%(event)s</strong>."
@@ -4340,6 +4756,7 @@ msgid "Note:"
 msgstr "Note :"
 
 #, python-format
+
 msgid ""
 "Your RSVP (<strong>%(response)s</strong>) for <strong>%(event)s</strong> has "
 "been confirmed! ✅"
@@ -4357,6 +4774,7 @@ msgid "Dietary restrictions:"
 msgstr "Restrictions alimentaires :"
 
 #, python-format
+
 msgid "%(user)s has RSVP'd %(response)s for %(event)s."
 msgstr "%(user)s a répondu %(response)s pour %(event)s."
 
@@ -4364,6 +4782,7 @@ msgid "RSVP Details:"
 msgstr "Détails de la réponse :"
 
 #, python-format
+
 msgid "Your RSVP (%(response)s) for %(event)s has been confirmed! ✅"
 msgstr "Ta réponse (%(response)s) pour %(event)s a été confirmée ! ✅"
 
@@ -4371,6 +4790,7 @@ msgid "Your Response:"
 msgstr "Ta réponse :"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has changed their RSVP from <strong>%(old)s</"
 "strong> to <strong>%(new)s</strong> for <strong>%(event)s</strong>."
@@ -4379,6 +4799,7 @@ msgstr ""
 "<strong>%(new)s</strong> pour <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> updated their RSVP note for <strong>%(event)s</"
 "strong>."
@@ -4396,6 +4817,7 @@ msgid "New Response:"
 msgstr "Nouvelle réponse :"
 
 #, python-format
+
 msgid ""
 "Your RSVP for <strong>%(event)s</strong> has been updated from "
 "<strong>%(old)s</strong> to <strong>%(new)s</strong>."
@@ -4407,10 +4829,12 @@ msgid "Updated Response"
 msgstr "Réponse mise à jour"
 
 #, python-format
+
 msgid "%(user)s has changed their RSVP from %(old)s to %(new)s for %(event)s."
 msgstr "%(user)s a modifié sa réponse de %(old)s à %(new)s pour %(event)s."
 
 #, python-format
+
 msgid "%(user)s updated their RSVP note for %(event)s."
 msgstr "%(user)s a mis à jour sa note RSVP pour %(event)s."
 
@@ -4418,6 +4842,7 @@ msgid "Updated RSVP Details:"
 msgstr "Détails de la réponse mis à jour :"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been updated from %(old)s to %(new)s."
 msgstr "Ta réponse pour %(event)s a été mise à jour de %(old)s à %(new)s."
 
@@ -4425,6 +4850,7 @@ msgid "Updated Response:"
 msgstr "Réponse mise à jour :"
 
 #, python-format
+
 msgid ""
 "<strong>%(counter)s</strong> new event has been scheduled for "
 "<strong>%(series)s</strong>."
@@ -4445,6 +4871,7 @@ msgid "View Series"
 msgstr "Voir la série"
 
 #, python-format
+
 msgid "%(counter)s new event has been scheduled for %(series)s."
 msgid_plural "%(counter)s new events have been scheduled for %(series)s."
 msgstr[0] "%(counter)s nouvel événement a été programmé pour %(series)s."
@@ -4454,6 +4881,7 @@ msgid "View the series:"
 msgstr "Voir la série :"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> has been cancelled."
@@ -4468,6 +4896,7 @@ msgid "Tickets cancelled:"
 msgstr "Billets annulés :"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "pass holder."
@@ -4476,6 +4905,7 @@ msgstr ""
 "le·la titulaire du pass."
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> will be processed to "
 "your original payment method within 5-10 business days."
@@ -4484,16 +4914,19 @@ msgstr ""
 "sur ton mode de paiement d'origine sous 5 à 10 jours ouvrés."
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s has been cancelled."
 msgstr "Ton pass de série %(pass_name)s pour %(series)s a été annulé."
 
 #, python-format
+
 msgid "A refund of %(amount)s %(currency)s has been issued to the pass holder."
 msgstr ""
 "Un remboursement de %(amount)s %(currency)s a été émis pour le·la titulaire "
 "du pass."
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s will be processed to your original "
 "payment method within 5-10 business days."
@@ -4502,6 +4935,7 @@ msgstr ""
 "paiement d'origine sous 5 à 10 jours ouvrés."
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> now covers <strong>%(counter)s</strong> new event."
@@ -4519,6 +4953,7 @@ msgid "New Events"
 msgstr "Nouveaux événements"
 
 #, python-format
+
 msgid ""
 "Your series pass %(pass_name)s for %(series)s now covers %(counter)s new "
 "event."
@@ -4536,6 +4971,7 @@ msgid "New Events:"
 msgstr "Nouveaux événements :"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> is now active."
@@ -4553,6 +4989,7 @@ msgid "Price paid:"
 msgstr "Prix payé :"
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s is now active."
 msgstr "Ton pass de série %(pass_name)s pour %(series)s est maintenant actif."
 
@@ -4563,6 +5000,7 @@ msgid "Subscription Cancelled"
 msgstr "Abonnement annulé"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> has "
 "been cancelled effective immediately."
@@ -4571,6 +5009,7 @@ msgstr ""
 "annulé avec effet immédiat."
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> will "
 "end on %(date)s."
@@ -4588,12 +5027,14 @@ msgid "We hope to see you again in the future."
 msgstr "Nous espérons te revoir à l'avenir."
 
 #, python-format
+
 msgid ""
 "Your %(plan)s subscription at %(org)s has been cancelled effective "
 "immediately."
 msgstr "Ton abonnement %(plan)s chez %(org)s a été annulé avec effet immédiat."
 
 #, python-format
+
 msgid "Your %(plan)s subscription at %(org)s will end on %(date)s."
 msgstr "Ton abonnement %(plan)s chez %(org)s prendra fin le %(date)s."
 
@@ -4601,6 +5042,7 @@ msgid "Membership Ended"
 msgstr "Adhésion terminée"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> ended "
 "on %(date)s."
@@ -4612,10 +5054,12 @@ msgid "Ended on:"
 msgstr "Terminée le :"
 
 #, python-format
+
 msgid "You can reactivate your membership until <strong>%(date)s</strong>."
 msgstr "Tu peux réactiver ton adhésion jusqu'au <strong>%(date)s</strong>."
 
 #, python-format
+
 msgid "Reactivate by %(date)s"
 msgstr "Réactiver avant le %(date)s"
 
@@ -4626,10 +5070,12 @@ msgstr ""
 "moment."
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s ended on %(date)s."
 msgstr "Ton adhésion %(plan)s chez %(org)s a pris fin le %(date)s."
 
 #, python-format
+
 msgid "You can reactivate your membership until %(date)s."
 msgstr "Tu peux réactiver ton adhésion jusqu'au %(date)s."
 
@@ -4640,6 +5086,7 @@ msgid "Payment Failed"
 msgstr "Paiement échoué"
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your <strong>%(plan)s</strong> "
 "membership at <strong>%(org)s</strong>."
@@ -4654,6 +5101,7 @@ msgid "Grace period ends:"
 msgstr "Fin de la période de grâce :"
 
 #, python-format
+
 msgid ""
 "Please resolve this before <strong>%(date)s</strong> to keep your membership "
 "active."
@@ -4665,6 +5113,7 @@ msgid "Update Payment Method"
 msgstr "Mettre à jour le mode de paiement"
 
 #, python-format
+
 msgid ""
 "Please <a href=\"%(url)s\">contact %(org)s</a> to renew your membership."
 msgstr ""
@@ -4672,6 +5121,7 @@ msgstr ""
 "adhésion."
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your %(plan)s membership at %(org)s."
 msgstr ""
@@ -4679,6 +5129,7 @@ msgstr ""
 "%(org)s."
 
 #, python-format
+
 msgid "Please resolve this before %(date)s to keep your membership active."
 msgstr ""
 "Merci de régler cela avant le %(date)s pour maintenir ton adhésion active."
@@ -4687,6 +5138,7 @@ msgid "Update payment method:"
 msgstr "Mettre à jour le mode de paiement :"
 
 #, python-format
+
 msgid "Contact %(org)s to renew:"
 msgstr "Contacter %(org)s pour renouveler :"
 
@@ -4694,6 +5146,7 @@ msgid "Subscription Price Update"
 msgstr "Mise à jour du prix de l'abonnement"
 
 #, python-format
+
 msgid ""
 "The price for your <strong>%(plan)s</strong> subscription at "
 "<strong>%(org)s</strong> is changing."
@@ -4714,10 +5167,12 @@ msgid "Effective from:"
 msgstr "En vigueur à partir du :"
 
 #, python-format
+
 msgid "Your subscription will move from %(old)s to %(new)s starting %(date)s."
 msgstr "Ton abonnement passera de %(old)s à %(new)s à partir du %(date)s."
 
 #, python-format
+
 msgid "The price for your %(plan)s subscription at %(org)s is changing."
 msgstr "Le prix de ton abonnement %(plan)s chez %(org)s change."
 
@@ -4725,6 +5180,7 @@ msgid "Membership Renewing Soon"
 msgstr "Adhésion bientôt renouvelée"
 
 #, python-format
+
 msgid ""
 "Heads up — your <strong>%(plan)s</strong> membership at <strong>%(org)s</"
 "strong> renews on %(date)s for <strong>%(amount)s</strong>."
@@ -4742,6 +5198,7 @@ msgid "Manage Billing"
 msgstr "Gérer la facturation"
 
 #, python-format
+
 msgid ""
 "If you don't want to renew, please <a href=\"%(url)s\">contact %(org)s</a> "
 "before the renewal date."
@@ -4750,6 +5207,7 @@ msgstr ""
 "%(org)s</a> avant la date de renouvellement."
 
 #, python-format
+
 msgid ""
 "Heads up — your %(plan)s membership at %(org)s renews on %(date)s for "
 "%(amount)s."
@@ -4761,6 +5219,7 @@ msgid "Manage billing:"
 msgstr "Gérer la facturation :"
 
 #, python-format
+
 msgid "If you don't want to renew, please contact %(org)s:"
 msgstr "Si tu ne souhaites pas renouveler, merci de contacter %(org)s :"
 
@@ -4768,6 +5227,7 @@ msgid "Membership Renewed"
 msgstr "Adhésion renouvelée"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> has "
 "been successfully renewed."
@@ -4785,6 +5245,7 @@ msgid "Next renewal:"
 msgstr "Prochain renouvellement :"
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s has been successfully renewed."
 msgstr "Ton adhésion %(plan)s chez %(org)s a été renouvelée avec succès."
 
@@ -4792,6 +5253,7 @@ msgid "Renew Your Membership"
 msgstr "Renouvelle ton adhésion"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has set up the renewal of your <strong>%(plan)s</"
 "strong> membership. Complete the payment to reactivate it."
@@ -4810,6 +5272,7 @@ msgstr ""
 "peux relancer le renouvellement depuis la page de ton adhésion."
 
 #, python-format
+
 msgid ""
 "%(org)s has set up the renewal of your %(plan)s membership. Complete the "
 "payment to reactivate it."
@@ -4827,6 +5290,7 @@ msgid "Read more:"
 msgstr "En savoir plus :"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> cancelled their ticket for <strong>%(event)s</"
 "strong>."
@@ -4835,6 +5299,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> was "
 "refunded via the Stripe dashboard."
@@ -4843,6 +5308,7 @@ msgstr ""
 "été remboursé via le tableau de bord Stripe."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "cancelled."
@@ -4851,15 +5317,18 @@ msgstr ""
 "été annulé."
 
 #, python-format
+
 msgid "You cancelled your ticket for <strong>%(event)s</strong>."
 msgstr "Tu as annulé ton ticket pour <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been cancelled and refunded."
 msgstr "Ton ticket pour <strong>%(event)s</strong> a été annulé et remboursé."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> has been cancelled."
 msgstr "Ton ticket pour <strong>%(event)s</strong> a été annulé."
 
@@ -4870,6 +5339,7 @@ msgid "Cancelled Ticket"
 msgstr "Ticket annulé"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "ticket holder."
@@ -4878,10 +5348,12 @@ msgstr ""
 "le·la titulaire du ticket."
 
 #, python-format
+
 msgid "%(holder)s cancelled their ticket for %(event)s."
 msgstr "%(holder)s a annulé son ticket pour %(event)s."
 
 #, python-format
+
 msgid ""
 "%(holder)s's ticket for %(event)s was refunded via the Stripe dashboard."
 msgstr ""
@@ -4889,6 +5361,7 @@ msgstr ""
 "bord Stripe."
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been cancelled."
 msgstr "Le ticket de %(holder)s pour %(event)s a été annulé."
 
@@ -4896,14 +5369,17 @@ msgid "Ticket Holder:"
 msgstr "Titulaire du ticket :"
 
 #, python-format
+
 msgid "You cancelled your ticket for %(event)s."
 msgstr "Tu as annulé ton ticket pour %(event)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled and refunded."
 msgstr "Ton ticket pour %(event)s a été annulé et remboursé."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled."
 msgstr "Ton ticket pour %(event)s a été annulé."
 
@@ -4911,6 +5387,7 @@ msgid "Cancelled Ticket:"
 msgstr "Ticket annulé :"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s has been issued to the ticket holder."
 msgstr ""
@@ -4918,6 +5395,7 @@ msgstr ""
 "du ticket."
 
 #, python-format
+
 msgid "You have been checked in for <strong>%(event)s</strong>!"
 msgstr "Ta présence a été enregistrée pour <strong>%(event)s</strong> !"
 
@@ -4925,10 +5403,12 @@ msgid "Enjoy the event!"
 msgstr "Profite bien de l'événement !"
 
 #, python-format
+
 msgid "You have been checked in for %(event)s!"
 msgstr "Ta présence a été enregistrée pour %(event)s !"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> has registered for <strong>%(event)s</strong>."
 msgstr ""
@@ -4941,6 +5421,7 @@ msgid "Holder:"
 msgstr "Titulaire :"
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> is pending payment confirmation."
 msgstr ""
@@ -4958,10 +5439,12 @@ msgstr ""
 "Ton ticket te sera envoyé par e-mail dès que ton paiement sera confirmé."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> is confirmed! 🎉"
 msgstr "Ton ticket pour <strong>%(event)s</strong> est confirmé ! 🎉"
 
 #, python-format
+
 msgid "%(holder)s has registered for %(event)s."
 msgstr "%(holder)s s'est inscrit·e pour %(event)s."
 
@@ -4969,6 +5452,7 @@ msgid "Ticket Details:"
 msgstr "Détails du ticket :"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is pending payment confirmation."
 msgstr ""
 "Ton ticket pour %(event)s est en attente de la confirmation du paiement."
@@ -4977,10 +5461,12 @@ msgid "Payment Instructions:"
 msgstr "Instructions de paiement :"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is confirmed! 🎉"
 msgstr "Ton ticket pour %(event)s est confirmé ! 🎉"
 
 #, python-format
+
 msgid "Your ticket refund for <strong>%(event)s</strong> has been processed."
 msgstr ""
 "Le remboursement de ton ticket pour <strong>%(event)s</strong> a été "
@@ -4995,6 +5481,7 @@ msgstr ""
 "ta carte."
 
 #, python-format
+
 msgid "Your ticket refund for %(event)s has been processed."
 msgstr "Le remboursement de ton ticket pour %(event)s a été effectué."
 
@@ -5006,6 +5493,7 @@ msgstr ""
 "jours ouvrés, selon ta banque ou l'émetteur·rice de ta carte."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "<strong>%(action)s</strong>."
@@ -5014,6 +5502,7 @@ msgstr ""
 "été <strong>%(action)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been <strong>%(action)s</"
 "strong>."
@@ -5024,10 +5513,12 @@ msgid "Updated Ticket Information"
 msgstr "Informations de ticket mises à jour"
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been %(action)s."
 msgstr "Le ticket de %(holder)s pour %(event)s a été %(action)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been confirmed! 🎉"
 msgstr "Ton ticket pour %(event)s est confirmé ! 🎉"
 
@@ -5035,6 +5526,7 @@ msgid "Your payment has been confirmed. Your ticket is now active!"
 msgstr "Ton paiement a été confirmé. Ton ticket est maintenant actif !"
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been updated."
 msgstr "Ton ticket pour %(event)s a été mis à jour."
 
@@ -5042,6 +5534,7 @@ msgid "Updated Ticket Information:"
 msgstr "Informations de ticket mises à jour :"
 
 #, python-format
+
 msgid "A spot just opened up for <strong>%(event)s</strong>!"
 msgstr "Une place vient de se libérer pour <strong>%(event)s</strong> !"
 
@@ -5068,6 +5561,7 @@ msgid "Claim your spot:"
 msgstr "Réclamer sa place :"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> has been approved. "
 "You now have full access to view and participate in their events."
@@ -5080,6 +5574,7 @@ msgid "Verification Approved"
 msgstr "Vérification approuvée"
 
 #, python-format
+
 msgid ""
 "Your verification request for %(org)s has been approved. You now have full "
 "access to view and participate in their events."
@@ -5091,6 +5586,7 @@ msgid "New Verification Request"
 msgstr "Nouvelle demande de vérification"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested verification for <strong>%(org)s</"
 "strong>."
@@ -5112,6 +5608,7 @@ msgstr ""
 "une vérification pour accéder à ton organisation."
 
 #, python-format
+
 msgid "%(name)s has requested verification for %(org)s."
 msgstr "%(name)s a demandé une vérification pour %(org)s."
 
@@ -5119,6 +5616,7 @@ msgid "Review this request:"
 msgstr "Examiner cette demande :"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> was not approved at "
 "this time."
@@ -5135,6 +5633,7 @@ msgid "Verification Update"
 msgstr "Mise à jour de la vérification"
 
 #, python-format
+
 msgid "Your verification request for %(org)s was not approved at this time."
 msgstr ""
 "Ta demande de vérification pour %(org)s n'a pas été approuvée pour le moment."
@@ -5156,6 +5655,12 @@ msgstr "Récapitulatif des notifications"
 
 msgid "View all notifications:"
 msgstr "Voir toutes les notifications :"
+
+msgid "You are not allowed to see this poll."
+msgstr "Tu n'es pas autorisé·e à voir ce sondage."
+
+msgid "You are not allowed to see the results for this poll."
+msgstr "Tu n'es pas autorisé·e à voir les résultats de ce sondage."
 
 msgid "Anonymity flags are immutable after a poll is created."
 msgstr ""
@@ -5190,12 +5695,102 @@ msgstr ""
 "public_anonymous doit être True lorsque result_visibility est PUBLIC ou "
 "UNLISTED."
 
+msgid "Only the organization owner can perform this action."
+msgstr ""
+"Seul·e le/la propriétaire de l'organisation peut effectuer cette action."
+
+msgid "Unknown event {} or it does not belong to this organization."
+msgstr "Événement {} inconnu ou n'appartenant pas à cette organisation."
+
+msgid "Unknown or cross-organization membership_tier ids: {}"
+msgstr ""
+"IDs membership_tier inconnus ou appartenant à une autre organisation : {}"
+
+msgid "Only DRAFT polls can be opened directly. Use reopen for CLOSED polls."
+msgstr ""
+"Seuls les sondages au statut DRAFT peuvent être ouverts directement. Utilise "
+"reopen pour les sondages au statut CLOSED."
+
+msgid "Only OPEN polls can be closed."
+msgstr "Seuls les sondages au statut OPEN peuvent être fermés."
+
+msgid "Only CLOSED polls can be reopened."
+msgstr "Seuls les sondages au statut CLOSED peuvent être rouverts."
+
+msgid "closes_at must be in the future."
+msgstr "closes_at doit être dans le futur."
+
+msgid "Cannot reopen: provide a future closes_at or set clear_closes_at=True."
+msgstr ""
+"Réouverture impossible : indique un closes_at futur ou définis "
+"clear_closes_at=True."
+
+msgid "Unknown multiple-choice question id: {}"
+msgstr "ID de question à choix multiples inconnu : {}"
+
+msgid "Unknown multiple-choice option id: {}"
+msgstr "ID d'option à choix multiples inconnu : {}"
+
+msgid "Unknown free-text question id: {}"
+msgstr "ID de question à texte libre inconnu : {}"
+
+msgid "Unknown file-upload question id: {}"
+msgstr "ID de question de téléversement de fichier inconnu : {}"
+
+msgid "Unknown or other-user file_upload ids: {}"
+msgstr "IDs file_upload inconnus ou appartenant à une autre personne : {}"
+
 msgid "You submitted answers refer to a different questionnaire."
 msgstr ""
 "Les réponses que tu as soumises font référence à un autre questionnaire."
 
 msgid "You are missing mandatory answers."
 msgstr "Il te manque des réponses obligatoires."
+
+msgid "File exceeds maximum upload size of {}MB."
+msgstr "Le fichier dépasse la taille maximale de téléversement de {} Mo."
+
+msgid ""
+"File type '{}' is not allowed. Allowed types: documents, images, audio, "
+"video, and archives."
+msgstr ""
+"Le type de fichier « {} » n'est pas autorisé. Types autorisés : documents, "
+"images, audio, vidéo et archives."
+
+msgid "Section ID in payload does not match the provided section."
+msgstr "L'ID de section du payload ne correspond pas à la section fournie."
+
+msgid "Section does not exist or does not belong to this questionnaire."
+msgstr "La section n'existe pas ou n'appartient pas à ce questionnaire."
+
+msgid "Option does not exist or does not belong to this questionnaire."
+msgstr "L'option n'existe pas ou n'appartient pas à ce questionnaire."
+
+msgid "Question does not belong to this questionnaire."
+msgstr "La question n'appartient pas à ce questionnaire."
+
+msgid "Some files do not exist or do not belong to you."
+msgstr "Certains fichiers n'existent pas ou ne t'appartiennent pas."
+
+msgid "Too many files. Maximum allowed: {}."
+msgstr "Trop de fichiers. Maximum autorisé : {}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' has type '{mime_type}' which is not allowed. Allowed "
+"types: {allowed_types}."
+msgstr ""
+"Le fichier « {filename} » a le type « {mime_type} », qui n'est pas autorisé. "
+"Types autorisés : {allowed_types}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes."
+msgstr ""
+"Le fichier « {filename} » ({size} octets) dépasse la taille maximale de "
+"{max_size} octets."
 
 msgid "Dashboard"
 msgstr "Tableau de bord"
@@ -5491,8 +6086,17 @@ msgstr "Groupes"
 msgid "Telegram integration is not enabled."
 msgstr "L'intégration Telegram n'est pas activée."
 
+msgid "Your account is already connected to Telegram."
+msgstr "Ton compte est déjà connecté à Telegram."
+
+msgid "Invalid or expired OTP code."
+msgstr "Code OTP invalide ou expiré."
+
 msgid "Connected banned Telegram account"
 msgstr "Compte Telegram banni connecté"
+
+msgid "No Telegram account is linked to your account."
+msgstr "Aucun compte Telegram n'est lié à ton compte."
 
 msgid "Django site admin"
 msgstr "Administration du site Django"
@@ -5502,3 +6106,9 @@ msgid ""
 msgstr ""
 "La génération du pass Wallet est temporairement indisponible. Réessaie plus "
 "tard."
+
+msgid "Invalid link"
+msgstr "Lien invalide"
+
+msgid "Link expired"
+msgstr "Lien expiré"

--- a/src/locale/it/LC_MESSAGES/django.po
+++ b/src/locale/it/LC_MESSAGES/django.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -44,36 +45,42 @@ msgid "Requeue failed payouts"
 msgstr "Rimetti in coda i pagamenti falliti"
 
 #, python-format
+
 msgid "Requeued %d failed payout."
 msgid_plural "Requeued %d failed payouts."
 msgstr[0] "%d pagamento fallito rimesso in coda."
 msgstr[1] "%d pagamenti falliti rimessi in coda."
 
 #, python-format
+
 msgid "Skipped %d payout (not in failed status)."
 msgid_plural "Skipped %d payouts (not in failed status)."
 msgstr[0] "%d pagamento saltato (non in stato fallito)."
 msgstr[1] "%d pagamenti saltati (non in stato fallito)."
 
 #, python-format
+
 msgid "Verification email sent to %d user."
 msgid_plural "Verification emails sent to %d users."
 msgstr[0] "Email di verifica inviata a %d utente."
 msgstr[1] "Email di verifica inviate a %d utenti."
 
 #, python-format
+
 msgid "Skipped %d user (already verified)."
 msgid_plural "Skipped %d users (already verified)."
 msgstr[0] "%d utente saltato (già verificato)."
 msgstr[1] "%d utenti saltati (già verificati)."
 
 #, python-format
+
 msgid "Password reset email sent to %d user."
 msgid_plural "Password reset emails sent to %d users."
 msgstr[0] "Email di reimpostazione password inviata a %d utente."
 msgstr[1] "Email di reimpostazione password inviate a %d utenti."
 
 #, python-format
+
 msgid "Skipped %d user (Google SSO or not found)."
 msgid_plural "Skipped %d users (Google SSO or not found)."
 msgstr[0] "%d utente saltato (Google SSO o non trovato)."
@@ -86,12 +93,14 @@ msgid "Violation of terms of service"
 msgstr "Violazione dei termini di servizio"
 
 #, python-format
+
 msgid "Banned %d user."
 msgid_plural "Banned %d users."
 msgstr[0] "%d utente bloccato."
 msgstr[1] "%d utenti bloccati."
 
 #, python-format
+
 msgid "Skipped %d user (staff/superuser or already banned)."
 msgid_plural "Skipped %d users (staff/superuser or already banned)."
 msgstr[0] "%d utente saltato (staff/superuser o già bloccato)."
@@ -140,6 +149,12 @@ msgstr "Hai già una restrizione per questo alimento."
 msgid "You have already added this dietary preference."
 msgstr "Hai già aggiunto questa preferenza alimentare."
 
+msgid "OTP is already enabled."
+msgstr "L'OTP è già attivo."
+
+msgid "Invalid OTP"
+msgstr "OTP non valido"
+
 msgid "Invalid or inactive referral code."
 msgstr "Codice referral non valido o inattivo."
 
@@ -153,6 +168,7 @@ msgid "Only active referrers can connect a Stripe account."
 msgstr "Solo i referrer attivi possono collegare un account Stripe."
 
 #, python-format
+
 msgid ""
 "Deleting your account will permanently forfeit %(count)s unpaid referral "
 "payout(s) totalling %(total)s %(currency)s, of which %(failed)s %(currency)s "
@@ -166,6 +182,9 @@ msgstr ""
 "riceverli, oppure invia di nuovo la richiesta con force=true per eliminarlo "
 "comunque."
 
+msgid "Token is blacklisted."
+msgstr "Il token è nella lista nera."
+
 msgid "Global Ban"
 msgstr "Blocco globale"
 
@@ -173,6 +192,7 @@ msgid "Global Bans"
 msgstr "Blocchi globali"
 
 #, python-format
+
 msgid "Password must be at least %(min_length)d characters long."
 msgstr "La password deve contenere almeno %(min_length)d caratteri."
 
@@ -193,6 +213,7 @@ msgstr ""
 "<>)[]=."
 
 #, python-format
+
 msgid ""
 "Your password must be at least %(min_length)d characters long, contain at "
 "least one uppercase letter, one lowercase letter, one digit, and one special "
@@ -235,11 +256,15 @@ msgid "Token has expired."
 msgstr "Il token è scaduto."
 
 #, python-brace-format
+
 msgid "Invalid token: {error}"
 msgstr "Token non valido: {error}"
 
 msgid "Invalid token type."
 msgstr "Tipo di token non valido."
+
+msgid "Billing profile already exists."
+msgstr "Il profilo di fatturazione esiste già."
 
 msgid "Registration is not available."
 msgstr "La registrazione non è disponibile."
@@ -259,11 +284,18 @@ msgstr "Non puoi impersonare i membri dello staff."
 msgid "Cannot impersonate inactive users."
 msgstr "Non puoi impersonare utenti inattivi."
 
+msgid "Impersonation not allowed."
+msgstr "L'impersonificazione non è consentita."
+
+msgid "Impersonation no longer allowed."
+msgstr "L'impersonificazione non è più consentita."
+
 msgid "Set a password before unlinking your only sign-in method."
 msgstr ""
 "Imposta una password prima di scollegare il tuo unico metodo di accesso."
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s (%(currency)s)"
 msgstr "Rendiconto referral %(document_number)s (%(currency)s)"
 
@@ -323,6 +355,7 @@ msgstr ""
 "associati verranno eliminati definitivamente."
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account immediately</a>."
@@ -346,6 +379,7 @@ msgid "Confirm Account Deletion"
 msgstr "Conferma cancellazione account"
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at\n"
@@ -366,6 +400,7 @@ msgid "Confirm Account Deletion."
 msgstr "Conferma cancellazione account."
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at %(frontend_base_url)s."
@@ -389,10 +424,12 @@ msgid "Please investigate this issue as soon as possible."
 msgstr "Si prega di investigare questo problema al più presto."
 
 #, python-format
+
 msgid "User: %(user.email)s"
 msgstr "Utente: %(user.email)s"
 
 #, python-format
+
 msgid "Error: %(error_message)s"
 msgstr "Errore: %(error_message)s"
 
@@ -403,6 +440,7 @@ msgid "Data Export Failed"
 msgstr "Esportazione dati utente fallita"
 
 #, python-format
+
 msgid "Hi %(user.first_name)s,"
 msgstr "Ciao %(user.first_name)s,"
 
@@ -436,6 +474,7 @@ msgid "Your Data Export is Ready"
 msgstr "L'esportazione dei tuoi dati è pronta"
 
 #, python-format
+
 msgid "Hi %(user.username)s,"
 msgstr "Ciao %(user.username)s,"
 
@@ -473,6 +512,7 @@ msgid "Your Revel email address has been changed"
 msgstr "Il tuo indirizzo email Revel è stato modificato"
 
 #, python-format
+
 msgid ""
 "This address (<strong>%(new_email)s</strong>) is now the primary email on "
 "your Revel account. The previous address (<strong>%(old_email)s</strong>) "
@@ -494,6 +534,7 @@ msgid "Your Revel email address has been changed."
 msgstr "Il tuo indirizzo email Revel è stato modificato."
 
 #, python-format
+
 msgid ""
 "This address (%(new_email)s) is now the primary email on your Revel account. "
 "The previous address (%(old_email)s) has been removed and can no longer be "
@@ -504,6 +545,7 @@ msgstr ""
 "essere usato per accedere."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from <strong>%(old_email)s</strong> to <strong>%(new_email)s</"
@@ -521,6 +563,7 @@ msgstr ""
 "sicurezza. D'ora in poi, accedi utilizzando il tuo nuovo indirizzo."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from %(old_email)s to %(new_email)s."
@@ -572,6 +615,7 @@ msgid "An email change was requested on your account"
 msgstr "È stata richiesta una modifica dell'email sul tuo account"
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "<strong>%(masked_new_email)s</strong>. The change is not active yet — it "
@@ -601,6 +645,7 @@ msgid "An email change was requested on your account."
 msgstr "È stata richiesta una modifica dell'email sul tuo account."
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "%(masked_new_email)s. The change is not active yet — it will only take "
@@ -611,6 +656,7 @@ msgstr ""
 "quando il nuovo indirizzo sarà confermato."
 
 #, python-format
+
 msgid ""
 "If this wasn't you, change your password immediately at "
 "%(frontend_base_url)s/account/password-reset and contact support."
@@ -647,6 +693,7 @@ msgid "Verify Email Now"
 msgstr "Verifica email ora"
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account</a>."
@@ -715,14 +762,17 @@ msgstr ""
 "finalità contabili."
 
 #, python-format
+
 msgid "User: %(user_email)s (%(user_id)s)"
 msgstr "Utente: %(user_email)s (%(user_id)s)"
 
 #, python-format
+
 msgid "Forfeited: %(unpaid_count)s payout(s), %(unpaid_total)s %(currency)s"
 msgstr "Persi: %(unpaid_count)s compenso/i, %(unpaid_total)s %(currency)s"
 
 #, python-format
+
 msgid "Of which failed transfers: %(failed_total)s %(currency)s"
 msgstr "Di cui da trasferimenti falliti: %(failed_total)s %(currency)s"
 
@@ -730,14 +780,17 @@ msgid "Referral payouts forfeited by an account deletion"
 msgstr "Compensi referral persi a seguito dell'eliminazione di un account"
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s"
 msgstr "Rendiconto referral %(document_number)s"
 
 #, python-format
+
 msgid "Referral Payout Statement %(document_number)s"
 msgstr "Rendiconto referral %(document_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached your referral payout statement %(document_number)s for "
 "the period %(period_start)s to %(period_end)s."
@@ -761,6 +814,7 @@ msgid "Users"
 msgstr "Utenti"
 
 #, python-format
+
 msgid "You are about to impersonate the user \"%(username)s\"."
 msgstr "Stai per impersonare l'utente \"%(username)s\"."
 
@@ -843,6 +897,7 @@ msgstr ""
 "partita IVA è stata salvata. Riprova più tardi."
 
 #, python-format
+
 msgid "Country code must match the VAT ID prefix (%(prefix)s)."
 msgstr ""
 "Il codice paese deve corrispondere al prefisso della partita IVA "
@@ -925,6 +980,24 @@ msgstr "refund_tickets è valido solo quando si annulla l'evento."
 msgid "Invitation not found."
 msgstr "Invito non trovato."
 
+msgid "Offer not found."
+msgstr "Offerta non trovata."
+
+msgid ""
+"Waitlist time window is not configured for this event. Provide expires_at in "
+"the payload."
+msgstr ""
+"Per questo evento non è configurata una finestra temporale per la lista "
+"d'attesa. Indica expires_at nel payload."
+
+msgid "User already has a pending offer for this event."
+msgstr "Questa persona ha già un'offerta in sospeso per questo evento."
+
+msgid "Event is at capacity. Revoke an existing pending offer to make room."
+msgstr ""
+"L'evento ha raggiunto la capienza massima. Revoca un'offerta in sospeso per "
+"fare spazio."
+
 msgid "This event does not have an open waitlist."
 msgstr "Questo evento non ha una lista d'attesa aperta."
 
@@ -977,14 +1050,19 @@ msgstr "Uno o più livelli di biglietto non sono stati trovati."
 msgid "No pending reservation found."
 msgstr "Nessuna prenotazione in sospeso trovata."
 
+msgid "This event has no venue."
+msgstr "Questo evento non ha una sede."
+
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr "Usa l'endpoint /checkout/pwyc per i biglietti a offerta libera"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at least {min_amount}"
 msgstr "L'importo PWYC deve essere almeno {min_amount}"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at most {max_amount}"
 msgstr "L'importo PWYC deve essere al massimo {max_amount}"
 
@@ -1020,6 +1098,9 @@ msgstr "La creazione di organizzazioni è disabilitata su questa istanza."
 msgid "Message sent."
 msgstr "Messaggio inviato."
 
+msgid "No matching blacklist entries found."
+msgstr "Nessuna voce corrispondente trovata nella lista nera."
+
 msgid "Token does not match this organization."
 msgstr "Questo token non corrisponde a questa organizzazione."
 
@@ -1031,6 +1112,12 @@ msgid "Only the organization owner can change staff permissions."
 msgstr ""
 "Solo il proprietario dell'organizzazione può modificare i permessi dello "
 "staff."
+
+msgid "Series has no template event."
+msgstr "La serie non ha un evento modello."
+
+msgid "date_from must be on or before date_to."
+msgstr "date_from deve essere precedente o uguale a date_to."
 
 msgid ""
 "ONLINE plans must be subscribed to by the member directly. Send them to the "
@@ -1067,8 +1154,27 @@ msgstr "Il PDF della fattura non è ancora stato generato."
 msgid "Invoice PDF could not be generated."
 msgstr "Impossibile generare il PDF della fattura."
 
+msgid "You must be the owner of this organization."
+msgstr "Devi essere proprietario/a di questa organizzazione."
+
+msgid "You must be the owner or a staff member of this organization."
+msgstr ""
+"Devi essere proprietario/a o membro dello staff di questa organizzazione."
+
 msgid "Ticket sales are paused."
 msgstr "La vendita dei biglietti è sospesa."
+
+msgid "You're outside of the sale window."
+msgstr "Sei fuori dalla finestra di vendita."
+
+msgid "The ticket can be purchased by {}"
+msgstr "Il biglietto può essere acquistato da {}"
+
+msgid "Apple Wallet is not configured"
+msgstr "Apple Wallet non è configurato"
+
+msgid "Google Wallet is not configured"
+msgstr "Google Wallet non è configurato"
 
 msgid ""
 "Your payment went through. We're still confirming your subscription — check "
@@ -1546,7 +1652,55 @@ msgstr ""
 msgid "This member has no ticket for this event."
 msgstr "Questo membro non ha un biglietto per questo evento."
 
+msgid "Event not found or does not belong to this organization"
+msgstr "Evento non trovato o non appartenente a questa organizzazione"
+
+msgid ""
+"Announcement must have at least one targeting option: event, "
+"target_all_members, target_tiers, or target_staff_only"
+msgstr ""
+"L'annuncio deve avere almeno un'opzione di targeting: event, "
+"target_all_members, target_tiers o target_staff_only"
+
+msgid "Only draft or scheduled announcements can be updated"
+msgstr "Solo gli annunci in bozza o programmati possono essere modificati"
+
+msgid "Re-sending to new sign-ups requires an event-targeted announcement"
+msgstr "Il rinvio ai nuovi iscritti richiede un annuncio mirato a un evento"
+
+msgid "Relative scheduling requires an event-targeted announcement"
+msgstr "La programmazione relativa richiede un annuncio mirato a un evento"
+
+msgid "Only draft announcements can be scheduled"
+msgstr "Solo gli annunci in bozza possono essere programmati"
+
+msgid "Relative scheduling requires both an anchor and an offset"
+msgstr ""
+"La programmazione relativa richiede sia un ancoraggio sia uno scostamento"
+
+msgid ""
+"Could not resolve a scheduled time (relative scheduling requires an event)"
+msgstr ""
+"Non è stato possibile determinare l'orario programmato (la programmazione "
+"relativa richiede un evento)"
+
+msgid "Scheduled time must be in the future"
+msgstr "L'orario programmato deve essere nel futuro"
+
+msgid "Only scheduled announcements can be unscheduled"
+msgstr "Solo gli annunci programmati possono essere deprogrammati"
+
+msgid "Only draft or scheduled announcements can be sent"
+msgstr "Solo gli annunci in bozza o programmati possono essere inviati"
+
+msgid "Only sent announcements can be resent"
+msgstr "Solo gli annunci già inviati possono essere reinviati"
+
+msgid "Announcement is not configured for resending"
+msgstr "L'annuncio non è configurato per il reinvio"
+
 #, python-brace-format
+
 msgid "Invoice totals do not reconcile with its line items: {details}"
 msgstr "I totali della fattura non coincidono con le sue righe: {details}"
 
@@ -1554,10 +1708,12 @@ msgid "Only draft invoices can be edited."
 msgstr "Solo le fatture in bozza possono essere modificate."
 
 #, python-brace-format
+
 msgid "Cannot edit fields: {fields}"
 msgstr "Impossibile modificare i campi: {fields}"
 
 #, python-brace-format
+
 msgid "Fields cannot be null: {fields}"
 msgstr "Questi campi non possono essere nulli: {fields}"
 
@@ -1566,6 +1722,20 @@ msgstr "Le fatture annullate non possono essere emesse."
 
 msgid "Only draft invoices can be deleted."
 msgstr "Solo le fatture in bozza possono essere eliminate."
+
+msgid "Organization must be EU-based (valid EU VAT country code required)"
+msgstr ""
+"L'organizzazione deve avere sede nell'UE (è richiesto un codice paese IVA UE "
+"valido)"
+
+msgid "VAT ID must be validated via VIES"
+msgstr "La partita IVA deve essere validata tramite VIES"
+
+msgid "Billing name (legal entity name) is required"
+msgstr "Il nome di fatturazione (ragione sociale) è obbligatorio"
+
+msgid "Billing address is required"
+msgstr "L'indirizzo di fatturazione è obbligatorio"
 
 msgid "Provide either seat_ids or price_category_id, not both."
 msgstr "Fornisci seat_ids oppure price_category_id, non entrambi."
@@ -1585,10 +1755,17 @@ msgstr ""
 "Uno o più posti selezionati non sono validi o non si trovano nel settore "
 "corretto."
 
+msgid "Ticket tier not found."
+msgstr "Livello di biglietto non trovato."
+
+msgid "All tiers must use the same currency."
+msgstr "Tutti i livelli di biglietto devono usare la stessa valuta."
+
 msgid "This ticket tier is sold out."
 msgstr "Questo livello di biglietto è esaurito."
 
 #, python-brace-format
+
 msgid "Only {available} ticket(s) remaining for this tier."
 msgstr "Restano solo {available} biglietto/i per questo livello."
 
@@ -1596,6 +1773,7 @@ msgid "This event is sold out."
 msgstr "Questo evento è esaurito."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining for this event."
 msgstr "Restano solo {available} posto/i per questo evento."
 
@@ -1603,6 +1781,7 @@ msgid "This sector is full."
 msgstr "Questo settore è al completo."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining in this sector."
 msgstr "Restano solo {available} posto/i in questo settore."
 
@@ -1629,9 +1808,6 @@ msgstr "Ogni livello può comparire una sola volta per checkout."
 msgid "The same seat cannot be purchased twice."
 msgstr "Lo stesso posto non può essere acquistato due volte."
 
-msgid "You're outside of the sale window."
-msgstr "Sei fuori dalla finestra di vendita."
-
 msgid "You are not allowed to purchase from this tier."
 msgstr "Non ti è consentito acquistare da questo livello."
 
@@ -1639,6 +1815,7 @@ msgid "You have reached the maximum number of tickets for this event."
 msgstr "Hai raggiunto il numero massimo di biglietti per questo evento."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this event."
 msgstr ""
 "Puoi acquistare solo {remaining} altro/i biglietto/i per questo evento."
@@ -1647,6 +1824,7 @@ msgid "You have reached the maximum number of tickets for this tier."
 msgstr "Hai raggiunto il numero massimo di biglietti per questo livello."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this tier."
 msgstr ""
 "Puoi acquistare solo {remaining} altro/i biglietto/i per questo livello."
@@ -1699,10 +1877,12 @@ msgid "Check-in is not currently open for this event."
 msgstr "Il check-in non è attualmente aperto per questo evento."
 
 #, python-brace-format
+
 msgid "Check-in is not open yet. It will open at {opens_at}."
 msgstr "Il check-in non è ancora aperto. Aprirà alle {opens_at}."
 
 #, python-brace-format
+
 msgid "Check-in has closed for this event. It ended at {ended_at}."
 msgstr "Il check-in per questo evento è chiuso. È terminato alle {ended_at}."
 
@@ -1716,6 +1896,7 @@ msgid "This ticket is pending payment confirmation."
 msgstr "Questo biglietto è in attesa di conferma del pagamento."
 
 #, python-brace-format
+
 msgid "Invalid ticket status: {status}"
 msgstr "Stato del biglietto non valido: {status}"
 
@@ -1762,6 +1943,7 @@ msgid "This discount code is not valid for this currency."
 msgstr "Questo codice sconto non è valido per questa valuta."
 
 #, python-brace-format
+
 msgid "Minimum purchase amount of {amount} required to use this discount code."
 msgstr ""
 "È richiesto un importo minimo di acquisto di {amount} per usare questo "
@@ -1804,6 +1986,7 @@ msgid "Waiting for questionnaire evaluation."
 msgstr "In attesa della valutazione del questionario."
 
 #, python-brace-format
+
 msgid ""
 "Questionnaire evaluation was insufficient. You can try again in {retry_on}."
 msgstr ""
@@ -1877,6 +2060,7 @@ msgid "You have reached the maximum number of attempts."
 msgstr "Hai raggiunto il numero massimo di tentativi."
 
 #, python-format
+
 msgid "You can retry after %(retry_on)s."
 msgstr "Puoi riprovare dopo %(retry_on)s."
 
@@ -1886,6 +2070,9 @@ msgstr ""
 
 msgid "Feedback questionnaires cannot require evaluation."
 msgstr "I questionari di feedback non possono richiedere una valutazione."
+
+msgid "LLM evaluation is not available."
+msgstr "La valutazione tramite LLM non è disponibile."
 
 msgid "One or more events do not exist or belong to this organization."
 msgstr ""
@@ -1919,6 +2106,24 @@ msgstr "Hai già inviato un feedback per questo evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "I questionari di feedback non possono essere valutati."
 
+msgid "Organization not found"
+msgstr "Organizzazione non trovata"
+
+msgid "Already following this organization"
+msgstr "Segui già questa organizzazione"
+
+msgid "Not following this organization"
+msgstr "Non segui questa organizzazione"
+
+msgid "Event series not found"
+msgstr "Serie di eventi non trovata"
+
+msgid "Already following this series"
+msgstr "Segui già questa serie"
+
+msgid "Not following this series"
+msgstr "Non segui questa serie"
+
 msgid "Invalid token."
 msgstr "Token non valido."
 
@@ -1941,6 +2146,7 @@ msgid "Invalid token type"
 msgstr "Tipo di token non valido"
 
 #, python-format
+
 msgid "Ticket tiers not found: %(ids)s"
 msgstr "Livelli di biglietto non trovati: %(ids)s"
 
@@ -2044,6 +2250,7 @@ msgstr ""
 "modificare la politica di abbonamento dei membri."
 
 #, python-format
+
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "
 "name."
@@ -2177,6 +2384,7 @@ msgid "This payment is already fully refunded."
 msgstr "Questo pagamento è già stato rimborsato integralmente."
 
 #, python-format
+
 msgid ""
 "Refund amount must be between 0 and the remaining refundable amount "
 "(%(amount)s)."
@@ -2189,6 +2397,9 @@ msgstr "Questo biglietto non ha alcun pagamento da rimborsare."
 
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "È necessario fornire un file quando resource_type è 'file'."
+
+msgid "Specify either month or quarter, not both."
+msgstr "Indica un mese oppure un trimestre, non entrambi."
 
 msgid "This seat is not available for this event."
 msgstr "Questo posto non è disponibile per questo evento."
@@ -2246,10 +2457,12 @@ msgstr ""
 "contatta l'organizzatore."
 
 #, python-brace-format
+
 msgid "Select one of this ticket tier's zones: {zones}."
 msgstr "Seleziona una delle zone di questo livello di biglietto: {zones}."
 
 #, python-brace-format
+
 msgid ""
 "Seat {seat} is in the \"{category}\" price category, which this ticket tier "
 "does not sell."
@@ -2276,6 +2489,7 @@ msgid "This pass has no upcoming events to purchase."
 msgstr "Questo pass non ha eventi futuri da acquistare."
 
 #, python-brace-format
+
 msgid "Event {name} is sold out."
 msgstr "L'evento {name} è esaurito."
 
@@ -2296,18 +2510,22 @@ msgid "Series passes are not supported on recurring series."
 msgstr "I pass stagionali non sono supportati sulle serie ricorrenti."
 
 #, python-format
+
 msgid "Event '%s' does not belong to this series."
 msgstr "L'evento '%s' non appartiene a questa serie."
 
 #, python-format
+
 msgid "Event '%s' is not open."
 msgstr "L'evento '%s' non è aperto."
 
 #, python-format
+
 msgid "Event '%s' does not require a ticket."
 msgstr "L'evento '%s' non richiede un biglietto."
 
 #, python-format
+
 msgid ""
 "Event '%s' is invitation-only or members-only and cannot be covered by a "
 "series pass."
@@ -2326,6 +2544,7 @@ msgid "One or more events do not exist."
 msgstr "Uno o più eventi non esistono."
 
 #, python-format
+
 msgid "Event '%s' is already covered by this pass via a different tier."
 msgstr "L'evento '%s' è già coperto da questo pass tramite un livello diverso."
 
@@ -2582,6 +2801,7 @@ msgid "Cannot refund a ticket that was never paid."
 msgstr "Impossibile rimborsare un biglietto mai pagato."
 
 #, python-format
+
 msgid "Refund amount must be between 0 and the amount paid (%(amount)s)."
 msgstr ""
 "L'importo del rimborso deve essere compreso tra 0 e l'importo pagato "
@@ -2591,6 +2811,7 @@ msgid "Price category must belong to the same venue as the seats."
 msgstr "La categoria di prezzo deve appartenere alla stessa sede dei posti."
 
 #, python-brace-format
+
 msgid ""
 "This price category is used by one or more ticket tiers and cannot be "
 "deleted: {tiers}. Remove it from those tiers' category prices first."
@@ -2654,18 +2875,22 @@ msgid "Only approved requests can be removed from whitelist."
 msgstr "Solo le richieste approvate possono essere rimosse dalla whitelist."
 
 #, python-format
+
 msgid "Confirm your RSVP to %(event_name)s"
 msgstr "Conferma la tua partecipazione a %(event_name)s"
 
 #, python-format
+
 msgid "Confirm your ticket for %(event_name)s"
 msgstr "Conferma il tuo biglietto per %(event_name)s"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s (%(currency)s)"
 msgstr "Fattura commissioni di piattaforma %(invoice_number)s (%(currency)s)"
 
 #, python-format
+
 msgid "Verify contact email for %(organization_name)s"
 msgstr "Verifica l'email di contatto per %(organization_name)s"
 
@@ -2676,6 +2901,7 @@ msgid "Confirm your RSVP"
 msgstr "Conferma la tua partecipazione"
 
 #, python-format
+
 msgid "You've indicated your interest in attending %(event_name)s."
 msgstr "Hai indicato il tuo interesse a partecipare a %(event_name)s."
 
@@ -2700,6 +2926,7 @@ msgid "Confirm your ticket purchase"
 msgstr "Conferma l'acquisto del biglietto"
 
 #, python-format
+
 msgid "You've requested a ticket for %(event_name)s (%(tier_name)s)."
 msgstr "Hai richiesto un biglietto per %(event_name)s (%(tier_name)s)."
 
@@ -2713,14 +2940,17 @@ msgid "To confirm your ticket purchase, please click the link below:"
 msgstr "Per confermare l'acquisto del biglietto, clicca il link qui sotto:"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s"
 msgstr "Fattura commissioni di piattaforma %(invoice_number)s"
 
 #, python-format
+
 msgid "Platform Fee Invoice %(invoice_number)s"
 msgstr "Fattura commissioni di piattaforma %(invoice_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached the platform fee invoice %(invoice_number)s for "
 "%(currency)s transactions in the period %(period_start)s to %(period_end)s."
@@ -2758,19 +2988,23 @@ msgstr ""
 "prezzo a prezzo."
 
 #, python-brace-format
+
 msgid "'{key}' is not a valid price category id."
 msgstr "'{key}' non è un id di categoria di prezzo valido."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a decimal string."
 msgstr ""
 "Il prezzo per la categoria {category} deve essere una stringa decimale."
 
 #, python-brace-format
+
 msgid "'{value}' is not a valid price for category {category}."
 msgstr "'{value}' non è un prezzo valido per la categoria {category}."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a non-negative number."
 msgstr ""
 "Il prezzo per la categoria {category} deve essere un numero non negativo."
@@ -2787,6 +3021,7 @@ msgstr ""
 "mai entrambi."
 
 #, python-brace-format
+
 msgid ""
 "Online tiers require every category price to be at least 1: {categories}."
 msgstr ""
@@ -2794,6 +3029,7 @@ msgstr ""
 "categoria sia almeno 1: {categories}."
 
 #, python-brace-format
+
 msgid "These price categories do not belong to the tier's venue: {categories}."
 msgstr ""
 "Queste categorie di prezzo non appartengono alla sede del livello di "
@@ -2844,6 +3080,7 @@ msgid "The import failed unexpectedly."
 msgstr "L'importazione non è riuscita in modo imprevisto."
 
 #, python-format
+
 msgid "Ticket class %(name)s could not be imported."
 msgstr "La classe di biglietti %(name)s non è stata importata."
 
@@ -2986,6 +3223,7 @@ msgid "Read more..."
 msgstr "Leggi di più..."
 
 #, python-format
+
 msgid "%(counter)s new notification"
 msgid_plural "%(counter)s new notifications"
 msgstr[0] "%(counter)s nuova notifica"
@@ -2998,94 +3236,117 @@ msgid "Revel - Your account has been suspended"
 msgstr "Revel - Il tuo account è stato sospeso"
 
 #, python-format
+
 msgid "New Event: %(event)s"
 msgstr "Nuovo evento: %(event)s"
 
 #, python-format
+
 msgid "%(org)s has published a new event"
 msgstr "%(org)s ha pubblicato un nuovo evento"
 
 #, python-format
+
 msgid "Reminder: %(event)s is tomorrow!"
 msgstr "Promemoria: %(event)s è domani!"
 
 #, python-format
+
 msgid "Reminder: %(event)s in %(days)d days"
 msgstr "Promemoria: %(event)s tra %(days)d giorni"
 
 #, python-format
+
 msgid "Tomorrow: %(event)s"
 msgstr "Domani: %(event)s"
 
 #, python-format
+
 msgid "Event Updated: %(event)s"
 msgstr "Evento aggiornato: %(event)s"
 
 #, python-format
+
 msgid "Important Update: %(event)s"
 msgstr "Aggiornamento importante: %(event)s"
 
 #, python-format
+
 msgid "Event Cancelled: %(event)s"
 msgstr "Evento annullato: %(event)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s"
 msgstr "%(follower)s ha iniziato a seguire %(org)s"
 
 #, python-format
+
 msgid "New follower - %(org)s"
 msgstr "Nuovo follower – %(org)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s"
 msgstr "%(follower)s ha iniziato a seguire %(series)s"
 
 #, python-format
+
 msgid "New follower - %(series)s"
 msgstr "Nuovo follower – %(series)s"
 
 #, python-format
+
 msgid "%(org)s created %(event)s"
 msgstr "%(org)s ha creato %(event)s"
 
 #, python-format
+
 msgid "New event from %(org)s"
 msgstr "Nuovo evento da %(org)s"
 
 #, python-format
+
 msgid "New event in %(series)s: %(event)s"
 msgstr "Nuovo evento in %(series)s: %(event)s"
 
 #, python-format
+
 msgid "New event in %(series)s"
 msgstr "Nuovo evento in %(series)s"
 
 #, python-format
+
 msgid "You're invited to %(event)s"
 msgstr "Sei invitato a %(event)s"
 
 #, python-format
+
 msgid "You're invited: %(event)s"
 msgstr "Sei invitato: %(event)s"
 
 #, python-format
+
 msgid "%(email)s requested invitation to %(event)s"
 msgstr "%(email)s ha richiesto un invito per %(event)s"
 
 #, python-format
+
 msgid "New invitation request: %(event)s"
 msgstr "Nuova richiesta di invito: %(event)s"
 
 #, python-format
+
 msgid "You're now a %(role)s of %(org)s"
 msgstr "Ora sei %(role)s di %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s"
 msgstr "Benvenuto in %(org)s"
 
 #, python-format
+
 msgid "Your membership card was updated: %(org)s"
 msgstr "La tua tessera di iscrizione è stata aggiornata: %(org)s"
 
@@ -3093,268 +3354,333 @@ msgid "Your membership card was updated"
 msgstr "La tua tessera di iscrizione è stata aggiornata"
 
 #, python-format
+
 msgid "You've been promoted to %(role)s in %(org)s"
 msgstr "Sei stato promosso a %(role)s in %(org)s"
 
 #, python-format
+
 msgid "Role Updated: %(role)s - %(org)s"
 msgstr "Ruolo aggiornato: %(role)s - %(org)s"
 
 #, python-format
+
 msgid "Membership Removed: %(org)s"
 msgstr "Iscrizione rimossa: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Approved: %(org)s"
 msgstr "Richiesta di iscrizione approvata: %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s - Request Approved"
 msgstr "Benvenuto in %(org)s - Richiesta approvata"
 
 #, python-format
+
 msgid "%(user)s requested to join %(org)s"
 msgstr "%(user)s ha richiesto di unirsi a %(org)s"
 
 #, python-format
+
 msgid "New membership request: %(org)s"
 msgstr "Nuova richiesta di iscrizione: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Declined: %(org)s"
 msgstr "Richiesta di iscrizione rifiutata: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Update: %(org)s"
 msgstr "Aggiornamento richiesta di iscrizione: %(org)s"
 
 #, python-format
+
 msgid "%(org)s: %(title)s"
 msgstr "%(org)s: %(title)s"
 
 #, python-format
+
 msgid "%(org)s - %(title)s"
 msgstr "%(org)s - %(title)s"
 
 #, python-format
+
 msgid "New contact message for %(org)s from %(sender)s"
 msgstr "Nuovo messaggio di contatto per %(org)s da %(sender)s"
 
 #, python-format
+
 msgid "New contact message: %(org)s"
 msgstr "Nuovo messaggio di contatto: %(org)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s"
 msgstr "%(actor)s ha aggiunto %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s"
 msgstr "%(actor)s ha aggiunto e riservato %(item)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s"
 msgstr "%(actor)s ha riservato %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item: %(item)s"
 msgstr "Nuovo articolo potluck: %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item Claimed: %(item)s"
 msgstr "Nuovo articolo potluck riservato: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Claimed: %(item)s"
 msgstr "Articolo potluck riservato: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Available: %(item)s"
 msgstr "Articolo potluck disponibile: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Removed: %(item)s"
 msgstr "Articolo potluck rimosso: %(item)s"
 
 #, python-format
+
 msgid "Potluck Update: %(item)s"
 msgstr "Aggiornamento potluck: %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s - %(event)s"
 msgstr "%(actor)s ha aggiunto %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s - %(event)s"
 msgstr "%(actor)s ha aggiunto e riservato %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s - %(event)s"
 msgstr "%(actor)s ha riservato %(item)s - %(event)s"
 
 #, python-format
+
 msgid "Potluck Item Removed - %(event)s"
 msgstr "Articolo potluck rimosso - %(event)s"
 
 #, python-format
+
 msgid "Potluck Update - %(event)s"
 msgstr "Aggiornamento potluck - %(event)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission: %(name)s"
 msgstr "Nuovo questionario ricevuto: %(name)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission - %(name)s"
 msgstr "Nuovo questionario ricevuto: %(name)s"
 
 #, python-format
+
 msgid "✅ Questionnaire Approved: %(name)s"
 msgstr "✅ Questionario approvato: %(name)s"
 
 #, python-format
+
 msgid "❌ Questionnaire Not Approved: %(name)s"
 msgstr "❌ Questionario non approvato: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation: %(name)s"
 msgstr "Valutazione questionario: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation Result - %(name)s"
 msgstr "Risultato valutazione questionario: %(name)s"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s: %(response)s)"
 msgstr "Partecipazione confermata: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(response)s)"
 msgstr "Partecipazione confermata: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s)"
 msgstr "Partecipazione confermata: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s"
 msgstr "Partecipazione confermata: %(event)s"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(response)s)"
 msgstr "Partecipazione aggiornata: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(response)s)"
 msgstr "Partecipazione aggiornata: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(new_response)s)"
 msgstr "Partecipazione aggiornata: %(event)s (%(user)s: %(new_response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s"
 msgstr "Partecipazione aggiornata: %(event)s"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s (%(user)s)"
 msgstr "RSVP annullata: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s"
 msgstr "RSVP annullata: %(event)s"
 
 #, python-format
+
 msgid "Series pass purchased: %(pass)s (%(series)s)"
 msgstr "Pass stagionale acquistato: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass purchased - %(pass)s"
 msgstr "Pass stagionale acquistato - %(pass)s"
 
 #, python-format
+
 msgid "%(pass)s now covers %(count)d new event"
 msgid_plural "%(pass)s now covers %(count)d new events"
 msgstr[0] "%(pass)s ora copre %(count)d nuovo evento"
 msgstr[1] "%(pass)s ora copre %(count)d nuovi eventi"
 
 #, python-format
+
 msgid "Your series pass has new events - %(pass)s"
 msgstr "Il tuo pass stagionale ha nuovi eventi - %(pass)s"
 
 #, python-format
+
 msgid "Series pass cancelled: %(pass)s (%(series)s)"
 msgstr "Pass stagionale annullato: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass cancelled - %(pass)s"
 msgstr "Pass stagionale annullato - %(pass)s"
 
 #, python-format
+
 msgid "%(count)d new event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "%(count)d nuovo evento programmato per %(series)s"
 msgstr[1] "%(count)d nuovi eventi programmati per %(series)s"
 
 #, python-format
+
 msgid "New event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "Nuovo evento programmato per %(series)s"
 msgstr[1] "%(count)d nuovi eventi programmati per %(series)s"
 
 #, python-format
+
 msgid "Membership renewed: %(org)s"
 msgstr "Iscrizione rinnovata: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership was renewed"
 msgstr "La tua iscrizione a %(org)s è stata rinnovata"
 
 #, python-format
+
 msgid "Payment failed: %(org)s membership"
 msgstr "Pagamento non riuscito: iscrizione a %(org)s"
 
 #, python-format
+
 msgid "Action needed: payment failed for %(org)s"
 msgstr "Azione necessaria: pagamento non riuscito per %(org)s"
 
 #, python-format
+
 msgid "Membership expired: %(org)s"
 msgstr "Iscrizione scaduta: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has expired"
 msgstr "La tua iscrizione a %(org)s è scaduta"
 
 #, python-format
+
 msgid "Membership cancelled: %(org)s"
 msgstr "Iscrizione annullata: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has been cancelled"
 msgstr "La tua iscrizione a %(org)s è stata annullata"
 
 #, python-format
+
 msgid "Membership renews soon: %(org)s"
 msgstr "La tua iscrizione si rinnova presto: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership renews soon"
 msgstr "La tua iscrizione a %(org)s si rinnova presto"
 
 #, python-format
+
 msgid "Price change: %(org)s membership"
 msgstr "Cambio di prezzo: iscrizione a %(org)s"
 
 #, python-format
+
 msgid "Upcoming price change for your %(org)s membership"
 msgstr "Prossimo cambio di prezzo per la tua iscrizione a %(org)s"
 
 #, python-format
+
 msgid "Complete your membership renewal: %(org)s"
 msgstr "Completa il rinnovo della tua iscrizione: %(org)s"
 
 #, python-format
+
 msgid "Complete your %(org)s membership renewal"
 msgstr "Completa il rinnovo della tua iscrizione a %(org)s"
 
@@ -3362,38 +3688,47 @@ msgid "System Announcement"
 msgstr "Annuncio di sistema"
 
 #, python-format
+
 msgid "Revel - %(title)s"
 msgstr "Revel - %(title)s"
 
 #, python-format
+
 msgid "New Ticket: %(holder)s - %(event)s"
 msgstr "Nuovo biglietto: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending for %(event)s"
 msgstr "Biglietto in sospeso per %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed for %(event)s"
 msgstr "Biglietto confermato per %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending - %(event)s"
 msgstr "Biglietto in sospeso - %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed - %(event)s"
 msgstr "Biglietto confermato - %(event)s"
 
 #, python-format
+
 msgid "Ticket %(action)s: %(holder)s - %(event)s"
 msgstr "Biglietto %(action)s: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Update for %(event)s"
 msgstr "Aggiornamento biglietto per %(event)s"
 
 #, python-format
+
 msgid "Ticket Update - %(event)s"
 msgstr "Aggiornamento biglietto - %(event)s"
 
@@ -3401,14 +3736,17 @@ msgid "Payment Confirmation"
 msgstr "Conferma pagamento"
 
 #, python-format
+
 msgid "Payment Confirmation - %(event)s"
 msgstr "Conferma pagamento - %(event)s"
 
 #, python-format
+
 msgid "Checked in for %(event)s"
 msgstr "Check-in effettuato per %(event)s"
 
 #, python-format
+
 msgid "Checked in - %(event)s"
 msgstr "Check-in effettuato - %(event)s"
 
@@ -3416,48 +3754,59 @@ msgid "Refund could not be matched to a ticket"
 msgstr "Non è stato possibile associare il rimborso a un biglietto"
 
 #, python-format
+
 msgid "Action needed: unmatched refund - %(org)s"
 msgstr "Azione richiesta: rimborso non associato - %(org)s"
 
 #, python-format
+
 msgid "Refund sweep finished - %(event)s"
 msgstr "Ciclo di rimborso completato - %(event)s"
 
 #, python-format
+
 msgid "Spot available for %(event)s!"
 msgstr "Posto disponibile per %(event)s!"
 
 #, python-format
+
 msgid "%d spot available for %s!"
 msgid_plural "%d spots available for %s!"
 msgstr[0] "%d posto disponibile per %s!"
 msgstr[1] "%d posti disponibili per %s!"
 
 #, python-format
+
 msgid "Spot Available: %(event)s"
 msgstr "Posto disponibile: %(event)s"
 
 #, python-format
+
 msgid "%(user)s requested verification for %(org)s"
 msgstr "%(user)s ha richiesto la verifica per %(org)s"
 
 #, python-format
+
 msgid "New verification request: %(org)s"
 msgstr "Nuova richiesta di verifica: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved: %(org)s"
 msgstr "Verifica approvata: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved - %(org)s"
 msgstr "Verifica approvata - %(org)s"
 
 #, python-format
+
 msgid "Verification Declined: %(org)s"
 msgstr "Verifica rifiutata: %(org)s"
 
 #, python-format
+
 msgid "Verification Update: %(org)s"
 msgstr "Aggiornamento verifica: %(org)s"
 
@@ -3465,6 +3814,7 @@ msgid "Event details have been updated."
 msgstr "I dettagli dell'evento sono stati aggiornati."
 
 #, python-format
+
 msgid "You're invited: %(event_name)s"
 msgstr "Sei invitato: %(event_name)s"
 
@@ -3530,6 +3880,7 @@ msgid "Hello"
 msgstr "Ciao"
 
 #, python-format
+
 msgid ""
 "We regret to inform you that <strong>%(event)s</strong> has been cancelled."
 msgstr ""
@@ -3548,6 +3899,7 @@ msgid "We apologize for any inconvenience this may cause."
 msgstr "Ci scusiamo per qualsiasi disagio causato."
 
 #, python-format
+
 msgid "We regret to inform you that %(event)s has been cancelled."
 msgstr "Ci dispiace informarti che %(event)s è stato annullato."
 
@@ -3564,6 +3916,7 @@ msgid "Alternative event:"
 msgstr "Evento alternativo:"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has published a new event: <strong>%(event)s</"
 "strong>!"
@@ -3584,6 +3937,7 @@ msgid "View Event & Register"
 msgstr "Visualizza evento e iscriviti"
 
 #, python-format
+
 msgid "%(org)s has published a new event: %(event)s!"
 msgstr "%(org)s ha pubblicato un nuovo evento: %(event)s!"
 
@@ -3591,10 +3945,12 @@ msgid "View event details and register:"
 msgstr "Visualizza i dettagli dell'evento e iscriviti:"
 
 #, python-format
+
 msgid "Refund sweep for %(event)s finished"
 msgstr "Il ciclo di rimborso per %(event)s è terminato"
 
 #, python-format
+
 msgid ""
 "%(cancelled)s tickets cancelled, %(refunded)s refunds issued, %(failed)s "
 "refunds failed."
@@ -3603,6 +3959,7 @@ msgstr ""
 "rimborsi falliti."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent "
 "&mdash; check the event's ticket admin."
@@ -3612,6 +3969,7 @@ msgstr ""
 "dell'evento."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent - "
 "check the event's ticket admin."
@@ -3620,10 +3978,12 @@ msgstr ""
 "di questo riepilogo - controlla l'amministrazione dei biglietti dell'evento."
 
 #, python-format
+
 msgid "Reminder: <strong>%(event)s</strong> is tomorrow!"
 msgstr "Promemoria: <strong>%(event)s</strong> è domani!"
 
 #, python-format
+
 msgid ""
 "Reminder: <strong>%(event)s</strong> is in <strong>%(days)s days</strong>"
 msgstr ""
@@ -3645,6 +4005,7 @@ msgid "See you there!"
 msgstr "Ci vediamo lì!"
 
 #, python-format
+
 msgid "Reminder: %(event)s is in %(days)s days"
 msgstr "Promemoria: %(event)s è tra %(days)s giorni"
 
@@ -3655,6 +4016,7 @@ msgid "View event details:"
 msgstr "Visualizza i dettagli dell'evento:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(series)s</strong>."
 msgstr ""
@@ -3674,6 +4036,7 @@ msgid "Series:"
 msgstr "Serie:"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s."
 msgstr "%(follower)s ha iniziato a seguire %(series)s."
 
@@ -3681,6 +4044,7 @@ msgid "Follower Details:"
 msgstr "Dettagli follower:"
 
 #, python-format
+
 msgid "Important update about <strong>%(event)s</strong>"
 msgstr "Aggiornamento importante su <strong>%(event)s</strong>"
 
@@ -3694,6 +4058,7 @@ msgid "View Updated Event"
 msgstr "Visualizza evento aggiornato"
 
 #, python-format
+
 msgid "Important update about %(event)s"
 msgstr "Aggiornamento importante su %(event)s"
 
@@ -3716,6 +4081,7 @@ msgid "New Invitation Request"
 msgstr "Nuova richiesta di invito"
 
 #, python-format
+
 msgid ""
 "<strong>%(email)s</strong> has requested an invitation to <strong>%(event)s</"
 "strong>."
@@ -3736,6 +4102,7 @@ msgid "This is an automated notification from your event management system."
 msgstr "Questa è una notifica automatica dal tuo sistema di gestione eventi."
 
 #, python-format
+
 msgid "%(email)s has requested an invitation to %(event)s."
 msgstr "%(email)s ha richiesto un invito per %(event)s."
 
@@ -3743,6 +4110,7 @@ msgid "View and manage this request:"
 msgstr "Visualizza e gestisci questa richiesta:"
 
 #, python-format
+
 msgid ""
 "Your membership tier in <strong>%(org)s</strong> changed to "
 "<strong>%(tier)s</strong>."
@@ -3761,6 +4129,7 @@ msgid "View Organization"
 msgstr "Visualizza organizzazione"
 
 #, python-format
+
 msgid "Your membership tier in %(org)s changed to %(tier)s."
 msgstr "Il tuo livello di iscrizione in %(org)s è cambiato in %(tier)s."
 
@@ -3774,6 +4143,7 @@ msgid "View organization:"
 msgstr "Visualizza organizzazione:"
 
 #, python-format
+
 msgid "You are now a <strong>%(role)s</strong> of <strong>%(org)s</strong>!"
 msgstr "Ora sei <strong>%(role)s</strong> di <strong>%(org)s</strong>!"
 
@@ -3790,6 +4160,7 @@ msgid "Connect with other members"
 msgstr "Connetterti con altri membri"
 
 #, python-format
+
 msgid "You are now a %(role)s of %(org)s!"
 msgstr "Ora sei %(role)s di %(org)s!"
 
@@ -3809,6 +4180,7 @@ msgid "New Membership Request"
 msgstr "Nuova richiesta di iscrizione"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested to join <strong>%(org)s</strong>."
 msgstr ""
@@ -3821,6 +4193,7 @@ msgstr ""
 "dell'organizzazione."
 
 #, python-format
+
 msgid "%(name)s has requested to join %(org)s."
 msgstr "%(name)s ha richiesto di unirsi a %(org)s."
 
@@ -3828,6 +4201,7 @@ msgid "Request Declined"
 msgstr "Richiesta rifiutata"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> created a new event: <strong>%(event)s</strong>"
 msgstr ""
@@ -3853,6 +4227,7 @@ msgid "View Event"
 msgstr "Vai all'evento"
 
 #, python-format
+
 msgid "%(org)s created a new event: %(event)s"
 msgstr "%(org)s ha creato un nuovo evento: %(event)s"
 
@@ -3860,6 +4235,7 @@ msgid "View the event:"
 msgstr "Vai all'evento:"
 
 #, python-format
+
 msgid "New event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 msgstr ""
 "Nuovo evento in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
@@ -3871,6 +4247,7 @@ msgid "New Contact Message"
 msgstr "Nuovo messaggio di contatto"
 
 #, python-format
+
 msgid "<strong>%(sender)s</strong> sent a message to <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(sender)s</strong> ha inviato un messaggio a <strong>%(org)s</"
@@ -3883,6 +4260,7 @@ msgid "View Message"
 msgstr "Visualizza messaggio"
 
 #, python-format
+
 msgid "%(sender)s sent a message to %(org)s."
 msgstr "%(sender)s ha inviato un messaggio a %(org)s."
 
@@ -3890,16 +4268,19 @@ msgid "View this message:"
 msgstr "Visualizza questo messaggio:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(follower)s</strong> ha iniziato a seguire <strong>%(org)s</strong>."
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s."
 msgstr "%(follower)s ha iniziato a seguire %(org)s."
 
 #, python-format
+
 msgid ""
 "Thank you! Your payment for <strong>%(event)s</strong> has been confirmed. 🎉"
 msgstr ""
@@ -3929,6 +4310,7 @@ msgstr ""
 "all'ingresso dell'evento."
 
 #, python-format
+
 msgid "Thank you! Your payment for %(event)s has been confirmed. 🎉"
 msgstr "Grazie! Il tuo pagamento per %(event)s è stato confermato. 🎉"
 
@@ -3948,6 +4330,7 @@ msgid "Sign up to accept this invitation:"
 msgstr "Registrati per accettare questo invito:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> claimed <strong>\"%(item)s\"</strong> for "
 "<strong>%(event)s</strong>."
@@ -3956,6 +4339,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been claimed for <strong>%(event)s</"
 "strong>."
@@ -3982,10 +4366,12 @@ msgid "View Potluck List"
 msgstr "Visualizza lista potluck"
 
 #, python-format
+
 msgid "%(actor)s claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s ha riservato \"%(item)s\" per %(event)s."
 
 #, python-format
+
 msgid "\"%(item)s\" has been claimed for %(event)s."
 msgstr "\"%(item)s\" è stato riservato per %(event)s."
 
@@ -3996,6 +4382,7 @@ msgid "View potluck list:"
 msgstr "Visualizza lista potluck:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added <strong>\"%(item)s\"</strong> to the "
 "potluck for <strong>%(event)s</strong>."
@@ -4004,6 +4391,7 @@ msgstr ""
 "potluck per <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added to "
 "<strong>%(event)s</strong>."
@@ -4018,10 +4406,12 @@ msgid "Claim Item"
 msgstr "Riserva articolo"
 
 #, python-format
+
 msgid "%(actor)s added \"%(item)s\" to the potluck for %(event)s."
 msgstr "%(actor)s ha aggiunto \"%(item)s\" al potluck per %(event)s."
 
 #, python-format
+
 msgid "A new potluck item \"%(item)s\" has been added to %(event)s."
 msgstr "Un nuovo articolo potluck \"%(item)s\" è stato aggiunto a %(event)s."
 
@@ -4029,6 +4419,7 @@ msgid "Claim this item or view the potluck list:"
 msgstr "Riserva questo articolo o visualizza la lista potluck:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added and claimed <strong>\"%(item)s\"</strong> "
 "for <strong>%(event)s</strong>."
@@ -4037,6 +4428,7 @@ msgstr ""
 "strong> per <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added and claimed "
 "for <strong>%(event)s</strong>."
@@ -4048,10 +4440,12 @@ msgid "Added and claimed by:"
 msgstr "Aggiunto e riservato da:"
 
 #, python-format
+
 msgid "%(actor)s added and claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s ha aggiunto e riservato \"%(item)s\" per %(event)s."
 
 #, python-format
+
 msgid ""
 "A new potluck item \"%(item)s\" has been added and claimed for %(event)s."
 msgstr ""
@@ -4059,6 +4453,7 @@ msgstr ""
 "%(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been removed from the potluck for "
 "<strong>%(event)s</strong>."
@@ -4067,10 +4462,12 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been removed from the potluck for %(event)s."
 msgstr "\"%(item)s\" è stato rimosso dal potluck per %(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> is now available for <strong>%(event)s</"
 "strong>."
@@ -4079,6 +4476,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" is now available for %(event)s."
 msgstr "\"%(item)s\" è ora disponibile per %(event)s."
 
@@ -4086,6 +4484,7 @@ msgid "Claim this item:"
 msgstr "Riserva questo articolo:"
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been updated for <strong>%(event)s</"
 "strong>."
@@ -4094,10 +4493,12 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been updated for %(event)s."
 msgstr "\"%(item)s\" è stato aggiornato per %(event)s."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(event)s</strong> has been approved."
@@ -4106,6 +4507,7 @@ msgstr ""
 "<strong>%(event)s</strong> è stato approvato."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(org)s</strong> has been approved."
@@ -4114,6 +4516,7 @@ msgstr ""
 "<strong>%(org)s</strong> è stato approvato."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(event)s</"
 "strong> was not approved."
@@ -4122,6 +4525,7 @@ msgstr ""
 "<strong>%(event)s</strong> non è stato approvato."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(org)s</"
 "strong> was not approved."
@@ -4168,19 +4572,23 @@ msgid "RSVP Now"
 msgstr "Conferma ora"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s has been approved!"
 msgstr "Il tuo questionario %(questionnaire)s per %(event)s è stato approvato!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s has been approved!"
 msgstr "Il tuo questionario %(questionnaire)s è stato approvato!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s was not approved."
 msgstr ""
 "Il tuo questionario %(questionnaire)s per %(event)s non è stato approvato."
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s was not approved."
 msgstr "Il tuo questionario %(questionnaire)s non è stato approvato."
 
@@ -4194,6 +4602,7 @@ msgid "RSVP now:"
 msgstr "Conferma ora:"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has submitted the questionnaire "
 "<strong>%(questionnaire)s</strong>."
@@ -4211,6 +4620,7 @@ msgid "Review Submission"
 msgstr "Valuta questionario"
 
 #, python-format
+
 msgid "%(name)s has submitted the questionnaire %(questionnaire)s."
 msgstr "%(name)s ha compilato il questionario %(questionnaire)s."
 
@@ -4221,6 +4631,7 @@ msgid "Review the submission:"
 msgstr "Valuta il questionario:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s arrived from Stripe on payment "
 "%(intent)s, but Revel could not tell which ticket it belongs to. No ticket "
@@ -4234,6 +4645,7 @@ msgid "It could apply to any of these tickets:"
 msgstr "Potrebbe riguardare uno di questi biglietti:"
 
 #, python-format
+
 msgid "seat %(seat)s"
 msgstr "posto %(seat)s"
 
@@ -4251,6 +4663,7 @@ msgid "Refund ID:"
 msgstr "ID rimborso:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has cancelled their RSVP for <strong>%(event)s</"
 "strong>."
@@ -4262,6 +4675,7 @@ msgid "Cancellation Details"
 msgstr "Dettagli annullamento"
 
 #, python-format
+
 msgid "Your RSVP for <strong>%(event)s</strong> has been cancelled."
 msgstr "La tua RSVP per <strong>%(event)s</strong> è stata annullata."
 
@@ -4269,6 +4683,7 @@ msgid "You can RSVP again anytime if you change your mind."
 msgstr "Puoi confermare nuovamente la tua presenza in qualsiasi momento."
 
 #, python-format
+
 msgid "%(user)s has cancelled their RSVP for %(event)s."
 msgstr "%(user)s ha annullato la RSVP per %(event)s."
 
@@ -4276,10 +4691,12 @@ msgid "Cancellation Details:"
 msgstr "Dettagli annullamento:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been cancelled."
 msgstr "La tua RSVP per %(event)s è stata annullata."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has RSVP'd <strong>%(response)s</strong> for "
 "<strong>%(event)s</strong>."
@@ -4297,6 +4714,7 @@ msgid "Note:"
 msgstr "Nota:"
 
 #, python-format
+
 msgid ""
 "Your RSVP (<strong>%(response)s</strong>) for <strong>%(event)s</strong> has "
 "been confirmed! ✅"
@@ -4314,6 +4732,7 @@ msgid "Dietary restrictions:"
 msgstr "Restrizioni alimentari:"
 
 #, python-format
+
 msgid "%(user)s has RSVP'd %(response)s for %(event)s."
 msgstr "%(user)s ha confermato la partecipazione %(response)s per %(event)s."
 
@@ -4321,6 +4740,7 @@ msgid "RSVP Details:"
 msgstr "Dettagli partecipazione:"
 
 #, python-format
+
 msgid "Your RSVP (%(response)s) for %(event)s has been confirmed! ✅"
 msgstr ""
 "La tua partecipazione (%(response)s) per %(event)s è stata confermata! ✅"
@@ -4329,6 +4749,7 @@ msgid "Your Response:"
 msgstr "La tua risposta:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has changed their RSVP from <strong>%(old)s</"
 "strong> to <strong>%(new)s</strong> for <strong>%(event)s</strong>."
@@ -4338,6 +4759,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> updated their RSVP note for <strong>%(event)s</"
 "strong>."
@@ -4355,6 +4777,7 @@ msgid "New Response:"
 msgstr "Nuova risposta:"
 
 #, python-format
+
 msgid ""
 "Your RSVP for <strong>%(event)s</strong> has been updated from "
 "<strong>%(old)s</strong> to <strong>%(new)s</strong>."
@@ -4366,12 +4789,14 @@ msgid "Updated Response"
 msgstr "Risposta aggiornata"
 
 #, python-format
+
 msgid "%(user)s has changed their RSVP from %(old)s to %(new)s for %(event)s."
 msgstr ""
 "%(user)s ha modificato la propria partecipazione da %(old)s a %(new)s per "
 "%(event)s."
 
 #, python-format
+
 msgid "%(user)s updated their RSVP note for %(event)s."
 msgstr "%(user)s ha aggiornato la nota RSVP per %(event)s."
 
@@ -4379,6 +4804,7 @@ msgid "Updated RSVP Details:"
 msgstr "Dettagli partecipazione aggiornati:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been updated from %(old)s to %(new)s."
 msgstr ""
 "La tua partecipazione per %(event)s è stata aggiornata da %(old)s a %(new)s."
@@ -4387,6 +4813,7 @@ msgid "Updated Response:"
 msgstr "Risposta aggiornata:"
 
 #, python-format
+
 msgid ""
 "<strong>%(counter)s</strong> new event has been scheduled for "
 "<strong>%(series)s</strong>."
@@ -4407,6 +4834,7 @@ msgid "View Series"
 msgstr "Visualizza serie"
 
 #, python-format
+
 msgid "%(counter)s new event has been scheduled for %(series)s."
 msgid_plural "%(counter)s new events have been scheduled for %(series)s."
 msgstr[0] "%(counter)s nuovo evento è stato programmato per %(series)s."
@@ -4416,6 +4844,7 @@ msgid "View the series:"
 msgstr "Visualizza la serie:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> has been cancelled."
@@ -4430,6 +4859,7 @@ msgid "Tickets cancelled:"
 msgstr "Biglietti annullati:"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "pass holder."
@@ -4438,6 +4868,7 @@ msgstr ""
 "titolare del pass."
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> will be processed to "
 "your original payment method within 5-10 business days."
@@ -4446,15 +4877,18 @@ msgstr ""
 "tuo metodo di pagamento originale entro 5-10 giorni lavorativi."
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s has been cancelled."
 msgstr "Il tuo pass stagionale %(pass_name)s per %(series)s è stato annullato."
 
 #, python-format
+
 msgid "A refund of %(amount)s %(currency)s has been issued to the pass holder."
 msgstr ""
 "Un rimborso di %(amount)s %(currency)s è stato emesso al titolare del pass."
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s will be processed to your original "
 "payment method within 5-10 business days."
@@ -4463,6 +4897,7 @@ msgstr ""
 "pagamento originale entro 5-10 giorni lavorativi."
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> now covers <strong>%(counter)s</strong> new event."
@@ -4482,6 +4917,7 @@ msgid "New Events"
 msgstr "Nuovi eventi"
 
 #, python-format
+
 msgid ""
 "Your series pass %(pass_name)s for %(series)s now covers %(counter)s new "
 "event."
@@ -4499,6 +4935,7 @@ msgid "New Events:"
 msgstr "Nuovi eventi:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> is now active."
@@ -4516,6 +4953,7 @@ msgid "Price paid:"
 msgstr "Prezzo pagato:"
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s is now active."
 msgstr "Il tuo pass stagionale %(pass_name)s per %(series)s è ora attivo."
 
@@ -4526,6 +4964,7 @@ msgid "Subscription Cancelled"
 msgstr "Abbonamento annullato"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> has "
 "been cancelled effective immediately."
@@ -4534,6 +4973,7 @@ msgstr ""
 "è stato annullato con effetto immediato."
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> will "
 "end on %(date)s."
@@ -4551,6 +4991,7 @@ msgid "We hope to see you again in the future."
 msgstr "Speriamo di rivederti in futuro."
 
 #, python-format
+
 msgid ""
 "Your %(plan)s subscription at %(org)s has been cancelled effective "
 "immediately."
@@ -4559,6 +5000,7 @@ msgstr ""
 "immediato."
 
 #, python-format
+
 msgid "Your %(plan)s subscription at %(org)s will end on %(date)s."
 msgstr "Il tuo abbonamento %(plan)s presso %(org)s terminerà il %(date)s."
 
@@ -4566,6 +5008,7 @@ msgid "Membership Ended"
 msgstr "Iscrizione terminata"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> ended "
 "on %(date)s."
@@ -4577,10 +5020,12 @@ msgid "Ended on:"
 msgstr "Terminata il:"
 
 #, python-format
+
 msgid "You can reactivate your membership until <strong>%(date)s</strong>."
 msgstr "Puoi riattivare la tua iscrizione fino al <strong>%(date)s</strong>."
 
 #, python-format
+
 msgid "Reactivate by %(date)s"
 msgstr "Riattiva entro il %(date)s"
 
@@ -4591,10 +5036,12 @@ msgstr ""
 "momento."
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s ended on %(date)s."
 msgstr "La tua iscrizione %(plan)s presso %(org)s è terminata il %(date)s."
 
 #, python-format
+
 msgid "You can reactivate your membership until %(date)s."
 msgstr "Puoi riattivare la tua iscrizione fino al %(date)s."
 
@@ -4605,6 +5052,7 @@ msgid "Payment Failed"
 msgstr "Pagamento non riuscito"
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your <strong>%(plan)s</strong> "
 "membership at <strong>%(org)s</strong>."
@@ -4619,6 +5067,7 @@ msgid "Grace period ends:"
 msgstr "Il periodo di tolleranza termina:"
 
 #, python-format
+
 msgid ""
 "Please resolve this before <strong>%(date)s</strong> to keep your membership "
 "active."
@@ -4630,6 +5079,7 @@ msgid "Update Payment Method"
 msgstr "Aggiorna metodo di pagamento"
 
 #, python-format
+
 msgid ""
 "Please <a href=\"%(url)s\">contact %(org)s</a> to renew your membership."
 msgstr ""
@@ -4637,6 +5087,7 @@ msgstr ""
 "iscrizione."
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your %(plan)s membership at %(org)s."
 msgstr ""
@@ -4644,6 +5095,7 @@ msgstr ""
 "presso %(org)s."
 
 #, python-format
+
 msgid "Please resolve this before %(date)s to keep your membership active."
 msgstr ""
 "Risolvi il problema prima del %(date)s per mantenere attiva la tua "
@@ -4653,6 +5105,7 @@ msgid "Update payment method:"
 msgstr "Aggiorna metodo di pagamento:"
 
 #, python-format
+
 msgid "Contact %(org)s to renew:"
 msgstr "Contatta %(org)s per rinnovare:"
 
@@ -4660,6 +5113,7 @@ msgid "Subscription Price Update"
 msgstr "Aggiornamento del prezzo dell'abbonamento"
 
 #, python-format
+
 msgid ""
 "The price for your <strong>%(plan)s</strong> subscription at "
 "<strong>%(org)s</strong> is changing."
@@ -4680,11 +5134,13 @@ msgid "Effective from:"
 msgstr "In vigore dal:"
 
 #, python-format
+
 msgid "Your subscription will move from %(old)s to %(new)s starting %(date)s."
 msgstr ""
 "Il tuo abbonamento passerà da %(old)s a %(new)s a partire dal %(date)s."
 
 #, python-format
+
 msgid "The price for your %(plan)s subscription at %(org)s is changing."
 msgstr "Il prezzo del tuo abbonamento %(plan)s presso %(org)s sta cambiando."
 
@@ -4692,6 +5148,7 @@ msgid "Membership Renewing Soon"
 msgstr "Iscrizione in rinnovo a breve"
 
 #, python-format
+
 msgid ""
 "Heads up — your <strong>%(plan)s</strong> membership at <strong>%(org)s</"
 "strong> renews on %(date)s for <strong>%(amount)s</strong>."
@@ -4710,6 +5167,7 @@ msgid "Manage Billing"
 msgstr "Gestisci fatturazione"
 
 #, python-format
+
 msgid ""
 "If you don't want to renew, please <a href=\"%(url)s\">contact %(org)s</a> "
 "before the renewal date."
@@ -4718,6 +5176,7 @@ msgstr ""
 "data di rinnovo."
 
 #, python-format
+
 msgid ""
 "Heads up — your %(plan)s membership at %(org)s renews on %(date)s for "
 "%(amount)s."
@@ -4729,6 +5188,7 @@ msgid "Manage billing:"
 msgstr "Gestisci fatturazione:"
 
 #, python-format
+
 msgid "If you don't want to renew, please contact %(org)s:"
 msgstr "Se non vuoi rinnovare, contatta %(org)s:"
 
@@ -4736,6 +5196,7 @@ msgid "Membership Renewed"
 msgstr "Iscrizione rinnovata"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> has "
 "been successfully renewed."
@@ -4753,6 +5214,7 @@ msgid "Next renewal:"
 msgstr "Prossimo rinnovo:"
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s has been successfully renewed."
 msgstr ""
 "La tua iscrizione %(plan)s presso %(org)s è stata rinnovata con successo."
@@ -4761,6 +5223,7 @@ msgid "Renew Your Membership"
 msgstr "Rinnova la tua iscrizione"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has set up the renewal of your <strong>%(plan)s</"
 "strong> membership. Complete the payment to reactivate it."
@@ -4779,6 +5242,7 @@ msgstr ""
 "riavviare il rinnovo dalla pagina della tua iscrizione."
 
 #, python-format
+
 msgid ""
 "%(org)s has set up the renewal of your %(plan)s membership. Complete the "
 "payment to reactivate it."
@@ -4796,6 +5260,7 @@ msgid "Read more:"
 msgstr "Leggi di più:"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> cancelled their ticket for <strong>%(event)s</"
 "strong>."
@@ -4804,6 +5269,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> was "
 "refunded via the Stripe dashboard."
@@ -4812,6 +5278,7 @@ msgstr ""
 "stato rimborsato tramite la dashboard di Stripe."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "cancelled."
@@ -4820,10 +5287,12 @@ msgstr ""
 "stato annullato."
 
 #, python-format
+
 msgid "You cancelled your ticket for <strong>%(event)s</strong>."
 msgstr "Hai annullato il tuo biglietto per <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been cancelled and refunded."
 msgstr ""
@@ -4831,6 +5300,7 @@ msgstr ""
 "rimborsato."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> has been cancelled."
 msgstr "Il tuo biglietto per <strong>%(event)s</strong> è stato annullato."
 
@@ -4841,6 +5311,7 @@ msgid "Cancelled Ticket"
 msgstr "Biglietto annullato"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "ticket holder."
@@ -4849,10 +5320,12 @@ msgstr ""
 "titolare del biglietto."
 
 #, python-format
+
 msgid "%(holder)s cancelled their ticket for %(event)s."
 msgstr "%(holder)s ha annullato il proprio biglietto per %(event)s."
 
 #, python-format
+
 msgid ""
 "%(holder)s's ticket for %(event)s was refunded via the Stripe dashboard."
 msgstr ""
@@ -4860,6 +5333,7 @@ msgstr ""
 "dashboard di Stripe."
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been cancelled."
 msgstr "Il biglietto di %(holder)s per %(event)s è stato annullato."
 
@@ -4867,14 +5341,17 @@ msgid "Ticket Holder:"
 msgstr "Titolare del biglietto:"
 
 #, python-format
+
 msgid "You cancelled your ticket for %(event)s."
 msgstr "Hai annullato il tuo biglietto per %(event)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled and refunded."
 msgstr "Il tuo biglietto per %(event)s è stato annullato e rimborsato."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled."
 msgstr "Il tuo biglietto per %(event)s è stato annullato."
 
@@ -4882,6 +5359,7 @@ msgid "Cancelled Ticket:"
 msgstr "Biglietto annullato:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s has been issued to the ticket holder."
 msgstr ""
@@ -4889,6 +5367,7 @@ msgstr ""
 "biglietto."
 
 #, python-format
+
 msgid "You have been checked in for <strong>%(event)s</strong>!"
 msgstr "Hai effettuato il check-in per <strong>%(event)s</strong>!"
 
@@ -4896,10 +5375,12 @@ msgid "Enjoy the event!"
 msgstr "Buon evento!"
 
 #, python-format
+
 msgid "You have been checked in for %(event)s!"
 msgstr "Hai effettuato il check-in per %(event)s!"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> has registered for <strong>%(event)s</strong>."
 msgstr ""
@@ -4912,6 +5393,7 @@ msgid "Holder:"
 msgstr "Titolare:"
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> is pending payment confirmation."
 msgstr ""
@@ -4930,10 +5412,12 @@ msgstr ""
 "confermato."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> is confirmed! 🎉"
 msgstr "Il tuo biglietto per <strong>%(event)s</strong> è confermato! 🎉"
 
 #, python-format
+
 msgid "%(holder)s has registered for %(event)s."
 msgstr "%(holder)s si è registrato per %(event)s."
 
@@ -4941,6 +5425,7 @@ msgid "Ticket Details:"
 msgstr "Dettagli biglietto:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is pending payment confirmation."
 msgstr "Il tuo biglietto per %(event)s è in attesa di conferma del pagamento."
 
@@ -4948,10 +5433,12 @@ msgid "Payment Instructions:"
 msgstr "Istruzioni per il pagamento:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is confirmed! 🎉"
 msgstr "Il tuo biglietto per %(event)s è confermato! 🎉"
 
 #, python-format
+
 msgid "Your ticket refund for <strong>%(event)s</strong> has been processed."
 msgstr ""
 "Il rimborso del tuo biglietto per <strong>%(event)s</strong> è stato "
@@ -4966,6 +5453,7 @@ msgstr ""
 "dell'emittente della carta."
 
 #, python-format
+
 msgid "Your ticket refund for %(event)s has been processed."
 msgstr "Il rimborso del tuo biglietto per %(event)s è stato elaborato."
 
@@ -4977,6 +5465,7 @@ msgstr ""
 "giorni lavorativi, a seconda della tua banca o dell'emittente della carta."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "<strong>%(action)s</strong>."
@@ -4985,6 +5474,7 @@ msgstr ""
 "stato <strong>%(action)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been <strong>%(action)s</"
 "strong>."
@@ -4996,10 +5486,12 @@ msgid "Updated Ticket Information"
 msgstr "Informazioni biglietto aggiornate"
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been %(action)s."
 msgstr "Il biglietto di %(holder)s per %(event)s è stato %(action)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been confirmed! 🎉"
 msgstr "Il tuo biglietto per %(event)s è stato confermato! 🎉"
 
@@ -5007,6 +5499,7 @@ msgid "Your payment has been confirmed. Your ticket is now active!"
 msgstr "Il tuo pagamento è stato confermato. Il tuo biglietto è ora attivo!"
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been updated."
 msgstr "Il tuo biglietto per %(event)s è stato aggiornato."
 
@@ -5014,6 +5507,7 @@ msgid "Updated Ticket Information:"
 msgstr "Informazioni biglietto aggiornate:"
 
 #, python-format
+
 msgid "A spot just opened up for <strong>%(event)s</strong>!"
 msgstr "Si è appena liberato un posto per <strong>%(event)s</strong>!"
 
@@ -5041,6 +5535,7 @@ msgid "Claim your spot:"
 msgstr "Riserva il tuo posto:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> has been approved. "
 "You now have full access to view and participate in their events."
@@ -5052,6 +5547,7 @@ msgid "Verification Approved"
 msgstr "Verifica approvata"
 
 #, python-format
+
 msgid ""
 "Your verification request for %(org)s has been approved. You now have full "
 "access to view and participate in their events."
@@ -5063,6 +5559,7 @@ msgid "New Verification Request"
 msgstr "Nuova richiesta di verifica"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested verification for <strong>%(org)s</"
 "strong>."
@@ -5084,6 +5581,7 @@ msgstr ""
 "verifica per accedere alla tua organizzazione."
 
 #, python-format
+
 msgid "%(name)s has requested verification for %(org)s."
 msgstr "%(name)s ha richiesto la verifica per %(org)s."
 
@@ -5091,6 +5589,7 @@ msgid "Review this request:"
 msgstr "Esamina questa richiesta:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> was not approved at "
 "this time."
@@ -5108,6 +5607,7 @@ msgid "Verification Update"
 msgstr "Aggiornamento verifica"
 
 #, python-format
+
 msgid "Your verification request for %(org)s was not approved at this time."
 msgstr ""
 "La tua richiesta di verifica per %(org)s non è stata approvata in questo "
@@ -5130,6 +5630,12 @@ msgstr "Il tuo riepilogo notifiche"
 
 msgid "View all notifications:"
 msgstr "Visualizza tutte le notifiche:"
+
+msgid "You are not allowed to see this poll."
+msgstr "Non puoi visualizzare questo sondaggio."
+
+msgid "You are not allowed to see the results for this poll."
+msgstr "Non puoi visualizzare i risultati di questo sondaggio."
 
 msgid "Anonymity flags are immutable after a poll is created."
 msgstr ""
@@ -5164,11 +5670,101 @@ msgstr ""
 "public_anonymous deve essere True quando result_visibility è PUBLIC o "
 "UNLISTED."
 
+msgid "Only the organization owner can perform this action."
+msgstr ""
+"Solo il/la proprietario/a dell'organizzazione può eseguire questa azione."
+
+msgid "Unknown event {} or it does not belong to this organization."
+msgstr "Evento {} sconosciuto o non appartenente a questa organizzazione."
+
+msgid "Unknown or cross-organization membership_tier ids: {}"
+msgstr ""
+"ID membership_tier sconosciuti o appartenenti a un'altra organizzazione: {}"
+
+msgid "Only DRAFT polls can be opened directly. Use reopen for CLOSED polls."
+msgstr ""
+"Solo i sondaggi in stato DRAFT possono essere aperti direttamente. Usa "
+"reopen per i sondaggi in stato CLOSED."
+
+msgid "Only OPEN polls can be closed."
+msgstr "Solo i sondaggi in stato OPEN possono essere chiusi."
+
+msgid "Only CLOSED polls can be reopened."
+msgstr "Solo i sondaggi in stato CLOSED possono essere riaperti."
+
+msgid "closes_at must be in the future."
+msgstr "closes_at deve essere nel futuro."
+
+msgid "Cannot reopen: provide a future closes_at or set clear_closes_at=True."
+msgstr ""
+"Impossibile riaprire: indica un closes_at futuro oppure imposta "
+"clear_closes_at=True."
+
+msgid "Unknown multiple-choice question id: {}"
+msgstr "ID di domanda a scelta multipla sconosciuto: {}"
+
+msgid "Unknown multiple-choice option id: {}"
+msgstr "ID di opzione a scelta multipla sconosciuto: {}"
+
+msgid "Unknown free-text question id: {}"
+msgstr "ID di domanda a testo libero sconosciuto: {}"
+
+msgid "Unknown file-upload question id: {}"
+msgstr "ID di domanda con caricamento di file sconosciuto: {}"
+
+msgid "Unknown or other-user file_upload ids: {}"
+msgstr "ID file_upload sconosciuti o appartenenti a un'altra persona: {}"
+
 msgid "You submitted answers refer to a different questionnaire."
 msgstr "Le risposte che hai inviato si riferiscono a un questionario diverso."
 
 msgid "You are missing mandatory answers."
 msgstr "Mancano risposte obbligatorie."
+
+msgid "File exceeds maximum upload size of {}MB."
+msgstr "Il file supera la dimensione massima di caricamento di {} MB."
+
+msgid ""
+"File type '{}' is not allowed. Allowed types: documents, images, audio, "
+"video, and archives."
+msgstr ""
+"Il tipo di file '{}' non è consentito. Tipi consentiti: documenti, immagini, "
+"audio, video e archivi."
+
+msgid "Section ID in payload does not match the provided section."
+msgstr "L'ID della sezione nel payload non corrisponde alla sezione fornita."
+
+msgid "Section does not exist or does not belong to this questionnaire."
+msgstr "La sezione non esiste o non appartiene a questo questionario."
+
+msgid "Option does not exist or does not belong to this questionnaire."
+msgstr "L'opzione non esiste o non appartiene a questo questionario."
+
+msgid "Question does not belong to this questionnaire."
+msgstr "La domanda non appartiene a questo questionario."
+
+msgid "Some files do not exist or do not belong to you."
+msgstr "Alcuni file non esistono o non ti appartengono."
+
+msgid "Too many files. Maximum allowed: {}."
+msgstr "Troppi file. Massimo consentito: {}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' has type '{mime_type}' which is not allowed. Allowed "
+"types: {allowed_types}."
+msgstr ""
+"Il file '{filename}' ha il tipo '{mime_type}', che non è consentito. Tipi "
+"consentiti: {allowed_types}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes."
+msgstr ""
+"Il file '{filename}' ({size} byte) supera la dimensione massima di "
+"{max_size} byte."
 
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -5464,8 +6060,17 @@ msgstr "Gruppi"
 msgid "Telegram integration is not enabled."
 msgstr "L'integrazione con Telegram non è abilitata."
 
+msgid "Your account is already connected to Telegram."
+msgstr "Il tuo account è già collegato a Telegram."
+
+msgid "Invalid or expired OTP code."
+msgstr "Codice OTP non valido o scaduto."
+
 msgid "Connected banned Telegram account"
 msgstr "Account Telegram bloccato collegato"
+
+msgid "No Telegram account is linked to your account."
+msgstr "Nessun account Telegram è collegato al tuo account."
 
 msgid "Django site admin"
 msgstr "Amministrazione del sito Django"
@@ -5475,3 +6080,9 @@ msgid ""
 msgstr ""
 "La generazione del pass per il Wallet non è temporaneamente disponibile. Per "
 "favore riprova più tardi."
+
+msgid "Invalid link"
+msgstr "Link non valido"
+
+msgid "Link expired"
+msgstr "Link scaduto"

--- a/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/locale/pt/LC_MESSAGES/django.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -44,36 +45,42 @@ msgid "Requeue failed payouts"
 msgstr "Recolocar na fila os pagamentos falhados"
 
 #, python-format
+
 msgid "Requeued %d failed payout."
 msgid_plural "Requeued %d failed payouts."
 msgstr[0] "%d pagamento falhado recolocado na fila."
 msgstr[1] "%d pagamentos falhados recolocados na fila."
 
 #, python-format
+
 msgid "Skipped %d payout (not in failed status)."
 msgid_plural "Skipped %d payouts (not in failed status)."
 msgstr[0] "%d pagamento ignorado (não está no estado falhado)."
 msgstr[1] "%d pagamentos ignorados (não estão no estado falhado)."
 
 #, python-format
+
 msgid "Verification email sent to %d user."
 msgid_plural "Verification emails sent to %d users."
 msgstr[0] "E-mail de verificação enviado a %d utilizador."
 msgstr[1] "E-mails de verificação enviados a %d utilizadores."
 
 #, python-format
+
 msgid "Skipped %d user (already verified)."
 msgid_plural "Skipped %d users (already verified)."
 msgstr[0] "%d utilizador ignorado (já verificado)."
 msgstr[1] "%d utilizadores ignorados (já verificados)."
 
 #, python-format
+
 msgid "Password reset email sent to %d user."
 msgid_plural "Password reset emails sent to %d users."
 msgstr[0] "E-mail de reposição da palavra-passe enviado a %d utilizador."
 msgstr[1] "E-mails de reposição da palavra-passe enviados a %d utilizadores."
 
 #, python-format
+
 msgid "Skipped %d user (Google SSO or not found)."
 msgid_plural "Skipped %d users (Google SSO or not found)."
 msgstr[0] "%d utilizador ignorado (Google SSO ou não encontrado)."
@@ -86,12 +93,14 @@ msgid "Violation of terms of service"
 msgstr "Violação dos termos de serviço"
 
 #, python-format
+
 msgid "Banned %d user."
 msgid_plural "Banned %d users."
 msgstr[0] "%d utilizador bloqueado."
 msgstr[1] "%d utilizadores bloqueados."
 
 #, python-format
+
 msgid "Skipped %d user (staff/superuser or already banned)."
 msgid_plural "Skipped %d users (staff/superuser or already banned)."
 msgstr[0] "%d utilizador ignorado (staff/superuser ou já bloqueado)."
@@ -139,6 +148,12 @@ msgstr "Já tens uma restrição para este alimento."
 msgid "You have already added this dietary preference."
 msgstr "Já adicionaste esta preferência alimentar."
 
+msgid "OTP is already enabled."
+msgstr "O OTP já está ativado."
+
+msgid "Invalid OTP"
+msgstr "OTP inválido"
+
 msgid "Invalid or inactive referral code."
 msgstr "Código de referência inválido ou inativo."
 
@@ -152,6 +167,7 @@ msgid "Only active referrers can connect a Stripe account."
 msgstr "Apenas os referenciadores ativos podem associar uma conta Stripe."
 
 #, python-format
+
 msgid ""
 "Deleting your account will permanently forfeit %(count)s unpaid referral "
 "payout(s) totalling %(total)s %(currency)s, of which %(failed)s %(currency)s "
@@ -164,6 +180,9 @@ msgstr ""
 "falhadas. Contacta o suporte antes de eliminares a conta se quiseres recebê-"
 "los, ou volta a enviar o pedido com force=true para eliminar mesmo assim."
 
+msgid "Token is blacklisted."
+msgstr "O token está na lista negra."
+
 msgid "Global Ban"
 msgstr "Bloqueio global"
 
@@ -171,6 +190,7 @@ msgid "Global Bans"
 msgstr "Bloqueios globais"
 
 #, python-format
+
 msgid "Password must be at least %(min_length)d characters long."
 msgstr "A palavra-passe deve ter pelo menos %(min_length)d caracteres."
 
@@ -191,6 +211,7 @@ msgstr ""
 "{}|<>)[]=."
 
 #, python-format
+
 msgid ""
 "Your password must be at least %(min_length)d characters long, contain at "
 "least one uppercase letter, one lowercase letter, one digit, and one special "
@@ -233,11 +254,15 @@ msgid "Token has expired."
 msgstr "O token expirou."
 
 #, python-brace-format
+
 msgid "Invalid token: {error}"
 msgstr "Token inválido: {error}"
 
 msgid "Invalid token type."
 msgstr "Tipo de token inválido."
+
+msgid "Billing profile already exists."
+msgstr "O perfil de faturação já existe."
 
 msgid "Registration is not available."
 msgstr "O registo não está disponível."
@@ -257,12 +282,19 @@ msgstr "Não podes personificar membros do staff."
 msgid "Cannot impersonate inactive users."
 msgstr "Não podes personificar utilizadores inativos."
 
+msgid "Impersonation not allowed."
+msgstr "A representação de identidade não é permitida."
+
+msgid "Impersonation no longer allowed."
+msgstr "A representação de identidade já não é permitida."
+
 msgid "Set a password before unlinking your only sign-in method."
 msgstr ""
 "Define uma palavra-passe antes de desvincular o teu único método de início "
 "de sessão."
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s (%(currency)s)"
 msgstr "Extrato de pagamento de referência %(document_number)s (%(currency)s)"
 
@@ -322,6 +354,7 @@ msgstr ""
 "dados associados serão eliminados definitivamente."
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account immediately</a>."
@@ -344,6 +377,7 @@ msgid "Confirm Account Deletion"
 msgstr "Confirmar a eliminação da conta"
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at\n"
@@ -362,6 +396,7 @@ msgid "Confirm Account Deletion."
 msgstr "Confirmar a eliminação da conta."
 
 #, python-format
+
 msgid ""
 "You have received this email because you have requested to delete your "
 "account at %(frontend_base_url)s."
@@ -385,10 +420,12 @@ msgid "Please investigate this issue as soon as possible."
 msgstr "Por favor, investiga este problema o mais rapidamente possível."
 
 #, python-format
+
 msgid "User: %(user.email)s"
 msgstr "Utilizador: %(user.email)s"
 
 #, python-format
+
 msgid "Error: %(error_message)s"
 msgstr "Erro: %(error_message)s"
 
@@ -399,6 +436,7 @@ msgid "Data Export Failed"
 msgstr "Falha na exportação de dados"
 
 #, python-format
+
 msgid "Hi %(user.first_name)s,"
 msgstr "Olá %(user.first_name)s,"
 
@@ -432,6 +470,7 @@ msgid "Your Data Export is Ready"
 msgstr "A exportação dos teus dados está pronta"
 
 #, python-format
+
 msgid "Hi %(user.username)s,"
 msgstr "Olá %(user.username)s,"
 
@@ -470,6 +509,7 @@ msgid "Your Revel email address has been changed"
 msgstr "O teu endereço de e-mail Revel foi alterado"
 
 #, python-format
+
 msgid ""
 "This address (<strong>%(new_email)s</strong>) is now the primary email on "
 "your Revel account. The previous address (<strong>%(old_email)s</strong>) "
@@ -489,6 +529,7 @@ msgid "Your Revel email address has been changed."
 msgstr "O teu endereço de e-mail Revel foi alterado."
 
 #, python-format
+
 msgid ""
 "This address (%(new_email)s) is now the primary email on your Revel account. "
 "The previous address (%(old_email)s) has been removed and can no longer be "
@@ -499,6 +540,7 @@ msgstr ""
 "para iniciar sessão."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from <strong>%(old_email)s</strong> to <strong>%(new_email)s</"
@@ -516,6 +558,7 @@ msgstr ""
 "partir de agora, inicia sessão com o teu novo endereço."
 
 #, python-format
+
 msgid ""
 "This is a confirmation that the email address on your Revel account has been "
 "changed from %(old_email)s to %(new_email)s."
@@ -568,6 +611,7 @@ msgid "An email change was requested on your account"
 msgstr "Foi pedida uma alteração de e-mail na tua conta"
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "<strong>%(masked_new_email)s</strong>. The change is not active yet — it "
@@ -597,6 +641,7 @@ msgid "An email change was requested on your account."
 msgstr "Foi pedida uma alteração de e-mail na tua conta."
 
 #, python-format
+
 msgid ""
 "Someone asked to change the email address on your Revel account to "
 "%(masked_new_email)s. The change is not active yet — it will only take "
@@ -607,6 +652,7 @@ msgstr ""
 "quando o novo endereço for confirmado."
 
 #, python-format
+
 msgid ""
 "If this wasn't you, change your password immediately at "
 "%(frontend_base_url)s/account/password-reset and contact support."
@@ -643,6 +689,7 @@ msgid "Verify Email Now"
 msgstr "Verificar e-mail agora"
 
 #, python-format
+
 msgid ""
 "If you didn't sign up for Revel, you can <a href=\"%(link)s\">delete your "
 "account</a>."
@@ -711,14 +758,17 @@ msgstr ""
 "fins contabilísticos."
 
 #, python-format
+
 msgid "User: %(user_email)s (%(user_id)s)"
 msgstr "Utilizador: %(user_email)s (%(user_id)s)"
 
 #, python-format
+
 msgid "Forfeited: %(unpaid_count)s payout(s), %(unpaid_total)s %(currency)s"
 msgstr "Perdidos: %(unpaid_count)s pagamento(s), %(unpaid_total)s %(currency)s"
 
 #, python-format
+
 msgid "Of which failed transfers: %(failed_total)s %(currency)s"
 msgstr "Dos quais transferências falhadas: %(failed_total)s %(currency)s"
 
@@ -727,14 +777,17 @@ msgstr ""
 "Pagamentos de referência perdidos na sequência da eliminação de uma conta"
 
 #, python-format
+
 msgid "Referral payout statement %(document_number)s"
 msgstr "Extrato de pagamento de referência %(document_number)s"
 
 #, python-format
+
 msgid "Referral Payout Statement %(document_number)s"
 msgstr "Extrato de pagamento de referência %(document_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached your referral payout statement %(document_number)s for "
 "the period %(period_start)s to %(period_end)s."
@@ -757,6 +810,7 @@ msgid "Users"
 msgstr "Utilizadores"
 
 #, python-format
+
 msgid "You are about to impersonate the user \"%(username)s\"."
 msgstr "Estás prestes a personificar o utilizador \"%(username)s\"."
 
@@ -838,6 +892,7 @@ msgstr ""
 "IVA foi guardado. Tenta novamente mais tarde."
 
 #, python-format
+
 msgid "Country code must match the VAT ID prefix (%(prefix)s)."
 msgstr ""
 "O código do país deve corresponder ao prefixo do número de IVA (%(prefix)s)."
@@ -918,6 +973,23 @@ msgstr "refund_tickets só é válido ao cancelar o evento."
 msgid "Invitation not found."
 msgstr "Convite não encontrado."
 
+msgid "Offer not found."
+msgstr "Oferta não encontrada."
+
+msgid ""
+"Waitlist time window is not configured for this event. Provide expires_at in "
+"the payload."
+msgstr ""
+"Este evento não tem uma janela temporal de lista de espera configurada. "
+"Indica expires_at no payload."
+
+msgid "User already has a pending offer for this event."
+msgstr "Esta pessoa já tem uma oferta pendente para este evento."
+
+msgid "Event is at capacity. Revoke an existing pending offer to make room."
+msgstr ""
+"O evento está à lotação máxima. Revoga uma oferta pendente para abrir espaço."
+
 msgid "This event does not have an open waitlist."
 msgstr "Este evento não tem uma lista de espera aberta."
 
@@ -973,16 +1045,21 @@ msgstr "Um ou mais tipos de bilhete não foram encontrados."
 msgid "No pending reservation found."
 msgstr "Nenhuma reserva pendente encontrada."
 
+msgid "This event has no venue."
+msgstr "Este evento não tem local."
+
 msgid "Use /checkout/pwyc endpoint for pay-what-you-can tickets"
 msgstr ""
 "Usa o endpoint /checkout/pwyc para bilhetes de valor livre (paga o que "
 "puderes)"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at least {min_amount}"
 msgstr "O valor PWYC deve ser de pelo menos {min_amount}"
 
 #, python-brace-format
+
 msgid "PWYC amount must be at most {max_amount}"
 msgstr "O valor PWYC deve ser no máximo {max_amount}"
 
@@ -1018,6 +1095,9 @@ msgstr "A criação de organizações está desativada nesta instância."
 msgid "Message sent."
 msgstr "Mensagem enviada."
 
+msgid "No matching blacklist entries found."
+msgstr "Não foram encontradas entradas correspondentes na lista negra."
+
 msgid "Token does not match this organization."
 msgstr "O token não corresponde a esta organização."
 
@@ -1027,6 +1107,12 @@ msgstr "Apenas o proprietário da organização pode criar membros do staff."
 msgid "Only the organization owner can change staff permissions."
 msgstr ""
 "Apenas o proprietário da organização pode alterar as permissões do staff."
+
+msgid "Series has no template event."
+msgstr "A série não tem evento modelo."
+
+msgid "date_from must be on or before date_to."
+msgstr "date_from tem de ser anterior ou igual a date_to."
 
 msgid ""
 "ONLINE plans must be subscribed to by the member directly. Send them to the "
@@ -1063,8 +1149,26 @@ msgstr "O PDF da fatura ainda não foi gerado."
 msgid "Invoice PDF could not be generated."
 msgstr "Não foi possível gerar o PDF da fatura."
 
+msgid "You must be the owner of this organization."
+msgstr "Tens de ser proprietário/a desta organização."
+
+msgid "You must be the owner or a staff member of this organization."
+msgstr "Tens de ser proprietário/a ou membro do staff desta organização."
+
 msgid "Ticket sales are paused."
 msgstr "A venda de bilhetes está pausada."
+
+msgid "You're outside of the sale window."
+msgstr "Estás fora da janela de venda."
+
+msgid "The ticket can be purchased by {}"
+msgstr "O bilhete pode ser comprado por {}"
+
+msgid "Apple Wallet is not configured"
+msgstr "O Apple Wallet não está configurado"
+
+msgid "Google Wallet is not configured"
+msgstr "O Google Wallet não está configurado"
 
 msgid ""
 "Your payment went through. We're still confirming your subscription — check "
@@ -1523,7 +1627,54 @@ msgstr ""
 msgid "This member has no ticket for this event."
 msgstr "Este membro não tem bilhete para este evento."
 
+msgid "Event not found or does not belong to this organization"
+msgstr "Evento não encontrado ou não pertence a esta organização"
+
+msgid ""
+"Announcement must have at least one targeting option: event, "
+"target_all_members, target_tiers, or target_staff_only"
+msgstr ""
+"O anúncio tem de ter pelo menos uma opção de segmentação: event, "
+"target_all_members, target_tiers ou target_staff_only"
+
+msgid "Only draft or scheduled announcements can be updated"
+msgstr "Só é possível atualizar anúncios em rascunho ou agendados"
+
+msgid "Re-sending to new sign-ups requires an event-targeted announcement"
+msgstr "O reenvio para novas inscrições requer um anúncio dirigido a um evento"
+
+msgid "Relative scheduling requires an event-targeted announcement"
+msgstr "O agendamento relativo requer um anúncio dirigido a um evento"
+
+msgid "Only draft announcements can be scheduled"
+msgstr "Só é possível agendar anúncios em rascunho"
+
+msgid "Relative scheduling requires both an anchor and an offset"
+msgstr "O agendamento relativo requer tanto uma âncora como um desvio"
+
+msgid ""
+"Could not resolve a scheduled time (relative scheduling requires an event)"
+msgstr ""
+"Não foi possível determinar a hora agendada (o agendamento relativo requer "
+"um evento)"
+
+msgid "Scheduled time must be in the future"
+msgstr "A hora agendada tem de estar no futuro"
+
+msgid "Only scheduled announcements can be unscheduled"
+msgstr "Só é possível desagendar anúncios agendados"
+
+msgid "Only draft or scheduled announcements can be sent"
+msgstr "Só é possível enviar anúncios em rascunho ou agendados"
+
+msgid "Only sent announcements can be resent"
+msgstr "Só é possível reenviar anúncios já enviados"
+
+msgid "Announcement is not configured for resending"
+msgstr "O anúncio não está configurado para reenvio"
+
 #, python-brace-format
+
 msgid "Invoice totals do not reconcile with its line items: {details}"
 msgstr "Os totais da fatura não conferem com as suas linhas: {details}"
 
@@ -1531,10 +1682,12 @@ msgid "Only draft invoices can be edited."
 msgstr "Só é possível editar faturas em rascunho."
 
 #, python-brace-format
+
 msgid "Cannot edit fields: {fields}"
 msgstr "Não é possível editar os campos: {fields}"
 
 #, python-brace-format
+
 msgid "Fields cannot be null: {fields}"
 msgstr "Estes campos não podem ser nulos: {fields}"
 
@@ -1543,6 +1696,20 @@ msgstr "As faturas canceladas não podem ser emitidas."
 
 msgid "Only draft invoices can be deleted."
 msgstr "Só é possível eliminar faturas em rascunho."
+
+msgid "Organization must be EU-based (valid EU VAT country code required)"
+msgstr ""
+"A organização tem de estar sediada na UE (é necessário um código de país de "
+"IVA da UE válido)"
+
+msgid "VAT ID must be validated via VIES"
+msgstr "O número de IVA tem de ser validado através do VIES"
+
+msgid "Billing name (legal entity name) is required"
+msgstr "O nome de faturação (denominação social) é obrigatório"
+
+msgid "Billing address is required"
+msgstr "A morada de faturação é obrigatória"
 
 msgid "Provide either seat_ids or price_category_id, not both."
 msgstr "Indica seat_ids ou price_category_id, não ambos."
@@ -1561,10 +1728,17 @@ msgid "One or more selected seats are invalid or not in the correct sector."
 msgstr ""
 "Um ou mais lugares selecionados são inválidos ou não estão no setor correto."
 
+msgid "Ticket tier not found."
+msgstr "Tipo de bilhete não encontrado."
+
+msgid "All tiers must use the same currency."
+msgstr "Todos os tipos de bilhete têm de usar a mesma moeda."
+
 msgid "This ticket tier is sold out."
 msgstr "Este tipo de bilhete está esgotado."
 
 #, python-brace-format
+
 msgid "Only {available} ticket(s) remaining for this tier."
 msgstr "Resta(m) apenas {available} bilhete(s) para este tipo."
 
@@ -1572,6 +1746,7 @@ msgid "This event is sold out."
 msgstr "Este evento está esgotado."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining for this event."
 msgstr "Resta(m) apenas {available} vaga(s) para este evento."
 
@@ -1579,6 +1754,7 @@ msgid "This sector is full."
 msgstr "Este setor está cheio."
 
 #, python-brace-format
+
 msgid "Only {available} spot(s) remaining in this sector."
 msgstr "Resta(m) apenas {available} vaga(s) neste setor."
 
@@ -1605,9 +1781,6 @@ msgstr "Cada tipo de bilhete só pode aparecer uma vez por checkout."
 msgid "The same seat cannot be purchased twice."
 msgstr "O mesmo lugar não pode ser comprado duas vezes."
 
-msgid "You're outside of the sale window."
-msgstr "Estás fora da janela de venda."
-
 msgid "You are not allowed to purchase from this tier."
 msgstr "Não tens autorização para comprar deste tipo de bilhete."
 
@@ -1615,6 +1788,7 @@ msgid "You have reached the maximum number of tickets for this event."
 msgstr "Atingiste o número máximo de bilhetes para este evento."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this event."
 msgstr "Só podes comprar mais {remaining} bilhete(s) para este evento."
 
@@ -1622,6 +1796,7 @@ msgid "You have reached the maximum number of tickets for this tier."
 msgstr "Atingiste o número máximo de bilhetes para este tipo."
 
 #, python-brace-format
+
 msgid "You can only purchase {remaining} more ticket(s) for this tier."
 msgstr "Só podes comprar mais {remaining} bilhete(s) deste tipo."
 
@@ -1672,10 +1847,12 @@ msgid "Check-in is not currently open for this event."
 msgstr "O check-in não está atualmente aberto para este evento."
 
 #, python-brace-format
+
 msgid "Check-in is not open yet. It will open at {opens_at}."
 msgstr "O check-in ainda não está aberto. Abre às {opens_at}."
 
 #, python-brace-format
+
 msgid "Check-in has closed for this event. It ended at {ended_at}."
 msgstr "O check-in deste evento está encerrado. Terminou às {ended_at}."
 
@@ -1689,6 +1866,7 @@ msgid "This ticket is pending payment confirmation."
 msgstr "Este bilhete está a aguardar confirmação do pagamento."
 
 #, python-brace-format
+
 msgid "Invalid ticket status: {status}"
 msgstr "Estado do bilhete inválido: {status}"
 
@@ -1735,6 +1913,7 @@ msgid "This discount code is not valid for this currency."
 msgstr "Este código de desconto não é válido para esta moeda."
 
 #, python-brace-format
+
 msgid "Minimum purchase amount of {amount} required to use this discount code."
 msgstr ""
 "É necessário um valor mínimo de compra de {amount} para usar este código de "
@@ -1780,6 +1959,7 @@ msgid "Waiting for questionnaire evaluation."
 msgstr "A aguardar a avaliação do questionário."
 
 #, python-brace-format
+
 msgid ""
 "Questionnaire evaluation was insufficient. You can try again in {retry_on}."
 msgstr ""
@@ -1853,6 +2033,7 @@ msgid "You have reached the maximum number of attempts."
 msgstr "Atingiste o número máximo de tentativas."
 
 #, python-format
+
 msgid "You can retry after %(retry_on)s."
 msgstr "Podes tentar novamente depois de %(retry_on)s."
 
@@ -1861,6 +2042,9 @@ msgstr "Não é possível filtrar por event_id e event_series_id em simultâneo.
 
 msgid "Feedback questionnaires cannot require evaluation."
 msgstr "Os questionários de feedback não podem exigir avaliação."
+
+msgid "LLM evaluation is not available."
+msgstr "A avaliação por LLM não está disponível."
 
 msgid "One or more events do not exist or belong to this organization."
 msgstr "Um ou mais eventos não existem ou não pertencem a esta organização."
@@ -1893,6 +2077,24 @@ msgstr "Já enviaste feedback para este evento."
 msgid "Feedback questionnaires cannot be evaluated."
 msgstr "Os questionários de feedback não podem ser avaliados."
 
+msgid "Organization not found"
+msgstr "Organização não encontrada"
+
+msgid "Already following this organization"
+msgstr "Já segues esta organização"
+
+msgid "Not following this organization"
+msgstr "Não segues esta organização"
+
+msgid "Event series not found"
+msgstr "Série de eventos não encontrada"
+
+msgid "Already following this series"
+msgstr "Já segues esta série"
+
+msgid "Not following this series"
+msgstr "Não segues esta série"
+
 msgid "Invalid token."
 msgstr "Token inválido."
 
@@ -1915,6 +2117,7 @@ msgid "Invalid token type"
 msgstr "Tipo de token inválido"
 
 #, python-format
+
 msgid "Ticket tiers not found: %(ids)s"
 msgstr "Tipos de bilhete não encontrados: %(ids)s"
 
@@ -2018,6 +2221,7 @@ msgstr ""
 "de subscrição de adesões."
 
 #, python-format
+
 msgid ""
 "The name contains a reserved word: \"%(token)s\". Please choose a different "
 "name."
@@ -2151,6 +2355,7 @@ msgid "This payment is already fully refunded."
 msgstr "Este pagamento já foi totalmente reembolsado."
 
 #, python-format
+
 msgid ""
 "Refund amount must be between 0 and the remaining refundable amount "
 "(%(amount)s)."
@@ -2163,6 +2368,9 @@ msgstr "Este bilhete não tem nenhum pagamento a reembolsar."
 
 msgid "A file must be provided when resource_type is 'file'."
 msgstr "É necessário fornecer um ficheiro quando resource_type é 'file'."
+
+msgid "Specify either month or quarter, not both."
+msgstr "Indica um mês ou um trimestre, não ambos."
 
 msgid "This seat is not available for this event."
 msgstr "Este lugar não está disponível para este evento."
@@ -2220,10 +2428,12 @@ msgstr ""
 "organiza."
 
 #, python-brace-format
+
 msgid "Select one of this ticket tier's zones: {zones}."
 msgstr "Seleciona uma das zonas deste tipo de bilhete: {zones}."
 
 #, python-brace-format
+
 msgid ""
 "Seat {seat} is in the \"{category}\" price category, which this ticket tier "
 "does not sell."
@@ -2250,6 +2460,7 @@ msgid "This pass has no upcoming events to purchase."
 msgstr "Este passe não tem eventos futuros para comprar."
 
 #, python-brace-format
+
 msgid "Event {name} is sold out."
 msgstr "O evento {name} está esgotado."
 
@@ -2269,18 +2480,22 @@ msgid "Series passes are not supported on recurring series."
 msgstr "Os passes de série não são suportados em séries recorrentes."
 
 #, python-format
+
 msgid "Event '%s' does not belong to this series."
 msgstr "O evento '%s' não pertence a esta série."
 
 #, python-format
+
 msgid "Event '%s' is not open."
 msgstr "O evento '%s' não está aberto."
 
 #, python-format
+
 msgid "Event '%s' does not require a ticket."
 msgstr "O evento '%s' não requer bilhete."
 
 #, python-format
+
 msgid ""
 "Event '%s' is invitation-only or members-only and cannot be covered by a "
 "series pass."
@@ -2299,6 +2514,7 @@ msgid "One or more events do not exist."
 msgstr "Um ou mais eventos não existem."
 
 #, python-format
+
 msgid "Event '%s' is already covered by this pass via a different tier."
 msgstr ""
 "O evento '%s' já está abrangido por este passe através de um tipo diferente."
@@ -2550,6 +2766,7 @@ msgid "Cannot refund a ticket that was never paid."
 msgstr "Não é possível reembolsar um bilhete que nunca foi pago."
 
 #, python-format
+
 msgid "Refund amount must be between 0 and the amount paid (%(amount)s)."
 msgstr "O valor do reembolso tem de estar entre 0 e o valor pago (%(amount)s)."
 
@@ -2557,6 +2774,7 @@ msgid "Price category must belong to the same venue as the seats."
 msgstr "A categoria de preço tem de pertencer ao mesmo local que os lugares."
 
 #, python-brace-format
+
 msgid ""
 "This price category is used by one or more ticket tiers and cannot be "
 "deleted: {tiers}. Remove it from those tiers' category prices first."
@@ -2620,18 +2838,22 @@ msgid "Only approved requests can be removed from whitelist."
 msgstr "Só os pedidos aprovados podem ser removidos da lista branca."
 
 #, python-format
+
 msgid "Confirm your RSVP to %(event_name)s"
 msgstr "Confirma a tua presença em %(event_name)s"
 
 #, python-format
+
 msgid "Confirm your ticket for %(event_name)s"
 msgstr "Confirma o teu bilhete para %(event_name)s"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s (%(currency)s)"
 msgstr "Fatura de comissões de plataforma %(invoice_number)s (%(currency)s)"
 
 #, python-format
+
 msgid "Verify contact email for %(organization_name)s"
 msgstr "Verifica o e-mail de contacto de %(organization_name)s"
 
@@ -2642,6 +2864,7 @@ msgid "Confirm your RSVP"
 msgstr "Confirma a tua presença"
 
 #, python-format
+
 msgid "You've indicated your interest in attending %(event_name)s."
 msgstr "Manifestaste interesse em participar em %(event_name)s."
 
@@ -2664,6 +2887,7 @@ msgid "Confirm your ticket purchase"
 msgstr "Confirma a compra do teu bilhete"
 
 #, python-format
+
 msgid "You've requested a ticket for %(event_name)s (%(tier_name)s)."
 msgstr "Pediste um bilhete para %(event_name)s (%(tier_name)s)."
 
@@ -2677,14 +2901,17 @@ msgid "To confirm your ticket purchase, please click the link below:"
 msgstr "Para confirmares a compra do bilhete, clica na ligação abaixo:"
 
 #, python-format
+
 msgid "Platform fee invoice %(invoice_number)s"
 msgstr "Fatura de comissões de plataforma %(invoice_number)s"
 
 #, python-format
+
 msgid "Platform Fee Invoice %(invoice_number)s"
 msgstr "Fatura de comissões de plataforma %(invoice_number)s"
 
 #, python-format
+
 msgid ""
 "Please find attached the platform fee invoice %(invoice_number)s for "
 "%(currency)s transactions in the period %(period_start)s to %(period_end)s."
@@ -2721,18 +2948,22 @@ msgstr ""
 "para preço."
 
 #, python-brace-format
+
 msgid "'{key}' is not a valid price category id."
 msgstr "'{key}' não é um id de categoria de preço válido."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a decimal string."
 msgstr "O preço da categoria {category} tem de ser uma string decimal."
 
 #, python-brace-format
+
 msgid "'{value}' is not a valid price for category {category}."
 msgstr "'{value}' não é um preço válido para a categoria {category}."
 
 #, python-brace-format
+
 msgid "Price for category {category} must be a non-negative number."
 msgstr "O preço da categoria {category} tem de ser um número não negativo."
 
@@ -2747,6 +2978,7 @@ msgstr ""
 "Um tipo de bilhete é de preço livre ou com preços por categoria, nunca ambos."
 
 #, python-brace-format
+
 msgid ""
 "Online tiers require every category price to be at least 1: {categories}."
 msgstr ""
@@ -2754,6 +2986,7 @@ msgstr ""
 "menos 1: {categories}."
 
 #, python-brace-format
+
 msgid "These price categories do not belong to the tier's venue: {categories}."
 msgstr ""
 "Estas categorias de preço não pertencem ao local do tipo de bilhete: "
@@ -2804,6 +3037,7 @@ msgid "The import failed unexpectedly."
 msgstr "A importação falhou inesperadamente."
 
 #, python-format
+
 msgid "Ticket class %(name)s could not be imported."
 msgstr "A classe de bilhetes %(name)s não pôde ser importada."
 
@@ -2939,6 +3173,7 @@ msgid "Read more..."
 msgstr "Ler mais..."
 
 #, python-format
+
 msgid "%(counter)s new notification"
 msgid_plural "%(counter)s new notifications"
 msgstr[0] "%(counter)s nova notificação"
@@ -2951,94 +3186,117 @@ msgid "Revel - Your account has been suspended"
 msgstr "Revel - A tua conta foi suspensa"
 
 #, python-format
+
 msgid "New Event: %(event)s"
 msgstr "Novo evento: %(event)s"
 
 #, python-format
+
 msgid "%(org)s has published a new event"
 msgstr "%(org)s publicou um novo evento"
 
 #, python-format
+
 msgid "Reminder: %(event)s is tomorrow!"
 msgstr "Lembrete: %(event)s é amanhã!"
 
 #, python-format
+
 msgid "Reminder: %(event)s in %(days)d days"
 msgstr "Lembrete: %(event)s daqui a %(days)d dias"
 
 #, python-format
+
 msgid "Tomorrow: %(event)s"
 msgstr "Amanhã: %(event)s"
 
 #, python-format
+
 msgid "Event Updated: %(event)s"
 msgstr "Evento atualizado: %(event)s"
 
 #, python-format
+
 msgid "Important Update: %(event)s"
 msgstr "Atualização importante: %(event)s"
 
 #, python-format
+
 msgid "Event Cancelled: %(event)s"
 msgstr "Evento cancelado: %(event)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s"
 msgstr "%(follower)s começou a seguir %(org)s"
 
 #, python-format
+
 msgid "New follower - %(org)s"
 msgstr "Novo seguidor - %(org)s"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s"
 msgstr "%(follower)s começou a seguir %(series)s"
 
 #, python-format
+
 msgid "New follower - %(series)s"
 msgstr "Novo seguidor - %(series)s"
 
 #, python-format
+
 msgid "%(org)s created %(event)s"
 msgstr "%(org)s criou %(event)s"
 
 #, python-format
+
 msgid "New event from %(org)s"
 msgstr "Novo evento de %(org)s"
 
 #, python-format
+
 msgid "New event in %(series)s: %(event)s"
 msgstr "Novo evento em %(series)s: %(event)s"
 
 #, python-format
+
 msgid "New event in %(series)s"
 msgstr "Novo evento em %(series)s"
 
 #, python-format
+
 msgid "You're invited to %(event)s"
 msgstr "Tens um convite para %(event)s"
 
 #, python-format
+
 msgid "You're invited: %(event)s"
 msgstr "Tens um convite: %(event)s"
 
 #, python-format
+
 msgid "%(email)s requested invitation to %(event)s"
 msgstr "%(email)s pediu um convite para %(event)s"
 
 #, python-format
+
 msgid "New invitation request: %(event)s"
 msgstr "Novo pedido de convite: %(event)s"
 
 #, python-format
+
 msgid "You're now a %(role)s of %(org)s"
 msgstr "Agora és %(role)s de %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s"
 msgstr "Boas-vindas a %(org)s"
 
 #, python-format
+
 msgid "Your membership card was updated: %(org)s"
 msgstr "O teu cartão de membro foi atualizado: %(org)s"
 
@@ -3046,268 +3304,333 @@ msgid "Your membership card was updated"
 msgstr "O teu cartão de membro foi atualizado"
 
 #, python-format
+
 msgid "You've been promoted to %(role)s in %(org)s"
 msgstr "Foste promovido a %(role)s em %(org)s"
 
 #, python-format
+
 msgid "Role Updated: %(role)s - %(org)s"
 msgstr "Função atualizada: %(role)s - %(org)s"
 
 #, python-format
+
 msgid "Membership Removed: %(org)s"
 msgstr "Adesão removida: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Approved: %(org)s"
 msgstr "Pedido de adesão aprovado: %(org)s"
 
 #, python-format
+
 msgid "Welcome to %(org)s - Request Approved"
 msgstr "Boas-vindas a %(org)s - Pedido aprovado"
 
 #, python-format
+
 msgid "%(user)s requested to join %(org)s"
 msgstr "%(user)s pediu para se juntar a %(org)s"
 
 #, python-format
+
 msgid "New membership request: %(org)s"
 msgstr "Novo pedido de adesão: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Declined: %(org)s"
 msgstr "Pedido de adesão recusado: %(org)s"
 
 #, python-format
+
 msgid "Membership Request Update: %(org)s"
 msgstr "Atualização do pedido de adesão: %(org)s"
 
 #, python-format
+
 msgid "%(org)s: %(title)s"
 msgstr "%(org)s: %(title)s"
 
 #, python-format
+
 msgid "%(org)s - %(title)s"
 msgstr "%(org)s - %(title)s"
 
 #, python-format
+
 msgid "New contact message for %(org)s from %(sender)s"
 msgstr "Nova mensagem de contacto para %(org)s de %(sender)s"
 
 #, python-format
+
 msgid "New contact message: %(org)s"
 msgstr "Nova mensagem de contacto: %(org)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s"
 msgstr "%(actor)s adicionou %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s"
 msgstr "%(actor)s adicionou e reservou %(item)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s"
 msgstr "%(actor)s reservou %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item: %(item)s"
 msgstr "Nova contribuição: %(item)s"
 
 #, python-format
+
 msgid "New Potluck Item Claimed: %(item)s"
 msgstr "Nova contribuição reservada: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Claimed: %(item)s"
 msgstr "Contribuição reservada: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Available: %(item)s"
 msgstr "Contribuição disponível: %(item)s"
 
 #, python-format
+
 msgid "Potluck Item Removed: %(item)s"
 msgstr "Contribuição removida: %(item)s"
 
 #, python-format
+
 msgid "Potluck Update: %(item)s"
 msgstr "Atualização das contribuições: %(item)s"
 
 #, python-format
+
 msgid "%(actor)s added %(item)s - %(event)s"
 msgstr "%(actor)s adicionou %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s added and claimed %(item)s - %(event)s"
 msgstr "%(actor)s adicionou e reservou %(item)s - %(event)s"
 
 #, python-format
+
 msgid "%(actor)s claimed %(item)s - %(event)s"
 msgstr "%(actor)s reservou %(item)s - %(event)s"
 
 #, python-format
+
 msgid "Potluck Item Removed - %(event)s"
 msgstr "Contribuição removida - %(event)s"
 
 #, python-format
+
 msgid "Potluck Update - %(event)s"
 msgstr "Atualização das contribuições - %(event)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission: %(name)s"
 msgstr "Novo questionário recebido: %(name)s"
 
 #, python-format
+
 msgid "New Questionnaire Submission - %(name)s"
 msgstr "Novo questionário recebido - %(name)s"
 
 #, python-format
+
 msgid "✅ Questionnaire Approved: %(name)s"
 msgstr "✅ Questionário aprovado: %(name)s"
 
 #, python-format
+
 msgid "❌ Questionnaire Not Approved: %(name)s"
 msgstr "❌ Questionário não aprovado: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation: %(name)s"
 msgstr "Avaliação do questionário: %(name)s"
 
 #, python-format
+
 msgid "Questionnaire Evaluation Result - %(name)s"
 msgstr "Resultado da avaliação do questionário - %(name)s"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s: %(response)s)"
 msgstr "Presença confirmada: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(response)s)"
 msgstr "Presença confirmada: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s (%(user)s)"
 msgstr "Presença confirmada: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Confirmed: %(event)s"
 msgstr "Presença confirmada: %(event)s"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(response)s)"
 msgstr "Presença atualizada: %(event)s (%(user)s: %(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(response)s)"
 msgstr "Presença atualizada: %(event)s (%(response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s (%(user)s: %(new_response)s)"
 msgstr "Presença atualizada: %(event)s (%(user)s: %(new_response)s)"
 
 #, python-format
+
 msgid "RSVP Updated: %(event)s"
 msgstr "Presença atualizada: %(event)s"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s (%(user)s)"
 msgstr "Presença cancelada: %(event)s (%(user)s)"
 
 #, python-format
+
 msgid "RSVP Cancelled: %(event)s"
 msgstr "Presença cancelada: %(event)s"
 
 #, python-format
+
 msgid "Series pass purchased: %(pass)s (%(series)s)"
 msgstr "Passe de série comprado: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass purchased - %(pass)s"
 msgstr "Passe de série comprado - %(pass)s"
 
 #, python-format
+
 msgid "%(pass)s now covers %(count)d new event"
 msgid_plural "%(pass)s now covers %(count)d new events"
 msgstr[0] "%(pass)s abrange agora %(count)d novo evento"
 msgstr[1] "%(pass)s abrange agora %(count)d novos eventos"
 
 #, python-format
+
 msgid "Your series pass has new events - %(pass)s"
 msgstr "O teu passe de série tem novos eventos - %(pass)s"
 
 #, python-format
+
 msgid "Series pass cancelled: %(pass)s (%(series)s)"
 msgstr "Passe de série cancelado: %(pass)s (%(series)s)"
 
 #, python-format
+
 msgid "Series pass cancelled - %(pass)s"
 msgstr "Passe de série cancelado - %(pass)s"
 
 #, python-format
+
 msgid "%(count)d new event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "%(count)d novo evento agendado para %(series)s"
 msgstr[1] "%(count)d novos eventos agendados para %(series)s"
 
 #, python-format
+
 msgid "New event scheduled for %(series)s"
 msgid_plural "%(count)d new events scheduled for %(series)s"
 msgstr[0] "Novo evento agendado para %(series)s"
 msgstr[1] "%(count)d novos eventos agendados para %(series)s"
 
 #, python-format
+
 msgid "Membership renewed: %(org)s"
 msgstr "Adesão renovada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership was renewed"
 msgstr "A tua adesão a %(org)s foi renovada"
 
 #, python-format
+
 msgid "Payment failed: %(org)s membership"
 msgstr "Pagamento falhado: adesão a %(org)s"
 
 #, python-format
+
 msgid "Action needed: payment failed for %(org)s"
 msgstr "Ação necessária: o pagamento para %(org)s falhou"
 
 #, python-format
+
 msgid "Membership expired: %(org)s"
 msgstr "Adesão expirada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has expired"
 msgstr "A tua adesão a %(org)s expirou"
 
 #, python-format
+
 msgid "Membership cancelled: %(org)s"
 msgstr "Adesão cancelada: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership has been cancelled"
 msgstr "A tua adesão a %(org)s foi cancelada"
 
 #, python-format
+
 msgid "Membership renews soon: %(org)s"
 msgstr "A adesão renova-se em breve: %(org)s"
 
 #, python-format
+
 msgid "Your %(org)s membership renews soon"
 msgstr "A tua adesão a %(org)s renova-se em breve"
 
 #, python-format
+
 msgid "Price change: %(org)s membership"
 msgstr "Alteração de preço: adesão a %(org)s"
 
 #, python-format
+
 msgid "Upcoming price change for your %(org)s membership"
 msgstr "Próxima alteração de preço da tua adesão a %(org)s"
 
 #, python-format
+
 msgid "Complete your membership renewal: %(org)s"
 msgstr "Conclui a renovação da tua adesão: %(org)s"
 
 #, python-format
+
 msgid "Complete your %(org)s membership renewal"
 msgstr "Conclui a renovação da tua adesão a %(org)s"
 
@@ -3315,38 +3638,47 @@ msgid "System Announcement"
 msgstr "Anúncio do sistema"
 
 #, python-format
+
 msgid "Revel - %(title)s"
 msgstr "Revel - %(title)s"
 
 #, python-format
+
 msgid "New Ticket: %(holder)s - %(event)s"
 msgstr "Novo bilhete: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending for %(event)s"
 msgstr "Bilhete pendente para %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed for %(event)s"
 msgstr "Bilhete confirmado para %(event)s"
 
 #, python-format
+
 msgid "Ticket Pending - %(event)s"
 msgstr "Bilhete pendente - %(event)s"
 
 #, python-format
+
 msgid "Ticket Confirmed - %(event)s"
 msgstr "Bilhete confirmado - %(event)s"
 
 #, python-format
+
 msgid "Ticket %(action)s: %(holder)s - %(event)s"
 msgstr "Bilhete %(action)s: %(holder)s - %(event)s"
 
 #, python-format
+
 msgid "Ticket Update for %(event)s"
 msgstr "Atualização do bilhete para %(event)s"
 
 #, python-format
+
 msgid "Ticket Update - %(event)s"
 msgstr "Atualização do bilhete - %(event)s"
 
@@ -3354,14 +3686,17 @@ msgid "Payment Confirmation"
 msgstr "Confirmação de pagamento"
 
 #, python-format
+
 msgid "Payment Confirmation - %(event)s"
 msgstr "Confirmação de pagamento - %(event)s"
 
 #, python-format
+
 msgid "Checked in for %(event)s"
 msgstr "Check-in efetuado para %(event)s"
 
 #, python-format
+
 msgid "Checked in - %(event)s"
 msgstr "Check-in efetuado - %(event)s"
 
@@ -3369,48 +3704,59 @@ msgid "Refund could not be matched to a ticket"
 msgstr "Não foi possível associar o reembolso a um bilhete"
 
 #, python-format
+
 msgid "Action needed: unmatched refund - %(org)s"
 msgstr "Ação necessária: reembolso não associado - %(org)s"
 
 #, python-format
+
 msgid "Refund sweep finished - %(event)s"
 msgstr "Ronda de reembolsos concluída - %(event)s"
 
 #, python-format
+
 msgid "Spot available for %(event)s!"
 msgstr "Vaga disponível para %(event)s!"
 
 #, python-format
+
 msgid "%d spot available for %s!"
 msgid_plural "%d spots available for %s!"
 msgstr[0] "%d vaga disponível para %s!"
 msgstr[1] "%d vagas disponíveis para %s!"
 
 #, python-format
+
 msgid "Spot Available: %(event)s"
 msgstr "Vaga disponível: %(event)s"
 
 #, python-format
+
 msgid "%(user)s requested verification for %(org)s"
 msgstr "%(user)s pediu a verificação de %(org)s"
 
 #, python-format
+
 msgid "New verification request: %(org)s"
 msgstr "Novo pedido de verificação: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved: %(org)s"
 msgstr "Verificação aprovada: %(org)s"
 
 #, python-format
+
 msgid "Verification Approved - %(org)s"
 msgstr "Verificação aprovada - %(org)s"
 
 #, python-format
+
 msgid "Verification Declined: %(org)s"
 msgstr "Verificação recusada: %(org)s"
 
 #, python-format
+
 msgid "Verification Update: %(org)s"
 msgstr "Atualização da verificação: %(org)s"
 
@@ -3418,6 +3764,7 @@ msgid "Event details have been updated."
 msgstr "Os detalhes do evento foram atualizados."
 
 #, python-format
+
 msgid "You're invited: %(event_name)s"
 msgstr "Tens um convite: %(event_name)s"
 
@@ -3481,6 +3828,7 @@ msgid "Hello"
 msgstr "Olá"
 
 #, python-format
+
 msgid ""
 "We regret to inform you that <strong>%(event)s</strong> has been cancelled."
 msgstr ""
@@ -3499,6 +3847,7 @@ msgid "We apologize for any inconvenience this may cause."
 msgstr "Pedimos desculpa por qualquer inconveniente causado."
 
 #, python-format
+
 msgid "We regret to inform you that %(event)s has been cancelled."
 msgstr "Lamentamos informar-te de que %(event)s foi cancelado."
 
@@ -3515,6 +3864,7 @@ msgid "Alternative event:"
 msgstr "Evento alternativo:"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has published a new event: <strong>%(event)s</"
 "strong>!"
@@ -3534,6 +3884,7 @@ msgid "View Event & Register"
 msgstr "Ver evento e inscrever-se"
 
 #, python-format
+
 msgid "%(org)s has published a new event: %(event)s!"
 msgstr "%(org)s publicou um novo evento: %(event)s!"
 
@@ -3541,10 +3892,12 @@ msgid "View event details and register:"
 msgstr "Ver os detalhes do evento e inscrever-se:"
 
 #, python-format
+
 msgid "Refund sweep for %(event)s finished"
 msgstr "A ronda de reembolsos para %(event)s foi concluída"
 
 #, python-format
+
 msgid ""
 "%(cancelled)s tickets cancelled, %(refunded)s refunds issued, %(failed)s "
 "refunds failed."
@@ -3553,6 +3906,7 @@ msgstr ""
 "%(failed)s reembolsos falhados."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent "
 "&mdash; check the event's ticket admin."
@@ -3561,6 +3915,7 @@ msgstr ""
 "enviado &mdash; verifica a administração de bilhetes do evento."
 
 #, python-format
+
 msgid ""
 "%(active)s tickets were still not cancelled when this summary was sent - "
 "check the event's ticket admin."
@@ -3569,10 +3924,12 @@ msgstr ""
 "enviado - verifica a administração de bilhetes do evento."
 
 #, python-format
+
 msgid "Reminder: <strong>%(event)s</strong> is tomorrow!"
 msgstr "Lembrete: <strong>%(event)s</strong> é amanhã!"
 
 #, python-format
+
 msgid ""
 "Reminder: <strong>%(event)s</strong> is in <strong>%(days)s days</strong>"
 msgstr ""
@@ -3594,6 +3951,7 @@ msgid "See you there!"
 msgstr "Até lá!"
 
 #, python-format
+
 msgid "Reminder: %(event)s is in %(days)s days"
 msgstr "Lembrete: %(event)s é daqui a %(days)s dias"
 
@@ -3604,6 +3962,7 @@ msgid "View event details:"
 msgstr "Ver os detalhes do evento:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(series)s</strong>."
 msgstr ""
@@ -3622,6 +3981,7 @@ msgid "Series:"
 msgstr "Série de eventos:"
 
 #, python-format
+
 msgid "%(follower)s started following %(series)s."
 msgstr "%(follower)s começou a seguir %(series)s."
 
@@ -3629,6 +3989,7 @@ msgid "Follower Details:"
 msgstr "Detalhes do seguidor:"
 
 #, python-format
+
 msgid "Important update about <strong>%(event)s</strong>"
 msgstr "Atualização importante sobre <strong>%(event)s</strong>"
 
@@ -3642,6 +4003,7 @@ msgid "View Updated Event"
 msgstr "Ver evento atualizado"
 
 #, python-format
+
 msgid "Important update about %(event)s"
 msgstr "Atualização importante sobre %(event)s"
 
@@ -3664,6 +4026,7 @@ msgid "New Invitation Request"
 msgstr "Novo pedido de convite"
 
 #, python-format
+
 msgid ""
 "<strong>%(email)s</strong> has requested an invitation to <strong>%(event)s</"
 "strong>."
@@ -3683,6 +4046,7 @@ msgid "This is an automated notification from your event management system."
 msgstr "Esta é uma notificação automática do teu sistema de gestão de eventos."
 
 #, python-format
+
 msgid "%(email)s has requested an invitation to %(event)s."
 msgstr "%(email)s pediu um convite para %(event)s."
 
@@ -3690,6 +4054,7 @@ msgid "View and manage this request:"
 msgstr "Ver e gerir este pedido:"
 
 #, python-format
+
 msgid ""
 "Your membership tier in <strong>%(org)s</strong> changed to "
 "<strong>%(tier)s</strong>."
@@ -3708,6 +4073,7 @@ msgid "View Organization"
 msgstr "Ver organização"
 
 #, python-format
+
 msgid "Your membership tier in %(org)s changed to %(tier)s."
 msgstr "O teu nível de adesão em %(org)s mudou para %(tier)s."
 
@@ -3721,6 +4087,7 @@ msgid "View organization:"
 msgstr "Ver organização:"
 
 #, python-format
+
 msgid "You are now a <strong>%(role)s</strong> of <strong>%(org)s</strong>!"
 msgstr "Agora és <strong>%(role)s</strong> de <strong>%(org)s</strong>!"
 
@@ -3737,6 +4104,7 @@ msgid "Connect with other members"
 msgstr "Ligar-te a outros membros"
 
 #, python-format
+
 msgid "You are now a %(role)s of %(org)s!"
 msgstr "Agora és %(role)s de %(org)s!"
 
@@ -3756,6 +4124,7 @@ msgid "New Membership Request"
 msgstr "Novo pedido de adesão"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested to join <strong>%(org)s</strong>."
 msgstr ""
@@ -3767,6 +4136,7 @@ msgstr ""
 "Esta é uma notificação automática do teu sistema de gestão da organização."
 
 #, python-format
+
 msgid "%(name)s has requested to join %(org)s."
 msgstr "%(name)s pediu para se juntar a %(org)s."
 
@@ -3774,6 +4144,7 @@ msgid "Request Declined"
 msgstr "Pedido recusado"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> created a new event: <strong>%(event)s</strong>"
 msgstr ""
@@ -3798,6 +4169,7 @@ msgid "View Event"
 msgstr "Ver evento"
 
 #, python-format
+
 msgid "%(org)s created a new event: %(event)s"
 msgstr "%(org)s criou um novo evento: %(event)s"
 
@@ -3805,6 +4177,7 @@ msgid "View the event:"
 msgstr "Ver o evento:"
 
 #, python-format
+
 msgid "New event in <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 msgstr "Novo evento em <strong>%(series)s</strong>: <strong>%(event)s</strong>"
 
@@ -3815,6 +4188,7 @@ msgid "New Contact Message"
 msgstr "Nova mensagem de contacto"
 
 #, python-format
+
 msgid "<strong>%(sender)s</strong> sent a message to <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(sender)s</strong> enviou uma mensagem a <strong>%(org)s</strong>."
@@ -3826,6 +4200,7 @@ msgid "View Message"
 msgstr "Ver mensagem"
 
 #, python-format
+
 msgid "%(sender)s sent a message to %(org)s."
 msgstr "%(sender)s enviou uma mensagem a %(org)s."
 
@@ -3833,16 +4208,19 @@ msgid "View this message:"
 msgstr "Ver esta mensagem:"
 
 #, python-format
+
 msgid ""
 "<strong>%(follower)s</strong> started following <strong>%(org)s</strong>."
 msgstr ""
 "<strong>%(follower)s</strong> começou a seguir <strong>%(org)s</strong>."
 
 #, python-format
+
 msgid "%(follower)s started following %(org)s."
 msgstr "%(follower)s começou a seguir %(org)s."
 
 #, python-format
+
 msgid ""
 "Thank you! Your payment for <strong>%(event)s</strong> has been confirmed. 🎉"
 msgstr ""
@@ -3871,6 +4249,7 @@ msgstr ""
 "entrada do evento."
 
 #, python-format
+
 msgid "Thank you! Your payment for %(event)s has been confirmed. 🎉"
 msgstr "Obrigado! O teu pagamento para %(event)s foi confirmado. 🎉"
 
@@ -3890,6 +4269,7 @@ msgid "Sign up to accept this invitation:"
 msgstr "Regista-te para aceitar este convite:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> claimed <strong>\"%(item)s\"</strong> for "
 "<strong>%(event)s</strong>."
@@ -3898,6 +4278,7 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been claimed for <strong>%(event)s</"
 "strong>."
@@ -3923,10 +4304,12 @@ msgid "View Potluck List"
 msgstr "Ver lista de contribuições"
 
 #, python-format
+
 msgid "%(actor)s claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s reservou \"%(item)s\" para %(event)s."
 
 #, python-format
+
 msgid "\"%(item)s\" has been claimed for %(event)s."
 msgstr "\"%(item)s\" foi reservado para %(event)s."
 
@@ -3937,6 +4320,7 @@ msgid "View potluck list:"
 msgstr "Ver lista de contribuições:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added <strong>\"%(item)s\"</strong> to the "
 "potluck for <strong>%(event)s</strong>."
@@ -3945,6 +4329,7 @@ msgstr ""
 "contribuições para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added to "
 "<strong>%(event)s</strong>."
@@ -3959,10 +4344,12 @@ msgid "Claim Item"
 msgstr "Reservar item"
 
 #, python-format
+
 msgid "%(actor)s added \"%(item)s\" to the potluck for %(event)s."
 msgstr "%(actor)s adicionou \"%(item)s\" às contribuições para %(event)s."
 
 #, python-format
+
 msgid "A new potluck item \"%(item)s\" has been added to %(event)s."
 msgstr "Um novo item de contribuição \"%(item)s\" foi adicionado a %(event)s."
 
@@ -3970,6 +4357,7 @@ msgid "Claim this item or view the potluck list:"
 msgstr "Reserva este item ou consulta a lista de contribuições:"
 
 #, python-format
+
 msgid ""
 "<strong>%(actor)s</strong> added and claimed <strong>\"%(item)s\"</strong> "
 "for <strong>%(event)s</strong>."
@@ -3978,6 +4366,7 @@ msgstr ""
 "strong> para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "A new potluck item <strong>\"%(item)s\"</strong> has been added and claimed "
 "for <strong>%(event)s</strong>."
@@ -3989,10 +4378,12 @@ msgid "Added and claimed by:"
 msgstr "Adicionado e reservado por:"
 
 #, python-format
+
 msgid "%(actor)s added and claimed \"%(item)s\" for %(event)s."
 msgstr "%(actor)s adicionou e reservou \"%(item)s\" para %(event)s."
 
 #, python-format
+
 msgid ""
 "A new potluck item \"%(item)s\" has been added and claimed for %(event)s."
 msgstr ""
@@ -4000,6 +4391,7 @@ msgstr ""
 "%(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been removed from the potluck for "
 "<strong>%(event)s</strong>."
@@ -4008,10 +4400,12 @@ msgstr ""
 "<strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been removed from the potluck for %(event)s."
 msgstr "\"%(item)s\" foi removido das contribuições para %(event)s."
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> is now available for <strong>%(event)s</"
 "strong>."
@@ -4020,6 +4414,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" is now available for %(event)s."
 msgstr "\"%(item)s\" está agora disponível para %(event)s."
 
@@ -4027,6 +4422,7 @@ msgid "Claim this item:"
 msgstr "Reserva este item:"
 
 #, python-format
+
 msgid ""
 "<strong>\"%(item)s\"</strong> has been updated for <strong>%(event)s</"
 "strong>."
@@ -4034,10 +4430,12 @@ msgstr ""
 "<strong>\"%(item)s\"</strong> foi atualizado para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid "\"%(item)s\" has been updated for %(event)s."
 msgstr "\"%(item)s\" foi atualizado para %(event)s."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(event)s</strong> has been approved."
@@ -4046,6 +4444,7 @@ msgstr ""
 "<strong>%(event)s</strong> foi aprovado."
 
 #, python-format
+
 msgid ""
 "Great news! Your questionnaire <strong>%(questionnaire)s</strong> for "
 "<strong>%(org)s</strong> has been approved."
@@ -4054,6 +4453,7 @@ msgstr ""
 "<strong>%(org)s</strong> foi aprovado."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(event)s</"
 "strong> was not approved."
@@ -4062,6 +4462,7 @@ msgstr ""
 "<strong>%(event)s</strong> não foi aprovado."
 
 #, python-format
+
 msgid ""
 "Your questionnaire <strong>%(questionnaire)s</strong> for <strong>%(org)s</"
 "strong> was not approved."
@@ -4107,18 +4508,22 @@ msgid "RSVP Now"
 msgstr "Confirmar presença"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s has been approved!"
 msgstr "O teu questionário %(questionnaire)s para %(event)s foi aprovado!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s has been approved!"
 msgstr "O teu questionário %(questionnaire)s foi aprovado!"
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s for %(event)s was not approved."
 msgstr "O teu questionário %(questionnaire)s para %(event)s não foi aprovado."
 
 #, python-format
+
 msgid "Your questionnaire %(questionnaire)s was not approved."
 msgstr "O teu questionário %(questionnaire)s não foi aprovado."
 
@@ -4132,6 +4537,7 @@ msgid "RSVP now:"
 msgstr "Confirmar presença:"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has submitted the questionnaire "
 "<strong>%(questionnaire)s</strong>."
@@ -4149,6 +4555,7 @@ msgid "Review Submission"
 msgstr "Avaliar questionário"
 
 #, python-format
+
 msgid "%(name)s has submitted the questionnaire %(questionnaire)s."
 msgstr "%(name)s submeteu o questionário %(questionnaire)s."
 
@@ -4159,6 +4566,7 @@ msgid "Review the submission:"
 msgstr "Avaliar o questionário:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s arrived from Stripe on payment "
 "%(intent)s, but Revel could not tell which ticket it belongs to. No ticket "
@@ -4172,6 +4580,7 @@ msgid "It could apply to any of these tickets:"
 msgstr "Pode dizer respeito a um destes bilhetes:"
 
 #, python-format
+
 msgid "seat %(seat)s"
 msgstr "lugar %(seat)s"
 
@@ -4190,6 +4599,7 @@ msgid "Refund ID:"
 msgstr "ID do reembolso:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has cancelled their RSVP for <strong>%(event)s</"
 "strong>."
@@ -4201,6 +4611,7 @@ msgid "Cancellation Details"
 msgstr "Detalhes do cancelamento"
 
 #, python-format
+
 msgid "Your RSVP for <strong>%(event)s</strong> has been cancelled."
 msgstr ""
 "A tua confirmação de presença para <strong>%(event)s</strong> foi cancelada."
@@ -4211,6 +4622,7 @@ msgstr ""
 "ideias."
 
 #, python-format
+
 msgid "%(user)s has cancelled their RSVP for %(event)s."
 msgstr "%(user)s cancelou a confirmação de presença para %(event)s."
 
@@ -4218,10 +4630,12 @@ msgid "Cancellation Details:"
 msgstr "Detalhes do cancelamento:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been cancelled."
 msgstr "A tua confirmação de presença para %(event)s foi cancelada."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has RSVP'd <strong>%(response)s</strong> for "
 "<strong>%(event)s</strong>."
@@ -4239,6 +4653,7 @@ msgid "Note:"
 msgstr "Nota:"
 
 #, python-format
+
 msgid ""
 "Your RSVP (<strong>%(response)s</strong>) for <strong>%(event)s</strong> has "
 "been confirmed! ✅"
@@ -4256,6 +4671,7 @@ msgid "Dietary restrictions:"
 msgstr "Restrições alimentares:"
 
 #, python-format
+
 msgid "%(user)s has RSVP'd %(response)s for %(event)s."
 msgstr "%(user)s respondeu %(response)s para %(event)s."
 
@@ -4263,6 +4679,7 @@ msgid "RSVP Details:"
 msgstr "Detalhes da resposta:"
 
 #, python-format
+
 msgid "Your RSVP (%(response)s) for %(event)s has been confirmed! ✅"
 msgstr "A tua resposta (%(response)s) para %(event)s foi confirmada! ✅"
 
@@ -4270,6 +4687,7 @@ msgid "Your Response:"
 msgstr "A tua resposta:"
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> has changed their RSVP from <strong>%(old)s</"
 "strong> to <strong>%(new)s</strong> for <strong>%(event)s</strong>."
@@ -4278,6 +4696,7 @@ msgstr ""
 "para <strong>%(new)s</strong> em <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(user)s</strong> updated their RSVP note for <strong>%(event)s</"
 "strong>."
@@ -4295,6 +4714,7 @@ msgid "New Response:"
 msgstr "Nova resposta:"
 
 #, python-format
+
 msgid ""
 "Your RSVP for <strong>%(event)s</strong> has been updated from "
 "<strong>%(old)s</strong> to <strong>%(new)s</strong>."
@@ -4306,10 +4726,12 @@ msgid "Updated Response"
 msgstr "Resposta atualizada"
 
 #, python-format
+
 msgid "%(user)s has changed their RSVP from %(old)s to %(new)s for %(event)s."
 msgstr "%(user)s alterou a resposta de %(old)s para %(new)s em %(event)s."
 
 #, python-format
+
 msgid "%(user)s updated their RSVP note for %(event)s."
 msgstr "%(user)s atualizou a nota da resposta para %(event)s."
 
@@ -4317,6 +4739,7 @@ msgid "Updated RSVP Details:"
 msgstr "Detalhes da resposta atualizados:"
 
 #, python-format
+
 msgid "Your RSVP for %(event)s has been updated from %(old)s to %(new)s."
 msgstr "A tua resposta para %(event)s foi alterada de %(old)s para %(new)s."
 
@@ -4324,6 +4747,7 @@ msgid "Updated Response:"
 msgstr "Resposta atualizada:"
 
 #, python-format
+
 msgid ""
 "<strong>%(counter)s</strong> new event has been scheduled for "
 "<strong>%(series)s</strong>."
@@ -4344,6 +4768,7 @@ msgid "View Series"
 msgstr "Ver série"
 
 #, python-format
+
 msgid "%(counter)s new event has been scheduled for %(series)s."
 msgid_plural "%(counter)s new events have been scheduled for %(series)s."
 msgstr[0] "%(counter)s novo evento foi agendado para %(series)s."
@@ -4353,6 +4778,7 @@ msgid "View the series:"
 msgstr "Ver a série:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> has been cancelled."
@@ -4367,6 +4793,7 @@ msgid "Tickets cancelled:"
 msgstr "Bilhetes cancelados:"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "pass holder."
@@ -4375,6 +4802,7 @@ msgstr ""
 "titular do passe."
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> will be processed to "
 "your original payment method within 5-10 business days."
@@ -4383,15 +4811,18 @@ msgstr ""
 "para o teu método de pagamento original no prazo de 5 a 10 dias úteis."
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s has been cancelled."
 msgstr "O teu passe de série %(pass_name)s para %(series)s foi cancelado."
 
 #, python-format
+
 msgid "A refund of %(amount)s %(currency)s has been issued to the pass holder."
 msgstr ""
 "Foi emitido um reembolso de %(amount)s %(currency)s para o titular do passe."
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s will be processed to your original "
 "payment method within 5-10 business days."
@@ -4400,6 +4831,7 @@ msgstr ""
 "pagamento original no prazo de 5 a 10 dias úteis."
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> now covers <strong>%(counter)s</strong> new event."
@@ -4417,6 +4849,7 @@ msgid "New Events"
 msgstr "Novos eventos"
 
 #, python-format
+
 msgid ""
 "Your series pass %(pass_name)s for %(series)s now covers %(counter)s new "
 "event."
@@ -4434,6 +4867,7 @@ msgid "New Events:"
 msgstr "Novos eventos:"
 
 #, python-format
+
 msgid ""
 "Your series pass <strong>%(pass_name)s</strong> for <strong>%(series)s</"
 "strong> is now active."
@@ -4451,6 +4885,7 @@ msgid "Price paid:"
 msgstr "Preço pago:"
 
 #, python-format
+
 msgid "Your series pass %(pass_name)s for %(series)s is now active."
 msgstr "O teu passe de série %(pass_name)s para %(series)s está agora ativo."
 
@@ -4461,6 +4896,7 @@ msgid "Subscription Cancelled"
 msgstr "Subscrição cancelada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> has "
 "been cancelled effective immediately."
@@ -4469,6 +4905,7 @@ msgstr ""
 "cancelada com efeito imediato."
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> subscription at <strong>%(org)s</strong> will "
 "end on %(date)s."
@@ -4486,6 +4923,7 @@ msgid "We hope to see you again in the future."
 msgstr "Esperamos voltar a ver-te no futuro."
 
 #, python-format
+
 msgid ""
 "Your %(plan)s subscription at %(org)s has been cancelled effective "
 "immediately."
@@ -4493,6 +4931,7 @@ msgstr ""
 "A tua subscrição %(plan)s em %(org)s foi cancelada com efeito imediato."
 
 #, python-format
+
 msgid "Your %(plan)s subscription at %(org)s will end on %(date)s."
 msgstr "A tua subscrição %(plan)s em %(org)s terminará a %(date)s."
 
@@ -4500,6 +4939,7 @@ msgid "Membership Ended"
 msgstr "Adesão terminada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> ended "
 "on %(date)s."
@@ -4511,10 +4951,12 @@ msgid "Ended on:"
 msgstr "Terminou a:"
 
 #, python-format
+
 msgid "You can reactivate your membership until <strong>%(date)s</strong>."
 msgstr "Podes reativar a tua adesão até <strong>%(date)s</strong>."
 
 #, python-format
+
 msgid "Reactivate by %(date)s"
 msgstr "Reativar até %(date)s"
 
@@ -4524,10 +4966,12 @@ msgstr ""
 "Se quiseres continuar, podes iniciar uma nova subscrição a qualquer momento."
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s ended on %(date)s."
 msgstr "A tua adesão %(plan)s em %(org)s terminou a %(date)s."
 
 #, python-format
+
 msgid "You can reactivate your membership until %(date)s."
 msgstr "Podes reativar a tua adesão até %(date)s."
 
@@ -4538,6 +4982,7 @@ msgid "Payment Failed"
 msgstr "Pagamento falhado"
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your <strong>%(plan)s</strong> "
 "membership at <strong>%(org)s</strong>."
@@ -4552,6 +4997,7 @@ msgid "Grace period ends:"
 msgstr "Fim do período de tolerância:"
 
 #, python-format
+
 msgid ""
 "Please resolve this before <strong>%(date)s</strong> to keep your membership "
 "active."
@@ -4563,6 +5009,7 @@ msgid "Update Payment Method"
 msgstr "Atualizar método de pagamento"
 
 #, python-format
+
 msgid ""
 "Please <a href=\"%(url)s\">contact %(org)s</a> to renew your membership."
 msgstr ""
@@ -4570,11 +5017,13 @@ msgstr ""
 "adesão."
 
 #, python-format
+
 msgid ""
 "We couldn't collect the payment for your %(plan)s membership at %(org)s."
 msgstr "Não conseguimos cobrar o pagamento da tua adesão %(plan)s em %(org)s."
 
 #, python-format
+
 msgid "Please resolve this before %(date)s to keep your membership active."
 msgstr ""
 "Resolve esta situação antes de %(date)s para manteres a tua adesão ativa."
@@ -4583,6 +5032,7 @@ msgid "Update payment method:"
 msgstr "Atualizar método de pagamento:"
 
 #, python-format
+
 msgid "Contact %(org)s to renew:"
 msgstr "Contacta %(org)s para renovar:"
 
@@ -4590,6 +5040,7 @@ msgid "Subscription Price Update"
 msgstr "Atualização do preço da subscrição"
 
 #, python-format
+
 msgid ""
 "The price for your <strong>%(plan)s</strong> subscription at "
 "<strong>%(org)s</strong> is changing."
@@ -4610,10 +5061,12 @@ msgid "Effective from:"
 msgstr "Em vigor a partir de:"
 
 #, python-format
+
 msgid "Your subscription will move from %(old)s to %(new)s starting %(date)s."
 msgstr "A tua subscrição passará de %(old)s para %(new)s a partir de %(date)s."
 
 #, python-format
+
 msgid "The price for your %(plan)s subscription at %(org)s is changing."
 msgstr "O preço da tua subscrição %(plan)s em %(org)s vai mudar."
 
@@ -4621,6 +5074,7 @@ msgid "Membership Renewing Soon"
 msgstr "Adesão a renovar em breve"
 
 #, python-format
+
 msgid ""
 "Heads up — your <strong>%(plan)s</strong> membership at <strong>%(org)s</"
 "strong> renews on %(date)s for <strong>%(amount)s</strong>."
@@ -4639,6 +5093,7 @@ msgid "Manage Billing"
 msgstr "Gerir faturação"
 
 #, python-format
+
 msgid ""
 "If you don't want to renew, please <a href=\"%(url)s\">contact %(org)s</a> "
 "before the renewal date."
@@ -4647,6 +5102,7 @@ msgstr ""
 "data de renovação."
 
 #, python-format
+
 msgid ""
 "Heads up — your %(plan)s membership at %(org)s renews on %(date)s for "
 "%(amount)s."
@@ -4658,6 +5114,7 @@ msgid "Manage billing:"
 msgstr "Gerir faturação:"
 
 #, python-format
+
 msgid "If you don't want to renew, please contact %(org)s:"
 msgstr "Se não quiseres renovar, contacta %(org)s:"
 
@@ -4665,6 +5122,7 @@ msgid "Membership Renewed"
 msgstr "Adesão renovada"
 
 #, python-format
+
 msgid ""
 "Your <strong>%(plan)s</strong> membership at <strong>%(org)s</strong> has "
 "been successfully renewed."
@@ -4682,6 +5140,7 @@ msgid "Next renewal:"
 msgstr "Próxima renovação:"
 
 #, python-format
+
 msgid "Your %(plan)s membership at %(org)s has been successfully renewed."
 msgstr "A tua adesão %(plan)s em %(org)s foi renovada com sucesso."
 
@@ -4689,6 +5148,7 @@ msgid "Renew Your Membership"
 msgstr "Renova a tua adesão"
 
 #, python-format
+
 msgid ""
 "<strong>%(org)s</strong> has set up the renewal of your <strong>%(plan)s</"
 "strong> membership. Complete the payment to reactivate it."
@@ -4707,6 +5167,7 @@ msgstr ""
 "reiniciar a renovação a partir da página da tua adesão."
 
 #, python-format
+
 msgid ""
 "%(org)s has set up the renewal of your %(plan)s membership. Complete the "
 "payment to reactivate it."
@@ -4724,6 +5185,7 @@ msgid "Read more:"
 msgstr "Ler mais:"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> cancelled their ticket for <strong>%(event)s</"
 "strong>."
@@ -4732,6 +5194,7 @@ msgstr ""
 "strong>."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> was "
 "refunded via the Stripe dashboard."
@@ -4740,6 +5203,7 @@ msgstr ""
 "reembolsado através do painel da Stripe."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "cancelled."
@@ -4748,16 +5212,19 @@ msgstr ""
 "cancelado."
 
 #, python-format
+
 msgid "You cancelled your ticket for <strong>%(event)s</strong>."
 msgstr "Cancelaste o teu bilhete para <strong>%(event)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been cancelled and refunded."
 msgstr ""
 "O teu bilhete para <strong>%(event)s</strong> foi cancelado e reembolsado."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> has been cancelled."
 msgstr "O teu bilhete para <strong>%(event)s</strong> foi cancelado."
 
@@ -4768,6 +5235,7 @@ msgid "Cancelled Ticket"
 msgstr "Bilhete cancelado"
 
 #, python-format
+
 msgid ""
 "A refund of <strong>%(amount)s %(currency)s</strong> has been issued to the "
 "ticket holder."
@@ -4776,10 +5244,12 @@ msgstr ""
 "titular do bilhete."
 
 #, python-format
+
 msgid "%(holder)s cancelled their ticket for %(event)s."
 msgstr "%(holder)s cancelou o seu bilhete para %(event)s."
 
 #, python-format
+
 msgid ""
 "%(holder)s's ticket for %(event)s was refunded via the Stripe dashboard."
 msgstr ""
@@ -4787,6 +5257,7 @@ msgstr ""
 "Stripe."
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been cancelled."
 msgstr "O bilhete de %(holder)s para %(event)s foi cancelado."
 
@@ -4794,14 +5265,17 @@ msgid "Ticket Holder:"
 msgstr "Titular do bilhete:"
 
 #, python-format
+
 msgid "You cancelled your ticket for %(event)s."
 msgstr "Cancelaste o teu bilhete para %(event)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled and refunded."
 msgstr "O teu bilhete para %(event)s foi cancelado e reembolsado."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been cancelled."
 msgstr "O teu bilhete para %(event)s foi cancelado."
 
@@ -4809,6 +5283,7 @@ msgid "Cancelled Ticket:"
 msgstr "Bilhete cancelado:"
 
 #, python-format
+
 msgid ""
 "A refund of %(amount)s %(currency)s has been issued to the ticket holder."
 msgstr ""
@@ -4816,6 +5291,7 @@ msgstr ""
 "bilhete."
 
 #, python-format
+
 msgid "You have been checked in for <strong>%(event)s</strong>!"
 msgstr "Check-in efetuado para <strong>%(event)s</strong>!"
 
@@ -4823,10 +5299,12 @@ msgid "Enjoy the event!"
 msgstr "Diverte-te no evento!"
 
 #, python-format
+
 msgid "You have been checked in for %(event)s!"
 msgstr "Check-in efetuado para %(event)s!"
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong> has registered for <strong>%(event)s</strong>."
 msgstr ""
@@ -4839,6 +5317,7 @@ msgid "Holder:"
 msgstr "Titular:"
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> is pending payment confirmation."
 msgstr ""
@@ -4856,10 +5335,12 @@ msgstr ""
 "Receberás o teu bilhete por e-mail assim que o teu pagamento for confirmado."
 
 #, python-format
+
 msgid "Your ticket for <strong>%(event)s</strong> is confirmed! 🎉"
 msgstr "O teu bilhete para <strong>%(event)s</strong> está confirmado! 🎉"
 
 #, python-format
+
 msgid "%(holder)s has registered for %(event)s."
 msgstr "%(holder)s registou-se para %(event)s."
 
@@ -4867,6 +5348,7 @@ msgid "Ticket Details:"
 msgstr "Detalhes do bilhete:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is pending payment confirmation."
 msgstr "O teu bilhete para %(event)s aguarda confirmação do pagamento."
 
@@ -4874,10 +5356,12 @@ msgid "Payment Instructions:"
 msgstr "Instruções de pagamento:"
 
 #, python-format
+
 msgid "Your ticket for %(event)s is confirmed! 🎉"
 msgstr "O teu bilhete para %(event)s está confirmado! 🎉"
 
 #, python-format
+
 msgid "Your ticket refund for <strong>%(event)s</strong> has been processed."
 msgstr ""
 "O reembolso do teu bilhete para <strong>%(event)s</strong> foi processado."
@@ -4891,6 +5375,7 @@ msgstr ""
 "emissora do cartão."
 
 #, python-format
+
 msgid "Your ticket refund for %(event)s has been processed."
 msgstr "O reembolso do teu bilhete para %(event)s foi processado."
 
@@ -4902,6 +5387,7 @@ msgstr ""
 "dias úteis, dependendo do teu banco ou da entidade emissora do cartão."
 
 #, python-format
+
 msgid ""
 "<strong>%(holder)s</strong>'s ticket for <strong>%(event)s</strong> has been "
 "<strong>%(action)s</strong>."
@@ -4910,6 +5396,7 @@ msgstr ""
 "<strong>%(action)s</strong>."
 
 #, python-format
+
 msgid ""
 "Your ticket for <strong>%(event)s</strong> has been <strong>%(action)s</"
 "strong>."
@@ -4921,10 +5408,12 @@ msgid "Updated Ticket Information"
 msgstr "Informações atualizadas do bilhete"
 
 #, python-format
+
 msgid "%(holder)s's ticket for %(event)s has been %(action)s."
 msgstr "O bilhete de %(holder)s para %(event)s foi %(action)s."
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been confirmed! 🎉"
 msgstr "O teu bilhete para %(event)s foi confirmado! 🎉"
 
@@ -4932,6 +5421,7 @@ msgid "Your payment has been confirmed. Your ticket is now active!"
 msgstr "O teu pagamento foi confirmado. O teu bilhete está agora ativo!"
 
 #, python-format
+
 msgid "Your ticket for %(event)s has been updated."
 msgstr "O teu bilhete para %(event)s foi atualizado."
 
@@ -4939,6 +5429,7 @@ msgid "Updated Ticket Information:"
 msgstr "Informações atualizadas do bilhete:"
 
 #, python-format
+
 msgid "A spot just opened up for <strong>%(event)s</strong>!"
 msgstr "Acabou de ficar disponível um lugar para <strong>%(event)s</strong>!"
 
@@ -4965,6 +5456,7 @@ msgid "Claim your spot:"
 msgstr "Garante o teu lugar:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> has been approved. "
 "You now have full access to view and participate in their events."
@@ -4976,6 +5468,7 @@ msgid "Verification Approved"
 msgstr "Verificação aprovada"
 
 #, python-format
+
 msgid ""
 "Your verification request for %(org)s has been approved. You now have full "
 "access to view and participate in their events."
@@ -4987,6 +5480,7 @@ msgid "New Verification Request"
 msgstr "Novo pedido de verificação"
 
 #, python-format
+
 msgid ""
 "<strong>%(name)s</strong> has requested verification for <strong>%(org)s</"
 "strong>."
@@ -5007,6 +5501,7 @@ msgstr ""
 "verificação para aceder à tua organização."
 
 #, python-format
+
 msgid "%(name)s has requested verification for %(org)s."
 msgstr "%(name)s pediu a verificação para %(org)s."
 
@@ -5014,6 +5509,7 @@ msgid "Review this request:"
 msgstr "Analisar este pedido:"
 
 #, python-format
+
 msgid ""
 "Your verification request for <strong>%(org)s</strong> was not approved at "
 "this time."
@@ -5029,6 +5525,7 @@ msgid "Verification Update"
 msgstr "Atualização da verificação"
 
 #, python-format
+
 msgid "Your verification request for %(org)s was not approved at this time."
 msgstr "O teu pedido de verificação para %(org)s não foi aprovado desta vez."
 
@@ -5049,6 +5546,12 @@ msgstr "O teu resumo de notificações"
 
 msgid "View all notifications:"
 msgstr "Ver todas as notificações:"
+
+msgid "You are not allowed to see this poll."
+msgstr "Não tens permissão para ver esta sondagem."
+
+msgid "You are not allowed to see the results for this poll."
+msgstr "Não tens permissão para ver os resultados desta sondagem."
 
 msgid "Anonymity flags are immutable after a poll is created."
 msgstr ""
@@ -5084,11 +5587,99 @@ msgstr ""
 "public_anonymous tem de ser True quando result_visibility é PUBLIC ou "
 "UNLISTED."
 
+msgid "Only the organization owner can perform this action."
+msgstr "Só o/a proprietário/a da organização pode realizar esta ação."
+
+msgid "Unknown event {} or it does not belong to this organization."
+msgstr "Evento {} desconhecido ou não pertence a esta organização."
+
+msgid "Unknown or cross-organization membership_tier ids: {}"
+msgstr "IDs de membership_tier desconhecidos ou de outra organização: {}"
+
+msgid "Only DRAFT polls can be opened directly. Use reopen for CLOSED polls."
+msgstr ""
+"Só as sondagens em estado DRAFT podem ser abertas diretamente. Usa reopen "
+"para as sondagens em estado CLOSED."
+
+msgid "Only OPEN polls can be closed."
+msgstr "Só as sondagens em estado OPEN podem ser fechadas."
+
+msgid "Only CLOSED polls can be reopened."
+msgstr "Só as sondagens em estado CLOSED podem ser reabertas."
+
+msgid "closes_at must be in the future."
+msgstr "closes_at tem de estar no futuro."
+
+msgid "Cannot reopen: provide a future closes_at or set clear_closes_at=True."
+msgstr ""
+"Não é possível reabrir: indica um closes_at futuro ou define "
+"clear_closes_at=True."
+
+msgid "Unknown multiple-choice question id: {}"
+msgstr "ID de pergunta de escolha múltipla desconhecido: {}"
+
+msgid "Unknown multiple-choice option id: {}"
+msgstr "ID de opção de escolha múltipla desconhecido: {}"
+
+msgid "Unknown free-text question id: {}"
+msgstr "ID de pergunta de texto livre desconhecido: {}"
+
+msgid "Unknown file-upload question id: {}"
+msgstr "ID de pergunta de carregamento de ficheiro desconhecido: {}"
+
+msgid "Unknown or other-user file_upload ids: {}"
+msgstr "IDs de file_upload desconhecidos ou pertencentes a outra pessoa: {}"
+
 msgid "You submitted answers refer to a different questionnaire."
 msgstr "As respostas que enviaste referem-se a um questionário diferente."
 
 msgid "You are missing mandatory answers."
 msgstr "Faltam respostas obrigatórias."
+
+msgid "File exceeds maximum upload size of {}MB."
+msgstr "O ficheiro excede o tamanho máximo de carregamento de {} MB."
+
+msgid ""
+"File type '{}' is not allowed. Allowed types: documents, images, audio, "
+"video, and archives."
+msgstr ""
+"O tipo de ficheiro '{}' não é permitido. Tipos permitidos: documentos, "
+"imagens, áudio, vídeo e arquivos."
+
+msgid "Section ID in payload does not match the provided section."
+msgstr "O ID de secção no payload não corresponde à secção indicada."
+
+msgid "Section does not exist or does not belong to this questionnaire."
+msgstr "A secção não existe ou não pertence a este questionário."
+
+msgid "Option does not exist or does not belong to this questionnaire."
+msgstr "A opção não existe ou não pertence a este questionário."
+
+msgid "Question does not belong to this questionnaire."
+msgstr "A pergunta não pertence a este questionário."
+
+msgid "Some files do not exist or do not belong to you."
+msgstr "Alguns ficheiros não existem ou não te pertencem."
+
+msgid "Too many files. Maximum allowed: {}."
+msgstr "Demasiados ficheiros. Máximo permitido: {}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' has type '{mime_type}' which is not allowed. Allowed "
+"types: {allowed_types}."
+msgstr ""
+"O ficheiro '{filename}' tem o tipo '{mime_type}', que não é permitido. Tipos "
+"permitidos: {allowed_types}."
+
+#, python-brace-format
+
+msgid ""
+"File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes."
+msgstr ""
+"O ficheiro '{filename}' ({size} bytes) excede o tamanho máximo de {max_size} "
+"bytes."
 
 msgid "Dashboard"
 msgstr "Painel"
@@ -5384,8 +5975,17 @@ msgstr "Grupos"
 msgid "Telegram integration is not enabled."
 msgstr "A integração com o Telegram não está ativada."
 
+msgid "Your account is already connected to Telegram."
+msgstr "A tua conta já está ligada ao Telegram."
+
+msgid "Invalid or expired OTP code."
+msgstr "Código OTP inválido ou expirado."
+
 msgid "Connected banned Telegram account"
 msgstr "Conta do Telegram banida ligada"
+
+msgid "No Telegram account is linked to your account."
+msgstr "Não há nenhuma conta do Telegram associada à tua conta."
 
 msgid "Django site admin"
 msgstr "Administração do site Django"
@@ -5395,3 +5995,9 @@ msgid ""
 msgstr ""
 "A geração do passe para a Wallet está temporariamente indisponível. Tenta "
 "novamente mais tarde."
+
+msgid "Invalid link"
+msgstr "Ligação inválida"
+
+msgid "Link expired"
+msgstr "Ligação expirada"

--- a/src/polls/controllers/poll_controller.py
+++ b/src/polls/controllers/poll_controller.py
@@ -16,6 +16,7 @@ import typing as t
 from uuid import UUID
 
 from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
 from ninja_extra.pagination import PageNumberPaginationExtra, PaginatedResponseSchema, paginate
@@ -161,7 +162,7 @@ class PollController(UserAwareController):
         poll = t.cast(Poll, self.get_object_or_exception(self._detail_base_queryset(), pk=poll_id))
         is_staff = eligibility.is_staff_or_owner(user, poll)
         if not eligibility.can_see_poll(user, poll, _is_staff=is_staff):
-            raise HttpError(403, "You are not allowed to see this poll.")
+            raise HttpError(403, str(_("You are not allowed to see this poll.")))
         return self._to_detail(poll, user, _is_staff=is_staff)
 
     @route.get("/{poll_id}/results", url_name="get_poll_results", response=PollResultsSchema)
@@ -171,7 +172,7 @@ class PollController(UserAwareController):
         poll = t.cast(Poll, self.get_object_or_exception(self._detail_queryset(), pk=poll_id))
         is_staff = eligibility.is_staff_or_owner(user, poll)
         if not eligibility.can_see_results(user, poll, _is_staff=is_staff):
-            raise HttpError(403, "You are not allowed to see the results for this poll.")
+            raise HttpError(403, str(_("You are not allowed to see the results for this poll.")))
         return compute_poll_results(
             poll, viewer_sees_identity=self._viewer_sees_identity(poll, user, _is_staff=is_staff)
         )

--- a/src/polls/permissions.py
+++ b/src/polls/permissions.py
@@ -11,6 +11,7 @@ import typing as t
 from uuid import UUID
 
 from django.http import HttpRequest
+from django.utils.translation import gettext_lazy as _
 from ninja_extra import ControllerBase
 from ninja_extra.exceptions import PermissionDenied
 
@@ -57,7 +58,7 @@ class IsPollOrganizationOwner(RootPermission):
         """Return True iff ``request.user`` owns the poll's organization."""
         if obj.organization.owner_id == request.user.id:
             return True
-        raise PermissionDenied("Only the organization owner can perform this action.")
+        raise PermissionDenied(str(_("Only the organization owner can perform this action.")))
 
 
 __all__ = ["IsPollOrganizationOwner", "PollPermission"]

--- a/src/polls/service/poll_service.py
+++ b/src/polls/service/poll_service.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from common.exception_handlers import format_validation_error
 from events.models.event import Event
@@ -101,7 +102,7 @@ def _resolve_event_or_raise(
     event = Event.objects.filter(pk=event_id, organization=organization).first()
     if event is None:
         raise PollValidationError(
-            f"Unknown event {event_id} or it does not belong to this organization.",
+            str(_("Unknown event {} or it does not belong to this organization.").format(event_id)),
         )
     return event
 
@@ -136,7 +137,7 @@ def _resolve_membership_tiers_or_raise(
         resolved_ids = {tier.id for tier in tiers}
         missing = sorted(str(tid) for tid in unique_ids - resolved_ids)
         raise PollValidationError(
-            f"Unknown or cross-organization membership_tier ids: {', '.join(missing)}",
+            str(_("Unknown or cross-organization membership_tier ids: {}").format(", ".join(missing))),
         )
     return tiers
 
@@ -449,7 +450,7 @@ def open_poll(poll: Poll) -> Poll:
     with transaction.atomic():
         locked = Poll.objects.select_for_update().get(pk=poll.pk)
         if locked.status != Poll.PollStatus.DRAFT:
-            raise PollLifecycleError("Only DRAFT polls can be opened directly. Use reopen for CLOSED polls.")
+            raise PollLifecycleError(str(_("Only DRAFT polls can be opened directly. Use reopen for CLOSED polls.")))
         locked.status = Poll.PollStatus.OPEN
         locked.opened_at = timezone.now()
         locked.save(update_fields=["status", "opened_at", "updated_at"])
@@ -471,7 +472,7 @@ def close_poll(poll: Poll) -> Poll:
     with transaction.atomic():
         locked = Poll.objects.select_for_update().get(pk=poll.pk)
         if locked.status != Poll.PollStatus.OPEN:
-            raise PollLifecycleError("Only OPEN polls can be closed.")
+            raise PollLifecycleError(str(_("Only OPEN polls can be closed.")))
         locked.status = Poll.PollStatus.CLOSED
         locked.closed_at = timezone.now()
         locked.save(update_fields=["status", "closed_at", "updated_at"])
@@ -502,19 +503,21 @@ def reopen_poll(poll: Poll, payload: PollReopenSchema) -> Poll:
     with transaction.atomic():
         locked = Poll.objects.select_for_update().get(pk=poll.pk)
         if locked.status != Poll.PollStatus.CLOSED:
-            raise PollLifecycleError("Only CLOSED polls can be reopened.")
+            raise PollLifecycleError(str(_("Only CLOSED polls can be reopened.")))
 
         if payload.clear_closes_at:
             locked.closes_at = None
         elif payload.closes_at is not None:
             if payload.closes_at <= timezone.now():
-                raise PollLifecycleError("closes_at must be in the future.")
+                raise PollLifecycleError(str(_("closes_at must be in the future.")))
             locked.closes_at = payload.closes_at
         else:
             # Neither override given: the existing closes_at must be a
             # meaningful future deadline.
             if locked.closes_at is None or locked.closes_at <= timezone.now():
-                raise PollLifecycleError("Cannot reopen: provide a future closes_at or set clear_closes_at=True.")
+                raise PollLifecycleError(
+                    str(_("Cannot reopen: provide a future closes_at or set clear_closes_at=True."))
+                )
 
         locked.status = Poll.PollStatus.OPEN
         locked.closed_at = None
@@ -670,12 +673,12 @@ def _write_mc_answer(submission: QuestionnaireSubmission, mc: McAnswerInput) -> 
     try:
         mc_question = MultipleChoiceQuestion.objects.get(id=mc.question_id, questionnaire=submission.questionnaire)
     except MultipleChoiceQuestion.DoesNotExist as exc:
-        raise PollValidationError(f"Unknown multiple-choice question id: {mc.question_id}") from exc
+        raise PollValidationError(str(_("Unknown multiple-choice question id: {}").format(mc.question_id))) from exc
     for opt_id in mc.option_ids:
         try:
             option = MultipleChoiceOption.objects.get(id=opt_id, question=mc_question)
         except MultipleChoiceOption.DoesNotExist as exc:
-            raise PollValidationError(f"Unknown multiple-choice option id: {opt_id}") from exc
+            raise PollValidationError(str(_("Unknown multiple-choice option id: {}").format(opt_id))) from exc
         MultipleChoiceAnswer.objects.create(submission=submission, question=mc_question, option=option)
 
 
@@ -686,7 +689,7 @@ def _write_free_text_answer(submission: QuestionnaireSubmission, ft: FreeTextAns
     try:
         ft_question = FreeTextQuestion.objects.get(id=ft.question_id, questionnaire=submission.questionnaire)
     except FreeTextQuestion.DoesNotExist as exc:
-        raise PollValidationError(f"Unknown free-text question id: {ft.question_id}") from exc
+        raise PollValidationError(str(_("Unknown free-text question id: {}").format(ft.question_id))) from exc
     FreeTextAnswer.objects.create(submission=submission, question=ft_question, answer=ft.answer)
 
 
@@ -697,7 +700,7 @@ def _write_file_upload_answer(submission: QuestionnaireSubmission, fu: FileUploa
     try:
         fu_question = FileUploadQuestion.objects.get(id=fu.question_id, questionnaire=submission.questionnaire)
     except FileUploadQuestion.DoesNotExist as exc:
-        raise PollValidationError(f"Unknown file-upload question id: {fu.question_id}") from exc
+        raise PollValidationError(str(_("Unknown file-upload question id: {}").format(fu.question_id))) from exc
     ans = FileUploadAnswer.objects.create(submission=submission, question=fu_question)
     unique_file_ids = set(fu.file_ids)
     if not unique_file_ids:
@@ -707,6 +710,6 @@ def _write_file_upload_answer(submission: QuestionnaireSubmission, fu: FileUploa
         resolved = {f.id for f in files}
         missing = sorted(str(fid) for fid in unique_file_ids - resolved)
         raise PollValidationError(
-            f"Unknown or other-user file_upload ids: {', '.join(missing)}",
+            str(_("Unknown or other-user file_upload ids: {}").format(", ".join(missing))),
         )
     ans.files.set(files)

--- a/src/questionnaires/service/file_service.py
+++ b/src/questionnaires/service/file_service.py
@@ -4,6 +4,7 @@ import hashlib
 
 import magic
 from django.db import IntegrityError, transaction
+from django.utils.translation import gettext_lazy as _
 from ninja.files import UploadedFile
 
 from accounts.models import RevelUser
@@ -46,7 +47,9 @@ def upload_questionnaire_file(user: RevelUser, file: UploadedFile) -> Questionna
     """
     # Validate global file size limit before processing
     if file.size and file.size > MAX_UPLOAD_FILE_SIZE:
-        raise FileSizeExceededError(f"File exceeds maximum upload size of {MAX_UPLOAD_FILE_SIZE // (1024 * 1024)}MB.")
+        raise FileSizeExceededError(
+            str(_("File exceeds maximum upload size of {}MB.").format(MAX_UPLOAD_FILE_SIZE // (1024 * 1024)))
+        )
 
     # Read file content for MIME detection
     file_content = file.read()
@@ -58,8 +61,11 @@ def upload_questionnaire_file(user: RevelUser, file: UploadedFile) -> Questionna
     # Validate MIME type against global allowlist
     if detected_mime_type not in ALLOWED_QUESTIONNAIRE_MIME_TYPES:
         raise DisallowedMimeTypeError(
-            f"File type '{detected_mime_type}' is not allowed. "
-            f"Allowed types: documents, images, audio, video, and archives."
+            str(
+                _(
+                    "File type '{}' is not allowed. Allowed types: documents, images, audio, video, and archives."
+                ).format(detected_mime_type)
+            )
         )
 
     # Strip EXIF metadata from images for privacy protection

--- a/src/questionnaires/service/questionnaire_service.py
+++ b/src/questionnaires/service/questionnaire_service.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from django.db import transaction
 from django.db.models import Prefetch
+from django.utils.translation import gettext_lazy as _
 
 from questionnaires.models import (
     FileUploadQuestion,
@@ -143,14 +144,14 @@ class QuestionnaireService:
         """
         # Validate section consistency if both provided
         if payload.section_id and section and payload.section_id != section.id:
-            raise SectionIntegrityError("Section ID in payload does not match the provided section.")
+            raise SectionIntegrityError(str(_("Section ID in payload does not match the provided section.")))
 
         # Resolve section from payload if not provided as parameter
         if payload.section_id and section is None:
             try:
                 section = QuestionnaireSection.objects.get(id=payload.section_id, questionnaire=self.questionnaire)
             except QuestionnaireSection.DoesNotExist:
-                raise SectionIntegrityError("Section does not exist or does not belong to this questionnaire.")
+                raise SectionIntegrityError(str(_("Section does not exist or does not belong to this questionnaire.")))
 
         # Resolve depends_on_option from payload if not provided as parameter
         if depends_on_option is None and payload.depends_on_option_id:
@@ -160,7 +161,7 @@ class QuestionnaireService:
                     question__questionnaire=self.questionnaire,
                 )
             except MultipleChoiceOption.DoesNotExist:
-                raise QuestionIntegrityError("Option does not exist or does not belong to this questionnaire.")
+                raise QuestionIntegrityError(str(_("Option does not exist or does not belong to this questionnaire.")))
 
         return section, depends_on_option
 
@@ -208,7 +209,7 @@ class QuestionnaireService:
                     question__questionnaire=self.questionnaire,
                 )
             except MultipleChoiceOption.DoesNotExist:
-                raise SectionIntegrityError("Option does not exist or does not belong to this questionnaire.")
+                raise SectionIntegrityError(str(_("Option does not exist or does not belong to this questionnaire.")))
 
         section_data = payload.model_dump(
             exclude={
@@ -317,7 +318,7 @@ class QuestionnaireService:
                 section = QuestionnaireSection.objects.get(id=payload.section_id, questionnaire=self.questionnaire)
                 mc_question.section = section
             except QuestionnaireSection.DoesNotExist:
-                raise SectionIntegrityError("Section does not exist or does not belong to this questionnaire.")
+                raise SectionIntegrityError(str(_("Section does not exist or does not belong to this questionnaire.")))
 
         self._validate_depends_on_option_id(payload.depends_on_option_id)
         for key, value in payload.model_dump(exclude={"section_id"}).items():
@@ -335,7 +336,7 @@ class QuestionnaireService:
         use the nested structure in create_mc_question's payload.
         """
         if question.questionnaire_id != self.questionnaire.id:
-            raise QuestionIntegrityError("Question does not belong to this questionnaire.")
+            raise QuestionIntegrityError(str(_("Question does not belong to this questionnaire.")))
         option = MultipleChoiceOption.objects.create(
             question=question,
             option=payload.option,
@@ -391,7 +392,7 @@ class QuestionnaireService:
                 section = QuestionnaireSection.objects.get(id=payload.section_id, questionnaire=self.questionnaire)
                 ft_question.section = section
             except QuestionnaireSection.DoesNotExist:
-                raise SectionIntegrityError("Section does not exist or does not belong to this questionnaire.")
+                raise SectionIntegrityError(str(_("Section does not exist or does not belong to this questionnaire.")))
 
         self._validate_depends_on_option_id(payload.depends_on_option_id)
         for key, value in payload.model_dump(exclude={"section_id"}).items():
@@ -435,7 +436,7 @@ class QuestionnaireService:
                 section = QuestionnaireSection.objects.get(id=payload.section_id, questionnaire=self.questionnaire)
                 fu_question.section = section
             except QuestionnaireSection.DoesNotExist:
-                raise SectionIntegrityError("Section does not exist or does not belong to this questionnaire.")
+                raise SectionIntegrityError(str(_("Section does not exist or does not belong to this questionnaire.")))
 
         self._validate_depends_on_option_id(payload.depends_on_option_id)
         for key, value in payload.model_dump(exclude={"section_id"}).items():

--- a/src/questionnaires/service/submission_service.py
+++ b/src/questionnaires/service/submission_service.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from accounts.models import RevelUser
 from questionnaires.models import (
@@ -419,9 +420,9 @@ class SubmissionService:
             uploader=user,
         )
         if files.count() != len(fu_answer_schema.file_ids):
-            raise FileOwnershipError("Some files do not exist or do not belong to you.")
+            raise FileOwnershipError(str(_("Some files do not exist or do not belong to you.")))
         if files.count() > question.max_files:
-            raise FileLimitExceededError(f"Too many files. Maximum allowed: {question.max_files}.")
+            raise FileLimitExceededError(str(_("Too many files. Maximum allowed: {}.").format(question.max_files)))
         # Validate MIME types if restricted
         if question.allowed_mime_types:
             # Build an expanded set that includes equivalent MIME types:
@@ -435,15 +436,28 @@ class SubmissionService:
             for f in files:
                 if f.mime_type not in expanded:
                     raise InvalidFileMimeTypeError(
-                        f"File '{f.original_filename}' has type '{f.mime_type}' which is not allowed. "
-                        f"Allowed types: {', '.join(question.allowed_mime_types)}."
+                        str(
+                            _(
+                                "File '{filename}' has type '{mime_type}' which is not allowed. "
+                                "Allowed types: {allowed_types}."
+                            ).format(
+                                filename=f.original_filename,
+                                mime_type=f.mime_type,
+                                allowed_types=", ".join(question.allowed_mime_types),
+                            )
+                        )
                     )
         # Validate file sizes
         for f in files:
             if f.file_size > question.max_file_size:
                 raise FileSizeExceededError(
-                    f"File '{f.original_filename}' ({f.file_size} bytes) exceeds maximum size "
-                    f"of {question.max_file_size} bytes."
+                    str(
+                        _("File '{filename}' ({size} bytes) exceeds maximum size of {max_size} bytes.").format(
+                            filename=f.original_filename,
+                            size=f.file_size,
+                            max_size=question.max_file_size,
+                        )
+                    )
                 )
         return files
 

--- a/src/telegram/service.py
+++ b/src/telegram/service.py
@@ -32,7 +32,7 @@ def connect_accounts(user: RevelUser, otp: str) -> None:
     """
     # Check if user already has a linked Telegram account
     if TelegramUser.objects.filter(user=user).exists():
-        raise HttpError(400, "Your account is already connected to Telegram.")
+        raise HttpError(400, str(_("Your account is already connected to Telegram.")))
 
     # Find TelegramUser with matching valid OTP
     tg_user = (
@@ -44,7 +44,7 @@ def connect_accounts(user: RevelUser, otp: str) -> None:
     )
 
     if not tg_user:
-        raise HttpError(400, "Invalid or expired OTP code.")
+        raise HttpError(400, str(_("Invalid or expired OTP code.")))
 
     # Check if the Telegram account is globally banned
     if tg_user.telegram_username and is_telegram_globally_banned(tg_user.telegram_username):
@@ -89,7 +89,7 @@ def disconnect_account(user: RevelUser) -> None:
     tg_user = TelegramUser.objects.filter(user=user).first()
 
     if not tg_user:
-        raise HttpError(400, "No Telegram account is linked to your account.")
+        raise HttpError(400, str(_("No Telegram account is linked to your account.")))
 
     # Capture `user` before clearing tg_user.user, since the on_commit lambda
     # will see tg_user.user as None by the time it fires.

--- a/src/wallet/controllers.py
+++ b/src/wallet/controllers.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from django.db.models import QuerySet
 from django.http import HttpResponse, HttpResponseRedirect
+from django.utils.translation import gettext_lazy as _
 from ninja import Query
 from ninja.errors import HttpError
 from ninja_extra import api_controller, route
@@ -52,7 +53,7 @@ class TicketWalletController(UserAwareController):
         ticket = self.get_object_or_exception(self.get_queryset(), id=ticket_id)
 
         if not ticket.apple_pass_available:
-            raise HttpError(503, "Apple Wallet is not configured")
+            raise HttpError(503, str(_("Apple Wallet is not configured")))
 
         pkpass_bytes = ticket_file_service.get_or_generate_pkpass(ticket)
 
@@ -83,7 +84,7 @@ class TicketWalletController(UserAwareController):
         ticket = self.get_object_or_exception(self.get_queryset(), id=ticket_id)
 
         if not ticket.google_pass_available:
-            raise HttpError(503, "Google Wallet is not configured")
+            raise HttpError(503, str(_("Google Wallet is not configured")))
 
         save_url = google_wallet_service.ticket_save_url(ticket)
         if format == "json":
@@ -114,13 +115,13 @@ class TicketWalletController(UserAwareController):
         try:
             expires = int(exp)
         except ValueError:
-            raise HttpError(403, "Invalid link")
+            raise HttpError(403, str(_("Invalid link")))
         if expires <= time.time():
-            raise HttpError(410, "Link expired")
+            raise HttpError(410, str(_("Link expired")))
 
         request_path = self.context.request.path  # type: ignore[union-attr]
         if not verify_signature(request_path, exp, sig):
-            raise HttpError(403, "Invalid link")
+            raise HttpError(403, str(_("Invalid link")))
 
         ticket = self.get_object_or_exception(
             Ticket.objects.full().filter(status__in=[Ticket.TicketStatus.ACTIVE, Ticket.TicketStatus.PENDING]),
@@ -128,7 +129,7 @@ class TicketWalletController(UserAwareController):
         )
 
         if not ticket.apple_pass_available:
-            raise HttpError(503, "Apple Wallet is not configured")
+            raise HttpError(503, str(_("Apple Wallet is not configured")))
 
         pkpass_bytes = ticket_file_service.get_or_generate_pkpass(ticket)
 
@@ -198,7 +199,7 @@ class MembershipWalletController(UserAwareController):
         """Generate and download the caller's membership card (.pkpass)."""
         member = self.get_member(slug)
         if not member.apple_pass_available:
-            raise HttpError(503, "Apple Wallet is not configured")
+            raise HttpError(503, str(_("Apple Wallet is not configured")))
         pkpass_bytes = get_apple_pass_generator().generate_membership_pass(member)
         response = HttpResponse(pkpass_bytes, content_type="application/vnd.apple.pkpass")
         safe_name = "membership_" + str(member.id).split("-")[0]
@@ -219,7 +220,7 @@ class MembershipWalletController(UserAwareController):
         """Redirect to (or return as JSON) the Google Wallet save link for the caller's card."""
         member = self.get_member(slug)
         if not member.google_pass_available:
-            raise HttpError(503, "Google Wallet is not configured")
+            raise HttpError(503, str(_("Google Wallet is not configured")))
         save_url = google_wallet_service.membership_save_url(member)
         if format == "json":
             return 200, GoogleWalletSaveUrlSchema(save_url=save_url)
@@ -266,19 +267,19 @@ class MembershipWalletSignedController(UserAwareController):
         try:
             expires = int(exp)
         except ValueError:
-            raise HttpError(403, "Invalid link")
+            raise HttpError(403, str(_("Invalid link")))
         if expires <= time.time():
-            raise HttpError(410, "Link expired")
+            raise HttpError(410, str(_("Link expired")))
         request_path = self.context.request.path  # type: ignore[union-attr]
         if not verify_signature(request_path, exp, sig):
-            raise HttpError(403, "Invalid link")
+            raise HttpError(403, str(_("Invalid link")))
 
         member = self.get_object_or_exception(
             OrganizationMember.objects.for_visibility().select_related("organization", "tier", "user"),
             id=member_id,
         )
         if not member.apple_pass_available:
-            raise HttpError(503, "Apple Wallet is not configured")
+            raise HttpError(503, str(_("Apple Wallet is not configured")))
         pkpass_bytes = get_apple_pass_generator().generate_membership_pass(member)
         response = HttpResponse(pkpass_bytes, content_type="application/vnd.apple.pkpass")
         safe_name = "membership_" + str(member.id).split("-")[0]


### PR DESCRIPTION
Tech-debt sweep finding 16.

Every message Ninja renders into an error body was shipping untranslated
English to all five locales: bare literals in `raise HttpError(status, "...")`
and in `raise <AppError>("...")` for exceptions mapped with
`make_simple_handler` (which renders `str(exc)` as `detail`), plus ~19
f-strings that xgettext cannot extract at all.

Mark all of them with the house idiom `str(_("..."))`. Interpolated messages
now translate first and `.format(...)` second, so the msgid reaches the
catalog. English msgids are byte-identical to the literals they replace, so
no assertion changed. Two messages become module constants: jwt.py's raise
site shadows `_` with a throwaway unpack target, and announcement_service
already used a constant.

Also wrap the announcement service's ValueError messages, which reach the
client verbatim through the controllers' `HttpError(422, str(e))`.

Add scripts/check_i18n_literals.py to stop this recurring: an AST walk that
reads each app's HANDLERS map, expands it over subclasses (dispatch is by
MRO), and flags a string constant or f-string in the message position of a
raise. It reports 77 violations on the pre-fix tree and 0 now. Wired into
`make check` and CI.

Catalogs regenerated once: 76 new msgids x 5 locales. gettext's fuzzy matches
were, as usual on this repo, semantically unrelated; all 50 discarded and
translated fresh. Zero fuzzy, zero untranslated.

**Merge note:** this PR and the wallet PR both add entries to the five `.po` catalogs. Whichever merges second needs a rebase: keep both sides of the catalog hunks (pure insertions), keep a blank line before each `msgid`, then `make i18n-check`. The new `make i18n-literals` gate was verified green against every other tech-debt PR in an integrated checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
