### PR TITLE
refactor(common): move file-upload helpers out of utils into a service module

### DIFF
--- a/src/accounts/controllers/account.py
+++ b/src/accounts/controllers/account.py
@@ -20,9 +20,9 @@ from accounts.service.auth import get_token_pair_for_user
 from common.authentication import I18nJWTAuth
 from common.controllers.base import UserAwareController
 from common.schema import EmailSchema, ErrorDetail, ResponseMessage
+from common.service.upload_service import safe_save_uploaded_file
 from common.throttling import UserDataExportThrottle, UserRegistrationThrottle, WriteThrottle
 from common.thumbnails.service import delete_image_with_derivatives
-from common.utils import safe_save_uploaded_file
 from revel.oidc_config import KEY_PATTERN
 
 

--- a/src/accounts/service/oidc.py
+++ b/src/accounts/service/oidc.py
@@ -38,7 +38,8 @@ from accounts.jwt import blacklist as blacklist_token
 from accounts.jwt import check_blacklist, consume_one_shot_token, create_oidc_login_token, validate_oidc_login_token
 from accounts.models import ExternalIdentity, RevelUser
 from common.models import SiteSettings
-from common.utils import get_or_create_with_race_protection, safe_save_uploaded_file
+from common.service.upload_service import safe_save_uploaded_file
+from common.utils import get_or_create_with_race_protection
 from revel.oidc_config import OIDCProviderConfig
 
 logger = structlog.get_logger(__name__)

--- a/src/common/service/upload_service.py
+++ b/src/common/service/upload_service.py
@@ -1,0 +1,183 @@
+"""File-upload service: validation, audit records, malware scan and thumbnail scheduling.
+
+Lives in the service layer (rather than ``common.utils``) because it depends on
+``common.models`` and ``common.tasks`` at module level, and ``common.models``
+imports ``common.utils`` — keeping these helpers here breaks that cycle.
+"""
+
+import hashlib
+import typing as t
+
+from django.conf import settings
+from django.contrib.auth.models import AbstractUser
+from django.core.exceptions import ValidationError
+from django.core.files import File
+from django.db import models, transaction
+
+from common import tasks
+from common.models import FileUploadAudit
+from common.thumbnails.config import THUMBNAIL_CONFIGS, get_thumbnail_field_names
+from common.thumbnails.tasks import (
+    delete_orphaned_thumbnails_task,
+    generate_thumbnails_task,
+)
+
+T = t.TypeVar("T", bound=models.Model)
+
+
+def create_file_audit_and_scan(
+    *,
+    app: str,
+    model: str,
+    instance_pk: t.Any,
+    field: str,
+    file_hash: str,
+    uploader_email: str,
+) -> None:
+    """Create audit record and schedule malware scan for an uploaded file.
+
+    This helper consolidates the audit + scan logic used by both:
+    - safe_save_uploaded_file (for replacing files on existing models)
+    - questionnaire file uploads (for user file libraries)
+
+    Args:
+        app: Django app label (e.g., "events", "questionnaires")
+        model: Model name (e.g., "organization", "questionnairefile")
+        instance_pk: Primary key of the model instance
+        field: Field name containing the file
+        file_hash: SHA-256 hash of the file content
+        uploader_email: Email of the user who uploaded the file
+
+    When ``FEATURE_MALWARE_SCAN`` is disabled the file is recorded as ``CLEAN``
+    immediately and no ClamAV scan is dispatched (self-host without an AV daemon).
+    """
+    audit = FileUploadAudit.objects.create(
+        app=app,
+        model=model,
+        instance_pk=instance_pk,
+        field=field,
+        file_hash=file_hash,
+        uploader=uploader_email,
+    )
+    if not settings.FEATURE_MALWARE_SCAN:
+        audit.status = FileUploadAudit.FileUploadAuditStatus.CLEAN
+        audit.save(update_fields=["status", "updated_at"])
+        return
+    transaction.on_commit(lambda: tasks.scan_for_malware.delay(app=app, model=model, pk=str(instance_pk), field=field))
+
+
+def _validate_file_field(instance: models.Model, field_name: str, file: File) -> None:  # type: ignore[type-arg]
+    """Run validators for a file field before saving.
+
+    Retrieves validators from the model field definition and runs them
+    against the uploaded file. This ensures validation errors are raised
+    BEFORE the model's save() method attempts EXIF stripping.
+
+    Args:
+        instance: The model instance being saved
+        field_name: Name of the file field
+        file: The uploaded file to validate
+
+    Raises:
+        ValidationError: If any validator fails, with errors keyed by field name.
+            This is caught by the API exception handler and returned as 400.
+    """
+    model_field = instance._meta.get_field(field_name)
+    errors: list[str] = []
+    # File fields are always Field instances with validators (not ForeignObjectRel/GenericForeignKey)
+    for validator in model_field.validators:  # type: ignore[union-attr]
+        try:
+            validator(file)
+        except ValidationError as e:
+            errors.extend(e.messages)
+    if errors:
+        raise ValidationError({field_name: errors})
+
+
+@transaction.atomic
+def safe_save_uploaded_file(
+    *,
+    instance: T,
+    field: str,
+    file: File,  # type: ignore[type-arg]
+    uploader: AbstractUser,
+) -> T:
+    """Safely save an uploaded file passing it to malware scan.
+
+    Validates the file against field validators before saving.
+    Deletes the old file if one exists before saving the new file.
+    Schedules thumbnail generation for image files.
+
+    Raises:
+        ValidationError: If file validation fails (returned as 400 by API).
+    """
+    # Validate BEFORE setting the file or saving
+    _validate_file_field(instance, field, file)
+
+    app = instance._meta.app_label
+    model = t.cast(str, instance._meta.model_name)
+    config_key = (app, model, field)
+    config = THUMBNAIL_CONFIGS.get(config_key)
+
+    # Collect old thumbnail paths for deletion
+    old_thumbnail_paths: list[str] = []
+    thumbnail_field_names: list[str] = []
+    if config:
+        thumbnail_field_names = get_thumbnail_field_names(config)
+        for thumb_field in thumbnail_field_names:
+            if hasattr(instance, thumb_field):
+                thumb_file = getattr(instance, thumb_field, None)
+                # ImageField returns an ImageFieldFile - get path via .name
+                if thumb_file and hasattr(thumb_file, "name") and thumb_file.name:
+                    old_thumbnail_paths.append(thumb_file.name)
+                # Clear the field (None for ImageField)
+                setattr(instance, thumb_field, None)
+
+    # Delete old file if it exists
+    old_file = getattr(instance, field)
+    if old_file:
+        old_file.delete(save=False)
+
+    # Schedule deletion of old thumbnails
+    if old_thumbnail_paths:
+        transaction.on_commit(lambda: delete_orphaned_thumbnails_task.delay(thumbnail_paths=old_thumbnail_paths))
+
+    setattr(instance, field, file)
+
+    # Determine which fields to update
+    update_fields = [field] + thumbnail_field_names
+
+    instance.save(update_fields=update_fields)
+    # Refresh from DB to get the actual storage path (not the original filename)
+    # We refresh the entire instance to ensure all file field attributes are updated
+    instance.refresh_from_db()
+    file_field = getattr(instance, field)
+    file_field.open()
+    # NOTE: Race condition possible if user uploads twice in rapid succession.
+    # File A upload: deletes old thumbnails async, schedules thumbnail generation
+    # File B upload (before A's thumbnails exist): deletes nothing, schedules generation
+    # Result: A's thumbnails may be orphaned. Accepted risk - orphaned files are harmless
+    # and a cleanup task can handle them periodically if needed.
+    file_hash = hashlib.sha256(file_field.read()).hexdigest()
+    file_field.seek(0)
+    create_file_audit_and_scan(
+        app=app,
+        model=model,
+        instance_pk=instance.pk,
+        field=field,
+        file_hash=file_hash,
+        uploader_email=uploader.email,
+    )
+
+    # Schedule thumbnail generation if configured for this model/field
+    if config:
+        transaction.on_commit(
+            lambda: generate_thumbnails_task.delay(
+                app=app,
+                model=model,
+                pk=str(instance.pk),
+                field=field,
+            )
+        )
+
+    return instance

--- a/src/common/tests/test_feature_malware_scan.py
+++ b/src/common/tests/test_feature_malware_scan.py
@@ -4,16 +4,17 @@ from unittest import mock
 
 import pytest
 
-from common import tasks, utils
+from common import tasks
 from common.models import FileUploadAudit
+from common.service import upload_service
 
 
 @pytest.mark.django_db
 def test_scan_dispatched_when_flag_on(settings: t.Any, django_capture_on_commit_callbacks: t.Any) -> None:
     settings.FEATURE_MALWARE_SCAN = True
-    with mock.patch("common.utils.tasks.scan_for_malware.delay") as delay:
+    with mock.patch("common.service.upload_service.tasks.scan_for_malware.delay") as delay:
         with django_capture_on_commit_callbacks(execute=True):
-            utils.create_file_audit_and_scan(
+            upload_service.create_file_audit_and_scan(
                 app="events",
                 model="organization",
                 instance_pk=uuid.uuid4(),
@@ -29,8 +30,8 @@ def test_scan_dispatched_when_flag_on(settings: t.Any, django_capture_on_commit_
 @pytest.mark.django_db
 def test_scan_skipped_and_audit_clean_when_flag_off(settings: t.Any) -> None:
     settings.FEATURE_MALWARE_SCAN = False
-    with mock.patch("common.utils.tasks.scan_for_malware.delay") as delay:
-        utils.create_file_audit_and_scan(
+    with mock.patch("common.service.upload_service.tasks.scan_for_malware.delay") as delay:
+        upload_service.create_file_audit_and_scan(
             app="events",
             model="organization",
             instance_pk=uuid.uuid4(),

--- a/src/common/tests/test_tasks.py
+++ b/src/common/tests/test_tasks.py
@@ -7,8 +7,8 @@ import pytest
 from django.core.files.base import ContentFile
 
 from common.models import FileUploadAudit, QuarantinedFile
+from common.service.upload_service import safe_save_uploaded_file
 from common.tasks import notify_malware_detected, scan_for_malware
-from common.utils import safe_save_uploaded_file
 from conftest import RevelUserFactory
 from events.models import AdditionalResource, Organization
 

--- a/src/common/tests/test_thumbnails_tasks.py
+++ b/src/common/tests/test_thumbnails_tasks.py
@@ -373,7 +373,7 @@ class TestSafeSaveUploadedFileIntegration:
         """Test that safe_save_uploaded_file schedules thumbnail generation task."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        from common.utils import safe_save_uploaded_file
+        from common.service.upload_service import safe_save_uploaded_file
 
         owner = revel_user_factory()
         org = Organization.objects.create(name="Test Org", owner=owner)
@@ -412,7 +412,7 @@ class TestSafeSaveUploadedFileIntegration:
         """Test that safe_save_uploaded_file clears old thumbnails when replacing file."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        from common.utils import safe_save_uploaded_file
+        from common.service.upload_service import safe_save_uploaded_file
 
         owner = revel_user_factory()
         org = Organization.objects.create(name="Test Org", owner=owner)

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -1,11 +1,8 @@
 import functools
-import hashlib
 import mimetypes
 import typing as t
 from io import BytesIO
 
-from django.conf import settings
-from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -15,10 +12,7 @@ from django.http import HttpResponse
 from PIL import Image
 from pydantic import BaseModel
 
-from common import tasks
 from common.fields import MAX_IMAGE_PIXELS
-
-from .models import FileUploadAudit
 
 # ``Image.info`` keys that carry metadata (EXIF incl. GPS, XMP, JPEG comments). Pillow's
 # built-in encoders only write what is passed to ``save()``, but plugins such as
@@ -200,170 +194,6 @@ def update_db_instance(
     for key, value in data.items():
         setattr(instance, key, value)
     instance.save()
-    return instance
-
-
-def create_file_audit_and_scan(
-    *,
-    app: str,
-    model: str,
-    instance_pk: t.Any,
-    field: str,
-    file_hash: str,
-    uploader_email: str,
-) -> None:
-    """Create audit record and schedule malware scan for an uploaded file.
-
-    This helper consolidates the audit + scan logic used by both:
-    - safe_save_uploaded_file (for replacing files on existing models)
-    - questionnaire file uploads (for user file libraries)
-
-    Args:
-        app: Django app label (e.g., "events", "questionnaires")
-        model: Model name (e.g., "organization", "questionnairefile")
-        instance_pk: Primary key of the model instance
-        field: Field name containing the file
-        file_hash: SHA-256 hash of the file content
-        uploader_email: Email of the user who uploaded the file
-
-    When ``FEATURE_MALWARE_SCAN`` is disabled the file is recorded as ``CLEAN``
-    immediately and no ClamAV scan is dispatched (self-host without an AV daemon).
-    """
-    audit = FileUploadAudit.objects.create(
-        app=app,
-        model=model,
-        instance_pk=instance_pk,
-        field=field,
-        file_hash=file_hash,
-        uploader=uploader_email,
-    )
-    if not settings.FEATURE_MALWARE_SCAN:
-        audit.status = FileUploadAudit.FileUploadAuditStatus.CLEAN
-        audit.save(update_fields=["status", "updated_at"])
-        return
-    transaction.on_commit(lambda: tasks.scan_for_malware.delay(app=app, model=model, pk=str(instance_pk), field=field))
-
-
-def _validate_file_field(instance: models.Model, field_name: str, file: File) -> None:  # type: ignore[type-arg]
-    """Run validators for a file field before saving.
-
-    Retrieves validators from the model field definition and runs them
-    against the uploaded file. This ensures validation errors are raised
-    BEFORE the model's save() method attempts EXIF stripping.
-
-    Args:
-        instance: The model instance being saved
-        field_name: Name of the file field
-        file: The uploaded file to validate
-
-    Raises:
-        ValidationError: If any validator fails, with errors keyed by field name.
-            This is caught by the API exception handler and returned as 400.
-    """
-    model_field = instance._meta.get_field(field_name)
-    errors: list[str] = []
-    # File fields are always Field instances with validators (not ForeignObjectRel/GenericForeignKey)
-    for validator in model_field.validators:  # type: ignore[union-attr]
-        try:
-            validator(file)
-        except ValidationError as e:
-            errors.extend(e.messages)
-    if errors:
-        raise ValidationError({field_name: errors})
-
-
-@transaction.atomic
-def safe_save_uploaded_file(
-    *,
-    instance: T,
-    field: str,
-    file: File,  # type: ignore[type-arg]
-    uploader: AbstractUser,
-) -> T:
-    """Safely save an uploaded file passing it to malware scan.
-
-    Validates the file against field validators before saving.
-    Deletes the old file if one exists before saving the new file.
-    Schedules thumbnail generation for image files.
-
-    Raises:
-        ValidationError: If file validation fails (returned as 400 by API).
-    """
-    from common.thumbnails.config import THUMBNAIL_CONFIGS, get_thumbnail_field_names
-    from common.thumbnails.tasks import (
-        delete_orphaned_thumbnails_task,
-        generate_thumbnails_task,
-    )
-
-    # Validate BEFORE setting the file or saving
-    _validate_file_field(instance, field, file)
-
-    app = instance._meta.app_label
-    model = t.cast(str, instance._meta.model_name)
-    config_key = (app, model, field)
-    config = THUMBNAIL_CONFIGS.get(config_key)
-
-    # Collect old thumbnail paths for deletion
-    old_thumbnail_paths: list[str] = []
-    thumbnail_field_names: list[str] = []
-    if config:
-        thumbnail_field_names = get_thumbnail_field_names(config)
-        for thumb_field in thumbnail_field_names:
-            if hasattr(instance, thumb_field):
-                thumb_file = getattr(instance, thumb_field, None)
-                # ImageField returns an ImageFieldFile - get path via .name
-                if thumb_file and hasattr(thumb_file, "name") and thumb_file.name:
-                    old_thumbnail_paths.append(thumb_file.name)
-                # Clear the field (None for ImageField)
-                setattr(instance, thumb_field, None)
-
-    # Delete old file if it exists
-    old_file = getattr(instance, field)
-    if old_file:
-        old_file.delete(save=False)
-
-    # Schedule deletion of old thumbnails
-    if old_thumbnail_paths:
-        transaction.on_commit(lambda: delete_orphaned_thumbnails_task.delay(thumbnail_paths=old_thumbnail_paths))
-
-    setattr(instance, field, file)
-
-    # Determine which fields to update
-    update_fields = [field] + thumbnail_field_names
-
-    instance.save(update_fields=update_fields)
-    # Refresh from DB to get the actual storage path (not the original filename)
-    # We refresh the entire instance to ensure all file field attributes are updated
-    instance.refresh_from_db()
-    file_field = getattr(instance, field)
-    file_field.open()
-    # NOTE: Race condition possible if user uploads twice in rapid succession.
-    # File A upload: deletes old thumbnails async, schedules thumbnail generation
-    # File B upload (before A's thumbnails exist): deletes nothing, schedules generation
-    # Result: A's thumbnails may be orphaned. Accepted risk - orphaned files are harmless
-    # and a cleanup task can handle them periodically if needed.
-    file_hash = hashlib.sha256(file_field.read()).hexdigest()
-    file_field.seek(0)
-    create_file_audit_and_scan(
-        app=app,
-        model=model,
-        instance_pk=instance.pk,
-        field=field,
-        file_hash=file_hash,
-        uploader_email=uploader.email,
-    )
-
-    # Schedule thumbnail generation if configured for this model/field
-    if config:
-        transaction.on_commit(
-            lambda: generate_thumbnails_task.delay(
-                app=app,
-                model=model,
-                pk=str(instance.pk),
-                field=field,
-            )
-        )
-
     return instance
 
 

--- a/src/events/controllers/event_admin/core.py
+++ b/src/events/controllers/event_admin/core.py
@@ -9,9 +9,9 @@ from ninja_extra import api_controller, route
 from common.authentication import I18nJWTAuth
 from common.models import Tag
 from common.schema import ErrorDetail, TagSchema, ValidationErrorResponse
+from common.service.upload_service import safe_save_uploaded_file
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from common.thumbnails.service import delete_image_with_derivatives
-from common.utils import safe_save_uploaded_file
 from events import models, schema
 from events.controllers.permissions import CanDuplicateEvent, EventPermission
 from events.service import event_service, refund_service

--- a/src/events/controllers/event_series_admin.py
+++ b/src/events/controllers/event_series_admin.py
@@ -10,9 +10,9 @@ from common.authentication import I18nJWTAuth
 from common.controllers import UserAwareController
 from common.models import Tag
 from common.schema import TagSchema, ValidationErrorResponse
+from common.service.upload_service import safe_save_uploaded_file
 from common.throttling import WriteThrottle
 from common.thumbnails.service import delete_image_with_derivatives
-from common.utils import safe_save_uploaded_file
 from events import models, schema
 from events.service import event_series_service, update_db_instance
 

--- a/src/events/controllers/organization_admin/core.py
+++ b/src/events/controllers/organization_admin/core.py
@@ -7,9 +7,9 @@ from ninja_extra import api_controller, route
 from accounts.schema import VerifyEmailSchema
 from common.authentication import I18nJWTAuth
 from common.schema import EmailSchema, ErrorDetail, ValidationErrorResponse
+from common.service.upload_service import safe_save_uploaded_file
 from common.throttling import UserDefaultThrottle, WriteThrottle
 from common.thumbnails.service import delete_image_with_derivatives
-from common.utils import safe_save_uploaded_file
 from events import models, schema
 from events.controllers.permissions import IsOrganizationOwner, IsOrganizationStaff, OrganizationPermission
 from events.service import event_service, organization_service, stripe_service

--- a/src/questionnaires/service/file_service.py
+++ b/src/questionnaires/service/file_service.py
@@ -7,7 +7,8 @@ from django.db import IntegrityError, transaction
 from ninja.files import UploadedFile
 
 from accounts.models import RevelUser
-from common.utils import create_file_audit_and_scan, strip_exif
+from common.service.upload_service import create_file_audit_and_scan
+from common.utils import strip_exif
 
 from ..exceptions import DisallowedMimeTypeError, FileSizeExceededError
 from ..models import QuestionnaireFile

--- a/src/questionnaires/tests/test_file_controller.py
+++ b/src/questionnaires/tests/test_file_controller.py
@@ -197,7 +197,7 @@ class TestUploadFile:
         assert response.status_code == 401
 
     @pytest.mark.django_db(transaction=True)
-    @mock.patch("common.utils.tasks.scan_for_malware")
+    @mock.patch("common.service.upload_service.tasks.scan_for_malware")
     def test_upload_file_triggers_malware_scan(
         self, mock_scan: mock.MagicMock, user_client: Client, user: RevelUser, png_bytes: bytes
     ) -> None:


### PR DESCRIPTION
Tech-debt sweep finding 23.

common/utils.py imported common.tasks and common.models.FileUploadAudit at
module level while common/tasks.py imports common.models back, so
common/models/base.py and common/models/tags.py had to defer their
common.utils imports inside functions to avoid importing a half-initialised
common.models.

Move create_file_audit_and_scan, _validate_file_field and
safe_save_uploaded_file, the sole holders of both offending imports, into a
new common/service/upload_service.py. They belong in the service layer anyway:
they create audit rows, dispatch Celery scans and schedule thumbnails. Their
common.thumbnails imports become module-level there, since the reason for
deferring them is gone.

common/utils.py now imports neither common.models nor common.tasks and keeps
only import-light helpers (strip_exif, the race-protection wrappers,
update_db_instance, serve_image_or_placeholder). No compatibility re-export is
added, since it would recreate the exact module-level edge being deleted, so
every importer is updated, including the three string mock.patch targets that
would otherwise have broken silently.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
