### PR TITLE
docs: correct RevelUser.save docstring and integrations provider-seam docstrings (tech-debt 43, 44)

### DIFF
--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -108,7 +108,7 @@ class RevelUser(ExifStripMixin, StripeConnectMixin, AbstractUser):
         ]
 
     def save(self, *args: t.Any, **kwargs: t.Any) -> None:
-        """Override save method to call clean()."""
+        """Normalize the phone number and strip whitespace from name fields before saving."""
         if self.phone_number:
             self.phone_number = normalize_phone_number(self.phone_number)
         for field in ("first_name", "last_name", "preferred_name"):

--- a/src/integrations/enums.py
+++ b/src/integrations/enums.py
@@ -19,7 +19,7 @@ class IntegrationErrorCode(StrEnum):
     STATE_INVALID = "state_invalid"
     ACCOUNT_UNKNOWN = "account_unknown"
     WEBHOOK_REGISTRATION_FAILED = "webhook_registration_failed"
-    # Sync-time codes (spec §9) — declared now so the contract is complete; used from phase 2.
+    # Sync-time codes (spec §9).
     EVENT_PRIVATE = "event_private"
     EVENT_OPEN_ENDED = "event_open_ended"
     EVENT_NO_TICKETS = "event_no_tickets"

--- a/src/integrations/providers/base.py
+++ b/src/integrations/providers/base.py
@@ -1,8 +1,8 @@
 """The provider seam: one Protocol, neutral shapes, no provider JSON above this line.
 
-Spec §3.1–3.2. Phase 1 declares the connection and webhook half of the protocol; Phase 2
-adds the read/write half. The read/write/count methods arrive with phase 2/3 and extend
-this Protocol in place.
+Spec §3.1–3.2. The Protocol covers the whole provider surface: connection/OAuth and
+account discovery, webhook registration and intake, and the read/write/count operations on
+remote events and ticket classes that the sync and reconcile services drive.
 """
 
 import typing as t

--- a/src/integrations/providers/eventbrite/client.py
+++ b/src/integrations/providers/eventbrite/client.py
@@ -91,12 +91,14 @@ def _raise_for(response: httpx.Response) -> None:
 
 
 class EventbriteClient:
-    """Opens a fresh httpx client per call, by design in phase 1.
+    """Opens a fresh httpx client per call.
 
-    One API call per operation; the client is opened and closed around each request rather
-    than pooled across the object's lifetime. Pooling can come with the phase-3 reconcile if
-    call volume justifies it.
+    One API call per operation, so there is nothing to amortise: the client is opened and
+    closed around each request rather than pooled across the object's lifetime.
     """
+
+    # ponytail: no connection pooling. Pool the client (one ``httpx.Client`` per instance or a
+    # module-level pool) if reconcile/sync call volume ever justifies it.
 
     def __init__(self, access_token: str | None = None, *, transport: httpx.BaseTransport | None = None) -> None:
         """Store the credentials for opening a client on each call; ``transport`` swaps in a fake for tests."""

--- a/src/integrations/providers/eventbrite/provider.py
+++ b/src/integrations/providers/eventbrite/provider.py
@@ -1,4 +1,4 @@
-"""Eventbrite implementation of ``ListingProvider`` (connection + webhook half; sync arrives in phase 2)."""
+"""Eventbrite implementation of ``ListingProvider``."""
 
 import re
 import typing as t

--- a/src/integrations/service/webhook_service.py
+++ b/src/integrations/service/webhook_service.py
@@ -1,8 +1,9 @@
 """Inbound webhook intake and dispatch (spec §8).
 
-Phase 1 authenticated by path secret, parsed, and recorded. Phase 3 adds the dispatch: every
-recorded delivery is picked up by a Celery task after commit, resolved against the provider's
-own host, and routed to a counts refresh or the remote-status transition matrix.
+A delivery is authenticated by the connection's path secret, parsed via the provider, and
+recorded as an audit row. After commit a Celery task picks it up, resolves it against the
+provider's own host with the connection's token, and routes it to a debounced counts refresh
+or the remote-status transition matrix.
 """
 
 from uuid import UUID


### PR DESCRIPTION
## Summary

- `RevelUser.save()` docstring claimed it "calls clean()"; it never did — nothing in the MRO (`ExifStripMixin`, `StripeConnectMixin`, `AbstractBaseUser`) calls `clean()`/`full_clean()` from `save()`. It now describes what the method does: normalize the phone number and strip whitespace from the name fields.
- The `integrations` provider seam (`providers/base.py`, `eventbrite/provider.py`, `eventbrite/client.py`, `enums.py`, `service/webhook_service.py`) still narrated the phased rollout of ADR-0017 ("Phase 1 declares…", "arrives in phase 2", "used from phase 2", "Phase 3 adds the dispatch"). All three phases have shipped, so the docstrings now describe the present state in present tense; the fresh-httpx-client-per-call decision in `EventbriteClient` is kept as a standing decision and its ceiling marked with a `# ponytail:` comment (pool the client if call volume justifies it).

Refs 2026-09-10 tech-debt report findings 43, 44.

## Verification

- `make format` — 1585 files left unchanged
- `make lint` — All checks passed
- `make mypy` — Success: no issues found in 1339 source files
- `make check` — pass (migrations, i18n-check, i18n-literals, file-length, task-names)
- `DB_NAME=revel_td_e uv run pytest src/integrations/tests -q -n 4` — 301 passed
- `grep -rn -i "phase" src/integrations --include='*.py' | grep -v tests` — no matches
- `git diff` — docstrings/comments only, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
