### PR TITLE
chore(questionnaires): remove dead exceptions, with_questions and commented-out validation (tech-debt 38)

### DIFF
--- a/src/questionnaires/README.md
+++ b/src/questionnaires/README.md
@@ -265,7 +265,6 @@ Downloads the prompt injection detection model to `questionnaires/llms/sentinel/
 - `MissingMandatoryAnswerError`: Unanswered required questions
 - `SectionIntegrityError`: Invalid section references
 - `QuestionIntegrityError`: Invalid question references
-- `PromptInjectionDetectedError`: ML-detected injection attempts
 
 ### Validation Rules
 - Mandatory question enforcement

--- a/src/questionnaires/exceptions.py
+++ b/src/questionnaires/exceptions.py
@@ -35,20 +35,8 @@ class SubmissionInDraftError(QuestionnaireException):
     """Raised when a submission is in draft mode and an evaluation is triggered."""
 
 
-class SubmissionDoesNotExistError(QuestionnaireException):
-    """Raised when a submission does not exist."""
-
-
-class PromptInjectionDetectedError(QuestionnaireException):
-    """Raised when prompt injection is detected by the sentinel model."""
-
-
 class CrossQuestionnaireOptionDependencyError(ValidationError):
     """Raised when depends_on_option references an option from a different questionnaire."""
-
-
-class InvalidOptionDependencyOrderError(ValidationError):
-    """Raised when depends_on_option references an option from a question with higher order."""
 
 
 class FileValidationError(QuestionnaireException):

--- a/src/questionnaires/models.py
+++ b/src/questionnaires/models.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import Prefetch
 from django.utils import timezone
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field as PydanticField
@@ -168,25 +167,11 @@ class SubmissionSourceEventMetadata(t.TypedDict):
 class QuestionnaireQueryset(models.QuerySet["Questionnaire"]):
     """Questionnaire queryset."""
 
-    def with_questions(self) -> t.Self:
-        """With questions."""
-        return self.prefetch_related(
-            Prefetch(
-                "multiplechoicequestion_questions", queryset=MultipleChoiceQuestion.objects.prefetch_related("options")
-            ),
-            "freetextquestion_questions",
-            "fileuploadquestion_questions",
-        )
-
 
 class QuestionnaireManager(models.Manager["Questionnaire"]):
     def get_queryset(self) -> QuestionnaireQueryset:
         """Get questionnaire queryset."""
         return QuestionnaireQueryset(self.model)
-
-    def with_questions(self) -> QuestionnaireQueryset:
-        """With questions."""
-        return self.get_queryset().with_questions()
 
 
 class Questionnaire(TimeStampedModel):
@@ -478,11 +463,6 @@ class BaseQuestion(TimeStampedModel):
                 raise exceptions.CrossQuestionnaireOptionDependencyError(
                     {"depends_on_option": "The selected option does not belong to this questionnaire."}
                 )
-            # Ensure the dependency is on a question with lower order
-            # if self.depends_on_option.question.order >= self.order:
-            #     raise exceptions.InvalidOptionDependencyOrderError(
-            #         {"depends_on_option": "Cannot depend on an option from a question with equal or higher order."}
-            #     )
 
     class Meta:
         abstract = True

--- a/src/questionnaires/tests/test_models.py
+++ b/src/questionnaires/tests/test_models.py
@@ -20,7 +20,7 @@ def test_questionnaire_creation_and_manager(questionnaire: Questionnaire) -> Non
     """Test that a Questionnaire can be created successfully."""
     assert questionnaire.pk is not None
     assert questionnaire.name == "Test Questionnaire"
-    assert Questionnaire.objects.with_questions().count() == 1
+    assert Questionnaire.objects.count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Removes four pieces of confirmed dead code from the `questionnaires` app. No behaviour change; net −33 lines.

- **Three never-raised exceptions** dropped from `src/questionnaires/exceptions.py`: `SubmissionDoesNotExistError`, `PromptInjectionDetectedError`, `InvalidOptionDependencyOrderError`. `grep -rn <Name> src` for each shows only the class definition (plus, for `InvalidOptionDependencyOrderError`, the commented-out block below, and for `PromptInjectionDetectedError`, the README bullet below). None is raised, caught, or present in `exception_handlers.HANDLERS`; `exceptions.py` has no `__all__`.
- **Commented-out `clean()` rule** removed from `BaseQuestion.clean()` in `src/questionnaires/models.py` (the disabled "dependency must be on a lower-order question" check referencing `exceptions.InvalidOptionDependencyOrderError`). The live `CrossQuestionnaireSectionError` / `CrossQuestionnaireOptionDependencyError` validation directly above it is untouched.
- **Test-only `with_questions`** removed from both `QuestionnaireQueryset` and `QuestionnaireManager`, along with the now-orphaned `from django.db.models import Prefetch` import (no other `Prefetch` use in the file). `grep -rn with_questions src --include='*.py' | grep -v tests` returns only the two definitions and the manager's delegating call; the sole caller was a count-only assertion in `src/questionnaires/tests/test_models.py`, now `Questionnaire.objects.count() == 1` (the test still asserts pk/name, so it is kept). `poll_with_questions` in `src/polls/tests` is an unrelated fixture name. `QuestionnaireQueryset` is kept as a docstring-only class because `QuestionnaireManager.get_queryset` still returns it, matching the file's existing `MultipleChoiceQuestionQueryset` pattern.
- **README** (`src/questionnaires/README.md`): dropped the "Custom Exceptions" bullet documenting `PromptInjectionDetectedError` as live ("ML-detected injection attempts"). The other two deleted exceptions were not mentioned in the README.

Refs 2026-09-10 tech-debt report finding 38.

## Verification

All run in an isolated worktree on this branch:

- `make format && make lint` — pass (`1585 files left unchanged`, `All checks passed!`)
- `make mypy` — pass (`Success: no issues found in 1339 source files`)
- `make check` — pass (format, lint, mypy, migration-check "No missing migrations", i18n-check, i18n-literals, file-length, task-names all green)
- `DB_NAME=revel_td_c uv run python src/manage.py makemigrations --check --dry-run` — `No changes detected`
- `DB_NAME=revel_td_c uv run pytest src/questionnaires/tests src/polls/tests -q -n 4` — `471 passed, 15 skipped`

No migrations touched; no other apps modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
