### PR TITLE
fix(cache): give the Django cache its own Redis DB (CACHE_REDIS_DB)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,14 @@ DB_PASSWORD=db-password
 DB_NAME=revel
 DB_PORT=5432
 
-# REDIS (cache + Celery broker)
+# REDIS (cache + Celery broker + aiogram FSM, one instance split by DB index)
 # REDIS_HOST=localhost
 # REDIS_PORT=6379
+# Logical DB indices — keep disjoint; `cache.clear()` is a FLUSHDB on its own index.
+#   CACHE_REDIS_DB=2   Django cache
+#   CELERY_REDIS_DB=0  Celery broker
+#   AIOGRAM_REDIS_DB=1 Telegram bot FSM state
+# CACHE_REDIS_DB=2
 # Per-operation socket timeouts (seconds) for the Django cache client. Bound every
 # cache op so a hung Redis errors out instead of blocking requests indefinitely (#880).
 # REDIS_SOCKET_CONNECT_TIMEOUT=1.0

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -197,6 +197,7 @@ Most external services have safe defaults for local development. Here's what act
 |---------|---------|---------|-------|
 | PostgreSQL | `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_PORT` | `revel`, `db-password`, `revel`, `5432` | Provided by Docker Compose (values from `.env.example`) |
 | Redis | `REDIS_HOST` | `localhost` | Provided by Docker Compose |
+| Redis DB indices | `CACHE_REDIS_DB`, `CELERY_REDIS_DB`, `AIOGRAM_REDIS_DB` | `2`, `0`, `1` | One Redis instance split by logical DB. Keep them disjoint — `cache.clear()` issues a `FLUSHDB` on the cache's index and would wipe anything sharing it |
 | Redis timeouts | `REDIS_SOCKET_CONNECT_TIMEOUT`, `REDIS_SOCKET_TIMEOUT` | `1.0`, `1.0` | Seconds; bound every cache op so a hung Redis errors instead of blocking requests (#880) |
 
 ### Required for specific features

--- a/docs/guides/telegram-bot.md
+++ b/docs/guides/telegram-bot.md
@@ -92,7 +92,7 @@ Superusers can broadcast messages to all bot users via a dedicated FSM flow.
 | `FEATURE_TELEGRAM` | `True` (on) | Master switch for the integration. When off, the OTP-linking endpoints (`/telegram/connect`, `/disconnect`, `/status`, `/botname`) return **404** and the notification dispatcher strips the Telegram channel platform-wide, so **no Telegram notifications are sent**. Key self-hosting toggle for instances running without a bot. |
 | `TELEGRAM_BOT_TOKEN` | `0000000000:AABBCCDD` (placeholder) | Bot token from [@BotFather](https://t.me/BotFather) |
 | `TELEGRAM_OTP_EXPIRATION_MINUTES` | `15` | How long an OTP code is valid for account linking |
-| `AIOGRAM_REDIS_DB` | `1` | Redis database index used for aiogram FSM state |
+| `AIOGRAM_REDIS_DB` | `1` | Redis database index used for aiogram FSM state. The one Redis instance is split by index — `0` Celery broker (`CELERY_REDIS_DB`), `1` aiogram FSM, `2` Django cache (`CACHE_REDIS_DB`). Keep them disjoint: a `FLUSHDB` on one index (which is what `cache.clear()` compiles to) takes out everything sharing it. |
 | `AIOGRAM_FSM_TTL_SECONDS` | `86400` (24h) | TTL on FSM state/data keys. Redis runs with `maxmemory-policy volatile-lru`, which can only evict keys that carry a TTL. A user whose state expires mid-flow simply restarts it. |
 
 Access control is **not** configured via environment variables: broadcast powers come from

--- a/src/revel/settings/base.py
+++ b/src/revel/settings/base.py
@@ -256,11 +256,18 @@ ACCOUNT_OTP_EXPIRATION_MINUTES = config("ACCOUNT_OTP_EXPIRATION_MINUTES", cast=i
 
 REDIS_HOST = config("REDIS_HOST", default="localhost")
 REDIS_PORT = config("REDIS_PORT", cast=int, default=6379)
+# One Redis instance, partitioned by logical DB index. Keep these disjoint — the
+# indices are a namespace, not an isolation boundary, and `cache.clear()` issues a
+# FLUSHDB that would take out whatever else shares the index.
+#   0 → Celery broker (CELERY_REDIS_DB, settings/celery.py)
+#   1 → aiogram FSM state (AIOGRAM_REDIS_DB, settings/telegram.py)
+#   2 → Django cache (below)
+CACHE_REDIS_DB = config("CACHE_REDIS_DB", cast=int, default=2)
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}",
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/{CACHE_REDIS_DB}",
         # Bound every cache op: the default redis-py client has NO timeouts, so a hung
         # (vs refused) Redis would block indefinitely — and the cache sits on every
         # request's hot path via the global throttles (#880). A refused/timed-out op


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Redis caching now uses a dedicated logical database by default.
  - Configure the cache database with `CACHE_REDIS_DB`; it defaults to database `2`.
  - Redis database assignments are documented: Celery uses `0`, aiogram FSM uses `1`, and Django cache uses `2`.
  - Keep these database assignments separate because clearing the cache affects all data in its Redis database.

- **Documentation**
  - Updated setup and troubleshooting guidance to explain Redis database separation and cache-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->