### PR TITLE
feat(admin): filter organizations by Stripe/events/VAT and sort by payment volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Admin: the Organizations changelist gained filters — Stripe connected, has events, VAT status, visibility and a created-date range — plus a sortable **Payments** column counting succeeded ticket sales, so a long organization list can be narrowed and ranked by processing volume
+- Admin: the dashboard's Organizations card now shows how many organizations have completed Stripe onboarding, and the Events card how many events have at least one online-payment tier
+
 ## [2.13.0] - 2026-09-12
 
 ### Added

--- a/src/common/models/__init__.py
+++ b/src/common/models/__init__.py
@@ -4,7 +4,13 @@ Models are grouped into focused modules by domain and re-exported here so that
 existing ``from common.models import X`` import paths keep working unchanged.
 """
 
-from common.models.base import EmailDeliverableMixin, ExifStripMixin, StripeConnectMixin, TimeStampedModel
+from common.models.base import (
+    STRIPE_CONNECTED_Q,
+    EmailDeliverableMixin,
+    ExifStripMixin,
+    StripeConnectMixin,
+    TimeStampedModel,
+)
 from common.models.email import EmailLog
 from common.models.exchange import ExchangeRate
 from common.models.files import FileExport, FileUploadAudit, QuarantinedFile
@@ -12,6 +18,7 @@ from common.models.site import Legal, SiteSettings
 from common.models.tags import Tag, TagAssignment, TaggableMixin, TagManager
 
 __all__ = [
+    "STRIPE_CONNECTED_Q",
     "EmailDeliverableMixin",
     "EmailLog",
     "ExchangeRate",

--- a/src/common/models/base.py
+++ b/src/common/models/base.py
@@ -4,6 +4,7 @@ import typing as t
 import uuid
 
 from django.db import models
+from django.db.models import Q
 
 
 class TimeStampedModel(models.Model):
@@ -145,6 +146,16 @@ class EmailDeliverableMixin(models.Model):
         self.email_delivery_error = ""
         if hasattr(self, "updated_at"):
             self.updated_at = now
+
+
+# ORM equivalent of ``StripeConnectMixin.is_stripe_connected``, for filtering and
+# counting across a queryset (the property itself is unreachable from the ORM).
+# Keep the two in lockstep.
+STRIPE_CONNECTED_Q = Q(
+    stripe_account_id__isnull=False,
+    stripe_charges_enabled=True,
+    stripe_details_submitted=True,
+)
 
 
 class StripeConnectMixin(models.Model):

--- a/src/events/admin/organization.py
+++ b/src/events/admin/organization.py
@@ -5,14 +5,16 @@ import typing as t
 
 from django.conf import settings
 from django.contrib import admin, messages
-from django.db.models import Count, OuterRef, QuerySet, Subquery
+from django.db.models import Count, Exists, OuterRef, QuerySet, Subquery
+from django.db.models.functions import Coalesce
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from unfold.admin import ModelAdmin
-from unfold.contrib.filters.admin import AutocompleteSelectFilter
+from unfold.contrib.filters.admin import AutocompleteSelectFilter, RangeDateFilter
 
+from common.models import STRIPE_CONNECTED_Q
 from events import models
 from events.admin.base import (
     EventSeriesInline,
@@ -24,6 +26,64 @@ from events.admin.base import (
     UserLinkMixin,
     VenueInline,
 )
+
+
+class StripeConnectedFilter(admin.SimpleListFilter):
+    """Filter organizations by whether Stripe Connect onboarding is complete."""
+
+    title = "Stripe connected"
+    parameter_name = "stripe_connected"
+
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:  # type: ignore[type-arg]
+        return [("yes", "Yes"), ("no", "No")]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> QuerySet[models.Organization]:
+        if self.value() == "yes":
+            return queryset.filter(STRIPE_CONNECTED_Q)
+        if self.value() == "no":
+            return queryset.exclude(STRIPE_CONNECTED_Q)
+        return queryset
+
+
+class HasEventsFilter(admin.SimpleListFilter):
+    """Filter organizations by whether they have at least one non-template event."""
+
+    title = "has events"
+    parameter_name = "has_events"
+
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:  # type: ignore[type-arg]
+        return [("yes", "Yes"), ("no", "No")]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> QuerySet[models.Organization]:
+        has_events = Exists(models.Event.objects.exclude_templates().filter(organization=OuterRef("pk")))
+        if self.value() == "yes":
+            return queryset.filter(has_events)
+        if self.value() == "no":
+            return queryset.filter(~has_events)
+        return queryset
+
+
+class VatStatusFilter(admin.SimpleListFilter):
+    """Filter organizations by VAT ID presence and VIES validation state."""
+
+    title = "VAT status"
+    parameter_name = "vat_status"
+
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:  # type: ignore[type-arg]
+        return [
+            ("none", "No VAT ID"),
+            ("unvalidated", "VAT ID, not validated"),
+            ("validated", "VAT ID validated"),
+        ]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet[models.Organization]) -> QuerySet[models.Organization]:
+        if self.value() == "none":
+            return queryset.filter(vat_id="")
+        if self.value() == "unvalidated":
+            return queryset.exclude(vat_id="").filter(vat_id_validated=False)
+        if self.value() == "validated":
+            return queryset.exclude(vat_id="").filter(vat_id_validated=True)
+        return queryset
 
 
 @admin.register(models.Organization)
@@ -55,11 +115,20 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
         "owner_link",
         "members_count",
         "events_count",
+        "payments_count",
         "stripe_connected",
         "vat_status",
         "visibility",
         "created_at",
     ]
+    list_filter = [
+        StripeConnectedFilter,
+        HasEventsFilter,
+        VatStatusFilter,
+        "visibility",
+        ("created_at", RangeDateFilter),
+    ]
+    list_filter_submit = True
     list_select_related = ["owner"]
     search_fields = ["name", "slug", "owner__username"]
     autocomplete_fields = ["owner", "city", "staff_members", "members"]
@@ -232,9 +301,23 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
             .annotate(cnt=Count("id"))
             .values("cnt")
         )
+        # Successful ticket sales, reached through ticket -> event -> organization.
+        # Series-pass and membership payments live in separate tables and are not
+        # counted here; this column is "tickets sold online", not total revenue.
+        payments_subquery = (
+            models.Payment.objects.filter(
+                ticket__event__organization=OuterRef("pk"),
+                status=models.Payment.PaymentStatus.SUCCEEDED,
+            )
+            .values("ticket__event__organization")
+            .annotate(cnt=Count("id"))
+            .values("cnt")
+        )
         return qs.annotate(
             _members_count=Subquery(members_subquery),
             _events_count=Subquery(events_subquery),
+            # Coalesced so orgs with no sales sort as 0 rather than clumping with NULLs.
+            _payments_count=Coalesce(Subquery(payments_subquery), 0),
         )
 
     def owner_link(self, obj: models.Organization) -> str:
@@ -249,6 +332,10 @@ class OrganizationAdmin(ModelAdmin, UserLinkMixin):  # type: ignore[misc]
     @admin.display(description="Events", ordering="_events_count")
     def events_count(self, obj: models.Organization) -> int:
         return t.cast(int, getattr(obj, "_events_count", 0))
+
+    @admin.display(description="Payments", ordering="_payments_count")
+    def payments_count(self, obj: models.Organization) -> int:
+        return t.cast(int, getattr(obj, "_payments_count", 0))
 
     @admin.display(description="Stripe", boolean=True)
     def stripe_connected(self, obj: models.Organization) -> bool:

--- a/src/events/tests/test_admin/test_organization_admin_filters.py
+++ b/src/events/tests/test_admin/test_organization_admin_filters.py
@@ -1,0 +1,244 @@
+"""Tests for the OrganizationAdmin changelist filters and the payments-volume column.
+
+The filters exist so an operator can narrow a large organization list: which orgs
+finished Stripe onboarding, which ones actually run events, and where each stands
+on VAT. The payments column makes the list sortable by processing volume.
+
+Each test drives the real changelist URL rather than the filter classes in
+isolation, so a filter that is implemented but never wired into ``list_filter``
+still fails.
+"""
+
+import typing as t
+import uuid
+from decimal import Decimal
+
+import pytest
+from django.test import Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from conftest import RevelUserFactory
+from events.models import Event, Organization, Payment, Ticket, TicketTier
+
+pytestmark = pytest.mark.django_db
+
+CHANGELIST = reverse("admin:events_organization_changelist")
+
+# The changelist renders Unfold templates that reach for hashed static assets.
+NO_MANIFEST_STORAGE = override_settings(
+    STORAGES={
+        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+    }
+)
+
+
+def _org(owner: RevelUser, name: str, **kwargs: t.Any) -> Organization:
+    return Organization.objects.create(name=name, slug=name.lower().replace(" ", "-"), owner=owner, **kwargs)
+
+
+def _event(org: Organization, *, is_template: bool = False) -> Event:
+    return Event.objects.create(
+        organization=org,
+        name=f"{org.name} Event",
+        slug=f"event-{org.slug}",
+        event_type=Event.EventType.PUBLIC,
+        visibility=Event.Visibility.PUBLIC,
+        max_attendees=100,
+        # The template_events_must_be_draft constraint forbids an OPEN template.
+        status=Event.EventStatus.DRAFT if is_template else Event.EventStatus.OPEN,
+        start=timezone.now(),
+        requires_ticket=True,
+        is_template=is_template,
+    )
+
+
+def _succeeded_payment(
+    event: Event,
+    user: RevelUser,
+    *,
+    status: Payment.PaymentStatus = Payment.PaymentStatus.SUCCEEDED,
+) -> Payment:
+    # TicketTier has a unique (event, name) constraint, so each ticket needs its own tier.
+    tier = TicketTier.objects.create(event=event, name=f"GA-{uuid.uuid4().hex[:8]}")
+    ticket = Ticket.objects.create(
+        event=event, user=user, tier=tier, status=Ticket.TicketStatus.ACTIVE, guest_name="Guest"
+    )
+    return Payment.objects.create(
+        ticket=ticket,
+        user=user,
+        amount=Decimal("40.00"),
+        platform_fee=Decimal("0.00"),
+        currency="EUR",
+        status=status,
+        stripe_session_id=f"cs_test_{ticket.id}",
+    )
+
+
+def _changelist(admin_client: Client, query: str = "") -> t.Any:
+    """GET the organization changelist and return its ``ChangeList``."""
+    response = admin_client.get(f"{CHANGELIST}{query}")
+    assert response.status_code == 200
+    context = response.context_data
+    assert context is not None
+    return context["cl"]
+
+
+def _payments_column_index(admin_client: Client) -> int:
+    """Position of the Payments column for the ``?o=`` sort param.
+
+    Read off the rendered ChangeList rather than ``ModelAdmin.list_display``:
+    Django prepends ``action_checkbox`` when the admin defines actions, so the
+    two lists are off by one.
+    """
+    return list(_changelist(admin_client).list_display).index("payments_count")
+
+
+def _names(admin_client: Client, query: str = "") -> set[str]:
+    """Return the org names the changelist yields for ``query``."""
+    return {org.name for org in _changelist(admin_client, query).queryset}
+
+
+@pytest.fixture
+def stripe_orgs(revel_user_factory: RevelUserFactory) -> dict[str, Organization]:
+    """Three orgs spanning the Stripe-onboarding states, including a half-finished one."""
+    owner = revel_user_factory()
+    return {
+        "connected": _org(
+            owner,
+            "Connected",
+            stripe_account_id="acct_connected",
+            stripe_charges_enabled=True,
+            stripe_details_submitted=True,
+        ),
+        # Onboarding started but charges never enabled — must not read as connected.
+        "half": _org(
+            owner,
+            "Half",
+            stripe_account_id="acct_half",
+            stripe_charges_enabled=False,
+            stripe_details_submitted=True,
+        ),
+        "none": _org(owner, "None"),
+    }
+
+
+@NO_MANIFEST_STORAGE
+def test_stripe_connected_filter_requires_all_three_columns(
+    admin_client: Client, stripe_orgs: dict[str, Organization]
+) -> None:
+    """Only an org with an account id, charges enabled AND details submitted is 'connected'."""
+    assert _names(admin_client, "?stripe_connected=yes") == {"Connected"}
+    assert _names(admin_client, "?stripe_connected=no") == {"Half", "None"}
+
+
+@NO_MANIFEST_STORAGE
+def test_stripe_connected_filter_absent_returns_everything(
+    admin_client: Client, stripe_orgs: dict[str, Organization]
+) -> None:
+    """No filter selected leaves the queryset untouched."""
+    assert _names(admin_client) == {"Connected", "Half", "None"}
+
+
+@NO_MANIFEST_STORAGE
+def test_has_events_filter_ignores_template_events(admin_client: Client, revel_user_factory: RevelUserFactory) -> None:
+    """A recurring-series template is not a real event, so its org has no events."""
+    owner = revel_user_factory()
+    with_event = _org(owner, "With Event")
+    _event(with_event)
+    template_only = _org(owner, "Template Only")
+    _event(template_only, is_template=True)
+    _org(owner, "Empty")
+
+    assert _names(admin_client, "?has_events=yes") == {"With Event"}
+    assert _names(admin_client, "?has_events=no") == {"Template Only", "Empty"}
+
+
+@NO_MANIFEST_STORAGE
+def test_vat_status_filter_partitions_all_orgs(admin_client: Client, revel_user_factory: RevelUserFactory) -> None:
+    """The three VAT lookups are mutually exclusive and together cover every org."""
+    owner = revel_user_factory()
+    _org(owner, "No Vat")
+    _org(owner, "Unvalidated", vat_id="IT12345678901", vat_id_validated=False)
+    _org(owner, "Validated", vat_id="AT12345678901", vat_id_validated=True)
+
+    assert _names(admin_client, "?vat_status=none") == {"No Vat"}
+    assert _names(admin_client, "?vat_status=unvalidated") == {"Unvalidated"}
+    assert _names(admin_client, "?vat_status=validated") == {"Validated"}
+
+
+@NO_MANIFEST_STORAGE
+def test_filters_compose(admin_client: Client, revel_user_factory: RevelUserFactory) -> None:
+    """Two filters at once narrow rather than replace each other."""
+    owner = revel_user_factory()
+    connected_kwargs: dict[str, t.Any] = {
+        "stripe_account_id": "acct_both",
+        "stripe_charges_enabled": True,
+        "stripe_details_submitted": True,
+    }
+    both = _org(owner, "Both", **connected_kwargs)
+    _event(both)
+    _org(
+        owner, "Stripe Only", stripe_account_id="acct_solo", stripe_charges_enabled=True, stripe_details_submitted=True
+    )
+    events_only = _org(owner, "Events Only")
+    _event(events_only)
+
+    assert _names(admin_client, "?stripe_connected=yes&has_events=yes") == {"Both"}
+
+
+@NO_MANIFEST_STORAGE
+def test_payments_count_counts_only_succeeded_payments(
+    admin_client: Client, revel_user_factory: RevelUserFactory
+) -> None:
+    """Pending and failed checkouts must not inflate an org's processing volume."""
+    owner = revel_user_factory()
+    buyer = revel_user_factory()
+    org = _org(owner, "Seller")
+    event = _event(org)
+    _succeeded_payment(event, buyer)
+    _succeeded_payment(event, buyer)
+    _succeeded_payment(event, buyer, status=Payment.PaymentStatus.PENDING)
+    _succeeded_payment(event, buyer, status=Payment.PaymentStatus.FAILED)
+
+    row = _changelist(admin_client).queryset.get(pk=org.pk)
+
+    assert row._payments_count == 2
+
+
+@NO_MANIFEST_STORAGE
+def test_payments_count_is_zero_not_null_for_orgs_without_sales(
+    admin_client: Client, revel_user_factory: RevelUserFactory
+) -> None:
+    """Coalesced to 0 so the column renders and sorts sanely for orgs that never sold."""
+    owner = revel_user_factory()
+    org = _org(owner, "Quiet")
+
+    row = _changelist(admin_client).queryset.get(pk=org.pk)
+
+    assert row._payments_count == 0
+
+
+@NO_MANIFEST_STORAGE
+def test_changelist_orders_by_payment_volume(admin_client: Client, revel_user_factory: RevelUserFactory) -> None:
+    """The Payments column is sortable, descending, with no-sales orgs last."""
+    owner = revel_user_factory()
+    buyer = revel_user_factory()
+
+    busy = _org(owner, "Busy")
+    busy_event = _event(busy)
+    for _ in range(3):
+        _succeeded_payment(busy_event, buyer)
+
+    quiet = _org(owner, "Quiet")
+    quiet_event = _event(quiet)
+    _succeeded_payment(quiet_event, buyer)
+
+    _org(owner, "Dormant")
+
+    # Django's ORDER_VAR is a 0-based index into list_display; "-" prefixes descending.
+    ordered = [org.name for org in _changelist(admin_client, f"?o=-{_payments_column_index(admin_client)}").queryset]
+
+    assert ordered == ["Busy", "Quiet", "Dormant"]

--- a/src/revel/dashboard.py
+++ b/src/revel/dashboard.py
@@ -5,14 +5,14 @@ from datetime import date, datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
-from django.db.models import Count
+from django.db.models import Count, Exists, OuterRef
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import timezone
 
 from accounts.models import RevelUser
-from common.models import SiteSettings
-from events.models import Event, Organization
+from common.models import STRIPE_CONNECTED_Q, SiteSettings
+from events.models import Event, Organization, TicketTier
 from notifications.enums import DeliveryStatus
 from notifications.models import NotificationDelivery
 from telegram.models import TelegramUser
@@ -399,7 +399,18 @@ def dashboard_callback(request: HttpRequest, context: dict[str, t.Any]) -> dict[
     total_users = RevelUser.objects.count()
     connected_telegram = TelegramUser.objects.filter(user__isnull=False).count()
     total_organizations = Organization.objects.count()
+    connected_stripe = Organization.objects.filter(STRIPE_CONNECTED_Q).count()
     total_events = Event.objects.count()
+    # Exists() rather than a join + .distinct(): a semi-join needs no dedup pass,
+    # and an event with several online tiers must still count once.
+    events_with_online_payment = Event.objects.filter(
+        Exists(
+            TicketTier.objects.filter(
+                event=OuterRef("pk"),
+                payment_method=TicketTier.PaymentMethod.ONLINE,
+            )
+        )
+    ).count()
 
     # User growth data
     user_growth = _get_user_growth_data(days=30)
@@ -456,7 +467,9 @@ def dashboard_callback(request: HttpRequest, context: dict[str, t.Any]) -> dict[
                     "total_users": total_users,
                     "connected_telegram": connected_telegram,
                     "total_organizations": total_organizations,
+                    "connected_stripe": connected_stripe,
                     "total_events": total_events,
+                    "events_with_online_payment": events_with_online_payment,
                 },
                 "user_growth": user_growth,
                 "pronoun_distribution": pronoun_distribution,

--- a/src/revel/tests/test_dashboard_quick_stats.py
+++ b/src/revel/tests/test_dashboard_quick_stats.py
@@ -1,0 +1,119 @@
+"""Tests for the two Stripe-oriented quick stats on the admin dashboard.
+
+``connected_stripe`` sits under the Total Organizations card and
+``events_with_online_payment`` under Total Events, mirroring how
+``connected_telegram`` hangs off Total Users.
+"""
+
+import typing as t
+
+import pytest
+from django.test import RequestFactory
+from django.utils import timezone
+
+from accounts.models import RevelUser
+from conftest import RevelUserFactory
+from events.models import Event, Organization, TicketTier
+from revel.dashboard import dashboard_callback
+
+pytestmark = pytest.mark.django_db
+
+
+def _quick_stats(user: RevelUser) -> dict[str, t.Any]:
+    request = RequestFactory().get("/admin/")
+    request.user = user
+    context = dashboard_callback(request, {})
+    return t.cast(dict[str, t.Any], context["dashboard"]["quick_stats"])
+
+
+def _org(owner: RevelUser, name: str, **kwargs: t.Any) -> Organization:
+    return Organization.objects.create(name=name, slug=name.lower().replace(" ", "-"), owner=owner, **kwargs)
+
+
+def _event(org: Organization, slug: str) -> Event:
+    return Event.objects.create(
+        organization=org,
+        name=slug,
+        slug=slug,
+        event_type=Event.EventType.PUBLIC,
+        visibility=Event.Visibility.PUBLIC,
+        max_attendees=100,
+        status=Event.EventStatus.OPEN,
+        start=timezone.now(),
+        requires_ticket=True,
+    )
+
+
+def test_connected_stripe_requires_full_onboarding(superuser: RevelUser, revel_user_factory: RevelUserFactory) -> None:
+    """A half-onboarded org (details submitted, charges still off) is not counted."""
+    owner = revel_user_factory()
+    _org(
+        owner,
+        "Connected",
+        stripe_account_id="acct_connected",
+        stripe_charges_enabled=True,
+        stripe_details_submitted=True,
+    )
+    _org(
+        owner,
+        "Half",
+        stripe_account_id="acct_half",
+        stripe_charges_enabled=False,
+        stripe_details_submitted=True,
+    )
+    _org(owner, "None")
+
+    stats = _quick_stats(superuser)
+
+    assert stats["total_organizations"] == 3
+    assert stats["connected_stripe"] == 1
+
+
+def test_event_with_several_online_tiers_counts_once(
+    superuser: RevelUser, revel_user_factory: RevelUserFactory
+) -> None:
+    """The metric counts events, not tiers — two online tiers on one event is still one event."""
+    org = _org(revel_user_factory(), "Org")
+    event = _event(org, "multi-tier")
+    TicketTier.objects.create(event=event, name="Early", payment_method=TicketTier.PaymentMethod.ONLINE)
+    TicketTier.objects.create(event=event, name="Late", payment_method=TicketTier.PaymentMethod.ONLINE)
+
+    assert _quick_stats(superuser)["events_with_online_payment"] == 1
+
+
+def test_non_online_payment_methods_are_excluded(superuser: RevelUser, revel_user_factory: RevelUserFactory) -> None:
+    """Only ONLINE counts; offline, at-the-door and free tiers take no money through us."""
+    org = _org(revel_user_factory(), "Org")
+    online = _event(org, "online")
+    TicketTier.objects.create(event=online, name="GA", payment_method=TicketTier.PaymentMethod.ONLINE)
+    for slug, method in (
+        ("offline", TicketTier.PaymentMethod.OFFLINE),
+        ("door", TicketTier.PaymentMethod.AT_THE_DOOR),
+        ("free", TicketTier.PaymentMethod.FREE),
+    ):
+        TicketTier.objects.create(event=_event(org, slug), name="GA", payment_method=method)
+
+    stats = _quick_stats(superuser)
+
+    assert stats["total_events"] == 4
+    assert stats["events_with_online_payment"] == 1
+
+
+def test_event_without_tiers_is_not_counted(superuser: RevelUser, revel_user_factory: RevelUserFactory) -> None:
+    """An RSVP-only event has no online tier and must not appear in the count."""
+    org = _org(revel_user_factory(), "Org")
+    event = _event(org, "rsvp-only")
+    event.ticket_tiers.all().delete()  # a signal auto-creates a tier for requires_ticket events
+
+    stats = _quick_stats(superuser)
+
+    assert stats["total_events"] == 1
+    assert stats["events_with_online_payment"] == 0
+
+
+def test_empty_database_reports_zeroes(superuser: RevelUser) -> None:
+    """Both stats are plain counts, so an empty instance renders 0 rather than blowing up."""
+    stats = _quick_stats(superuser)
+
+    assert stats["connected_stripe"] == 0
+    assert stats["events_with_online_payment"] == 0

--- a/src/templates/admin/index.html
+++ b/src/templates/admin/index.html
@@ -78,18 +78,36 @@
             {# Total Organizations #}
             <div class="bg-white dark:bg-base-900 border border-base-200 dark:border-base-800 rounded-lg shadow p-6">
                 <h2 class="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">Total Organizations</h2>
-                <div class="flex items-center justify-between">
+                <div class="flex items-center justify-between mb-2">
                     <p class="text-3xl font-bold text-primary-600 dark:text-primary-500">{{ dashboard.quick_stats.total_organizations }}</p>
                     <span class="text-4xl">🏢</span>
+                </div>
+                <div class="mt-3 pt-3 border-t border-base-200 dark:border-base-700">
+                    <div class="flex items-center justify-between text-sm">
+                        <span class="text-gray-600 dark:text-gray-400 flex items-center gap-1">
+                            <span>💳</span>
+                            <span>Connected Stripe</span>
+                        </span>
+                        <span class="font-semibold text-gray-900 dark:text-gray-100">{{ dashboard.quick_stats.connected_stripe }}</span>
+                    </div>
                 </div>
             </div>
 
             {# Total Events #}
             <div class="bg-white dark:bg-base-900 border border-base-200 dark:border-base-800 rounded-lg shadow p-6">
                 <h2 class="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">Total Events</h2>
-                <div class="flex items-center justify-between">
+                <div class="flex items-center justify-between mb-2">
                     <p class="text-3xl font-bold text-primary-600 dark:text-primary-500">{{ dashboard.quick_stats.total_events }}</p>
                     <span class="text-4xl">📅</span>
+                </div>
+                <div class="mt-3 pt-3 border-t border-base-200 dark:border-base-700">
+                    <div class="flex items-center justify-between text-sm">
+                        <span class="text-gray-600 dark:text-gray-400 flex items-center gap-1">
+                            <span>💳</span>
+                            <span>Online payment</span>
+                        </span>
+                        <span class="font-semibold text-gray-900 dark:text-gray-100">{{ dashboard.quick_stats.events_with_online_payment }}</span>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Why

The Organizations changelist had **no `list_filter` at all** — just a search box. That stops scaling once an instance has more than a screenful of orgs, and there was no way to see which ones actually take money.

## What

### Organizations changelist (`events/admin/organization.py`)

Four filters plus a date range, with `list_filter_submit = True` to match the repo's other admins:

| Filter | Behaviour |
|---|---|
| **Stripe connected** | yes/no over all three onboarding columns — a half-onboarded org (account id + details submitted, charges still off) reads as **not** connected |
| **Has events** | `Exists()` on non-template events; a recurring-series template alone doesn't count |
| **VAT status** | no VAT ID / VAT ID unvalidated / VAT ID validated |
| **Visibility** | plain field filter |
| **Created** | unfold `RangeDateFilter` |

Plus a sortable **Payments** column: succeeded `Payment` rows reached via `ticket → event → organization`. Series-pass and membership payments live in separate tables and are deliberately out of scope for now — this column is "tickets sold online", not total revenue.

### Dashboard (`revel/dashboard.py`, `templates/admin/index.html`)

Two new sub-lines, mirroring how `connected_telegram` hangs off the Total Users card:

- **Total Organizations** → `💳 Connected Stripe`
- **Total Events** → `💳 Online payment` (events with ≥1 `TicketTier(payment_method=ONLINE)`)

### `common/models/base.py`

`STRIPE_CONNECTED_Q` next to `StripeConnectMixin`. `is_stripe_connected` is a Python property the ORM can't filter or count on, and both the admin and the dashboard now need the predicate — the constant keeps the two definitions from drifting.

## Implementation notes

- **Correlated subquery, not a join.** The existing `get_queryset` already uses `Subquery` for members/events precisely because two `Count`s over two reverse FKs in one query fan out and both come back wrong. The payments count follows suit, wrapped in `Coalesce(..., 0)` so orgs with no sales render `0` and sort as `0` rather than clumping with NULLs.
- **`Exists()` over `.distinct()`** for the online-payment metric. An event with two online tiers must count once, but the `DISTINCT` form is the pattern behind the my-tickets planner blowup (#880); a semi-join needs no dedup pass.
- **Plain English strings, no `gettext`.** `events/admin/organization.py` contains zero `_()` calls today; marking these staff-only labels would demand a translated msgid in all five locale catalogs for no user-facing gain. `make i18n-check` passes.
- No migrations.

## Testing

13 new tests. The admin ones drive the real changelist URL rather than the filter classes in isolation, so a filter that's implemented but never wired into `list_filter` still fails.

- `src/events/tests/test_admin/test_organization_admin_filters.py` (8) — each filter's partitioning, filters composing, succeeded-only counting, the coalesced zero, and descending sort by volume
- `src/revel/tests/test_dashboard_quick_stats.py` (5) — half-onboarded org excluded, multi-tier event counted once, non-online methods excluded, tier-less event excluded, empty DB

```
make check                                          ✅ all green (ruff, mypy --strict, migrations, i18n, file-length, task-names)
pytest src/revel/tests/ src/events/tests/test_admin/                48 passed
pytest .../test_organization_admin_stripe.py .../test_tag_endpoints.py src/common/tests   432 passed
pytest src/events/tests/test_controllers/test_organization_admin/   574 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization admin filters for Stripe connection, events, VAT status, visibility, and creation date.
  * Added a sortable Payments column showing successful ticket sales per organization.
  * Added dashboard metrics for organizations completing Stripe onboarding and events with online-payment tiers.
  * Added secondary metrics to the Organizations and Events dashboard cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->