### PR TITLE
refactor(notifications): extract notify_org_staff; honour staff prefs on 7 more fan-outs

### DIFF
--- a/src/events/service/follow_service.py
+++ b/src/events/service/follow_service.py
@@ -12,8 +12,7 @@ from common.models import SiteSettings
 from events.models import EventSeries, Organization, OrganizationMember
 from events.models.follow import EventSeriesFollow, OrganizationFollow
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
-from notifications.signals import notification_requested
+from notifications.service.notification_helpers import notify_org_staff
 
 # Type variable for follow models
 FollowT = t.TypeVar("FollowT", OrganizationFollow, EventSeriesFollow)
@@ -139,23 +138,21 @@ def _send_org_follow_notification(user: RevelUser, organization: Organization) -
     """Send notification to org admins about a new follower."""
 
     def send() -> None:
-        staff_users = get_staff_for_notification(organization.id, NotificationType.ORGANIZATION_FOLLOWED)
         frontend_base_url = SiteSettings.get_solo().frontend_base_url
 
-        for staff_user in staff_users:
-            notification_requested.send(
-                sender=OrganizationFollow,
-                user=staff_user,
-                notification_type=NotificationType.ORGANIZATION_FOLLOWED,
-                context={
-                    "organization_id": str(organization.id),
-                    "organization_name": organization.name,
-                    "follower_id": str(user.id),
-                    "follower_name": user.display_name,
-                    "follower_email": user.email,
-                    "frontend_url": f"{frontend_base_url}/org/{organization.slug}",
-                },
-            )
+        notify_org_staff(
+            organization_id=organization.id,
+            notification_type=NotificationType.ORGANIZATION_FOLLOWED,
+            context={
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+                "follower_id": str(user.id),
+                "follower_name": user.display_name,
+                "follower_email": user.email,
+                "frontend_url": f"{frontend_base_url}/org/{organization.slug}",
+            },
+            sender=OrganizationFollow,
+        )
 
     transaction.on_commit(send)
 
@@ -270,25 +267,23 @@ def _send_series_follow_notification(user: RevelUser, event_series: EventSeries)
 
     def send() -> None:
         organization = event_series.organization
-        staff_users = get_staff_for_notification(organization.id, NotificationType.EVENT_SERIES_FOLLOWED)
         frontend_base_url = SiteSettings.get_solo().frontend_base_url
 
-        for staff_user in staff_users:
-            notification_requested.send(
-                sender=EventSeriesFollow,
-                user=staff_user,
-                notification_type=NotificationType.EVENT_SERIES_FOLLOWED,
-                context={
-                    "organization_id": str(organization.id),
-                    "organization_name": organization.name,
-                    "event_series_id": str(event_series.id),
-                    "event_series_name": event_series.name,
-                    "follower_id": str(user.id),
-                    "follower_name": user.display_name,
-                    "follower_email": user.email,
-                    "frontend_url": f"{frontend_base_url}/events/{organization.slug}/series/{event_series.slug}",
-                },
-            )
+        notify_org_staff(
+            organization_id=organization.id,
+            notification_type=NotificationType.EVENT_SERIES_FOLLOWED,
+            context={
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+                "event_series_id": str(event_series.id),
+                "event_series_name": event_series.name,
+                "follower_id": str(user.id),
+                "follower_name": user.display_name,
+                "follower_email": user.email,
+                "frontend_url": f"{frontend_base_url}/events/{organization.slug}/series/{event_series.slug}",
+            },
+            sender=EventSeriesFollow,
+        )
 
     transaction.on_commit(send)
 

--- a/src/events/service/whitelist_service.py
+++ b/src/events/service/whitelist_service.py
@@ -102,32 +102,26 @@ def create_whitelist_request(
 
     # Send notification to org admins
     def send_notification() -> None:
-        from notifications.service.eligibility import get_staff_for_notification
-
-        staff = get_staff_for_notification(
-            organization.id,
-            NotificationType.WHITELIST_REQUEST_CREATED,
-        )
+        from notifications.service.notification_helpers import notify_org_staff
 
         frontend_base_url = SiteSettings.get_solo().frontend_base_url
 
-        for staff_member in staff:
-            notification_requested.send(
-                sender=WhitelistRequest,
-                user=staff_member,
-                notification_type=NotificationType.WHITELIST_REQUEST_CREATED,
-                context={
-                    "request_id": str(request.id),
-                    "organization_id": str(organization.id),
-                    "organization_name": organization.name,
-                    "requester_id": str(user.id),
-                    "requester_name": user.get_display_name(),
-                    "requester_email": user.email,
-                    "request_message": message,
-                    "matched_entries_count": len(matched_entries),
-                    "frontend_url": f"{frontend_base_url}/org/{organization.slug}/admin/blacklist",
-                },
-            )
+        notify_org_staff(
+            organization_id=organization.id,
+            notification_type=NotificationType.WHITELIST_REQUEST_CREATED,
+            context={
+                "request_id": str(request.id),
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+                "requester_id": str(user.id),
+                "requester_name": user.get_display_name(),
+                "requester_email": user.email,
+                "request_message": message,
+                "matched_entries_count": len(matched_entries),
+                "frontend_url": f"{frontend_base_url}/org/{organization.slug}/admin/blacklist",
+            },
+            sender=WhitelistRequest,
+        )
 
     transaction.on_commit(send_notification)
 

--- a/src/events/tests/test_controllers/test_follow_controller.py
+++ b/src/events/tests/test_controllers/test_follow_controller.py
@@ -159,7 +159,7 @@ class TestOrganizationFollowEndpoints:
 
             # Act
             url = reverse("api:follow_organization", kwargs={"slug": organization.slug})
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 with django_capture_on_commit_callbacks(execute=True):
                     response = client.post(url, data=payload, content_type="application/json")
 
@@ -192,7 +192,7 @@ class TestOrganizationFollowEndpoints:
 
             # Act
             url = reverse("api:follow_organization", kwargs={"slug": organization.slug})
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 with django_capture_on_commit_callbacks(execute=True):
                     response = client.post(url, data=payload, content_type="application/json")
 
@@ -224,7 +224,7 @@ class TestOrganizationFollowEndpoints:
 
             # Act
             url = reverse("api:follow_organization", kwargs={"slug": organization.slug})
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 response = client.post(url, data=payload, content_type="application/json")
 
             # Assert

--- a/src/events/tests/test_controllers/test_follow_controller_following.py
+++ b/src/events/tests/test_controllers/test_follow_controller_following.py
@@ -318,7 +318,7 @@ class TestFollowEndToEndFlow:
 
         # 1. Follow the organization
         follow_url = reverse("api:follow_organization", kwargs={"slug": organization.slug})
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 response = client.post(
                     follow_url,
@@ -353,7 +353,7 @@ class TestFollowEndToEndFlow:
         assert response.json()["count"] == 0
 
         # 5. Re-follow (reactivation)
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 response = client.post(
                     follow_url,

--- a/src/events/tests/test_controllers/test_follow_controller_series.py
+++ b/src/events/tests/test_controllers/test_follow_controller_series.py
@@ -157,7 +157,7 @@ class TestEventSeriesFollowEndpoints:
 
             # Act
             url = reverse("api:follow_event_series", kwargs={"series_id": event_series.id})
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 with django_capture_on_commit_callbacks(execute=True):
                     response = client.post(url, data=payload, content_type="application/json")
 
@@ -191,7 +191,7 @@ class TestEventSeriesFollowEndpoints:
 
             # Act
             url = reverse("api:follow_event_series", kwargs={"series_id": event_series.id})
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 response = client.post(url, data=payload, content_type="application/json")
 
             # Assert

--- a/src/events/tests/test_service/test_follow_service.py
+++ b/src/events/tests/test_service/test_follow_service.py
@@ -38,7 +38,7 @@ class TestFollowOrganization:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_organization(nonmember_user, organization)
 
@@ -65,7 +65,7 @@ class TestFollowOrganization:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_organization(
                     nonmember_user,
@@ -94,7 +94,7 @@ class TestFollowOrganization:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send") as mock_send:
+        with patch("notifications.signals.notification_requested.send") as mock_send:
             with django_capture_on_commit_callbacks(execute=True):
                 follow_service.follow_organization(nonmember_user, organization)
 
@@ -141,7 +141,7 @@ class TestFollowOrganization:
         original_id = existing_follow.id
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_organization(
                     nonmember_user,
@@ -179,7 +179,7 @@ class TestFollowOrganization:
 
         # Act & Assert
         with pytest.raises(HttpError) as exc_info:
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 follow_service.follow_organization(nonmember_user, organization)
 
         assert exc_info.value.status_code == 400
@@ -382,7 +382,7 @@ class TestFollowEventSeries:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_event_series(nonmember_user, event_series)
 
@@ -408,7 +408,7 @@ class TestFollowEventSeries:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_event_series(
                     nonmember_user,
@@ -436,7 +436,7 @@ class TestFollowEventSeries:
         organization.save()
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send") as mock_send:
+        with patch("notifications.signals.notification_requested.send") as mock_send:
             with django_capture_on_commit_callbacks(execute=True):
                 follow_service.follow_event_series(nonmember_user, event_series)
 
@@ -478,7 +478,7 @@ class TestFollowEventSeries:
         original_id = existing_follow.id
 
         # Act
-        with patch("events.service.follow_service.notification_requested.send"):
+        with patch("notifications.signals.notification_requested.send"):
             with django_capture_on_commit_callbacks(execute=True):
                 follow = follow_service.follow_event_series(
                     nonmember_user,
@@ -513,7 +513,7 @@ class TestFollowEventSeries:
 
         # Act & Assert
         with pytest.raises(HttpError) as exc_info:
-            with patch("events.service.follow_service.notification_requested.send"):
+            with patch("notifications.signals.notification_requested.send"):
                 follow_service.follow_event_series(nonmember_user, event_series)
 
         assert exc_info.value.status_code == 400
@@ -637,3 +637,62 @@ class TestUpdateEventSeriesFollowPreferences:
 
         assert exc_info.value.status_code == 400
         assert "Not following" in str(exc_info.value)
+
+
+class TestFollowNotificationsRespectStaffPreferences:
+    """Follow fan-outs must honour the recipient's per-type preference.
+
+    Both sites used to loop over ``get_staff_for_notification`` and send
+    unconditionally, so a staff member who switched the type off still received
+    every follow notification.
+    """
+
+    def _set_enabled(self, staff_user: RevelUser, notification_type: NotificationType, enabled: bool) -> None:
+        prefs = staff_user.notification_preferences
+        prefs.notification_type_settings[notification_type] = {"enabled": enabled}
+        prefs.save(update_fields=["notification_type_settings"])
+
+    def _notified(self, mock_send: t.Any, notification_type: NotificationType, staff_user: RevelUser) -> bool:
+        return any(
+            c.kwargs.get("notification_type") == notification_type and c.kwargs.get("user") == staff_user
+            for c in mock_send.call_args_list
+        )
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_organization_followed_respects_preference(
+        self,
+        organization: Organization,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+        enabled: bool,
+    ) -> None:
+        """ORGANIZATION_FOLLOWED reaches the owner only while they have it enabled."""
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        self._set_enabled(organization.owner, NotificationType.ORGANIZATION_FOLLOWED, enabled)
+
+        with patch("notifications.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                follow_service.follow_organization(nonmember_user, organization)
+
+        assert self._notified(mock_send, NotificationType.ORGANIZATION_FOLLOWED, organization.owner) is enabled
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_event_series_followed_respects_preference(
+        self,
+        organization: Organization,
+        event_series: EventSeries,
+        nonmember_user: RevelUser,
+        django_capture_on_commit_callbacks: t.Any,
+        enabled: bool,
+    ) -> None:
+        """EVENT_SERIES_FOLLOWED reaches the owner only while they have it enabled."""
+        organization.visibility = Organization.Visibility.PUBLIC
+        organization.save()
+        self._set_enabled(organization.owner, NotificationType.EVENT_SERIES_FOLLOWED, enabled)
+
+        with patch("notifications.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                follow_service.follow_event_series(nonmember_user, event_series)
+
+        assert self._notified(mock_send, NotificationType.EVENT_SERIES_FOLLOWED, organization.owner) is enabled

--- a/src/events/tests/test_service/test_membership_notifications.py
+++ b/src/events/tests/test_service/test_membership_notifications.py
@@ -52,7 +52,7 @@ def test_apply_fires_request_created_notification_for_staff(
         ]
     )
 
-    with patch("notifications.signals.membership.notification_requested.send") as mock_send:
+    with patch("notifications.signals.notification_requested.send") as mock_send:
         client = _client(nonmember_user)
         url = reverse("api:apply_for_membership", kwargs={"slug": organization.slug})
         response = client.post(url, data={"tier_id": str(tier.id)}, content_type="application/json")

--- a/src/events/tests/test_service/test_whitelist_service.py
+++ b/src/events/tests/test_service/test_whitelist_service.py
@@ -10,6 +10,7 @@ Tests cover:
 - Notification dispatching
 """
 
+import typing as t
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,7 @@ from ninja.errors import HttpError
 from accounts.models import RevelUser
 from events.models import Blacklist, Organization, WhitelistRequest
 from events.service import whitelist_service
+from notifications.enums import NotificationType
 
 pytestmark = pytest.mark.django_db
 
@@ -450,3 +452,42 @@ class TestRemoveFromWhitelist:
         )
 
         assert new_request.status == WhitelistRequest.Status.PENDING
+
+
+class TestWhitelistRequestNotificationRespectsStaffPreference:
+    """The whitelist-request fan-out must honour the recipient's per-type preference.
+
+    It used to loop over ``get_staff_for_notification`` and send unconditionally,
+    so an admin who switched WHITELIST_REQUEST_CREATED off still received it.
+    """
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_respects_staff_preference(
+        self,
+        whitelist_org: Organization,
+        whitelist_admin: RevelUser,
+        requester_user: RevelUser,
+        fuzzy_blacklist_entry: Blacklist,
+        django_capture_on_commit_callbacks: t.Any,
+        enabled: bool,
+    ) -> None:
+        """WHITELIST_REQUEST_CREATED reaches the owner only while they have it enabled."""
+        prefs = whitelist_admin.notification_preferences
+        prefs.notification_type_settings[NotificationType.WHITELIST_REQUEST_CREATED] = {"enabled": enabled}
+        prefs.save(update_fields=["notification_type_settings"])
+
+        with patch("notifications.signals.notification_requested.send") as mock_send:
+            with django_capture_on_commit_callbacks(execute=True):
+                whitelist_service.create_whitelist_request(
+                    user=requester_user,
+                    organization=whitelist_org,
+                    matched_entries=[fuzzy_blacklist_entry],
+                    message="Please review",
+                )
+
+        notified = any(
+            c.kwargs.get("notification_type") == NotificationType.WHITELIST_REQUEST_CREATED
+            and c.kwargs.get("user") == whitelist_admin
+            for c in mock_send.call_args_list
+        )
+        assert notified is enabled

--- a/src/notifications/service/notification_helpers.py
+++ b/src/notifications/service/notification_helpers.py
@@ -19,6 +19,7 @@ from notifications.service.dispatcher import NotificationData, bulk_create_notif
 from notifications.service.eligibility import (
     BatchParticipationChecker,
     get_eligible_users_for_event_notification,
+    get_staff_for_notification,
 )
 
 logger = structlog.get_logger(__name__)
@@ -41,6 +42,55 @@ def get_event_location_for_user(event: Event, user: RevelUser) -> tuple[str, str
     if event.can_user_see_address(user):
         return event.full_address(), event.location_maps_url or ""
     return "", ""
+
+
+def notify_org_staff(
+    *,
+    organization_id: UUID,
+    notification_type: NotificationType,
+    context: t.Mapping[str, t.Any],
+    sender: t.Any,
+    recipients: t.Sequence[RevelUser] | None = None,
+) -> int:
+    """Fan a notification out to the org staff/owners who have that type enabled.
+
+    Replaces the fan-out block that every staff-facing notification used to
+    repeat: resolve the eligible staff, skip anyone who disabled the type in
+    their ``NotificationPreference``, and fire ``notification_requested`` for
+    the rest.
+
+    Args:
+        organization_id: Organization whose staff/owners should be notified.
+        notification_type: The notification type being sent; also selects the
+            permission required to receive it and gates each recipient's
+            preference.
+        context: Notification context, sent verbatim to every recipient.
+        sender: Signal ``sender`` — a model class or the calling function.
+            Only used for logging, so callers pass whatever identifies them.
+        recipients: Pre-materialised staff list to reuse instead of querying.
+            Pass it when notifying the same staff repeatedly in a loop (batch
+            paths) so the query is not repeated per iteration.
+
+    Returns:
+        Number of staff members notified.
+    """
+    from notifications.signals import notification_requested
+
+    staff_and_owners = (
+        recipients if recipients is not None else get_staff_for_notification(organization_id, notification_type)
+    )
+
+    notified = 0
+    for staff_user in staff_and_owners:
+        if staff_user.notification_preferences.is_notification_type_enabled(notification_type):
+            notification_requested.send(
+                sender=sender,
+                user=staff_user,
+                notification_type=notification_type,
+                context=context,
+            )
+            notified += 1
+    return notified
 
 
 def notify_event_opened(event: Event) -> int:

--- a/src/notifications/signals/contact.py
+++ b/src/notifications/signals/contact.py
@@ -11,8 +11,7 @@ from common.models import SiteSettings
 from events.models import OrganizationContactMessage
 from events.tasks import send_organization_contact_message_email
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
-from notifications.signals import notification_requested
+from notifications.service.notification_helpers import notify_org_staff
 
 logger = structlog.get_logger(__name__)
 
@@ -43,28 +42,26 @@ def handle_contact_message_created(
         admin_url = f"{frontend_base_url}/org/{organization.slug}/admin/contact-messages/{instance.id}"
         message_preview = instance.message[:_MESSAGE_PREVIEW_CHARS]
 
-        recipients = get_staff_for_notification(organization.id, NotificationType.ORG_CONTACT_MESSAGE_RECEIVED)
-        for recipient in recipients:
-            notification_requested.send(
-                sender=handle_contact_message_created,
-                user=recipient,
-                notification_type=NotificationType.ORG_CONTACT_MESSAGE_RECEIVED,
-                context={
-                    "message_id": str(instance.id),
-                    "organization_id": str(organization.id),
-                    "organization_name": organization.name,
-                    "sender_email": instance.sender_email_snapshot,
-                    "subject": instance.subject,
-                    "message_preview": message_preview,
-                    "admin_url": admin_url,
-                },
-            )
+        notified = notify_org_staff(
+            organization_id=organization.id,
+            notification_type=NotificationType.ORG_CONTACT_MESSAGE_RECEIVED,
+            context={
+                "message_id": str(instance.id),
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+                "sender_email": instance.sender_email_snapshot,
+                "subject": instance.subject,
+                "message_preview": message_preview,
+                "admin_url": admin_url,
+            },
+            sender=handle_contact_message_created,
+        )
 
         logger.info(
             "organization_contact_message_dispatched",
             message_id=str(instance.id),
             organization_id=str(organization.id),
-            recipient_count=len(recipients),
+            recipient_count=notified,
         )
 
     transaction.on_commit(fire)

--- a/src/notifications/signals/invitation.py
+++ b/src/notifications/signals/invitation.py
@@ -11,8 +11,7 @@ from common.models import SiteSettings
 from events.models import EventInvitation, EventInvitationRequest, PendingEventInvitation
 from events.tasks import build_attendee_visibility_flags
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
-from notifications.service.notification_helpers import format_event_datetime
+from notifications.service.notification_helpers import format_event_datetime, notify_org_staff
 from notifications.signals import notification_requested
 
 logger = structlog.get_logger(__name__)
@@ -99,31 +98,26 @@ def handle_invitation_request_created(
         frontend_url = f"{frontend_base_url}/org/{event.organization.slug}/admin/events/{event.id}/invitations"
 
         # Notify staff and owners with invite_to_event permission
-        staff_and_owners = get_staff_for_notification(
-            event.organization.id, NotificationType.INVITATION_REQUEST_CREATED
+        notified = notify_org_staff(
+            organization_id=event.organization.id,
+            notification_type=NotificationType.INVITATION_REQUEST_CREATED,
+            context={
+                "request_id": str(instance.id),
+                "event_id": str(event.id),
+                "event_name": event.name,
+                "requester_email": requester.email,
+                "requester_name": requester.display_name,
+                "request_message": instance.message or "",
+                "frontend_url": frontend_url,
+            },
+            sender=handle_invitation_request_created,
         )
-
-        for staff_member in staff_and_owners:
-            notification_requested.send(
-                sender=handle_invitation_request_created,
-                user=staff_member,
-                notification_type=NotificationType.INVITATION_REQUEST_CREATED,
-                context={
-                    "request_id": str(instance.id),
-                    "event_id": str(event.id),
-                    "event_name": event.name,
-                    "requester_email": requester.email,
-                    "requester_name": requester.display_name,
-                    "request_message": instance.message or "",
-                    "frontend_url": frontend_url,
-                },
-            )
 
         logger.info(
             "invitation_request_notifications_sent",
             request_id=str(instance.id),
             event_id=str(event.id),
-            recipient_count=len(staff_and_owners),
+            recipient_count=notified,
         )
 
     transaction.on_commit(send_request_notifications)

--- a/src/notifications/signals/membership.py
+++ b/src/notifications/signals/membership.py
@@ -10,8 +10,7 @@ from django.dispatch import receiver
 from common.models import SiteSettings
 from events.models import OrganizationMembershipRequest
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
-from notifications.signals import notification_requested
+from notifications.service.notification_helpers import notify_org_staff
 
 logger = structlog.get_logger(__name__)
 
@@ -39,30 +38,27 @@ def handle_membership_request_created(
         frontend_url = f"{frontend_base_url}/org/{organization.slug}/admin/members?tab=requests"
 
         # Notify staff and owners with manage_members permission
-        staff_and_owners = get_staff_for_notification(organization.id, NotificationType.MEMBERSHIP_REQUEST_CREATED)
-
-        for staff_member in staff_and_owners:
-            notification_requested.send(
-                sender=handle_membership_request_created,
-                user=staff_member,
-                notification_type=NotificationType.MEMBERSHIP_REQUEST_CREATED,
-                context={
-                    "request_id": str(instance.id),
-                    "organization_id": str(organization.id),
-                    "organization_name": organization.name,
-                    "requester_id": str(requester.id),
-                    "requester_name": requester.display_name,
-                    "requester_email": requester.email,
-                    "request_message": instance.message or "",
-                    "frontend_url": frontend_url,
-                },
-            )
+        notified = notify_org_staff(
+            organization_id=organization.id,
+            notification_type=NotificationType.MEMBERSHIP_REQUEST_CREATED,
+            context={
+                "request_id": str(instance.id),
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+                "requester_id": str(requester.id),
+                "requester_name": requester.display_name,
+                "requester_email": requester.email,
+                "request_message": instance.message or "",
+                "frontend_url": frontend_url,
+            },
+            sender=handle_membership_request_created,
+        )
 
         logger.info(
             "membership_request_notifications_sent",
             request_id=str(instance.id),
             organization_id=str(organization.id),
-            recipient_count=len(staff_and_owners),
+            recipient_count=notified,
         )
 
     transaction.on_commit(send_request_notifications)

--- a/src/notifications/signals/payment.py
+++ b/src/notifications/signals/payment.py
@@ -13,8 +13,7 @@ from common.models import SiteSettings
 from events.models import Event, Payment, Ticket
 from notifications.context_schemas import EventRefundSummaryContext, RefundUnmatchedCandidate
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
-from notifications.service.notification_helpers import format_event_datetime
+from notifications.service.notification_helpers import format_event_datetime, notify_org_staff
 from notifications.signals import notification_requested
 
 logger = structlog.get_logger(__name__)
@@ -150,16 +149,12 @@ def _send_refund_notifications(payment: Payment) -> None:
         "ticket_holder_email": payment.user.email,
     }
 
-    staff_and_owners = get_staff_for_notification(event.organization_id, NotificationType.TICKET_REFUNDED)
-    for staff_user in staff_and_owners:
-        prefs = getattr(staff_user, "notification_preferences", None)
-        if prefs and prefs.is_notification_type_enabled(NotificationType.TICKET_REFUNDED):
-            notification_requested.send(
-                sender=_send_refund_notifications,
-                user=staff_user,
-                notification_type=NotificationType.TICKET_REFUNDED,
-                context=staff_context,
-            )
+    notify_org_staff(
+        organization_id=event.organization_id,
+        notification_type=NotificationType.TICKET_REFUNDED,
+        context=staff_context,
+        sender=_send_refund_notifications,
+    )
 
     logger.info(
         "refund_notifications_sent",
@@ -242,18 +237,12 @@ def send_refund_unmatched(
         "resolve_url": resolve_url,
     }
 
-    recipients = get_staff_for_notification(organization.id, NotificationType.REFUND_UNMATCHED)
-    notified = 0
-    for staff_user in recipients:
-        prefs = getattr(staff_user, "notification_preferences", None)
-        if prefs and prefs.is_notification_type_enabled(NotificationType.REFUND_UNMATCHED):
-            notification_requested.send(
-                sender=send_refund_unmatched,
-                user=staff_user,
-                notification_type=NotificationType.REFUND_UNMATCHED,
-                context=context,
-            )
-            notified += 1
+    notified = notify_org_staff(
+        organization_id=organization.id,
+        notification_type=NotificationType.REFUND_UNMATCHED,
+        context=context,
+        sender=send_refund_unmatched,
+    )
 
     logger.info(
         "refund_unmatched_notifications_sent",
@@ -302,18 +291,12 @@ def send_event_refund_summary(
         "still_active": still_active,
     }
 
-    recipients = get_staff_for_notification(event.organization_id, NotificationType.EVENT_REFUND_SUMMARY)
-    notified = 0
-    for staff_user in recipients:
-        prefs = getattr(staff_user, "notification_preferences", None)
-        if prefs and prefs.is_notification_type_enabled(NotificationType.EVENT_REFUND_SUMMARY):
-            notification_requested.send(
-                sender=send_event_refund_summary,
-                user=staff_user,
-                notification_type=NotificationType.EVENT_REFUND_SUMMARY,
-                context=context,
-            )
-            notified += 1
+    notified = notify_org_staff(
+        organization_id=event.organization_id,
+        notification_type=NotificationType.EVENT_REFUND_SUMMARY,
+        context=context,
+        sender=send_event_refund_summary,
+    )
 
     logger.info(
         "event_refund_summary_notifications_sent",

--- a/src/notifications/signals/questionnaire.py
+++ b/src/notifications/signals/questionnaire.py
@@ -10,6 +10,7 @@ from django.dispatch import receiver
 from common.models import SiteSettings
 from notifications.enums import NotificationType
 from notifications.service.eligibility import get_staff_for_notification
+from notifications.service.notification_helpers import notify_org_staff
 from notifications.signals import notification_requested
 from questionnaires.models import QuestionnaireEvaluation, QuestionnaireSubmission
 
@@ -81,19 +82,19 @@ def handle_questionnaire_submission(
     staff_list = list(staff_and_owners)
 
     def send_notifications() -> None:
-        for staff_user in staff_list:
-            notification_requested.send(
-                sender=sender,
-                user=staff_user,
-                notification_type=NotificationType.QUESTIONNAIRE_SUBMITTED,
-                context=context,
-            )
+        notified = notify_org_staff(
+            organization_id=organization_id,
+            notification_type=NotificationType.QUESTIONNAIRE_SUBMITTED,
+            context=context,
+            sender=sender,
+            recipients=staff_list,
+        )
 
         logger.info(
             "questionnaire_submission_notifications_sent",
             submission_id=str(instance.id),
             organization_id=str(organization_id),
-            recipients_count=len(staff_list),
+            recipients_count=notified,
         )
 
     transaction.on_commit(send_notifications)

--- a/src/notifications/signals/series_pass.py
+++ b/src/notifications/signals/series_pass.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from events.models import Event, HeldSeriesPass, Ticket
 from notifications.enums import NotificationType
-from notifications.service.eligibility import get_staff_for_notification
+from notifications.service.notification_helpers import notify_org_staff
 from notifications.signals import notification_requested
 
 
@@ -62,16 +62,12 @@ def send_series_pass_purchased(held_pass_id: UUID) -> None:
         "holder_name": held_pass.user.get_display_name(),
         "holder_email": held_pass.user.email,
     }
-    organization_id = held_pass.series_pass.event_series.organization_id
-    staff_and_owners = get_staff_for_notification(organization_id, NotificationType.SERIES_PASS_PURCHASED)
-    for staff_user in staff_and_owners:
-        if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.SERIES_PASS_PURCHASED):
-            notification_requested.send(
-                sender=HeldSeriesPass,
-                user=staff_user,
-                notification_type=NotificationType.SERIES_PASS_PURCHASED,
-                context=staff_context,
-            )
+    notify_org_staff(
+        organization_id=held_pass.series_pass.event_series.organization_id,
+        notification_type=NotificationType.SERIES_PASS_PURCHASED,
+        context=staff_context,
+        sender=HeldSeriesPass,
+    )
 
 
 def send_series_pass_extended(held_pass_id: UUID, event_ids: list[UUID]) -> None:
@@ -160,13 +156,9 @@ def send_series_pass_cancelled(held_pass_id: UUID, refunded_total: Decimal, canc
         "holder_name": held_pass.user.get_display_name(),
         "holder_email": held_pass.user.email,
     }
-    organization_id = held_pass.series_pass.event_series.organization_id
-    staff_and_owners = get_staff_for_notification(organization_id, NotificationType.SERIES_PASS_CANCELLED)
-    for staff_user in staff_and_owners:
-        if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.SERIES_PASS_CANCELLED):
-            notification_requested.send(
-                sender=HeldSeriesPass,
-                user=staff_user,
-                notification_type=NotificationType.SERIES_PASS_CANCELLED,
-                context=staff_context,
-            )
+    notify_org_staff(
+        organization_id=held_pass.series_pass.event_series.organization_id,
+        notification_type=NotificationType.SERIES_PASS_CANCELLED,
+        context=staff_context,
+        sender=HeldSeriesPass,
+    )

--- a/src/notifications/signals/ticket.py
+++ b/src/notifications/signals/ticket.py
@@ -11,7 +11,7 @@ from common.models import SiteSettings
 from events.models import Event, Ticket, TicketTier
 from notifications.enums import NotificationType
 from notifications.service.eligibility import get_staff_for_notification
-from notifications.service.notification_helpers import format_event_datetime
+from notifications.service.notification_helpers import format_event_datetime, notify_org_staff
 from notifications.signals import notification_requested
 
 logger = structlog.get_logger(__name__)
@@ -131,17 +131,6 @@ def _build_ticket_updated_context(ticket: Ticket, old_status: str) -> dict[str, 
     }
 
 
-def _build_ticket_refunded_context(ticket: Ticket, refund_amount: str | None = None) -> dict[str, t.Any]:
-    """Build notification context for TICKET_REFUNDED."""
-    return {
-        "ticket_id": str(ticket.id),
-        "ticket_reference": str(ticket.id),
-        "event_id": str(ticket.event.id),
-        "event_name": ticket.event.name,
-        "refund_amount": refund_amount or str(ticket.tier.price),
-    }
-
-
 def _send_ticket_created_notifications(ticket: Ticket) -> None:
     """Send notifications for newly created ticket.
 
@@ -179,15 +168,12 @@ def _send_ticket_created_notifications(ticket: Ticket) -> None:
         "include_ics": False,
         "include_pkpass": False,
     }
-    staff_and_owners = get_staff_for_notification(ticket.event.organization_id, NotificationType.TICKET_CREATED)
-    for staff_user in staff_and_owners:
-        if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.TICKET_CREATED):
-            notification_requested.send(
-                sender=Ticket,
-                user=staff_user,
-                notification_type=NotificationType.TICKET_CREATED,
-                context=staff_context,
-            )
+    notify_org_staff(
+        organization_id=ticket.event.organization_id,
+        notification_type=NotificationType.TICKET_CREATED,
+        context=staff_context,
+        sender=Ticket,
+    )
 
 
 def send_batch_ticket_created_notifications(tickets: list[Ticket]) -> None:
@@ -290,14 +276,14 @@ def send_batch_ticket_created_notifications(tickets: list[Ticket]) -> None:
             "include_ics": False,
             "include_pkpass": False,
         }
-        for staff_user in staff_and_owners:
-            if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.TICKET_CREATED):
-                notification_requested.send(
-                    sender=Ticket,
-                    user=staff_user,
-                    notification_type=NotificationType.TICKET_CREATED,
-                    context=staff_context,
-                )
+        notify_org_staff(
+            organization_id=event.organization_id,
+            notification_type=NotificationType.TICKET_CREATED,
+            context=staff_context,
+            sender=Ticket,
+            # Reuse the list hoisted above: one staff query for the whole batch.
+            recipients=staff_and_owners,
+        )
 
 
 def _send_ticket_activated_notification(ticket: Ticket, old_status: str) -> None:
@@ -357,53 +343,12 @@ def _send_ticket_cancelled_notifications(ticket: Ticket, old_status: str) -> Non
         "ticket_holder_name": ticket.user.get_display_name(),
         "ticket_holder_email": ticket.user.email,
     }
-    staff_and_owners = get_staff_for_notification(ticket.event.organization_id, NotificationType.TICKET_CANCELLED)
-    for staff_user in staff_and_owners:
-        if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.TICKET_CANCELLED):
-            notification_requested.send(
-                sender=Ticket,
-                user=staff_user,
-                notification_type=NotificationType.TICKET_CANCELLED,
-                context=staff_context,
-            )
-
-
-def _send_ticket_refunded_notifications(ticket: Ticket) -> None:
-    """Send notifications when ticket is refunded.
-
-    Notifies both the ticket holder and organization staff/owners about the refund.
-    Includes refund amount from ticket._refund_amount if available.
-
-    Args:
-        ticket: The ticket being refunded
-    """
-    # Add refund amount if available
-    refund_amount_value = getattr(ticket, "_refund_amount", None)
-    context = _build_ticket_refunded_context(ticket, refund_amount_value)
-
-    # Notify ticket holder
-    notification_requested.send(
+    notify_org_staff(
+        organization_id=ticket.event.organization_id,
+        notification_type=NotificationType.TICKET_CANCELLED,
+        context=staff_context,
         sender=Ticket,
-        user=ticket.user,
-        notification_type=NotificationType.TICKET_REFUNDED,
-        context=context,
     )
-
-    # Notify staff/owners with additional context
-    staff_context = {
-        **context,
-        "ticket_holder_name": ticket.user.get_display_name(),
-        "ticket_holder_email": ticket.user.email,
-    }
-    staff_and_owners = get_staff_for_notification(ticket.event.organization_id, NotificationType.TICKET_REFUNDED)
-    for staff_user in staff_and_owners:
-        if staff_user.notification_preferences.is_notification_type_enabled(NotificationType.TICKET_REFUNDED):
-            notification_requested.send(
-                sender=Ticket,
-                user=staff_user,
-                notification_type=NotificationType.TICKET_REFUNDED,
-                context=staff_context,
-            )
 
 
 def _handle_ticket_status_change(ticket: Ticket, old_status: str | None) -> None:
@@ -425,16 +370,12 @@ def _handle_ticket_status_change(ticket: Ticket, old_status: str | None) -> None
                 "include_ics": False,
                 "include_pkpass": False,
             }
-            staff_and_owners = get_staff_for_notification(ticket.event.organization_id, NotificationType.TICKET_CREATED)
-            for staff_user in list(staff_and_owners):
-                prefs = getattr(staff_user, "notification_preferences", None)
-                if prefs and prefs.is_notification_type_enabled(NotificationType.TICKET_CREATED):
-                    notification_requested.send(
-                        sender=Ticket,
-                        user=staff_user,
-                        notification_type=NotificationType.TICKET_CREATED,
-                        context=staff_context,
-                    )
+            notify_org_staff(
+                organization_id=ticket.event.organization_id,
+                notification_type=NotificationType.TICKET_CREATED,
+                context=staff_context,
+                sender=Ticket,
+            )
     elif ticket.status == Ticket.TicketStatus.CANCELLED:
         # TICKET_CANCELLED fires for every cancellation. When a Stripe refund is
         # involved, the cancellation_service / Stripe webhook handler set

--- a/src/notifications/tests/test_contact_message_signal.py
+++ b/src/notifications/tests/test_contact_message_signal.py
@@ -35,7 +35,7 @@ def test_default_channels_are_in_app_and_telegram() -> None:
 
 
 @patch("events.tasks.send_organization_contact_message_email.delay")
-@patch("notifications.signals.contact.notification_requested.send")
+@patch("notifications.signals.notification_requested.send")
 def test_signal_dispatches_to_owner_and_edit_org_staff(
     mock_signal: MagicMock,
     mock_email: MagicMock,
@@ -87,7 +87,7 @@ def test_signal_dispatches_to_owner_and_edit_org_staff(
 
 
 @patch("events.tasks.send_organization_contact_message_email.delay")
-@patch("notifications.signals.contact.notification_requested.send")
+@patch("notifications.signals.notification_requested.send")
 def test_signal_does_not_fire_on_update(
     mock_signal: MagicMock,
     mock_email: MagicMock,

--- a/src/notifications/tests/test_notification_helpers.py
+++ b/src/notifications/tests/test_notification_helpers.py
@@ -1,14 +1,18 @@
 """Tests for notification helper functions."""
 
+import typing as t
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
 from django.contrib.gis.geos import Point
 
+from accounts.models import RevelUser
+from events.models import Organization, OrganizationStaff, Ticket
 from geo.models import City
-from notifications.service.notification_helpers import format_event_datetime, get_event_timezone
+from notifications.enums import NotificationType
+from notifications.service.notification_helpers import format_event_datetime, get_event_timezone, notify_org_staff
 
 
 @pytest.fixture
@@ -220,3 +224,82 @@ class TestGetFormattedContextForTemplate:
         assert result["event_start_formatted"] == "Friday, February 6, 2026 at 6:00 PM CET"
         # Short format should NOT be added (would have wrong timezone)
         assert "event_start_short" not in result
+
+
+@pytest.mark.django_db
+class TestNotifyOrgStaff:
+    """Tests for the shared org-staff fan-out helper."""
+
+    def _disable(self, staff_user: RevelUser, notification_type: NotificationType) -> None:
+        prefs = staff_user.notification_preferences
+        prefs.notification_type_settings[notification_type] = {"enabled": False}
+        prefs.save(update_fields=["notification_type_settings"])
+
+    def test_notifies_staff_with_the_type_enabled(self, organization: Organization) -> None:
+        """The owner receives the notification and the helper reports one recipient."""
+        with patch("notifications.signals.notification_requested.send") as send_mock:
+            notified = notify_org_staff(
+                organization_id=organization.id,
+                notification_type=NotificationType.TICKET_CREATED,
+                context={"ticket_id": "abc"},
+                sender=Ticket,
+            )
+
+        assert notified == 1
+        send_mock.assert_called_once_with(
+            sender=Ticket,
+            user=organization.owner,
+            notification_type=NotificationType.TICKET_CREATED,
+            context={"ticket_id": "abc"},
+        )
+
+    def test_skips_staff_who_disabled_the_type(self, organization: Organization) -> None:
+        """A staff member who turned the type off is silently skipped."""
+        self._disable(organization.owner, NotificationType.TICKET_CREATED)
+
+        with patch("notifications.signals.notification_requested.send") as send_mock:
+            notified = notify_org_staff(
+                organization_id=organization.id,
+                notification_type=NotificationType.TICKET_CREATED,
+                context={"ticket_id": "abc"},
+                sender=Ticket,
+            )
+
+        assert notified == 0
+        send_mock.assert_not_called()
+
+    def test_reuses_supplied_recipients_without_querying(
+        self, organization: Organization, django_assert_num_queries: t.Any
+    ) -> None:
+        """Passing ``recipients`` skips the staff lookup so batch loops keep one query."""
+        recipients = [organization.owner]
+
+        with patch("notifications.signals.notification_requested.send") as send_mock:
+            with django_assert_num_queries(0):
+                notified = notify_org_staff(
+                    organization_id=organization.id,
+                    notification_type=NotificationType.TICKET_CREATED,
+                    context={"ticket_id": "abc"},
+                    sender=Ticket,
+                    recipients=recipients,
+                )
+
+        assert notified == 1
+        assert send_mock.call_args.kwargs["user"] == organization.owner
+
+    def test_returns_the_number_notified(self, organization: Organization, member_user: RevelUser) -> None:
+        """The return value counts only the staff who actually got the notification."""
+        OrganizationStaff.objects.create(organization=organization, user=member_user)
+        self._disable(member_user, NotificationType.TICKET_CREATED)
+
+        with patch("notifications.signals.notification_requested.send") as send_mock:
+            notified = notify_org_staff(
+                organization_id=organization.id,
+                notification_type=NotificationType.TICKET_CREATED,
+                context={"ticket_id": "abc"},
+                sender=Ticket,
+            )
+
+        assert notified == 1
+        assert send_mock.call_count == 1
+        assert send_mock.call_args.kwargs["user"] == organization.owner

--- a/src/notifications/tests/test_signals.py
+++ b/src/notifications/tests/test_signals.py
@@ -770,3 +770,42 @@ class TestEventCancelledNotificationReason:
         notifications = Notification.objects.filter(user=user, notification_type=NotificationType.EVENT_CANCELLED)
         assert notifications.count() == 1, "context failed schema validation and was swallowed"
         assert notifications.get().context["refund_available"] is True
+
+
+@pytest.mark.django_db(transaction=True)
+class TestStaffNotificationPreferenceGate:
+    """Staff fan-out must respect the recipient's per-type preference.
+
+    Uses transaction=True because the ticket notifications fire from an
+    ``on_commit`` callback, which pytest-django's rollback would otherwise
+    never run.
+    """
+
+    def test_staff_who_disabled_ticket_created_is_not_notified(
+        self, public_event: t.Any, organization: Organization, member_user: RevelUser
+    ) -> None:
+        prefs = organization.owner.notification_preferences
+        prefs.notification_type_settings[NotificationType.TICKET_CREATED] = {"enabled": False}
+        prefs.save(update_fields=["notification_type_settings"])
+
+        tier = TicketTier.objects.create(
+            event=public_event,
+            name="Staff Gate Tier",
+            price=Decimal("0.00"),
+            currency="EUR",
+            payment_method=TicketTier.PaymentMethod.FREE,
+        )
+
+        with patch("notifications.signals.ticket.notification_requested.send") as send_mock:
+            with transaction.atomic():
+                Ticket.objects.create(
+                    event=public_event,
+                    tier=tier,
+                    user=member_user,
+                    status=Ticket.TicketStatus.ACTIVE,
+                    guest_name=member_user.get_display_name(),
+                )
+
+        notified_users = [call.kwargs["user"] for call in send_mock.call_args_list]
+        assert member_user in notified_users, "the ticket holder must still be notified"
+        assert organization.owner not in notified_users

--- a/src/notifications/tests/test_staff_preference_gate.py
+++ b/src/notifications/tests/test_staff_preference_gate.py
@@ -1,0 +1,121 @@
+"""Staff fan-outs must honour the recipient's per-type notification preference.
+
+Regression for the staff fan-outs that looped over ``get_staff_for_notification``
+and sent unconditionally: a staff member who switched the notification type off
+still received every one of them. The ticket/payment/series-pass fan-outs always
+gated on the preference; these did not.
+"""
+
+import typing as t
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from accounts.models import RevelUser
+from events.models import (
+    Event,
+    EventInvitationRequest,
+    Organization,
+    OrganizationContactMessage,
+    OrganizationMembershipRequest,
+    OrganizationQuestionnaire,
+)
+from notifications.enums import NotificationType
+from questionnaires.models import Questionnaire, QuestionnaireSubmission
+
+pytestmark = pytest.mark.django_db
+
+
+def _set_enabled(user: RevelUser, notification_type: NotificationType, enabled: bool) -> None:
+    """Turn one notification type on or off for a user."""
+    prefs = user.notification_preferences
+    prefs.notification_type_settings[notification_type] = {"enabled": enabled}
+    prefs.save(update_fields=["notification_type_settings"])
+
+
+def _was_notified(send_mock: MagicMock, notification_type: NotificationType, user: RevelUser) -> bool:
+    """Whether ``user`` received ``notification_type`` on the patched signal."""
+    return any(
+        call.kwargs.get("notification_type") == notification_type and call.kwargs.get("user") == user
+        for call in send_mock.call_args_list
+    )
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_membership_request_respects_staff_preference(
+    organization: Organization,
+    member_user: RevelUser,
+    django_capture_on_commit_callbacks: t.Any,
+    enabled: bool,
+) -> None:
+    """MEMBERSHIP_REQUEST_CREATED reaches the owner only while they have it enabled."""
+    _set_enabled(organization.owner, NotificationType.MEMBERSHIP_REQUEST_CREATED, enabled)
+
+    with patch("notifications.signals.notification_requested.send") as send_mock:
+        with django_capture_on_commit_callbacks(execute=True):
+            OrganizationMembershipRequest.objects.create(organization=organization, user=member_user)
+
+    assert _was_notified(send_mock, NotificationType.MEMBERSHIP_REQUEST_CREATED, organization.owner) is enabled
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_invitation_request_respects_staff_preference(
+    organization: Organization,
+    public_event: Event,
+    member_user: RevelUser,
+    django_capture_on_commit_callbacks: t.Any,
+    enabled: bool,
+) -> None:
+    """INVITATION_REQUEST_CREATED reaches the owner only while they have it enabled."""
+    _set_enabled(organization.owner, NotificationType.INVITATION_REQUEST_CREATED, enabled)
+
+    with patch("notifications.signals.notification_requested.send") as send_mock:
+        with django_capture_on_commit_callbacks(execute=True):
+            EventInvitationRequest.objects.create(event=public_event, user=member_user)
+
+    assert _was_notified(send_mock, NotificationType.INVITATION_REQUEST_CREATED, organization.owner) is enabled
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_questionnaire_submission_respects_staff_preference(
+    organization: Organization,
+    member_user: RevelUser,
+    django_capture_on_commit_callbacks: t.Any,
+    enabled: bool,
+) -> None:
+    """QUESTIONNAIRE_SUBMITTED reaches the owner only while they have it enabled."""
+    _set_enabled(organization.owner, NotificationType.QUESTIONNAIRE_SUBMITTED, enabled)
+    questionnaire = Questionnaire.objects.create(name="Gate Questionnaire", min_score=0)
+    OrganizationQuestionnaire.objects.create(organization=organization, questionnaire=questionnaire)
+
+    with patch("notifications.signals.notification_requested.send") as send_mock:
+        with django_capture_on_commit_callbacks(execute=True):
+            QuestionnaireSubmission.objects.create(questionnaire=questionnaire, user=member_user)
+
+    assert _was_notified(send_mock, NotificationType.QUESTIONNAIRE_SUBMITTED, organization.owner) is enabled
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_contact_message_respects_staff_preference(
+    organization: Organization,
+    member_user: RevelUser,
+    django_capture_on_commit_callbacks: t.Any,
+    enabled: bool,
+) -> None:
+    """ORG_CONTACT_MESSAGE_RECEIVED reaches the owner only while they have it enabled."""
+    _set_enabled(organization.owner, NotificationType.ORG_CONTACT_MESSAGE_RECEIVED, enabled)
+
+    with (
+        patch("events.tasks.send_organization_contact_message_email.delay"),
+        patch("notifications.signals.notification_requested.send") as send_mock,
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            OrganizationContactMessage.objects.create(
+                organization=organization,
+                sender=member_user,
+                sender_email_snapshot=member_user.email,
+                subject="Gate check",
+                message="Hello there",
+            )
+
+    assert _was_notified(send_mock, NotificationType.ORG_CONTACT_MESSAGE_RECEIVED, organization.owner) is enabled


### PR DESCRIPTION
Tech-debt sweep finding 22.

Deduplication (no behaviour change):

Nine staff-facing notifications repeated the same block: resolve the org's
staff via get_staff_for_notification, loop, check the recipient's per-type
NotificationPreference, send notification_requested. Two variants of the
preference check had drifted apart (direct attribute access vs a
getattr(..., None) guard whose None branch is unreachable: a preference row
is get_or_created on every RevelUser post_save and was backfilled by
migration 0002).

Collapse all nine onto notify_org_staff() in notification_helpers, which
returns the number notified so the call sites that log recipient_count keep
doing so. The batch ticket path passes its hoisted staff list through
`recipients=` so it still issues one staff query per cart rather than one per
ticket. `sender=` stays a pass-through (it is only used for logging).

Also delete _send_ticket_refunded_notifications and its context builder: both
have had zero references since TICKET_REFUNDED moved to the Payment signal.

Preference gate on seven more fan-outs (BEHAVIOUR CHANGE):

Seven sibling fan-outs looped over get_staff_for_notification and sent
unconditionally: a staff member who switched the type off in their
notification preferences still received every one of them. They now go
through notify_org_staff too, so those preferences are finally honoured:

  MEMBERSHIP_REQUEST_CREATED      notifications/signals/membership.py
  INVITATION_REQUEST_CREATED      notifications/signals/invitation.py
  QUESTIONNAIRE_SUBMITTED         notifications/signals/questionnaire.py
  ORG_CONTACT_MESSAGE_RECEIVED    notifications/signals/contact.py
  ORGANIZATION_FOLLOWED           events/service/follow_service.py
  EVENT_SERIES_FOLLOWED           events/service/follow_service.py
  WHITELIST_REQUEST_CREATED       events/service/whitelist_service.py

Staff who never touched their preferences are unaffected (types default to
enabled); only an explicit opt-out now takes effect. The four recipient_count
log fields on these paths change from "eligible staff" to "staff notified".
Note that the three *_REQUEST_CREATED types announce inbound work queues; if
those should never be silenceable, that belongs at the preference layer.

Removing the now-unused notification_requested import from three modules
retargets 14 test patches onto the shared signal object (same singleton, and
the asserting tests already filter by notification_type).

Tests: unit tests for the helper (gate on/off, recipients reuse, return
count), a signal-level TICKET_CREATED gate test, and parametrised
enabled/disabled gate tests for all seven newly gated sites.

**Behaviour change:** seven more staff fan-outs now honour notification preferences. Three of them (membership, invitation, whitelist requests) announce inbound work queues; if those should never be silenceable, that belongs at the preference layer, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
