### PR TITLE
fix(geo,polls): remove needless .distinct() and fix get_city lookup (tech-debt 40, 41, 42)

### DIFF
--- a/src/geo/controllers/cities.py
+++ b/src/geo/controllers/cities.py
@@ -32,7 +32,7 @@ class CityController(ControllerBase):
         for autocomplete functionality. Useful for setting user location preferences or
         filtering events by location.
         """
-        return filters.filter(self.get_queryset()).distinct()
+        return filters.filter(self.get_queryset())
 
     @route.get("/countries", response=list[str], url_name="list_countries")
     def list_countries(self) -> list[str]:
@@ -50,4 +50,4 @@ class CityController(ControllerBase):
         Returns city details including name, coordinates, and country. Use this to
         get full city information after selecting from a search result.
         """
-        return t.cast(City, self.get_object_or_exception(self.get_queryset(), city_id=city_id))
+        return t.cast(City, self.get_object_or_exception(self.get_queryset(), pk=city_id))

--- a/src/geo/tests/test_controllers.py
+++ b/src/geo/tests/test_controllers.py
@@ -1,6 +1,8 @@
 import pytest
 from django.contrib.gis.geos import Point
+from django.db import connection
 from django.test import Client
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from geo.models import City
@@ -25,10 +27,16 @@ def test_list_cities(client: Client) -> None:
     )
 
     url = reverse("api:list_cities")
-    response = client.get(url)
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url, {"search": "Lon", "country": "GB"})
 
     assert response.status_code == 200
-    assert len(response.json()["results"])
+    assert [c["name"] for c in response.json()["results"]] == ["London"]
+    # City has no relations and the filter/search touch scalar columns only, so no
+    # row can be duplicated: DISTINCT would just force a Unique-over-Sort before LIMIT.
+    city_queries = [q["sql"] for q in ctx.captured_queries if '"geo_city"' in q["sql"]]
+    assert city_queries
+    assert not any("DISTINCT" in sql for sql in city_queries)
 
 
 @pytest.mark.django_db
@@ -42,8 +50,33 @@ def test_get_city(client: Client) -> None:
         location=Point(0.1278, 51.5074),
     )
 
-    url = reverse("api:get_city", kwargs={"city_id": city.city_id})
+    url = reverse("api:get_city", kwargs={"city_id": city.pk})
     response = client.get(url)
 
     assert response.status_code == 200
     assert response.json()["name"] == "London"
+
+
+@pytest.mark.django_db
+def test_get_city_looks_up_by_pk_not_external_city_id(client: Client) -> None:
+    """The detail route must accept the ``id`` exposed by ``CitySchema`` (the pk).
+
+    ``City.city_id`` is the external dataset id; the list endpoint never returns it,
+    so a client following ``id`` from the list would 404 whenever pk != city_id.
+    """
+    city = City.objects.create(
+        name="Vienna",
+        ascii_name="Vienna",
+        country="AT",
+        city_id=987_654_321,
+        location=Point(16.3738, 48.2082),
+    )
+    assert city.pk != city.city_id
+
+    response = client.get(reverse("api:get_city", kwargs={"city_id": city.pk}))
+    assert response.status_code == 200
+    assert response.json()["id"] == city.pk
+
+    assert not City.objects.filter(pk=city.city_id).exists()
+    response = client.get(reverse("api:get_city", kwargs={"city_id": city.city_id}))
+    assert response.status_code == 404

--- a/src/polls/models.py
+++ b/src/polls/models.py
@@ -169,10 +169,11 @@ class PollQuerySet(models.QuerySet["Poll"]):
         # Owners/org staff: everything in their org including DRAFT.
         # Other authenticated users: passes visibility OR has voted; DRAFT hidden.
         # Banned/blacklisted users do not see any poll from those orgs.
-        return (
-            self.filter(is_org_owner_or_staff | ((passes_vis | voted_q) & ~Q(status=Poll.PollStatus.DRAFT)))
-            .exclude(organization_id__in=excluded_org_ids)
-            .distinct()
+        # No DISTINCT: every predicate is an Exists() subquery or the single-valued
+        # organization FK, so rows cannot duplicate (and DISTINCT over the wide select
+        # list is pure planner cost, see #880).
+        return self.filter(is_org_owner_or_staff | ((passes_vis | voted_q) & ~Q(status=Poll.PollStatus.DRAFT))).exclude(
+            organization_id__in=excluded_org_ids
         )
 
 

--- a/src/polls/tests/test_controllers_list.py
+++ b/src/polls/tests/test_controllers_list.py
@@ -396,3 +396,50 @@ def test_detail_query_count_does_not_grow_with_voters(
         f"Detail GET scaled with voter count: {len(ctx_few.captured_queries)} queries "
         f"for 2 voters, {len(ctx_many.captured_queries)} for 10 (delta={delta})."
     )
+
+
+def test_list_poll_matching_several_predicates_appears_once_without_distinct(
+    organization: Organization,
+    questionnaire: Questionnaire,
+    event: t.Any,
+    revel_user_factory: t.Any,
+) -> None:
+    """A poll visible through ticket AND vote at once is listed exactly once, with no DISTINCT.
+
+    ``Poll.objects.for_user`` is built from ``Exists()`` subqueries and a forward FK
+    only, so the list query must not pay for DISTINCT over the wide select list (#880).
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+    from django.utils import timezone
+    from ninja_jwt.tokens import RefreshToken
+
+    from events.models.ticket import Ticket, TicketTier
+    from questionnaires.models import QuestionnaireSubmission
+
+    user = revel_user_factory()
+    tier = TicketTier.objects.create(event=event, name="General")
+    Ticket.objects.create(event=event, tier=tier, user=user, status=Ticket.TicketStatus.ACTIVE)
+    QuestionnaireSubmission.objects.create(
+        user=user,
+        questionnaire=questionnaire,
+        status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        submitted_at=timezone.now(),
+    )
+    poll = Poll.objects.create(
+        organization=organization,
+        questionnaire=questionnaire,
+        event=event,
+        vote_visibility=ResourceVisibility.ATTENDEES_ONLY,
+        status=Poll.PollStatus.OPEN,
+    )
+    client = Client(HTTP_AUTHORIZATION=f"Bearer {str(RefreshToken.for_user(user).access_token)}")  # type: ignore[attr-defined]
+
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get("/api/polls/")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["results"]] == [str(poll.id)]
+    poll_queries = [q["sql"] for q in ctx.captured_queries if 'FROM "polls_poll"' in q["sql"]]
+    assert poll_queries
+    assert not any("DISTINCT" in sql for sql in poll_queries)

--- a/src/polls/tests/test_for_user.py
+++ b/src/polls/tests/test_for_user.py
@@ -157,3 +157,40 @@ def test_for_user_banned_member_does_not_see_voted_poll(
         submitted_at=timezone.now(),
     )
     assert Poll.objects.for_user(user).count() == 0
+
+
+def test_for_user_no_distinct_and_no_duplicates_across_predicates(
+    organization: t.Any, questionnaire: t.Any, event: t.Any, revel_user_factory: t.Any
+) -> None:
+    """Every predicate is an Exists() or the forward organization FK, so DISTINCT is not needed.
+
+    A user matching several predicates at once (ticket holder, YES RSVP, invitee
+    and voter) must still yield the poll exactly once without DISTINCT.
+    """
+    from events.models.invitation import EventInvitation
+    from events.models.rsvp import EventRSVP
+    from events.models.ticket import Ticket, TicketTier
+
+    user = revel_user_factory()
+    tier = TicketTier.objects.create(event=event, name="General")
+    Ticket.objects.create(event=event, tier=tier, user=user, status=Ticket.TicketStatus.ACTIVE)
+    EventRSVP.objects.create(event=event, user=user, status=EventRSVP.RsvpStatus.YES)
+    EventInvitation.objects.create(event=event, user=user)
+    QuestionnaireSubmission.objects.create(
+        user=user,
+        questionnaire=questionnaire,
+        status=QuestionnaireSubmission.QuestionnaireSubmissionStatus.READY,
+        submitted_at=timezone.now(),
+    )
+    poll = Poll.objects.create(
+        organization=organization,
+        questionnaire=questionnaire,
+        event=event,
+        vote_visibility=ResourceVisibility.PRIVATE,
+        result_visibility=ResourceVisibility.ATTENDEES_ONLY,
+        status=Poll.PollStatus.OPEN,
+    )
+
+    qs = Poll.objects.for_user(user)
+    assert qs.query.distinct is False
+    assert list(qs.values_list("pk", flat=True)) == [poll.pk]


### PR DESCRIPTION
## Summary

- **40 — `.distinct()` on the polls list queryset** (`src/polls/models.py`, `PollQuerySet.for_user`): removed. Every predicate is an `Exists()` subquery or the single-valued `organization` FK, so no row can be duplicated and DISTINCT over the wide select list was pure Postgres planning cost.
- **41 — `.distinct()` on the cities autocomplete** (`src/geo/controllers/cities.py`, `list_cities`): removed. `City` has no relations and `CityFilterSchema` (`country`) plus `@searching` (`name`, `ascii_name`, `country`) only touch scalar columns, so DISTINCT just forced a Unique-over-Sort over the whole table (incl. the `location` geography column) before `LIMIT 20`.
- **42 — `get_city` looked up by `city_id` while the list exposes only `pk`** (`src/geo/controllers/cities.py`, `get_city`): now looks up by `pk`. `City.city_id` is the external dataset id and `CitySchema` exposes `["id", "name", "country", "admin_name"]`, so the detail route was unreachable with any `id` taken from the list response (404 whenever `pk != city_id`, i.e. essentially always). The URL (`/api/cities/{city_id}`), `url_name="get_city"` and the OpenAPI operation are unchanged, so no frontend change or client regeneration is needed.

## Evidence for 40 (`str(Poll.objects.for_user(user).query)`)

Predicates in `for_user` for an authenticated non-superuser:

| predicate | kind |
|---|---|
| `org_owner_q = Q(organization__owner=user)` | forward FK (`polls_poll.organization_id -> events_organization.id`, single-valued) |
| `org_staff_q` | `Exists(OrganizationStaff ...)` |
| `member_q` | `Exists(OrganizationMember.for_visibility() ...)` (used twice) |
| `ticket_q` | `Exists(Ticket ...)` |
| `rsvp_q` | `Exists(EventRSVP ...)` |
| `invite_q` | `Exists(EventInvitation ...)` |
| `voted_q` | `Exists(QuestionnaireSubmission ...)` |
| `passes_vis` | scalar `vote_visibility`/`result_visibility` columns AND'ed with the `Exists` above |
| `.exclude(organization_id__in=excluded_org_ids)` | literal `set` of ids (materialised by `get_excluded_org_ids`), no join |

The generated SQL contains exactly one JOIN and ten `EXISTS(...)`:

```
FROM "polls_poll" INNER JOIN "events_organization" ON ("polls_poll"."organization_id" = "events_organization"."id")
WHERE ("events_organization"."owner_id" = <uid>
   OR EXISTS(SELECT 1 FROM "events_organizationstaff" U0 WHERE U0."organization_id" = ("polls_poll"."organization_id") AND U0."user_id" = <uid> LIMIT 1)
   OR ((... OR ("polls_poll"."vote_visibility" = 'members-only' AND EXISTS(SELECT 1 FROM "events_organizationmember" U0 ...))
        OR ("polls_poll"."vote_visibility" IN ('private', 'attendees-only') AND (EXISTS(SELECT 1 FROM "events_ticket" U0 ...) OR EXISTS(SELECT 1 FROM "events_eventrsvp" U0 ...)))
        OR ("polls_poll"."vote_visibility" = 'private' AND EXISTS(SELECT 1 FROM "events_eventinvitation" U0 ...))
        OR EXISTS(SELECT 1 FROM "questionnaires_questionnairesubmission" U0 ...))
       AND NOT ("polls_poll"."status" = 'draft')))
```

The controller's `_list_queryset` adds `with_user_annotations` (all `Exists()`/`Subquery` annotations) and `select_related("organization", "event", "questionnaire")` — three more forward-FK JOINs — and never re-applied `.distinct()`. The `prefetch_related` on the two M2M tier fields is a separate query.

Refs 2026-09-10 tech-debt report findings 40, 41, 42 (and #880 for the DISTINCT planning cost).

## Tests

- `src/geo/tests/test_controllers.py`
  - `test_get_city` now resolves the detail URL with `city.pk` (it previously encoded the bug by passing `city.city_id`).
  - new `test_get_city_looks_up_by_pk_not_external_city_id`: city with `city_id=987654321`, GET by pk -> 200 with matching `id`; GET by the external `city_id` -> 404 (guarded by an assertion that no row has that pk). Written first and confirmed red (404 by pk) before the fix.
  - `test_list_cities` now captures the SQL for a filtered+searched request and asserts no `DISTINCT` on `geo_city` (was red before the fix).
- `src/polls/tests/test_for_user.py` — new `test_for_user_no_distinct_and_no_duplicates_across_predicates`: user is ticket holder + YES RSVP + invitee + voter on a PRIVATE/ATTENDEES_ONLY event poll; asserts `qs.query.distinct is False` and the poll comes back exactly once.
- `src/polls/tests/test_controllers_list.py` — new `test_list_poll_matching_several_predicates_appears_once_without_distinct`: same shape through `GET /api/polls/` (ticket AND vote), asserts exactly one result and no `DISTINCT` in any captured `polls_poll` query.

## Verification

- `make format && make lint` — 1585 files left unchanged / All checks passed!
- `make check` — format, lint, mypy `--strict` (Success: no issues found in 1339 source files), migration-check (No changes detected), i18n-check, i18n-literals, file-length, task-names: all green
- `DB_NAME=revel_td_d uv run pytest src/geo/tests src/polls/tests -q -n 4` — 222 passed
- `make dump-openapi` — `.artifacts/openapi.json` unchanged (`git status` clean for `.artifacts/`)
- No migrations touched; no frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
